### PR TITLE
docs: record post-stack GA baseline evidence

### DIFF
--- a/docs/GA_BURNIN_LOG.md
+++ b/docs/GA_BURNIN_LOG.md
@@ -11,6 +11,29 @@
 - End: 2026-03-09
 - Cadence: weekly checkpoints
 
+## Post-Stack Baseline (After #44/#45/#46)
+
+- Date (UTC): 2026-03-03
+- Baseline merge commit (`main`): `7c07609f414dce5546257837a539a63c7ce32bd5` (PR #46)
+- Stack merge commits:
+  - `4f2f88338ba55b6559655273e9b97951eb0d7d3f` (PR #44)
+  - `3caffa2319d67772bc31e9f4ae67e7abad6ba0f0` (PR #45)
+  - `7c07609f414dce5546257837a539a63c7ce32bd5` (PR #46)
+- PR evidence:
+  - PR #44 CI: <https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/22526800151>
+  - PR #44 Gatekeeper: <https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/22526800160>
+  - PR #45 CI: <https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/22549996865>
+  - PR #45 Gatekeeper: <https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/22549996838>
+  - PR #46 CI: <https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/22606688905>
+  - PR #46 Gatekeeper: <https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/22606688908>
+- Main baseline runs for `7c07609f414dce5546257837a539a63c7ce32bd5`:
+  - CI: <https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/22612154224>
+  - Gatekeeper: <https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/22612154206>
+- Notes:
+  - PR #46 merged via admin path due repository base-branch policy behavior.
+  - `CI / test each commit` is non-required and was still in progress at merge time.
+  - All protected required status-check contexts for PR #46 were green at merge time.
+
 ## Checkpoint Template
 
 - Date (UTC):


### PR DESCRIPTION
## Summary
- add a post-stack baseline section in `docs/GA_BURNIN_LOG.md` after PRs #44/#45/#46
- record merge SHAs and CI/Gatekeeper evidence links used for GA safety tracking
- document non-required `test each commit` behavior at #46 merge time

## Validation
- docs-only change
- links verified at authoring time