### PR TITLE
GA safety: add relay soak harness and PQ mempool churn stress

### DIFF
--- a/contrib/soak/run_pq_mempool_soak.sh
+++ b/contrib/soak/run_pq_mempool_soak.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# PQBTC GA soak harness for relay/mempool witness-heavy traffic.
+# Runs mempool_pq_stress.py repeatedly and emits deterministic artifacts.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNS="${RUNS:-10}"
+JOBS="${JOBS:-1}"
+OUTDIR="${OUTDIR:-${ROOT_DIR}/build/soak-artifacts/pq-mempool-$(date -u +%Y%m%dT%H%M%SZ)}"
+TEST_RUNNER="${ROOT_DIR}/build/test/functional/test_runner.py"
+TEST_NAME="mempool_pq_stress.py"
+
+if [[ ! -x "${TEST_RUNNER}" ]]; then
+  echo "Missing functional test runner: ${TEST_RUNNER}" >&2
+  exit 1
+fi
+
+mkdir -p "${OUTDIR}"
+RESULTS_TSV="${OUTDIR}/results.tsv"
+SUMMARY_JSON="${OUTDIR}/summary.json"
+
+printf "run\tstatus\tduration_s\tfinished_utc\n" > "${RESULTS_TSV}"
+
+passed=0
+failed=0
+
+for run in $(seq 1 "${RUNS}"); do
+  started_epoch="$(date -u +%s)"
+  finished_utc=""
+  log_file="${OUTDIR}/run_${run}.log"
+  status="FAIL"
+
+  if "${TEST_RUNNER}" --jobs="${JOBS}" "${TEST_NAME}" >"${log_file}" 2>&1; then
+    status="PASS"
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+  fi
+
+  finished_epoch="$(date -u +%s)"
+  duration_s="$((finished_epoch - started_epoch))"
+  finished_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf "%s\t%s\t%s\t%s\n" "${run}" "${status}" "${duration_s}" "${finished_utc}" >> "${RESULTS_TSV}"
+done
+
+cat > "${SUMMARY_JSON}" <<EOF
+{
+  "runs": ${RUNS},
+  "passed": ${passed},
+  "failed": ${failed},
+  "jobs": ${JOBS},
+  "test": "${TEST_NAME}",
+  "results_tsv": "$(basename "${RESULTS_TSV}")"
+}
+EOF
+
+echo "Soak artifacts written to: ${OUTDIR}"
+echo "Summary: ${SUMMARY_JSON}"
+echo "Results: ${RESULTS_TSV}"
+
+if [[ ${failed} -ne 0 ]]; then
+  exit 1
+fi

--- a/contrib/soak/run_pq_mempool_soak.sh
+++ b/contrib/soak/run_pq_mempool_soak.sh
@@ -3,6 +3,8 @@
 # PQBTC GA soak harness for relay/mempool witness-heavy traffic.
 # Runs mempool_pq_stress.py repeatedly and emits deterministic artifacts.
 
+export LC_ALL=C
+
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/docs/GA_BURNIN_LOG.md
+++ b/docs/GA_BURNIN_LOG.md
@@ -17,6 +17,8 @@
 - Commit / tag under test:
 - Environment:
 - Summary:
+- Soak artifacts path:
+- Soak summary (`runs/passed/failed`):
 - Findings:
   - `priority:P0`:
   - `priority:P1`:
@@ -36,6 +38,8 @@
 - Commit / tag under test:
 - Environment:
 - Summary:
+- Soak artifacts path:
+- Soak summary (`runs/passed/failed`):
 - Findings:
   - `priority:P0`:
   - `priority:P1`:
@@ -55,6 +59,8 @@
 - Commit / tag under test:
 - Environment:
 - Summary:
+- Soak artifacts path:
+- Soak summary (`runs/passed/failed`):
 - Findings:
   - `priority:P0`:
   - `priority:P1`:

