### PR TITLE
bench: make pqsig counters runtime-derived

### DIFF
--- a/src/bench/pqsig.cpp
+++ b/src/bench/pqsig.cpp
@@ -5,9 +5,7 @@
 #include <bench/bench.h>
 #include <crypto/pqsig/pqsig.h>
 #include <crypto/pqsig/pqsig_internal.h>
-#include <crypto/pqsig/params.h>
 
-#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <iomanip>
@@ -20,12 +18,6 @@ void CheckEnvelopeAndPrint(
     const pqsig::PQSigMetrics& sign_metrics,
     const pqsig::PQSigMetrics& verify_metrics)
 {
-    assert(sign_metrics.hash_calls == pqsig::params::BENCH_SIGN_HASHES);
-    assert(sign_metrics.compression_calls == pqsig::params::BENCH_SIGN_COMPRESSIONS);
-    assert(sign_metrics.outer_search_iters == pqsig::params::BENCH_SIGN_OUTER_SEARCH);
-
-    assert(verify_metrics.compression_calls == pqsig::params::BENCH_VERIFY_COMPRESSIONS);
-
     const double per_byte = static_cast<double>(verify_metrics.compression_calls) / static_cast<double>(pqsig::SIG_SIZE);
     std::cout << "PQSIG_BENCH_ENVELOPE "
               << "verify_compressions=" << verify_metrics.compression_calls << ' '

--- a/src/crypto/pqsig/params.h
+++ b/src/crypto/pqsig/params.h
@@ -51,10 +51,6 @@ static_assert(EXPECTED_SIG_SIZE == pqsig::SIG_SIZE);
 
 inline constexpr uint32_t WOTS_COUNT_MAX{4096};
 
-inline constexpr uint32_t BENCH_VERIFY_COMPRESSIONS{2309};
-inline constexpr uint32_t BENCH_SIGN_HASHES{5265659};
-inline constexpr uint32_t BENCH_SIGN_COMPRESSIONS{10603073};
-inline constexpr uint32_t BENCH_SIGN_OUTER_SEARCH{1};
 inline constexpr uint32_t SIGN_COUNTER_MAX{1048576};
 
 // Consensus/profile locks for v1. Any change here requires explicit governance.

--- a/src/crypto/pqsig/pqsig.cpp
+++ b/src/crypto/pqsig/pqsig.cpp
@@ -309,12 +309,10 @@ bool PQSigSign(
         return false;
     }
 
-    metrics.outer_search_iters = 1;
-    metrics.wots_search_iters_total = 0;
-
     const auto r = ComputeR(sk_seed, msg32, pk_script33, &metrics);
     const auto hmsg = ComputeHmsg(std::span<const uint8_t>{r}, msg32, pk_script33, &metrics);
 
+    ++metrics.outer_search_iters;
     if (!EncodeSignatureCandidate(
             out_sig4480,
             sk_seed,

--- a/src/test/pqsig_tests.cpp
+++ b/src/test/pqsig_tests.cpp
@@ -293,13 +293,16 @@ BOOST_AUTO_TEST_CASE(pqsig_envelope_metrics)
     std::vector<uint8_t> sig(pqsig::SIG_SIZE);
     BOOST_CHECK(pqsig::PQSigSign(sig, msg, sk, pk));
     const pqsig::PQSigMetrics sign_metrics = pqsig::GetLastPQSigMetrics();
-    BOOST_CHECK_EQUAL(sign_metrics.hash_calls, 5265659U);
-    BOOST_CHECK_EQUAL(sign_metrics.compression_calls, 10603073U);
-    BOOST_CHECK_EQUAL(sign_metrics.outer_search_iters, 1U);
+    BOOST_CHECK_GT(sign_metrics.hash_calls, 0U);
+    BOOST_CHECK_GT(sign_metrics.compression_calls, 0U);
+    BOOST_CHECK_GE(sign_metrics.outer_search_iters, 1U);
 
     BOOST_CHECK(pqsig::PQSigVerify(sig, msg, pk));
     const pqsig::PQSigMetrics verify_metrics = pqsig::GetLastPQSigMetrics();
-    BOOST_CHECK_EQUAL(verify_metrics.compression_calls, 2081U);
+    BOOST_CHECK_GT(verify_metrics.hash_calls, 0U);
+    BOOST_CHECK_GT(verify_metrics.compression_calls, 0U);
+    BOOST_CHECK_EQUAL(verify_metrics.outer_search_iters, 0U);
+    BOOST_CHECK_NE(verify_metrics.compression_calls, sign_metrics.compression_calls);
 }
 
 BOOST_AUTO_TEST_CASE(pqsig_rejects_malformed_inputs)


### PR DESCRIPTION
Implements #33 narrowly by removing the remaining pre-populated PQSig bench counters and making the checked-in bench policy the sole exact-value authority.

Changes:
- replace the hardcoded sign-path `outer_search_iters = 1` assignment with runtime accounting at the candidate encoding boundary
- remove C++ bench self-asserts and the bench-only exact counter constants from `src/crypto/pqsig/params.h`
- keep the emitted bench envelope fields unchanged
- relax the PQSig unit metrics test to runtime invariants instead of hardcoded exact numbers

Validation:
- `cmake --build build -j8 --target bench_pqbtc test_pqbtc`
- `build/bin/test_pqbtc --run_test=pqsig_tests/pqsig_envelope_metrics`
- `python3 ci/test/check_pqsig_bench.py --bench build/bin/bench_pqbtc --repeat 3`
- negative check with a temporary mismatched policy still fails in `check_pqsig_bench.py`, not in the C++ bench binary