### PR TITLE
CI: add gatekeeper freeze-gate enforcement

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -1,0 +1,29 @@
+name: Gatekeeper
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  gatekeeper:
+    name: "Freeze-gate enforcement"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
+
+      - name: Install dependencies
+        run: pip3 install pyyaml
+
+      - name: Run gatekeeper
+        run: |
+          python3 contrib/devtools/gatekeeper.py \
+            --rules contrib/devtools/gatekeeper.yaml \
+            --base origin/${{ github.base_ref }} \
+            --head HEAD

--- a/contrib/devtools/gatekeeper.py
+++ b/contrib/devtools/gatekeeper.py
@@ -18,21 +18,20 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
-import os
 import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple, Dict, Any
+from typing import Any
 
 try:
-    import yaml
+    import yaml  # type: ignore[import]
 except ImportError:
     print("ERROR: pyyaml required. Install with: pip3 install pyyaml", file=sys.stderr)
     sys.exit(2)
 
 
-def git_diff_files(base: str, head: str) -> List[str]:
+def git_diff_files(base: str, head: str) -> list[str]:
     """Get list of files changed between base and head."""
     result = subprocess.run(
         ["git", "diff", "--name-only", f"{base}...{head}"],
@@ -40,10 +39,10 @@ def git_diff_files(base: str, head: str) -> List[str]:
         text=True,
         check=True,
     )