--- a/docs/RUNBOOK_V1_RC1.md
+++ b/docs/RUNBOOK_V1_RC1.md
@@ -69,6 +69,17 @@ FUZZ=pqsig_verify build-fuzz/bin/fuzz "$tmpdir"
 rm -rf "$tmpdir"
 ```
 
+4. Relay/mempool soak artifact run (GA safety track):
+
+```bash
+RUNS=10 JOBS=1 contrib/soak/run_pq_mempool_soak.sh
+```
+
+Required artifact outputs:
+- `build/soak-artifacts/<stamp>/summary.json`
+- `build/soak-artifacts/<stamp>/results.tsv`
+- `build/soak-artifacts/<stamp>/run_*.log`
+
 ## GA Rollback Triggers (Safety-Only Window)
 
 The GA burn-in window (2026-02-24 through 2026-03-09) uses strict rollback triggers:

--- a/test/functional/mempool_pq_stress.py
+++ b/test/functional/mempool_pq_stress.py
@@ -44,16 +44,48 @@ class MempoolPQStressTest(BitcoinTestFramework):
         self.generateblock(node0, output="raw(51)", transactions=fund_hex)
         self.sync_all()
 
-        def build_witness_heavy_spend(*, fund_txid: str, amount: int, payload_size: int, fee_sat: int) -> CTransaction:
+        def build_witness_heavy_spend(
+            *,
+            fund_txid: str,
+            amount: int,
+            payload_size: int,
+            fee_sat: int,
+            sequence: int = SEQUENCE_FINAL - 1,
+        ) -> CTransaction:
             tx = CTransaction()
-            tx.vin = [CTxIn(COutPoint(int(fund_txid, 16), 0), b"", SEQUENCE_FINAL - 1)]
+            tx.vin = [CTxIn(COutPoint(int(fund_txid, 16), 0), b"", sequence)]
             tx.vout = [CTxOut(amount - fee_sat, dest_spk)]
             tx.wit.vtxinwit = [CTxInWitness()]
             tx.wit.vtxinwit[0].scriptWitness.stack = [b"S" * payload_size, bytes(witness_script)]
             return tx
 
-        spend_txids = []
-        for idx, (fund_tx, fund_txid) in enumerate(fund_txs):
+        # RBF churn on one UTXO with large witness payloads.
+        rbf_fund, rbf_fund_txid = fund_txs[0]
+        rbf_fees = [22_000, 28_000, 34_000, 40_000, 46_000]
+        rbf_last_txid = None
+        for fee_sat in rbf_fees:
+            replacement = build_witness_heavy_spend(
+                fund_txid=rbf_fund_txid,
+                amount=rbf_fund.vout[0].nValue,
+                payload_size=9_500,
+                fee_sat=fee_sat,
+                sequence=SEQUENCE_FINAL - 2,
+            )
+            replacement_hex = replacement.serialize().hex()
+            accepted0 = node0.testmempoolaccept([replacement_hex])[0]
+            accepted1 = node1.testmempoolaccept([replacement_hex])[0]
+            assert accepted0["allowed"], accepted0
+            assert accepted1["allowed"], accepted1
+            txid = node0.sendrawtransaction(replacement_hex)
+            self.wait_until(lambda txid=txid: txid in node0.getrawmempool(False))
+            self.wait_until(lambda txid=txid: txid in node1.getrawmempool(False))
+            if rbf_last_txid is not None:
+                self.wait_until(lambda txid=rbf_last_txid: txid not in node0.getrawmempool(False))
+                self.wait_until(lambda txid=rbf_last_txid: txid not in node1.getrawmempool(False))
+            rbf_last_txid = txid
+
+        spend_txids = [rbf_last_txid] if rbf_last_txid is not None else []
+        for idx, (fund_tx, fund_txid) in enumerate(fund_txs[1:]):
             spend = build_witness_heavy_spend(
                 fund_txid=fund_txid,
                 amount=fund_tx.vout[0].nValue,


### PR DESCRIPTION
## Summary
- add repeatable GA soak harness script: `contrib/soak/run_pq_mempool_soak.sh`
- extend `mempool_pq_stress.py` with explicit large-witness RBF churn before multi-UTXO propagation/restart/reorg checks
- add soak artifact fields to burn-in log template and runbook soak command/evidence requirements

## Local validation
- `build/test/functional/test_runner.py --jobs=1 mempool_pq_stress.py`
- `RUNS=2 JOBS=1 contrib/soak/run_pq_mempool_soak.sh`

## Soak artifact sample
- path: `/Users/scott/quantum-proof-bitcoin/build/soak-artifacts/pq-mempool-20260228T184317Z`
- summary: `runs=2, passed=2, failed=0`

Closes #39
Closes #30
