### PR TITLE
[codex] GA safety consensus signature hardening

### DIFF
--- a/src/crypto/pqsig/params.h
+++ b/src/crypto/pqsig/params.h
@@ -55,6 +55,21 @@ inline constexpr uint32_t BENCH_VERIFY_COMPRESSIONS{1292};
 inline constexpr uint32_t BENCH_SIGN_HASHES{6027717};
 inline constexpr uint32_t BENCH_SIGN_COMPRESSIONS{6869634};
 inline constexpr uint32_t BENCH_SIGN_OUTER_SEARCH{244170};
+inline constexpr uint32_t SIGN_COUNTER_MAX{1048576};
+
+// Consensus/profile locks for v1. Any change here requires explicit governance.
+static_assert(QS_LOG2 == 40);
+static_assert(H == 44);
+static_assert(D == 4);
+static_assert(A == 16);
+static_assert(K == 8);
+static_assert(W == 16);
+static_assert(L == 32);
+static_assert(SWN == 240);
+static_assert(pqsig::PK_SCRIPT_SIZE == 33);
+static_assert(pqsig::SIG_SIZE == 4480);
+static_assert(pqsig::ALG_ID_V1 == 0x00);
+static_assert(SIGN_COUNTER_MAX == 1048576);
 
 } // namespace params
 } // namespace pqsig

