### PR TITLE
GA safety: harden PQ signature acceptance and adversarial coverage

### DIFF
--- a/src/crypto/pqsig/pqsig.cpp
+++ b/src/crypto/pqsig/pqsig.cpp
@@ -22,6 +22,29 @@ namespace {
 
 thread_local PQSigMetrics g_last_metrics{};
 
+constexpr bool ConsensusProfileLocked()
+{
+    return PK_SCRIPT_SIZE == 33 &&
+           PK_CORE_SIZE == 32 &&
+           MSG32_SIZE == 32 &&
+           SIG_SIZE == 4480 &&
+           ALG_ID_V1 == 0x00 &&
+           params::N == 16 &&
+           params::QS_LOG2 == 40 &&
+           params::H == 44 &&
+           params::D == 4 &&
+           params::A == 16 &&
+           params::K == 8 &&
+           params::W == 16 &&
+           params::L == 32 &&
+           params::SWN == 240 &&
+           params::PORS_MMAX == 97 &&
+           params::SIGN_COUNTER_MAX == 1048576 &&
+           params::EXPECTED_SIG_SIZE == SIG_SIZE;
+}
+
+static_assert(ConsensusProfileLocked(), "PQSIG v1 consensus profile drifted");
+
 void PublishMetrics(const PQSigMetrics& metrics)
 {
     g_last_metrics = metrics;
@@ -65,6 +88,7 @@ bool ParsePkScript(
     std::array<uint8_t, params::N>& pk_root,
     PQSigMetrics* metrics)
 {
+    if (!ConsensusProfileLocked()) return false;
     if (!IsValidPkScript(pk_script)) return false;
     std::copy_n(pk_script.begin() + 1, params::N, pk_seed.begin());
     std::copy_n(pk_script.begin() + 1 + params::N, params::N, pk_root.begin());
@@ -197,6 +221,9 @@ bool VerifySignatureStructure(
     const std::span<const uint8_t> pk_root,
     PQSigMetrics* metrics)
 {
+    if (!ConsensusProfileLocked()) return false;
+    if (sig4480.size() != SIG_SIZE || msg32.size() != MSG32_SIZE || pk_script.size() != PK_SCRIPT_SIZE) return false;
+
     const auto r = sig4480.first(params::SIG_R_SIZE);
     const auto reveals = sig4480.subspan(params::PORS_REVEAL_OFFSET, params::PORS_REVEAL_SIZE);
     const auto auth_pad = sig4480.subspan(params::PORS_AUTH_OFFSET, params::PORS_AUTH_PAD_SIZE);
@@ -262,7 +289,7 @@ bool PQSigVerify(
 {
     PQSigMetrics metrics{};
 
-    if (sig4480.size() != SIG_SIZE || msg32.size() != MSG32_SIZE) {
+    if (!ConsensusProfileLocked() || sig4480.size() != SIG_SIZE || msg32.size() != MSG32_SIZE) {
         PublishMetrics(metrics);
         return false;
     }
@@ -298,7 +325,7 @@ bool PQSigSign(
         return false;
     }
 
-    if (out_sig4480.size() != SIG_SIZE || msg32.size() != MSG32_SIZE || sk_seed.empty()) {
+    if (!ConsensusProfileLocked() || out_sig4480.size() != SIG_SIZE || msg32.size() != MSG32_SIZE || sk_seed.size() != MSG32_SIZE) {
         PublishMetrics(metrics);
         return false;
     }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -17,6 +17,15 @@ typedef std::vector<unsigned char> valtype;
 
 namespace {
 
+static_assert(pqsig::PK_SCRIPT_SIZE == 33, "PQSIG v1 pubkey script size drifted");
+static_assert(pqsig::SIG_SIZE == 4480, "PQSIG v1 signature size drifted");
+static_assert(pqsig::ALG_ID_V1 == 0x00, "PQSIG v1 ALG_ID drifted");
+
+constexpr bool IsPreTaprootPQSigVersion(const SigVersion sigversion)
+{
+    return sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0;
+}
+
 inline bool set_success(ScriptError* ret)
 {
     if (ret)
@@ -178,6 +187,7 @@ public:
 static bool EvalChecksigPreTapscript(const valtype& vchSig, const valtype& vchPubKey, CScript::const_iterator pbegincodehash, CScript::const_iterator pend, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror, bool& fSuccess)
 {
     assert(sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0);
+    if (!IsPreTaprootPQSigVersion(sigversion)) return set_error(serror, SCRIPT_ERR_SIG_DER);
 
     // Subset of script starting at the most recent codeseparator
     CScript scriptCode(pbegincodehash, pend);
@@ -1544,8 +1554,7 @@ bool GenericTransactionSignatureChecker<T>::VerifySchnorrSignature(std::span<con
 template <class T>
 bool GenericTransactionSignatureChecker<T>::CheckECDSASignature(const std::vector<unsigned char>& vchSigIn, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
 {
-    // v1 consensus scope: pre-taproot CHECKSIG/CHECKMULTISIG only.
-    if (sigversion != SigVersion::BASE && sigversion != SigVersion::WITNESS_V0) return false;
+    if (!IsPreTaprootPQSigVersion(sigversion)) return false;
     if (vchSigIn.empty()) return false;
     if (vchSigIn.size() != pqsig::SIG_SIZE) return false;
     if (!pqsig::IsValidPkScript(vchPubKey)) return false;

--- a/src/test/pqsig_tests.cpp
+++ b/src/test/pqsig_tests.cpp
@@ -228,6 +228,8 @@ BOOST_AUTO_TEST_CASE(pqsig_signer_counter_bounds)
     const std::vector<uint8_t> pk = ParseHex(obj.find_value("pk_script33").get_str());
     std::vector<uint8_t> sig(pqsig::SIG_SIZE);
 
+    std::vector<uint8_t> short_sk(pqsig::MSG32_SIZE - 1, 0x42);
+    BOOST_CHECK(!pqsig::PQSigSign(sig, msg, short_sk, pk));
     BOOST_CHECK(!pqsig::PQSigSign(sig, msg, sk, pk, 0));
     BOOST_CHECK(!pqsig::PQSigSign(sig, msg, sk, pk, pqsig::params::SIGN_COUNTER_MAX + 1));
 }


### PR DESCRIPTION
## Summary
- lock PQSig v1 consensus profile in code with explicit compile-time/runtime guardrails
- enforce pre-taproot-only PQ signature path in script interpreter guards
- tighten signer tooling bounds (`sk_seed` length and `max_counter <= 1048576`)
- add curated invalid PQ vectors (`src/test/data/pqsig/invalid_v1.json`) and fuzz seed corpus files
- expand `pqsig_tests` and `pqsig_script_tests` negative coverage, including malformed size/ALG_ID/counter/input cases
- extend `pqsig_verify` fuzz target with structured valid-pk construction + mutation modes
- wire seeded fuzz-smoke corpus into CI scripts/workflow

## Files of note
- `src/crypto/pqsig/pqsig.cpp`
- `src/script/interpreter.cpp`
- `src/test/pqsig_tests.cpp`
- `src/test/pqsig_script_tests.cpp`
- `src/test/fuzz/pqsig_verify.cpp`
- `src/test/data/pqsig/invalid_v1.json`
- `src/test/data/pqsig/fuzz_seed_corpus/pqsig_verify/*`
- `ci/test/03_test_script.sh`
- `.github/workflows/ci.yml`

## Local validation
- `cmake --build build --target test_pqbtc -j8`
- `cmake --build build-fuzz --target fuzz -j8`
- `build/bin/test_pqbtc --run_test=pqsig_tests,pqsig_script_tests,script_tests,multisig_tests`
- `python3 ci/test/check_deterministic_artifacts.py`
- `python3 ci/test/check_pqsig_bench.py --bench build/bin/bench_pqbtc --repeat 3`
- `FUZZ=pqsig_verify build-fuzz/bin/fuzz <seeded_tmpdir>`

Closes #36
Closes #37
