### PR TITLE
ci: add measured-bench perf-regression workflow

### DIFF
--- a/.github/workflows/measured-bench.yml
+++ b/.github/workflows/measured-bench.yml
@@ -1,0 +1,80 @@
+# Copyright (c) 2026-present The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+name: measured-bench
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  measured-bench:
+    name: measured-bench
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      BUILD_DIR: ${{ github.workspace }}/build-measured-bench
+      PQSIG_BENCH_REPEATS: 8
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --no-upgrade -y \
+            build-essential \
+            bison \
+            ccache \
+            cmake \
+            e2fsprogs \
+            git \
+            libboost-dev \
+            libevent-dev \
+            ninja-build \
+            pkgconf \
+            python3
+
+      - name: Configure bench-only build
+        run: |
+          cmake -S . -B "${BUILD_DIR}" -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_BENCH=ON \
+            -DBUILD_BITCOIN_BIN=OFF \
+            -DBUILD_DAEMON=OFF \
+            -DBUILD_CLI=OFF \
+            -DBUILD_TX=OFF \
+            -DBUILD_UTIL=OFF \
+            -DBUILD_UTIL_CHAINSTATE=OFF \
+            -DBUILD_KERNEL_LIB=OFF \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_GUI=OFF \
+            -DBUILD_GUI_TESTS=OFF \
+            -DBUILD_FUZZ_BINARY=OFF \
+            -DENABLE_WALLET=OFF \
+            -DENABLE_IPC=OFF \
+            -DWITH_ZMQ=OFF \
+            -DWITH_USDT=OFF \
+            -DENABLE_EXTERNAL_SIGNER=OFF \
+            -DWERROR=ON
+
+      - name: Build bench_pqbtc
+        run: cmake --build "${BUILD_DIR}" --clean-first --parallel 3 --target bench_pqbtc
+
+      - name: Run measured bench gate
+        run: |
+          python3 ci/test/check_pqsig_bench.py \
+            --bench "${BUILD_DIR}/bin/bench_pqbtc" \
+            --repeat "${PQSIG_BENCH_REPEATS}" \
+            --enforce-variance \
+            --baseline-out "${RUNNER_TEMP}/pqsig_measured_bench_baseline.json"
+          cat "${RUNNER_TEMP}/pqsig_measured_bench_baseline.json"

--- a/ci/test/check_pqsig_bench.py
+++ b/ci/test/check_pqsig_bench.py
@@ -75,11 +75,9 @@ def load_policy(path: Path) -> dict[str, object]:
     return data
 
 
-def validate_envelope(envelope: dict[str, float | int], policy: dict[str, object], output: str) -> int:
+def validate_exact_counters(envelope: dict[str, float | int], policy: dict[str, object], output: str) -> int:
     exact_counters = policy["exact_counters"]
     assert isinstance(exact_counters, dict)
-    variance_bands = policy.get("variance_bands", {})
-    assert isinstance(variance_bands, dict)
 
     for key, expected in exact_counters.items():
         if key not in envelope:
