### PR TITLE
docs: record v1.0.0 ga decision

### DIFF
--- a/docs/GA_ACCEPTANCE_CHECKLIST.md
+++ b/docs/GA_ACCEPTANCE_CHECKLIST.md
@@ -97,12 +97,12 @@ Rules:
 
 ## Decision Record
 
-- Decision date (UTC):
-- Approver:
+- Decision date (UTC): 2026-03-09
+- Approver: Scott Hughes
 - Release decision:
-  - [ ] Promote to `v1.0.0`
-  - [x] Hold and cut `v1.0.0-rc2`
+  - [x] Promote to `v1.0.0`
+  - [ ] Hold and cut `v1.0.0-rc2`
 - Verify-path files touched during GA window:
   - [ ] No
   - [x] Yes (CFC verdict and accepted-set impact statement attached)
-- Notes: `2026-03-06` posture change for issue `#48`: old profile held, rc2 exact-root reprofile active, and fresh burn-in evidence required before any blocker closure.
+- Notes: `2026-03-06` posture change for issue `#48`: old profile held, rc2 exact-root reprofile active, and fresh burn-in evidence required before any blocker closure. `2026-03-09`: merge-commit CI and Gatekeeper are green on the shipped rc2 path, issue `#48` is closed, and the GA call is promote from current `main`.


### PR DESCRIPTION
## Summary
This PR records the March 9, 2026 GA release decision in the acceptance checklist.

The rc2 path is already merged to `main`, the merge-commit `CI` and `Gatekeeper` evidence is green, and issue `#48` has been closed. This follow-up is purely administrative: it updates the checklist decision record so the repository state explicitly matches the release call.

## Fix
- set the decision date to `2026-03-09`
- record the approver
- flip the release decision from `Hold and cut v1.0.0-rc2` to `Promote to v1.0.0`
- add a note tying the GA call to the green shipped rc2 merge evidence and closed blocker state

## Validation
- `git diff --check`
- only `docs/GA_ACCEPTANCE_CHECKLIST.md` changed in this PR