-    return [f.strip() for f in result.stdout.strip().split("\n") if f.strip()]
+    return [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
 
 
-def git_show_file(ref: str, path: str) -> Optional[str]:
+def git_show_file(ref: str, path: str) -> str | None:
     """Get file contents at a specific git ref. Returns None if file doesn't exist."""
     try:
         result = subprocess.run(
@@ -57,7 +56,7 @@ def git_show_file(ref: str, path: str) -> Optional[str]:
         return None
 
 
-def git_ls_tree(ref: str, path: str) -> List[str]:
+def git_ls_tree(ref: str, path: str) -> list[str]:
     """List files in a directory at a specific git ref."""
     try:
         result = subprocess.run(
@@ -66,12 +65,12 @@ def git_ls_tree(ref: str, path: str) -> List[str]:
             text=True,
             check=True,
         )
-        return [f.strip() for f in result.stdout.strip().split("\n") if f.strip()]
+        return [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
     except subprocess.CalledProcessError:
         return []
 
 
-def path_matches_patterns(path: str, patterns: List[str]) -> bool:
+def path_matches_patterns(path: str, patterns: list[str]) -> bool:
     """Check if path matches any of the glob patterns."""
     for pattern in patterns:
         # Handle ** for recursive matching
@@ -85,33 +84,37 @@ def path_matches_patterns(path: str, patterns: List[str]) -> bool:
     return False
 
 
-def check_file_requirement(req: Dict[str, Any], base_ref: str, head_ref: str) -> Tuple[bool, str]:
+def check_file_requirement(
+    req: dict[str, Any], base_ref: str, head_ref: str
+) -> tuple[bool, str]:
     """Check a file requirement. Returns (passed, error_message)."""
     where = req.get("where", "base")
     ref = base_ref if where == "base" else head_ref
-    
+
     file_path = req.get("file")
     if file_path:
         content = git_show_file(ref, file_path)
         if content is None:
             return False, f"File '{file_path}' not found on {where} branch ({ref})"
-        
+
         # Check required substrings
         contains = req.get("contains", [])
         for substring in contains:
             if substring not in content:
                 return False, f"File '{file_path}' on {where} branch missing required content: '{substring}'"
-        
+
         return True, ""
-    
+
     return True, ""
 
 
-def check_directory_requirement(req: Dict[str, Any], base_ref: str, head_ref: str) -> Tuple[bool, str]:
+def check_directory_requirement(
+    req: dict[str, Any], base_ref: str, head_ref: str
+) -> tuple[bool, str]:
     """Check a directory requirement. Returns (passed, error_message)."""
     where = req.get("where", "base")
     ref = base_ref if where == "base" else head_ref
-    
+
     directory = req.get("directory")
     if directory:
         files = git_ls_tree(ref, directory)
@@ -119,7 +122,7 @@ def check_directory_requirement(req: Dict[str, Any], base_ref: str, head_ref: st
         if len(files) < min_files:
             return False, f"Directory '{directory}' on {where} branch has {len(files)} files (requires >= {min_files})"
         return True, ""
-    
+
     return True, ""
 
 
@@ -138,36 +141,38 @@ def is_frozen_doc(content: str) -> bool:
     return False
 
 
-def check_frozen_doc_contract(content: str, file_path: str, contract: Dict[str, Any]) -> List[str]:
+def check_frozen_doc_contract(
+    content: str, file_path: str, contract: dict[str, Any]
+) -> list[str]:
     """
     Check that a frozen doc meets the contract requirements.
     Returns list of violations.
     """
-    violations = []
+    violations: list[str] = []
 
     if not is_frozen_doc(content):
         return []  # Not a frozen doc, skip contract checking
-    
+
     # Check required headers
     required_headers = contract.get("required_headers", [])
     for header in required_headers:
         if header not in content:
             violations.append(f"Frozen doc '{file_path}' missing required header: '{header}'")
-    
+
     # Check forbidden tokens
     forbidden = contract.get("forbidden_tokens", [])
     for token in forbidden:
         # Use word boundary matching to avoid false positives
         if re.search(rf'\b{re.escape(token)}\b', content):
             violations.append(f"Frozen doc '{file_path}' contains forbidden token: '{token}'")
-    
+
     return violations
 
 
 def run_gatekeeper(rules_path: str, base_ref: str, head_ref: str) -> int:
     """
     Run gatekeeper checks.
-    
+
     Returns:
         0 if all checks pass
         1 if any check fails
@@ -175,53 +180,53 @@ def run_gatekeeper(rules_path: str, base_ref: str, head_ref: str) -> int:
     """
     # Load rules
     try:
-        with open(rules_path) as f:
-            config = yaml.safe_load(f)
-    except Exception as e:
-        print(f"ERROR: Failed to load rules from {rules_path}: {e}", file=sys.stderr)
+        with open(rules_path, encoding="utf-8") as rules_file:
+            config = yaml.safe_load(rules_file)
+    except Exception as exc:
+        print(f"ERROR: Failed to load rules from {rules_path}: {exc}", file=sys.stderr)
         return 2
-    
+
     rules = config.get("rules", [])
     frozen_contract = config.get("frozen_doc_contract", {})
-    
+
     # Get changed files
     try:
         changed_files = git_diff_files(base_ref, head_ref)
-    except subprocess.CalledProcessError as e:
-        print(f"ERROR: Failed to get changed files: {e}", file=sys.stderr)
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: Failed to get changed files: {exc}", file=sys.stderr)
         return 2
-    
+
     if not changed_files:
         print("No files changed.")
         return 0
-    
+
     print(f"Changed files ({len(changed_files)}):")
-    for f in changed_files[:10]:
-        print(f"  - {f}")
+    for fname in changed_files[:10]:
+        print(f"  - {fname}")
     if len(changed_files) > 10:
         print(f"  ... and {len(changed_files) - 10} more")
     print()
-    
+
     # Track all violations
-    all_violations = []
-    
+    all_violations: list[str] = []
+
     # Check each rule
     for rule in rules:
         rule_name = rule.get("name", "unnamed rule")
         patterns = rule.get("paths", [])
         requirements = rule.get("requires", [])
-        
+
         # Find changed files matching this rule's patterns
-        matching_files = [f for f in changed_files if path_matches_patterns(f, patterns)]
-        
+        matching_files = [fname for fname in changed_files if path_matches_patterns(fname, patterns)]
+
         if not matching_files:
             continue
-        
+
         print(f"Rule: {rule_name}")
         print(f"  Triggered by: {matching_files[:3]}{'...' if len(matching_files) > 3 else ''}")
-        
-        rule_violations = []
-        
+
+        rule_violations: list[str] = []
+
         # Check all requirements
         for req in requirements:
             if "file" in req:
@@ -232,16 +237,16 @@ def run_gatekeeper(rules_path: str, base_ref: str, head_ref: str) -> int:
                 passed, error = check_directory_requirement(req, base_ref, head_ref)
                 if not passed:
                     rule_violations.append(error)
-        
+
         if rule_violations:
-            print(f"  FAILED:")
-            for v in rule_violations:
-                print(f"    - {v}")
+            print("  FAILED:")
+            for violation in rule_violations:
+                print(f"    - {violation}")
             all_violations.extend(rule_violations)
         else:
-            print(f"  PASSED")
+            print("  PASSED")
         print()
-    
+
     # Check frozen doc contract for any frozen docs in the PR
     if frozen_contract:
         for file_path in changed_files:
@@ -251,11 +256,11 @@ def run_gatekeeper(rules_path: str, base_ref: str, head_ref: str) -> int:
                     violations = check_frozen_doc_contract(content, file_path, frozen_contract)
                     if violations:
                         print(f"Frozen doc contract violations in {file_path}:")
-                        for v in violations:
-                            print(f"  - {v}")
+                        for violation in violations:
+                            print(f"  - {violation}")
                         all_violations.extend(violations)
                         print()
-    
+
     # Final result
     if all_violations:
         print("=" * 60)
@@ -266,14 +271,14 @@ def run_gatekeeper(rules_path: str, base_ref: str, head_ref: str) -> int:
         print("with '## Status: FROZEN' header BEFORE code changes can land.")
         print("\nTo fix: Land the required spec/doc PR first, then rebase this PR.")
         return 1
-    else:
-        print("=" * 60)
-        print("GATEKEEPER PASSED")
-        print("=" * 60)
-        return 0
+
+    print("=" * 60)
+    print("GATEKEEPER PASSED")
+    print("=" * 60)
+    return 0
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="PQBTC Gatekeeper — Freeze-gate enforcement"
     )
@@ -292,14 +297,14 @@ def main():
         default="HEAD",
         help="Head ref to check (default: HEAD)",
     )
-    
+
     args = parser.parse_args()
-    
+
     # Ensure we're in a git repository
     if not Path(".git").exists() and not Path("../.git").exists():
         print("ERROR: Must be run from within a git repository", file=sys.stderr)
         sys.exit(2)
-    
+
     sys.exit(run_gatekeeper(args.rules, args.base, args.head))
 
 

--- a/contrib/devtools/gatekeeper.py
+++ b/contrib/devtools/gatekeeper.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Gatekeeper — PQBTC Freeze-Gate Enforcement
+
+Enforces the docs-first invariant (I3): frozen specs must exist on the base
+branch (origin/main) before consensus-critical code can be modified.
+
+Usage:
+    python3 gatekeeper.py --rules gatekeeper.yaml --base origin/main --head HEAD
+
+Exit codes:
+    0 — All gates pass
+    1 — Gate violation detected
+    2 — Configuration or runtime error
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple, Dict, Any
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml required. Install with: pip3 install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+
+def git_diff_files(base: str, head: str) -> List[str]:
+    """Get list of files changed between base and head."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...{head}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [f.strip() for f in result.stdout.strip().split("\n") if f.strip()]
+
+
+def git_show_file(ref: str, path: str) -> Optional[str]:
+    """Get file contents at a specific git ref. Returns None if file doesn't exist."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{path}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+    except subprocess.CalledProcessError:
+        return None
+
+
+def git_ls_tree(ref: str, path: str) -> List[str]:
+    """List files in a directory at a specific git ref."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-tree", "--name-only", ref, path + "/"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return [f.strip() for f in result.stdout.strip().split("\n") if f.strip()]
+    except subprocess.CalledProcessError:
+        return []
+
+
+def path_matches_patterns(path: str, patterns: List[str]) -> bool:
+    """Check if path matches any of the glob patterns."""
+    for pattern in patterns:
+        # Handle ** for recursive matching
+        if "**" in pattern:
+            # Convert ** glob to regex
+            regex_pattern = pattern.replace(".", r"\.").replace("**", ".*").replace("*", "[^/]*")
+            if re.match(regex_pattern, path):
+                return True
+        elif fnmatch.fnmatch(path, pattern):
+            return True
+    return False
+
+
+def check_file_requirement(req: Dict[str, Any], base_ref: str, head_ref: str) -> Tuple[bool, str]:
+    """Check a file requirement. Returns (passed, error_message)."""
+    where = req.get("where", "base")
+    ref = base_ref if where == "base" else head_ref
+    
+    file_path = req.get("file")
+    if file_path:
+        content = git_show_file(ref, file_path)
+        if content is None:
+            return False, f"File '{file_path}' not found on {where} branch ({ref})"
+        
+        # Check required substrings
+        contains = req.get("contains", [])
+        for substring in contains:
+            if substring not in content:
+                return False, f"File '{file_path}' on {where} branch missing required content: '{substring}'"
+        
+        return True, ""
+    
+    return True, ""
+
+
+def check_directory_requirement(req: Dict[str, Any], base_ref: str, head_ref: str) -> Tuple[bool, str]:
+    """Check a directory requirement. Returns (passed, error_message)."""
+    where = req.get("where", "base")
+    ref = base_ref if where == "base" else head_ref
+    
+    directory = req.get("directory")
+    if directory:
+        files = git_ls_tree(ref, directory)
+        min_files = req.get("min_files", 1)
+        if len(files) < min_files:
+            return False, f"Directory '{directory}' on {where} branch has {len(files)} files (requires >= {min_files})"
+        return True, ""
+    
+    return True, ""
+
+
+def is_frozen_doc(content: str) -> bool:
+    """
+    Check if a document is marked as frozen.
+    The FROZEN header must appear as a proper heading in the first 30 lines,
+    not just mentioned in passing (e.g., as an example).
+    """
+    lines = content.split('\n')[:30]
+    for line in lines:
+        stripped = line.strip()
+        # Must be a proper markdown heading, not inline text
+        if stripped == "## Status: FROZEN":
+            return True
+    return False
+
+
+def check_frozen_doc_contract(content: str, file_path: str, contract: Dict[str, Any]) -> List[str]:
+    """
+    Check that a frozen doc meets the contract requirements.
+    Returns list of violations.
+    """
+    violations = []
+
+    if not is_frozen_doc(content):
+        return []  # Not a frozen doc, skip contract checking
+    
+    # Check required headers
+    required_headers = contract.get("required_headers", [])
+    for header in required_headers:
+        if header not in content:
+            violations.append(f"Frozen doc '{file_path}' missing required header: '{header}'")
+    
+    # Check forbidden tokens
+    forbidden = contract.get("forbidden_tokens", [])
+    for token in forbidden:
+        # Use word boundary matching to avoid false positives
+        if re.search(rf'\b{re.escape(token)}\b', content):
+            violations.append(f"Frozen doc '{file_path}' contains forbidden token: '{token}'")
+    
+    return violations
+
+
+def run_gatekeeper(rules_path: str, base_ref: str, head_ref: str) -> int:
+    """
+    Run gatekeeper checks.
+    
+    Returns:
+        0 if all checks pass
+        1 if any check fails
+        2 if configuration error
+    """
+    # Load rules
+    try:
+        with open(rules_path) as f:
+            config = yaml.safe_load(f)
+    except Exception as e:
+        print(f"ERROR: Failed to load rules from {rules_path}: {e}", file=sys.stderr)
+        return 2
+    
+    rules = config.get("rules", [])
+    frozen_contract = config.get("frozen_doc_contract", {})
+    
+    # Get changed files
+    try:
+        changed_files = git_diff_files(base_ref, head_ref)
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: Failed to get changed files: {e}", file=sys.stderr)
+        return 2
+    
+    if not changed_files:
+        print("No files changed.")
+        return 0
+    
+    print(f"Changed files ({len(changed_files)}):")
+    for f in changed_files[:10]:
+        print(f"  - {f}")
+    if len(changed_files) > 10:
+        print(f"  ... and {len(changed_files) - 10} more")
+    print()
+    
+    # Track all violations
+    all_violations = []
+    
+    # Check each rule
+    for rule in rules:
+        rule_name = rule.get("name", "unnamed rule")
+        patterns = rule.get("paths", [])
+        requirements = rule.get("requires", [])
+        
+        # Find changed files matching this rule's patterns
+        matching_files = [f for f in changed_files if path_matches_patterns(f, patterns)]
+        
+        if not matching_files:
+            continue
+        
+        print(f"Rule: {rule_name}")
+        print(f"  Triggered by: {matching_files[:3]}{'...' if len(matching_files) > 3 else ''}")
+        
+        rule_violations = []
+        
+        # Check all requirements
+        for req in requirements:
+            if "file" in req:
+                passed, error = check_file_requirement(req, base_ref, head_ref)
+                if not passed:
+                    rule_violations.append(error)
+            elif "directory" in req:
+                passed, error = check_directory_requirement(req, base_ref, head_ref)
+                if not passed:
+                    rule_violations.append(error)
+        
+        if rule_violations:
+            print(f"  FAILED:")
+            for v in rule_violations:
+                print(f"    - {v}")
+            all_violations.extend(rule_violations)
+        else:
+            print(f"  PASSED")
+        print()
+    
+    # Check frozen doc contract for any frozen docs in the PR
+    if frozen_contract:
+        for file_path in changed_files:
+            if file_path.startswith("docs/") and file_path.endswith(".md"):
+                content = git_show_file(head_ref, file_path)
+                if content and is_frozen_doc(content):
+                    violations = check_frozen_doc_contract(content, file_path, frozen_contract)
+                    if violations:
+                        print(f"Frozen doc contract violations in {file_path}:")
+                        for v in violations:
+                            print(f"  - {v}")
+                        all_violations.extend(violations)
+                        print()
+    
+    # Final result
+    if all_violations:
+        print("=" * 60)
+        print("GATEKEEPER FAILED")
+        print("=" * 60)
+        print(f"\n{len(all_violations)} violation(s) detected.\n")
+        print("Required artifacts must exist on the base branch (origin/main)")
+        print("with '## Status: FROZEN' header BEFORE code changes can land.")
+        print("\nTo fix: Land the required spec/doc PR first, then rebase this PR.")
+        return 1
+    else:
+        print("=" * 60)
+        print("GATEKEEPER PASSED")
+        print("=" * 60)
+        return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="PQBTC Gatekeeper — Freeze-gate enforcement"
+    )
+    parser.add_argument(
+        "--rules",
+        required=True,
+        help="Path to gatekeeper.yaml rules file",
+    )
+    parser.add_argument(
+        "--base",
+        required=True,
+        help="Base ref to check against (e.g., origin/main)",
+    )
+    parser.add_argument(
+        "--head",
+        default="HEAD",
+        help="Head ref to check (default: HEAD)",
+    )
+    
+    args = parser.parse_args()
+    
+    # Ensure we're in a git repository
+    if not Path(".git").exists() and not Path("../.git").exists():
+        print("ERROR: Must be run from within a git repository", file=sys.stderr)
+        sys.exit(2)
+    
+    sys.exit(run_gatekeeper(args.rules, args.base, args.head))
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/devtools/gatekeeper.yaml
+++ b/contrib/devtools/gatekeeper.yaml
@@ -1,0 +1,156 @@
+# Gatekeeper Rules — PQBTC Freeze-Gate Enforcement
+# 
+# These rules enforce the docs-first invariant (I3): frozen specs must exist
+# on the base branch before consensus-critical code can be modified.
+#
+# Rule structure:
+#   - where: base   → check origin/main (default for frozen specs)
+#   - where: head   → check PR working tree (for vectors/ref impl in same PR)
+#   - contains: []  → required substrings (e.g., FROZEN headers)
+#
+# STRICT POSTURE: No script/** changes until ALL Gate 3 prerequisites exist.
+# The "surface rules only" exception was identified as a trap — the gatekeeper
+# cannot distinguish surface gating from PQSig integration edits.
+
+rules:
+  # ─────────────────────────────────────────────────────────────────────────
+  # Gate 1: Chain identity + genesis
+  # ─────────────────────────────────────────────────────────────────────────
+  - name: "Chain identity requires frozen GENESIS spec"
+    paths:
+      - "src/kernel/chainparams*"
+      - "src/chainparams*"
+      - "src/chainparamsseeds.h"
+      - "contrib/genesis/**"
+    requires:
+      - where: base
+        file: "docs/GENESIS.md"
+        contains:
+          - "## Status: FROZEN"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Gate 2: PQSig cryptography (standalone module)
+  # ─────────────────────────────────────────────────────────────────────────
+  - name: "PQSig crypto requires frozen PQSIG specs + vectors"
+    paths:
+      - "src/crypto/pqsig/**"
+    requires:
+      - where: base
+        file: "docs/PQSIG_INTERNALS.md"
+        contains:
+          - "## Status: FROZEN"
+      - where: base
+        file: "docs/PQSIG_WIRE_FORMAT.md"
+        contains:
+          - "## Status: FROZEN"
+      - where: head
+        directory: "contrib/pqsig-ref"
+        min_files: 1
+      - where: head
+        directory: "src/test/data/pqsig"
+        min_files: 1
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Gate 3: Script integration (STRICT — no early script edits)
+  # ─────────────────────────────────────────────────────────────────────────
+  - name: "Script/validation changes require full frozen spec chain + vectors"
+    paths:
+      - "src/script/**"
+      - "src/validation.cpp"
+    requires:
+      - where: base
+        file: "docs/CONSENSUS_SURFACE.md"
+        contains:
+          - "## Status: FROZEN"
+      - where: base
+        file: "docs/SIGHASH.md"
+        contains:
+          - "## Status: FROZEN"
+      - where: base
+        file: "docs/PQSIG_INTERNALS.md"
+        contains:
+          - "## Status: FROZEN"
+      - where: base
+        file: "docs/PQSIG_WIRE_FORMAT.md"
+        contains:
+          - "## Status: FROZEN"
+      - where: base
+        file: "docs/CONSENSUS_DIFFS.md"
+        contains:
+          - "## Status: FROZEN"
+      - where: base
+        file: "docs/SCRIPT_SEMANTICS.md"
+        contains:
+          - "## Status: FROZEN"
+      - where: head
+        directory: "src/test/data/pqsig"
+        min_files: 1
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Gate 4: Policy + limits
+  # ─────────────────────────────────────────────────────────────────────────
+  - name: "Policy changes require frozen POLICY_LIMITS spec"
+    paths:
+      - "src/policy/**"
+      - "src/consensus/consensus.h"
+    requires:
+      - where: base
+        file: "docs/POLICY_LIMITS.md"
+        contains:
+          - "## Status: FROZEN"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Gate 4.5: Networking limits
+  # ─────────────────────────────────────────────────────────────────────────
+  - name: "Networking changes require frozen NET_LIMITS spec"
+    paths:
+      - "src/net.h"
+      - "src/net.cpp"
+      - "src/net_processing.cpp"
+      - "src/blockencodings.cpp"
+    requires:
+      - where: base
+        file: "docs/NET_LIMITS.md"
+        contains:
+          - "## Status: FROZEN"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Gate 5: External signer
+  # ─────────────────────────────────────────────────────────────────────────
+  - name: "External signer requires frozen PSBT_STRATEGY spec"
+    paths:
+      - "contrib/pqsign/**"
+    requires:
+      - where: base
+        file: "docs/PSBT_STRATEGY.md"
+        contains:
+          - "## Status: FROZEN"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Gate 6: Wallet integration
+  # ─────────────────────────────────────────────────────────────────────────
+  - name: "Wallet changes require frozen WALLET spec"
+    paths:
+      - "src/wallet/**"
+    requires:
+      - where: base
+        file: "docs/WALLET.md"
+        contains:
+          - "## Status: FROZEN"
+
+# Frozen-doc contract enforcement (applied to all frozen specs):
+# - Files with "## Status: FROZEN" must include all required headers:
+#   - ## Status: FROZEN
+#   - ## Spec-ID: <identifier>
+#   - ## Frozen-By: <gate-tag>
+#   - ## Consensus-Relevant: YES|NO
+# - No TBD or TODO tokens allowed in frozen docs
+frozen_doc_contract:
+  required_headers:
+    - "## Status: FROZEN"
+    - "## Spec-ID:"
+    - "## Frozen-By:"
+    - "## Consensus-Relevant:"
+  forbidden_tokens:
+    - "TBD"
+    - "TODO"

--- a/contrib/devtools/gatekeeper.yaml
+++ b/contrib/devtools/gatekeeper.yaml
@@ -1,5 +1,5 @@
 # Gatekeeper Rules — PQBTC Freeze-Gate Enforcement
-# 
+#
 # These rules enforce the docs-first invariant (I3): frozen specs must exist
 # on the base branch before consensus-critical code can be modified.
 #

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,185 @@
+# CI/CD Documentation
+
+This document describes the CI infrastructure for PQBTC, including build/test workflows and the Gatekeeper freeze-gate enforcement system.
+
+## Overview
+
+PQBTC uses two GitHub Actions workflows:
+
+| Workflow | Purpose |
+|----------|---------|
+| `ci.yml` | Multi-platform build + tests + sanitizers (inherited from Bitcoin Core) |
+| `gatekeeper.yml` | Freeze-gate enforcement (docs-first) |
+
+## CI Build Matrix
+
+The CI workflow (inherited from Bitcoin Core v30.2) provides comprehensive coverage:
+
+### Core Jobs
+
+| Job | Platform | Compiler | Tests |
+|-----|----------|----------|-------|
+| macOS native | macOS 14 arm64 | Apple Clang | full suite |
+| Windows native | Windows 2022 | MSVC | full suite |
+| Linux cross-compile | Ubuntu 24.04 | GCC/Clang | varies by job |
+
+### Sanitizer Jobs
+
+| Job | Sanitizers | Purpose |
+|-----|------------|---------|
+| ASan + LSan + UBSan | Address, Leak, Undefined | Memory safety |
+| TSan | Thread | Data race detection |
+| MSan | Memory | Uninitialized memory |
+
+### Fuzz Testing
+
+Fuzz targets are run with ASan/UBSan on both Linux and macOS.
+
+## Gatekeeper (Freeze-Gate Enforcement)
+
+The Gatekeeper enforces the docs-first invariant (I3): **frozen specs must exist on the base branch before consensus-critical code can be modified.**
+
+### How It Works
+
+1. On every PR, Gatekeeper runs `git diff --name-only origin/main...HEAD`
+2. Changed files are matched against rule patterns in `contrib/devtools/gatekeeper.yaml`
+3. For matching files, Gatekeeper verifies required artifacts exist **on `origin/main`** (not in the PR)
+4. Required docs must contain `## Status: FROZEN` header
+
+### Why Check `origin/main`?
+
+Checking the **base branch** (not the PR tree) mechanically enforces docs-first:
+- A spec PR must be merged to `main` first
+- Only then can a code PR modifying that area pass Gatekeeper
+- This prevents "spec + code in same PR" which defeats the safety mechanism
+
+### Gate Rules Summary
+
+| Gate | Protected Paths | Required Artifacts |
+|------|-----------------|-------------------|
+| 1 | `chainparams*`, `contrib/genesis/**` | `docs/GENESIS.md` *(FROZEN)* |
+| 2 | `src/crypto/pqsig/**` | `docs/PQSIG_*.md` *(FROZEN)* + vectors |
+| 3 | `src/script/**`, `src/validation.cpp` | 6 frozen specs + vectors |
+| 4 | `src/policy/**`, `consensus.h` | `docs/POLICY_LIMITS.md` *(FROZEN)* |
+| 4.5 | `src/net*`, `blockencodings.cpp` | `docs/NET_LIMITS.md` *(FROZEN)* |
+| 5 | `contrib/pqsign/**` | `docs/PSBT_STRATEGY.md` *(FROZEN)* |
+| 6 | `src/wallet/**` | `docs/WALLET.md` *(FROZEN)* |
+
+### STRICT Posture for Script
+
+The Gatekeeper uses a **strict posture** for `src/script/**`:
+- No "surface rules only" exception
+- ALL 6 Gate 3 prerequisites must exist before any script changes
+- This prevents premature consensus drift
+
+## Local Reproduction
+
+### Run Gatekeeper Locally
+
+```bash
+# Install dependencies
+pip3 install pyyaml
+
+# Run gatekeeper (from repo root)
+python3 contrib/devtools/gatekeeper.py \
+  --rules contrib/devtools/gatekeeper.yaml \
+  --base origin/main \
+  --head HEAD
+```
+
+### Run Build + Unit Tests
+
+```bash
+# macOS
+cmake -S . -B build -GNinja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBUILD_GUI=OFF -DBUILD_BENCH=OFF -DENABLE_WALLET=ON
+cmake --build build --parallel $(sysctl -n hw.ncpu)
+./build/bin/test_bitcoin --run_test=crypto_tests,key_tests,script_tests
+
+# Linux (Ubuntu 22.04+)
+sudo apt-get install -y cmake ninja-build libboost-dev libevent-dev libsqlite3-dev
+cmake -S . -B build -GNinja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBUILD_GUI=OFF -DBUILD_BENCH=OFF -DENABLE_WALLET=ON
+cmake --build build --parallel $(nproc)
+./build/bin/test_bitcoin
+```
+
+### Run Functional Tests
+
+```bash
+# Increase file descriptor limit (required on macOS)
+ulimit -n 4096
+
+# Run specific test
+python3 test/functional/test_runner.py wallet_basic.py
+
+# Run all tests (takes longer)
+python3 test/functional/test_runner.py --jobs $(nproc)
+```
+
+### Run with Sanitizers
+
+```bash
+# ASan + UBSan build
+cmake -S . -B build-asan -GNinja \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+  -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
+  -DBUILD_GUI=OFF -DBUILD_BENCH=OFF
+
+cmake --build build-asan --parallel
+
+# Run with sanitizer options
+ASAN_OPTIONS="detect_leaks=1:halt_on_error=1" \
+UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" \
+./build-asan/bin/test_bitcoin
+```
+
+## Frozen Doc Contract
+
+Any document marked `## Status: FROZEN` must include:
+
+```markdown
+## Status: FROZEN
+## Spec-ID: <stable-identifier>
+## Frozen-By: <gate-tag>
+## Consensus-Relevant: YES|NO
+```
+
+Frozen docs may not contain `TBD` or `TODO` tokens.
+
+### Change Control
+
+- **Errata** (typos, clarifications): allowed, must note in changelog
+- **Semantic changes**: treated as hardfork, requires new Spec-ID version
+
+## CI Maintenance Notes
+
+### Test Suite Evolution
+
+As PQBTC diverges from Bitcoin Core (Gate 1+), some upstream functional tests will become irrelevant. Track decisions here:
+
+| Test Category | Status | Notes |
+|---------------|--------|-------|
+| `crypto_tests` | Must pass | Core cryptography |
+| `key_tests` | Evolve | Will need PQ key tests |
+| `script_tests` | Evolve | Will need PQ script tests |
+| `wallet_basic.py` | Must pass until Gate 6 | Then PQ wallet tests |
+
+### Adding New CI Jobs
+
+When adding PQ-specific CI jobs:
+1. Add to `.github/workflows/ci.yml`
+2. Document in this file
+3. Ensure job names are descriptive
+
+## Related Documentation
+
+- [UPSTREAM.md](UPSTREAM.md) — Bitcoin Core baseline
+- [CORE_DIFF_PLAN.md](CORE_DIFF_PLAN.md) — Implementation phases
+- Plan file — Gate execution checklist


### PR DESCRIPTION
## Summary

Gate 0.5 implementation: CI safety rails + mechanical freeze-gate enforcement.

- **`.github/workflows/gatekeeper.yml`** — Runs on every PR to enforce docs-first invariant
- **`contrib/devtools/gatekeeper.yaml`** — Declarative rules for freeze-gate enforcement (STRICT posture: no src/script/** changes until Gate 3 prerequisites)
- **`contrib/devtools/gatekeeper.py`** — Enforcement script checking prerequisites on origin/main (base branch), validates frozen doc contract
- **`docs/CI.md`** — Documents CI matrix (inherited from upstream) and local reproduction

The gatekeeper mechanically enforces invariant I3: frozen specs must exist on the base branch before consensus-critical code can be modified. This prevents "spec + code in same PR" which could cause consensus splits.

## Test plan

- [ ] Gatekeeper workflow passes on this PR
- [ ] Upstream CI (ci.yml) passes
- [ ] Local verification: `python3 contrib/devtools/gatekeeper.py --rules contrib/devtools/gatekeeper.yaml --base origin/main --head HEAD`