@@ -91,19 +89,56 @@ def validate_envelope(envelope: dict[str, float | int], policy: dict[str, object
         else:
             if int(actual) != int(expected):
                 return fail(f"{key} mismatch: expected {expected}, got {actual}", output)
+    return 0
 
+
+def summarize_runs(envelopes: list[dict[str, float | int]]) -> dict[str, dict[str, float]]:
+    summary: dict[str, dict[str, float]] = {}
+    if not envelopes:
+        return summary
+
+    for key in sorted(envelopes[0].keys()):
+        values = [float(envelope[key]) for envelope in envelopes if key in envelope]
+        if not values:
+            continue
+        summary[key] = {
+            "mean": sum(values) / len(values),
+            "min": min(values),
+            "max": max(values),
+        }
+    return summary
+
+
+def validate_variance_bands(
+    envelopes: list[dict[str, float | int]],
+    policy: dict[str, object],
+) -> int:
+    variance_bands = policy.get("variance_bands", {})
+    assert isinstance(variance_bands, dict)
+    if not variance_bands:
+        return 0
+
+    summary = summarize_runs(envelopes)
     for key, bounds in variance_bands.items():
-        if key not in envelope:
-            return fail(f"bench output missing variance metric {key}", output)
+        if key not in summary:
+            return fail(f"bench output missing variance metric {key}")
         if not isinstance(bounds, dict):
-            return fail(f"variance band for {key} must be an object", output)
+            return fail(f"variance band for {key} must be an object")
         lower = bounds.get("min")
         upper = bounds.get("max")
-        actual = float(envelope[key])
-        if lower is not None and actual < float(lower):
-            return fail(f"{key} below minimum: min {lower}, got {actual}", output)
-        if upper is not None and actual > float(upper):
-            return fail(f"{key} above maximum: max {upper}, got {actual}", output)
+        actual_mean = summary[key]["mean"]
+        actual_min = summary[key]["min"]
+        actual_max = summary[key]["max"]
+        if lower is not None and actual_mean < float(lower):
+            return fail(
+                f"{key} mean below minimum: min {lower}, observed mean {actual_mean:.2f}, "
+                f"run min {actual_min:.2f}, run max {actual_max:.2f}"
+            )
+        if upper is not None and actual_mean > float(upper):
+            return fail(
+                f"{key} mean above maximum: max {upper}, observed mean {actual_mean:.2f}, "
+                f"run min {actual_min:.2f}, run max {actual_max:.2f}"
+            )
     return 0
 
 
@@ -113,6 +148,11 @@ def main() -> int:
     parser.add_argument("--repeat", type=int, default=1, help="Number of repeated bench envelope checks")
     parser.add_argument("--policy", default=str(DEFAULT_POLICY_PATH), help="Path to checked-in bench policy JSON")
     parser.add_argument("--baseline-out", help="Optional output path for JSON baseline summary")
+    parser.add_argument(
+        "--enforce-variance",
+        action="store_true",
+        help="Validate runtime variance bands from the checked-in policy file",
+    )
     args = parser.parse_args()
 
     if args.repeat < 1:
@@ -129,10 +169,15 @@ def main() -> int:
             envelope, output = run_bench(args.bench)
         except RuntimeError as exc:
             return fail(str(exc))
-        result = validate_envelope(envelope, policy, output)
+        result = validate_exact_counters(envelope, policy, output)
         if result != 0:
             return result
         envelopes.append(envelope)
+
+    if args.enforce_variance:
+        result = validate_variance_bands(envelopes, policy)
+        if result != 0:
+            return result
 
     if args.baseline_out:
         baseline_path = Path(args.baseline_out)
@@ -143,10 +188,14 @@ def main() -> int:
             "repeat": args.repeat,
             "expected": policy,
             "runs": envelopes,
+            "summary": summarize_runs(envelopes),
         }
         baseline_path.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    print(f"PQSIG bench envelope check passed ({args.repeat} run(s))")
+    if args.enforce_variance:
+        print(f"PQSIG bench envelope and variance check passed ({args.repeat} run(s))")
+    else:
+        print(f"PQSIG bench envelope check passed ({args.repeat} run(s))")
     return 0
 
 

--- a/ci/test/pqsig_bench_policy.json
+++ b/ci/test/pqsig_bench_policy.json
@@ -6,6 +6,12 @@
     "verify_compressions": 2309,
     "verify_compressions_per_byte": 0.5154017857142857
   },
-  "variance_bands": {},
-  "notes": "Default CI currently enforces exact counter equality only. Runtime variance bands are reserved for a dedicated measured-bench runner."
+  "variance_bands": {
+    "ns_per_op": {
+      "min": 30000,
+      "max": 250000
+    }
+  },
+  "runner_environment": "Initial conservative bands for the dedicated ubuntu-24.04 measured-bench workflow.",
+  "notes": "Default CI enforces exact counter equality only. Runtime variance bands are enforced by the separate measured-bench workflow."
 }

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -9,6 +9,7 @@ PQC-facing CI enforcement is split across two workflows:
 | Workflow | Purpose |
 |---|---|
 | `ci.yml` | Build, tests, benchmarks, fuzz, and PQ gating across platforms |
+| `measured-bench.yml` | Dedicated runtime variance gate for PQSig bench performance |
 | `gatekeeper.yml` | Docs-first freeze-gate checks against the selected base ref |
 
 ## RC Stabilization Controls
@@ -42,6 +43,9 @@ These interfaces are intentionally stable for v1:
 - `PQSIG_BENCH_REPEATS`
   - Number of repeated bench-envelope checks.
   - Default: `3`.
+- `PQSIG_BENCH_POLICY`
+  - Checked-in bench policy file for exact counters and measured-bench runtime bands.
+  - Default: `ci/test/pqsig_bench_policy.json`.
 
 ## Bench and Determinism Checks
 
@@ -58,7 +62,24 @@ Checked-in policy file:
 
 - `ci/test/pqsig_bench_policy.json`
 - current default CI uses the `exact_counters` block