--- a/src/crypto/pqsig/pqsig.cpp
+++ b/src/crypto/pqsig/pqsig.cpp
@@ -292,6 +292,12 @@ bool PQSigSign(
 {
     PQSigMetrics metrics{};
 
+    // v1 signer/search bounds are frozen for deterministic tooling behavior.
+    if (max_counter == 0 || max_counter > params::SIGN_COUNTER_MAX) {
+        PublishMetrics(metrics);
+        return false;
+    }
+
     if (out_sig4480.size() != SIG_SIZE || msg32.size() != MSG32_SIZE || sk_seed.empty()) {
         PublishMetrics(metrics);
         return false;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1544,6 +1544,8 @@ bool GenericTransactionSignatureChecker<T>::VerifySchnorrSignature(std::span<con
 template <class T>
 bool GenericTransactionSignatureChecker<T>::CheckECDSASignature(const std::vector<unsigned char>& vchSigIn, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
 {
+    // v1 consensus scope: pre-taproot CHECKSIG/CHECKMULTISIG only.
+    if (sigversion != SigVersion::BASE && sigversion != SigVersion::WITNESS_V0) return false;
     if (vchSigIn.empty()) return false;
     if (vchSigIn.size() != pqsig::SIG_SIZE) return false;
     if (!pqsig::IsValidPkScript(vchPubKey)) return false;
@@ -1553,6 +1555,7 @@ bool GenericTransactionSignatureChecker<T>::CheckECDSASignature(const std::vecto
 
     // v1 locks pre-taproot CHECKSIG/CHECKMULTISIG to a fixed SIGHASH_ALL policy.
     constexpr int32_t nHashType = SIGHASH_ALL;
+    static_assert(SIGHASH_ALL == 1, "SIGHASH_ALL must remain consensus-locked");
     const uint256 sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion, this->txdata, &m_sighash_cache);
     return pqsig::PQSigVerify(vchSigIn, std::span<const uint8_t>{sighash.begin(), sighash.size()}, vchPubKey);
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -140,6 +140,7 @@ if(NOT PQBTC_ENABLE_LEGACY_UNIT_TESTS)
   set(TEST_PQBTC_SOURCES
     main.cpp
     multisig_tests.cpp
+    pqsig_script_tests.cpp
     pqsig_tests.cpp
     script_tests.cpp
   )
@@ -160,10 +161,12 @@ if(PQBTC_ENABLE_LEGACY_UNIT_TESTS)
     data/tx_invalid.json
     data/tx_valid.json
     data/pqsig/kat_v1.json
+    data/pqsig/invalid_vectors.json
   )
 else()
   target_json_data_sources(test_pqbtc
     data/pqsig/kat_v1.json
+    data/pqsig/invalid_vectors.json
   )
 endif()
 target_raw_data_sources(test_pqbtc NAMESPACE test::data

--- a/src/test/data/pqsig/invalid_vectors.json
+++ b/src/test/data/pqsig/invalid_vectors.json
@@ -1,0 +1,36 @@
+{
+  "profile": "pqsig-v1-invalid",
+  "vectors": [
+    {
+      "name": "invalid_alg_id",
+      "base": "kat_01",
+      "mutations": [
+        {"field": "pk_script33", "offset": 0, "op": "set", "value": "01"}
+      ]
+    },
+    {
+      "name": "pk_root_mismatch",
+      "base": "kat_01",
+      "mutations": [
+        {"field": "pk_script33", "offset": 17, "op": "xor", "value": "80"}
+      ]
+    },
+    {
+      "name": "layer0_count_mismatch",
+      "base": "kat_01",
+      "mutations": [
+        {"field": "sig4480", "offset": 2400, "op": "xor", "value": "01"}
+      ]
+    },
+    {
+      "name": "layer3_count_overflow",
+      "base": "kat_01",
+      "mutations": [
+        {"field": "sig4480", "offset": 4476, "op": "set", "value": "ff"},
+        {"field": "sig4480", "offset": 4477, "op": "set", "value": "ff"},
+        {"field": "sig4480", "offset": 4478, "op": "set", "value": "ff"},
+        {"field": "sig4480", "offset": 4479, "op": "set", "value": "ff"}
+      ]
+    }
+  ]
+}

--- a/src/test/fuzz/pqsig_verify.cpp
+++ b/src/test/fuzz/pqsig_verify.cpp
@@ -3,19 +3,82 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/pqsig/pqsig.h>
+#include <crypto/pqsig/domains.h>
+#include <crypto/pqsig/params.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 
+#include <algorithm>
 #include <array>
 #include <vector>
+
+namespace {
+
+std::vector<uint8_t> ConsumeVariableBytes(FuzzedDataProvider& provider, const size_t max_size)
+{
+    const size_t size = provider.ConsumeIntegralInRange<size_t>(0, max_size);
+    return provider.ConsumeBytes<uint8_t>(size);
+}
+
+std::vector<uint8_t> BuildValidPkScript(FuzzedDataProvider& provider)
+{
+    std::array<uint8_t, pqsig::params::N> pk_seed{};
+    for (uint8_t& b : pk_seed) {
+        b = provider.ConsumeIntegral<uint8_t>();
+    }
+
+    const std::array<std::span<const uint8_t>, 1> parts{std::span<const uint8_t>{pk_seed}};
+    const auto pk_root = pqsig::domains::HashN(nullptr, "PQSIG-PK-ROOT", parts);
+
+    std::vector<uint8_t> pk(pqsig::PK_SCRIPT_SIZE);
+    pk[0] = pqsig::ALG_ID_V1;
+    std::copy(pk_seed.begin(), pk_seed.end(), pk.begin() + 1);
+    std::copy(pk_root.begin(), pk_root.end(), pk.begin() + 1 + pk_seed.size());
+    return pk;
+}
+
+void MutateLayerCounter(FuzzedDataProvider& provider, std::vector<uint8_t>& sig)
+{
+    if (sig.size() != pqsig::SIG_SIZE) return;
+
+    const size_t layer = provider.ConsumeIntegralInRange<size_t>(0, pqsig::params::D - 1);
+    const size_t layer_offset = pqsig::params::HT_OFFSET + layer * pqsig::params::HT_LAYER_SIZE;
+    const size_t count_offset = layer_offset + pqsig::params::HT_AUTH_SIZE + pqsig::params::HT_WOTS_SIZE;
+    sig[count_offset] ^= provider.ConsumeIntegral<uint8_t>();
+}
+
+} // namespace
 
 FUZZ_TARGET(pqsig_verify)
 {
     FuzzedDataProvider provider(buffer.data(), buffer.size());
 
-    std::vector<uint8_t> sig = provider.ConsumeBytes<uint8_t>(pqsig::SIG_SIZE);
-    std::vector<uint8_t> msg = provider.ConsumeBytes<uint8_t>(pqsig::MSG32_SIZE);
-    std::vector<uint8_t> pk = provider.ConsumeBytes<uint8_t>(pqsig::PK_SCRIPT_SIZE);
+    std::vector<uint8_t> sig = ConsumeVariableBytes(provider, pqsig::SIG_SIZE + 64);
+    std::vector<uint8_t> msg = ConsumeVariableBytes(provider, pqsig::MSG32_SIZE + 16);
+    std::vector<uint8_t> pk = ConsumeVariableBytes(provider, pqsig::PK_SCRIPT_SIZE + 16);
 
     (void)pqsig::PQSigVerify(sig, msg, pk);
+
+    // Structured path to force parser/verify coverage under valid outer wire sizes.
+    if (provider.ConsumeBool()) {
+        sig = provider.ConsumeBytes<uint8_t>(pqsig::SIG_SIZE);
+        sig.resize(pqsig::SIG_SIZE, 0);
+        msg = provider.ConsumeBytes<uint8_t>(pqsig::MSG32_SIZE);
+        msg.resize(pqsig::MSG32_SIZE, 0);
+        pk = BuildValidPkScript(provider);
+
+        if (provider.ConsumeBool()) {
+            MutateLayerCounter(provider, sig);
+        }
+        if (provider.ConsumeBool()) {
+            const size_t off = provider.ConsumeIntegralInRange<size_t>(0, pk.size() - 1);
+            pk[off] ^= provider.ConsumeIntegral<uint8_t>();
+        }
+        if (provider.ConsumeBool()) {
+            const size_t off = provider.ConsumeIntegralInRange<size_t>(0, msg.size() - 1);
+            msg[off] ^= provider.ConsumeIntegral<uint8_t>();
+        }
+
+        (void)pqsig::PQSigVerify(sig, msg, pk);
+    }
 }

--- a/src/test/pqsig_script_tests.cpp
+++ b/src/test/pqsig_script_tests.cpp
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(checksig_accepts_valid_pqsig)
     tx.vin[0].scriptSig = CScript{} << std::vector<unsigned char>{sig.begin(), sig.end()};
 
     const CTransaction tx_const{tx};
-    const TransactionSignatureChecker checker(&tx_const, /*nIn=*/0, /*amount=*/0, MissingDataBehavior::FAIL);
+    const TransactionSignatureChecker checker(&tx_const, /*nInIn=*/0, /*amountIn=*/0, MissingDataBehavior::FAIL);
 
     ScriptError err;
     BOOST_CHECK(VerifyScript(tx.vin[0].scriptSig, script_pubkey, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(checksig_rejects_wrong_sig_size_and_alg_id)
     const std::vector<uint8_t> good_sig = SignForScript(tx, good_script_pubkey, pk_script);
 
     const CTransaction tx_const{tx};
-    const TransactionSignatureChecker checker(&tx_const, /*nIn=*/0, /*amount=*/0, MissingDataBehavior::FAIL);
+    const TransactionSignatureChecker checker(&tx_const, /*nInIn=*/0, /*amountIn=*/0, MissingDataBehavior::FAIL);
 
     ScriptError err;
 
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(checkmultisig_accepts_valid_and_rejects_wrong_sighash)
     tx.vin[0].scriptSig = CScript{} << OP_0 << std::vector<unsigned char>{sig.begin(), sig.end()};
 
     const CTransaction tx_const{tx};
-    const TransactionSignatureChecker checker(&tx_const, /*nIn=*/0, /*amount=*/0, MissingDataBehavior::FAIL);
+    const TransactionSignatureChecker checker(&tx_const, /*nInIn=*/0, /*amountIn=*/0, MissingDataBehavior::FAIL);
     ScriptError err;
 
     BOOST_CHECK(VerifyScript(tx.vin[0].scriptSig, multisig_script, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(checkmultisig_accepts_valid_and_rejects_wrong_sighash)
     CMutableTransaction mutated_tx{tx};
     mutated_tx.vout[0].nValue -= 1;
     const CTransaction mutated_tx_const{mutated_tx};
-    const TransactionSignatureChecker mutated_checker(&mutated_tx_const, /*nIn=*/0, /*amount=*/0, MissingDataBehavior::FAIL);
+    const TransactionSignatureChecker mutated_checker(&mutated_tx_const, /*nInIn=*/0, /*amountIn=*/0, MissingDataBehavior::FAIL);
 
     BOOST_CHECK(!VerifyScript(mutated_tx.vin[0].scriptSig, multisig_script, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, mutated_checker, &err));
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_EVAL_FALSE);

--- a/src/test/pqsig_script_tests.cpp
+++ b/src/test/pqsig_script_tests.cpp
@@ -3,6 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
+#include <crypto/pqsig/domains.h>
+#include <crypto/pqsig/params.h>
 #include <crypto/pqsig/pqsig.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
@@ -12,16 +14,31 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <array>
+#include <stdexcept>
 #include <vector>
 
 namespace {
 
+constexpr std::array<uint8_t, 32> TEST_SK_SEED{
+    0x07, 0x11, 0x13, 0x17, 0x19, 0x23, 0x29, 0x31,
+    0x07, 0x11, 0x13, 0x17, 0x19, 0x23, 0x29, 0x31,
+    0x07, 0x11, 0x13, 0x17, 0x19, 0x23, 0x29, 0x31,
+    0x07, 0x11, 0x13, 0x17, 0x19, 0x23, 0x29, 0x31,
+};
+
 std::array<uint8_t, pqsig::PK_SCRIPT_SIZE> MakePkScript()
 {
+    const std::array<std::span<const uint8_t>, 1> parts{std::span<const uint8_t>{TEST_SK_SEED}};
+    const auto pk_seed = pqsig::domains::HashN(nullptr, "PQSIG-PK-SEED", parts);
+    const std::array<std::span<const uint8_t>, 1> root_parts{std::span<const uint8_t>{pk_seed}};
+    const auto pk_root = pqsig::domains::HashN(nullptr, "PQSIG-PK-ROOT", root_parts);
+
     std::array<uint8_t, pqsig::PK_SCRIPT_SIZE> out{};
     out[0] = pqsig::ALG_ID_V1;
-    for (size_t i = 1; i < out.size(); ++i) out[i] = static_cast<uint8_t>(i);
+    std::copy(pk_seed.begin(), pk_seed.end(), out.begin() + 1);
+    std::copy(pk_root.begin(), pk_root.end(), out.begin() + 1 + pk_seed.size());
     return out;
 }
 
@@ -29,11 +46,17 @@ std::vector<uint8_t> SignForScript(const CMutableTransaction& tx, const CScript&
 {
     const uint256 sighash = SignatureHash(script_code, tx, /*nIn=*/0, SIGHASH_ALL, /*amount=*/0, SigVersion::BASE);
     std::vector<uint8_t> sig(pqsig::SIG_SIZE);
-    const std::vector<uint8_t> sk_seed{7, 11, 13, 17, 19, 23, 29, 31};
-    if (!pqsig::PQSigSign(sig, std::span<const uint8_t>{sighash.begin(), sighash.size()}, sk_seed, pk_script)) {
+    if (!pqsig::PQSigSign(sig, std::span<const uint8_t>{sighash.begin(), sighash.size()}, TEST_SK_SEED, pk_script)) {
         throw std::runtime_error("failed to produce deterministic test signature");
     }
     return sig;
+}
+
+void MutateLayerCounter(std::vector<uint8_t>& sig, const size_t layer)
+{
+    const size_t layer_offset = pqsig::params::HT_OFFSET + layer * pqsig::params::HT_LAYER_SIZE;
+    const size_t count_offset = layer_offset + pqsig::params::HT_AUTH_SIZE + pqsig::params::HT_WOTS_SIZE;
+    sig[count_offset] ^= 0x01;
 }
 
 CMutableTransaction BuildSpendingTx()
@@ -88,6 +111,13 @@ BOOST_AUTO_TEST_CASE(checksig_rejects_wrong_sig_size_and_alg_id)
     BOOST_CHECK(!VerifyScript(tx.vin[0].scriptSig, good_script_pubkey, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_SIG_DER);
 
+    // Wrong pubkey script length is rejected deterministically.
+    std::vector<unsigned char> short_pk{pk_script.begin(), pk_script.end() - 1};
+    const CScript short_pk_script_pubkey = CScript{} << short_pk << OP_CHECKSIG;
+    tx.vin[0].scriptSig = CScript{} << std::vector<unsigned char>{good_sig.begin(), good_sig.end()};
+    BOOST_CHECK(!VerifyScript(tx.vin[0].scriptSig, short_pk_script_pubkey, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_PUBKEYTYPE);
+
     // Wrong algorithm identifier in the pubkey script is rejected deterministically.
     auto bad_pk_script = pk_script;
     bad_pk_script[0] = 0x01;
@@ -112,6 +142,16 @@ BOOST_AUTO_TEST_CASE(checkmultisig_accepts_valid_and_rejects_wrong_sighash)
 
     BOOST_CHECK(VerifyScript(tx.vin[0].scriptSig, multisig_script, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+
+    // Mutating a layer counter triggers strict internal signature rejection.
+    std::vector<uint8_t> malformed_sig = sig;
+    MutateLayerCounter(malformed_sig, 0);
+    tx.vin[0].scriptSig = CScript{} << OP_0 << std::vector<unsigned char>{malformed_sig.begin(), malformed_sig.end()};
+    BOOST_CHECK(!VerifyScript(tx.vin[0].scriptSig, multisig_script, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_EVAL_FALSE);
+
+    // Restore valid scriptSig before sighash mismatch check.
+    tx.vin[0].scriptSig = CScript{} << OP_0 << std::vector<unsigned char>{sig.begin(), sig.end()};
 
     // Mutate the transaction after signing to force a sighash mismatch.
     CMutableTransaction mutated_tx{tx};

--- a/src/test/pqsig_tests.cpp
+++ b/src/test/pqsig_tests.cpp
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(pqsig_invalid_corpus_vectors)
         std::vector<uint8_t> pk = ParseHex(base_obj.find_value("pk_script33").get_str());
         std::vector<uint8_t> sig = ParseHex(base_obj.find_value("sig4480").get_str());
 
-        const UniValue mutations = invalid_obj.find_value("mutations");
+        const UniValue& mutations = invalid_obj.find_value("mutations");
         BOOST_REQUIRE(mutations.isArray());
         for (unsigned int j = 0; j < mutations.get_array().size(); ++j) {
             ApplyMutation(msg, pk, sig, mutations.get_array()[j].get_obj());

--- a/src/test/pqsig_tests.cpp
+++ b/src/test/pqsig_tests.cpp
@@ -4,6 +4,8 @@
 
 #include <crypto/pqsig/pqsig.h>
 #include <crypto/pqsig/pqsig_internal.h>
+#include <crypto/pqsig/params.h>
+#include <test/data/pqsig/invalid_vectors.json.h>
 #include <test/data/pqsig/kat_v1.json.h>
 #include <util/strencodings.h>
 
@@ -11,6 +13,8 @@
 
 #include <array>
 #include <cstdint>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 #include <univalue.h>
@@ -37,6 +41,72 @@ const UniValue& GetKatVectors()
         loaded = true;
     }
     return vectors;
+}
+
+const UniValue& GetInvalidVectors()
+{
+    static UniValue vectors{UniValue::VARR};
+    static bool loaded{false};
+    if (!loaded) {
+        UniValue root;
+        BOOST_REQUIRE(root.read(json_tests::invalid_vectors));
+        vectors = root.get_obj().find_value("vectors");
+        BOOST_REQUIRE(vectors.isArray());
+        loaded = true;
+    }
+    return vectors;
+}
+
+const UniValue& FindKatVectorByName(const std::string& name)
+{
+    const UniValue& vectors = GetKatVectors();
+    for (unsigned int i = 0; i < vectors.get_array().size(); ++i) {
+        const UniValue& entry = vectors.get_array()[i];
+        const UniValue obj = entry.get_obj();
+        if (obj.find_value("name").get_str() == name) {
+            return entry;
+        }
+    }
+    throw std::runtime_error("missing KAT vector");
+}
+
+uint8_t ParseHexByte(const std::string& hex)
+{
+    const std::vector<uint8_t> parsed = ParseHex(hex);
+    BOOST_REQUIRE_EQUAL(parsed.size(), 1U);
+    return parsed[0];
+}
+
+void ApplyMutation(
+    std::vector<uint8_t>& msg,
+    std::vector<uint8_t>& pk,
+    std::vector<uint8_t>& sig,
+    const UniValue& mutation_obj)
+{
+    const std::string field = mutation_obj.find_value("field").get_str();
+    const size_t offset = mutation_obj.find_value("offset").getInt<int>();
+    const std::string op = mutation_obj.find_value("op").get_str();
+    const uint8_t value = ParseHexByte(mutation_obj.find_value("value").get_str());
+
+    std::vector<uint8_t>* target = nullptr;
+    if (field == "msg32") {
+        target = &msg;
+    } else if (field == "pk_script33") {
+        target = &pk;
+    } else if (field == "sig4480") {
+        target = &sig;
+    } else {
+        BOOST_FAIL("unknown mutation field");
+    }
+
+    BOOST_REQUIRE(offset < target->size());
+    if (op == "set") {
+        (*target)[offset] = value;
+    } else if (op == "xor") {
+        (*target)[offset] ^= value;
+    } else {
+        BOOST_FAIL("unknown mutation op");
+    }
 }
 
 } // namespace
@@ -100,7 +170,7 @@ BOOST_AUTO_TEST_CASE(pqsig_rejects_malformed_inputs)
     const UniValue obj = vectors.get_array()[0].get_obj();
     const std::vector<uint8_t> msg = ParseHex(obj.find_value("msg32").get_str());
     const std::vector<uint8_t> sk = ParseHex(obj.find_value("sk_seed").get_str());
-    std::vector<uint8_t> pk = ParseHex(obj.find_value("pk_script33").get_str());
+    const std::vector<uint8_t> pk = ParseHex(obj.find_value("pk_script33").get_str());
 
     std::vector<uint8_t> sig(pqsig::SIG_SIZE);
     BOOST_CHECK(pqsig::PQSigSign(sig, msg, sk, pk));
@@ -108,8 +178,58 @@ BOOST_AUTO_TEST_CASE(pqsig_rejects_malformed_inputs)
     std::vector<uint8_t> short_sig(pqsig::SIG_SIZE - 1);
     BOOST_CHECK(!pqsig::PQSigVerify(short_sig, msg, pk));
 
-    pk[0] = 0x7f;
-    BOOST_CHECK(!pqsig::PQSigVerify(sig, msg, pk));
+    const std::vector<uint8_t> short_msg(pqsig::MSG32_SIZE - 1, 0x00);
+    BOOST_CHECK(!pqsig::PQSigVerify(sig, short_msg, pk));
+
+    const std::vector<uint8_t> short_pk(pqsig::PK_SCRIPT_SIZE - 1, 0x00);
+    BOOST_CHECK(!pqsig::PQSigVerify(sig, msg, short_pk));
+
+    std::vector<uint8_t> bad_pk = pk;
+    bad_pk[0] = 0x7f;
+    BOOST_CHECK(!pqsig::PQSigVerify(sig, msg, bad_pk));
+
+}
+
+BOOST_AUTO_TEST_CASE(pqsig_invalid_corpus_vectors)
+{
+    const UniValue& invalid_vectors = GetInvalidVectors();
+    BOOST_REQUIRE(invalid_vectors.isArray());
+
+    for (unsigned int i = 0; i < invalid_vectors.get_array().size(); ++i) {
+        const UniValue invalid_obj = invalid_vectors.get_array()[i].get_obj();
+        const std::string base_name = invalid_obj.find_value("base").get_str();
+        const UniValue base_obj = FindKatVectorByName(base_name).get_obj();
+
+        std::vector<uint8_t> msg = ParseHex(base_obj.find_value("msg32").get_str());
+        std::vector<uint8_t> pk = ParseHex(base_obj.find_value("pk_script33").get_str());
+        std::vector<uint8_t> sig = ParseHex(base_obj.find_value("sig4480").get_str());
+
+        const UniValue mutations = invalid_obj.find_value("mutations");
+        BOOST_REQUIRE(mutations.isArray());
+        for (unsigned int j = 0; j < mutations.get_array().size(); ++j) {
+            ApplyMutation(msg, pk, sig, mutations.get_array()[j].get_obj());
+        }
+
+        BOOST_CHECK_MESSAGE(
+            !pqsig::PQSigVerify(sig, msg, pk),
+            "invalid corpus vector unexpectedly verified");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(pqsig_signer_counter_bounds)
+{
+    const UniValue& vectors = GetKatVectors();
+    BOOST_REQUIRE(vectors.isArray());
+    BOOST_REQUIRE(!vectors.get_array().empty());
+
+    const UniValue obj = vectors.get_array()[0].get_obj();
+    const std::vector<uint8_t> msg = ParseHex(obj.find_value("msg32").get_str());
+    const std::vector<uint8_t> sk = ParseHex(obj.find_value("sk_seed").get_str());
+    const std::vector<uint8_t> pk = ParseHex(obj.find_value("pk_script33").get_str());
+    std::vector<uint8_t> sig(pqsig::SIG_SIZE);
+
+    BOOST_CHECK(!pqsig::PQSigSign(sig, msg, sk, pk, 0));
+    BOOST_CHECK(!pqsig::PQSigSign(sig, msg, sk, pk, pqsig::params::SIGN_COUNTER_MAX + 1));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
This stacked PR adds consensus-signature hardening controls and adversarial verification coverage for PQSig v1.

## Problem
GA safety blockers required proof that consensus acceptance cannot be silently widened and that malformed PQ payloads are rejected deterministically across unit/script/fuzz paths.

## Root Cause
v1 implementation had strong baseline checks, but lacked explicit locked guardrails for signer bounds/profile constants and did not yet include a curated invalid corpus exercised by both unit tests and fuzz entry paths.

## Fix
### Consensus/Profile guardrails
- Added v1 profile static locks and signer counter ceiling in `/Users/scott/quantum-proof-bitcoin/src/crypto/pqsig/params.h`.
- Enforced signer `max_counter` bounds in `/Users/scott/quantum-proof-bitcoin/src/crypto/pqsig/pqsig.cpp`.
- Hardened interpreter signature checker scope to pre-taproot-only PQ paths and asserted fixed `SIGHASH_ALL` in `/Users/scott/quantum-proof-bitcoin/src/script/interpreter.cpp`.

### Adversarial test coverage
- Added curated invalid vector fixture `/Users/scott/quantum-proof-bitcoin/src/test/data/pqsig/invalid_vectors.json`.
- Expanded `/Users/scott/quantum-proof-bitcoin/src/test/pqsig_tests.cpp` with invalid corpus mutation checks and signer counter-bound rejection tests.
- Expanded `/Users/scott/quantum-proof-bitcoin/src/test/pqsig_script_tests.cpp` with bad pubkey length and mutated layer-counter rejection cases.
- Included `pqsig_script_tests` and invalid vectors in the PQ-first test target in `/Users/scott/quantum-proof-bitcoin/src/test/CMakeLists.txt`.

### Fuzz path strengthening
- Extended `/Users/scott/quantum-proof-bitcoin/src/test/fuzz/pqsig_verify.cpp` with a structured valid-outer-wire path and internal field mutation coverage.

## User/Operator Impact
No wire/consensus API expansion. This reduces risk of accidental acceptance broadening and strengthens deterministic reject behavior under adversarial malformed signatures.

## Validation
- `cmake --build build --target test_pqbtc fuzz -j8`
- `build/bin/test_pqbtc --run_test=pqsig_tests,pqsig_script_tests,script_tests,multisig_tests`

## Tracking
- Addresses GA safety scope for #36 and #37.
- Stacked on #41.
