### PR TITLE
docs: measured-bench observation-only PR

### DIFF
--- a/docs/artifacts/ci-observation/2026-03-23-measured-bench-observation.md
+++ b/docs/artifacts/ci-observation/2026-03-23-measured-bench-observation.md
@@ -1,0 +1,6 @@
+# Measured Bench Observation PR
+
+Temporary observation-only PR to collect one additional green `measured-bench` pull_request run before promoting `measured-bench` to a required branch protection check on `main`.
+
+Date: 2026-03-23
+Intent: close unmerged after the workflow run is recorded.


### PR DESCRIPTION
Observation-only PR to collect one additional green `measured-bench` pull_request run before promoting `measured-bench` to a required branch protection check on `main`.

Plan:
- wait for one green `main` measured-bench run
- wait for this PR's `measured-bench` run to finish green
- add `measured-bench` to required status checks on `main`
- close this PR unmerged