-- `variance_bands` are reserved for the later dedicated measured-bench runner
+- `variance_bands` are enforced only by `measured-bench.yml`
+
+Dedicated measured-bench workflow:
+
+```bash
+python3 ci/test/check_pqsig_bench.py \
+  --bench build-measured-bench/bin/bench_pqbtc \
+  --repeat 8 \
+  --enforce-variance \
+  --baseline-out /tmp/pqsig_measured_bench_baseline.json
+```
+
+Measured-bench rollout:
+
+1. `measured-bench.yml` runs on pull requests, pushes to `main`, weekly schedule, and manual dispatch.
+2. The workflow uses the checked-in `variance_bands` block from `ci/test/pqsig_bench_policy.json`.
+3. Branch protection should only add the `measured-bench` status after at least one green PR run and one green `main` run.
+4. Expected wall-clock budget for the dedicated job is under 15 minutes on `ubuntu-24.04`.
 
 Deterministic artifact check:
 
@@ -89,6 +110,37 @@ cp src/test/data/pqsig/fuzz/pqsig_verify/* "$tmpdir"/
 rm -f "$tmpdir"/README.md
 FUZZ=pqsig_verify build-fuzz/bin/fuzz "$tmpdir"
 rm -rf "$tmpdir"
+```
+
+Local measured-bench reproduction:
+
+```bash
+cmake -S . -B build-measured-bench -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_BENCH=ON \
+  -DBUILD_BITCOIN_BIN=OFF \
+  -DBUILD_DAEMON=OFF \
+  -DBUILD_CLI=OFF \
+  -DBUILD_TX=OFF \
+  -DBUILD_UTIL=OFF \
+  -DBUILD_UTIL_CHAINSTATE=OFF \
+  -DBUILD_KERNEL_LIB=OFF \
+  -DBUILD_TESTS=OFF \
+  -DBUILD_GUI=OFF \
+  -DBUILD_GUI_TESTS=OFF \
+  -DBUILD_FUZZ_BINARY=OFF \
+  -DENABLE_WALLET=OFF \
+  -DENABLE_IPC=OFF \
+  -DWITH_ZMQ=OFF \
+  -DWITH_USDT=OFF \
+  -DENABLE_EXTERNAL_SIGNER=OFF \
+  -DWERROR=ON
+cmake --build build-measured-bench --clean-first -j3 --target bench_pqbtc
+python3 ci/test/check_pqsig_bench.py \
+  --bench build-measured-bench/bin/bench_pqbtc \
+  --repeat 8 \
+  --enforce-variance \
+  --baseline-out /tmp/pqsig_measured_bench_baseline.json
 ```
 
 Functional PQ suites:


### PR DESCRIPTION
## Summary

Implement the first step of `#35` by adding a separate `measured-bench` workflow and the supporting checker/policy updates.

- add `.github/workflows/measured-bench.yml`
- extend `ci/test/check_pqsig_bench.py` with `--enforce-variance`
- populate `ci/test/pqsig_bench_policy.json` with an initial conservative `ns_per_op` band
- document the workflow and rollout in `docs/CI.md`

## Behavior

- existing `ci.yml` exact-counter checks remain unchanged
- runtime variance is enforced only by `measured-bench.yml`
- `measured-bench.yml` runs on `pull_request`, `push` to `main`, weekly schedule, and manual dispatch
- the dedicated job builds only `bench_pqbtc` from a clean bench-only configuration and checks the mean `ns_per_op` over 8 runs

## Validation

- `python3 -m py_compile ci/test/check_pqsig_bench.py`
- `python3 ci/test/check_pqsig_bench.py --bench build/bin/bench_pqbtc --repeat 8 --enforce-variance --baseline-out /tmp/pqsig_measured_bench_local.json`
- negative check with a temporary tight policy confirms metric-specific failure output
- clean bench-only build passes locally with:
  - `cmake -S . -B /tmp/pqbtc-measured-bench-build ... -DBUILD_BENCH=ON -DENABLE_WALLET=OFF -DENABLE_IPC=OFF ...`
  - `cmake --build /tmp/pqbtc-measured-bench-build --clean-first --parallel 3 --target bench_pqbtc`
  - `python3 ci/test/check_pqsig_bench.py --bench /tmp/pqbtc-measured-bench-build/bin/bench_pqbtc --repeat 8 --enforce-variance`

## Rollout

This PR is only step 1 of the measured-bench rollout.

After merge:
1. wait for one green PR run and one green `main` push run of `measured-bench`
2. add `measured-bench` to required status checks on `main`

Issue: `#35`
