### PR TITLE
wallet: add fixed watch-only pq descriptors

### DIFF
--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -13,9 +13,10 @@ and define the concrete work required for a full-and-complete post-v1 program.
 
 ### 1. Node + consensus first
 - v1 state: node validation, script semantics, policy/relay, fuzz/bench, and PQ-first CI are implemented.
+- post-v1 update: fixed watch-only `pq(<PK_script>)` descriptor import/list/inference is implemented for standard single-sig PQ P2WSH outputs.
 - deferred: wallet/keypool UX and end-user signing flows.
 - full-complete delta:
-  - descriptor-native PQ key types
+  - active/ranged PQ descriptor support for keypool-driven address generation
   - wallet keypool generation/backup/recovery invariants
   - PSBT construction/finalization for PQ scripts
   - wallet RPC parity and wallet functional coverage

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -4,6 +4,7 @@
 
 #include <script/descriptor.h>
 
+#include <crypto/pqsig/pqsig.h>
 #include <hash.h>
 #include <key_io.h>
 #include <pubkey.h>
@@ -23,6 +24,7 @@
 #include <util/vector.h>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -998,6 +1000,34 @@ public:
     virtual std::unique_ptr<DescriptorImpl> Clone() const = 0;
 };
 
+static bool ParsePqPkScript(std::span<const char> expr, std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& out_pk_script, std::string& error)
+{
+    const std::string pk_script_hex(expr.begin(), expr.end());
+    if (!IsHex(pk_script_hex)) {
+        error = "PK_script must be valid hex";
+        return false;
+    }
+    const auto pk_script = ParseHex(pk_script_hex);
+    if (pk_script.size() != pqsig::PK_SCRIPT_SIZE) {
+        error = strprintf("PK_script must be exactly %u bytes", static_cast<unsigned>(pqsig::PK_SCRIPT_SIZE));
+        return false;
+    }
+    std::copy(pk_script.begin(), pk_script.end(), out_pk_script.begin());
+    if (!pqsig::IsValidPkScript(out_pk_script)) {
+        error = strprintf("PK_script must use ALG_ID=0x%02x", pqsig::ALG_ID_RC2);
+        return false;
+    }
+    return true;
+}
+
+static bool MatchPQSingleSigWitnessScript(const CScript& script, std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& out_pk_script)
+{
+    if (script.size() != 1 + pqsig::PK_SCRIPT_SIZE + 1) return false;
+    if (script[0] != pqsig::PK_SCRIPT_SIZE || script.back() != OP_CHECKSIG) return false;
+    std::copy(script.begin() + 1, script.begin() + 1 + pqsig::PK_SCRIPT_SIZE, out_pk_script.begin());
+    return pqsig::IsValidPkScript(out_pk_script);
+}
+
 /** A parsed addr(A) descriptor. */
 class AddressDescriptor final : public DescriptorImpl
 {
@@ -1088,6 +1118,57 @@ public:
     std::unique_ptr<DescriptorImpl> Clone() const override
     {
         return std::make_unique<PKDescriptor>(m_pubkey_args.at(0)->Clone(), m_xonly);
+    }
+};
+
+/** A parsed pq(PK_script) descriptor. */
+class PQDescriptor final : public DescriptorImpl
+{
+private:
+    const std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> m_pk_script;
+
+    CScript MakeWitnessScript() const
+    {
+        return CScript() << std::vector<unsigned char>(m_pk_script.begin(), m_pk_script.end()) << OP_CHECKSIG;
+    }
+
+protected:
+    std::string ToStringExtra() const override { return HexStr(std::span{m_pk_script}); }
+
+    std::vector<CScript> MakeScripts(const std::vector<CPubKey>&, std::span<const CScript>, FlatSigningProvider& out) const override
+    {
+        const CScript witness_script = MakeWitnessScript();
+        out.scripts.emplace(CScriptID(witness_script), witness_script);
+        return Vector(GetScriptForDestination(WitnessV0ScriptHash(witness_script)));
+    }
+
+public:
+    explicit PQDescriptor(std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script) : DescriptorImpl({}, "pq"), m_pk_script(pk_script) {}
+
+    bool IsSingleType() const final { return true; }
+
+    bool ToPrivateString(const SigningProvider&, std::string&) const final { return false; }
+
+    std::optional<OutputType> GetOutputType() const override { return OutputType::BECH32; }
+
+    std::optional<int64_t> ScriptSize() const override { return 1 + 1 + 32; }
+
+    std::optional<int64_t> MaxSatSize(bool) const override
+    {
+        const auto witness_script_size = MakeWitnessScript().size();
+        return GetSizeOfCompactSize(pqsig::SIG_SIZE) + pqsig::SIG_SIZE + GetSizeOfCompactSize(witness_script_size) + witness_script_size;
+    }
+
+    std::optional<int64_t> MaxSatisfactionWeight(bool use_max_sig) const override
+    {
+        return MaxSatSize(use_max_sig);
+    }
+
+    std::optional<int64_t> MaxSatisfactionElems() const override { return 2; }
+
+    std::unique_ptr<DescriptorImpl> Clone() const override
+    {
+        return std::make_unique<PQDescriptor>(m_pk_script);
     }
 };
 
@@ -2285,6 +2366,18 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
         error = "Can only have wpkh() at top level or inside sh()";
         return {};
     }
+    if (ctx == ParseScriptContext::TOP && Func("pq", expr)) {
+        std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script;
+        if (!ParsePqPkScript(expr, pk_script, error)) {
+            error = strprintf("pq(): %s", error);
+            return {};
+        }
+        ret.emplace_back(std::make_unique<PQDescriptor>(pk_script));
+        return ret;
+    } else if (Func("pq", expr)) {
+        error = "Can only have pq() at top level";
+        return {};
+    }
     if (ctx == ParseScriptContext::TOP && Func("sh", expr)) {
         auto descs = ParseScript(key_exp_index, expr, ParseScriptContext::P2SH, out, error);
         if (descs.empty() || expr.size()) return {};
@@ -2624,6 +2717,12 @@ std::unique_ptr<DescriptorImpl> InferScript(const CScript& script, ParseScriptCo
         CScriptID scriptid{RIPEMD160(data[0])};
         CScript subscript;
         if (provider.GetCScript(scriptid, subscript)) {
+            if (ctx == ParseScriptContext::TOP) {
+                std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script;
+                if (MatchPQSingleSigWitnessScript(subscript, pk_script)) {
+                    return std::make_unique<PQDescriptor>(pk_script);
+                }
+            }
             auto sub = InferScript(subscript, ParseScriptContext::P2WSH, provider);
             if (sub) return std::make_unique<WSHDescriptor>(std::move(sub));
         }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TEST_PQBTC_SOURCES
   dbwrapper_tests.cpp
   denialofservice_tests.cpp
   descriptor_tests.cpp
+  pq_descriptor_tests.cpp
   disconnected_transactions.cpp
   feefrac_tests.cpp
   flatfile_tests.cpp
@@ -140,6 +141,7 @@ if(NOT PQBTC_ENABLE_LEGACY_UNIT_TESTS)
   set(TEST_PQBTC_SOURCES
     main.cpp
     multisig_tests.cpp
+    pq_descriptor_tests.cpp
     pqsig_script_tests.cpp
     pqsig_tests.cpp
     script_tests.cpp

--- a/src/test/pq_descriptor_tests.cpp
+++ b/src/test/pq_descriptor_tests.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/pqsig/pqsig.h>
+#include <script/descriptor.h>
+#include <script/sign.h>
+#include <test/util/setup_common.h>
+#include <tinyformat.h>
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(pq_descriptor_tests)
+
+namespace {
+
+std::string WithChecksum(const std::string& desc)
+{
+    return desc + "#" + GetDescriptorChecksum(desc);
+}
+
+CScript MakePqWitnessScript(const std::vector<unsigned char>& pk_script)
+{
+    return CScript() << pk_script << OP_CHECKSIG;
+}
+
+void CheckUnparsable(const std::string& desc, const std::string& expected_error)
+{
+    FlatSigningProvider provider;
+    std::string error;
+    auto parsed = Parse(desc, provider, error);
+    BOOST_CHECK(parsed.empty());
+    BOOST_CHECK_EQUAL(error, expected_error);
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(roundtrip_expand_and_infer)
+{
+    std::vector<unsigned char> pk_script(pqsig::PK_SCRIPT_SIZE, 0x11);
+    pk_script[0] = pqsig::ALG_ID_RC2;
+    const std::string desc_body = "pq(" + HexStr(pk_script) + ")";
+    const std::string desc = WithChecksum(desc_body);
+
+    FlatSigningProvider provider;
+    std::string error;
+    auto parsed = Parse(desc, provider, error, /*require_checksum=*/true);
+    BOOST_REQUIRE_MESSAGE(!parsed.empty(), error);
+    BOOST_REQUIRE_EQUAL(parsed.size(), 1U);
+    BOOST_CHECK_EQUAL(parsed[0]->ToString(), desc);
+    BOOST_CHECK(parsed[0]->IsSolvable());
+    BOOST_CHECK(!parsed[0]->IsRange());
+    BOOST_CHECK_EQUAL(parsed[0]->GetOutputType(), OutputType::BECH32);
+    BOOST_CHECK_EQUAL(parsed[0]->ScriptSize(), 34);
+    BOOST_CHECK_EQUAL(parsed[0]->MaxSatisfactionElems(), 2);
+
+    std::string priv_desc;
+    BOOST_CHECK(!parsed[0]->ToPrivateString(provider, priv_desc));
+
+    FlatSigningProvider expand_out;
+    std::vector<CScript> output_scripts;
+    BOOST_REQUIRE(parsed[0]->Expand(0, DUMMY_SIGNING_PROVIDER, output_scripts, expand_out));
+    BOOST_REQUIRE_EQUAL(output_scripts.size(), 1U);
+
+    const CScript witness_script = MakePqWitnessScript(pk_script);
+    const CScript script_pubkey = GetScriptForDestination(WitnessV0ScriptHash(witness_script));
+    BOOST_CHECK_EQUAL(HexStr(output_scripts[0]), HexStr(script_pubkey));
+    BOOST_CHECK(expand_out.scripts.contains(CScriptID(witness_script)));
+    BOOST_CHECK_EQUAL(HexStr(expand_out.scripts.at(CScriptID(witness_script))), HexStr(witness_script));
+    BOOST_CHECK_EQUAL(parsed[0]->MaxSatisfactionWeight(false), GetSizeOfCompactSize(pqsig::SIG_SIZE) + pqsig::SIG_SIZE + GetSizeOfCompactSize(witness_script.size()) + witness_script.size());
+
+    FlatSigningProvider infer_provider;
+    infer_provider.scripts.emplace(CScriptID(witness_script), witness_script);
+    auto inferred = InferDescriptor(script_pubkey, infer_provider);
+    BOOST_REQUIRE(inferred);
+    BOOST_CHECK_EQUAL(inferred->ToString(), desc);
+}
+
+BOOST_AUTO_TEST_CASE(rejects_invalid_inputs)
+{
+    const std::string valid_hex = std::string("01") + std::string((pqsig::PK_SCRIPT_SIZE - 1) * 2, '1');
+    const std::string bad_alg_hex = std::string(pqsig::PK_SCRIPT_SIZE * 2, '2');
+
+    CheckUnparsable("pq(zz)", "pq(): PK_script must be valid hex");
+    CheckUnparsable("pq(01)", strprintf("pq(): PK_script must be exactly %u bytes", static_cast<unsigned>(pqsig::PK_SCRIPT_SIZE)));
+    CheckUnparsable("pq(" + bad_alg_hex + ")", strprintf("pq(): PK_script must use ALG_ID=0x%02x", pqsig::ALG_ID_RC2));
+    CheckUnparsable("wsh(pq(" + valid_hex + "))", "Can only have pq() at top level");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -170,6 +170,8 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
         int64_t range_start = 0, range_end = 1, next_index = 0;
         if (!parsed_descs.at(0)->IsRange() && data.exists("range")) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Range should not be specified for an un-ranged descriptor");
+        } else if (!parsed_descs.at(0)->IsRange() && data.exists("next_index")) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "next_index should not be specified for an un-ranged descriptor");
         } else if (parsed_descs.at(0)->IsRange()) {
             if (data.exists("range")) {
                 auto range = ParseDescriptorRange(data["range"]);

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -284,6 +284,7 @@ BASE_SCRIPTS = [
     'mempool_accept.py',
     'mempool_expiry.py',
     'wallet_importdescriptors.py',
+    'wallet_pq_descriptors.py',
     'wallet_crosschain.py',
     'mining_basic.py',
     'mining_mainnet.py',

--- a/test/functional/wallet_pq_descriptors.py
+++ b/test/functional/wallet_pq_descriptors.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test fixed watch-only pq(...) descriptors."""
+
+from decimal import Decimal
+
+from test_framework.address import script_to_p2wsh
+from test_framework.descriptors import descsum_create
+from test_framework.messages import COIN
+from test_framework.pqsig import build_pq_keypair, create_wallet_funded_tx
+from test_framework.script import CScript, OP_CHECKSIG, OP_TRUE
+from test_framework.script_util import script_to_p2wsh_script
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+RAW_TRUE_DESCRIPTOR = descsum_create("raw(51)")
+
+
+class WalletPQDescriptorsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-acceptnonstdtxn=1"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def mine_block(self):
+        self.nodes[0].generatetodescriptor(1, RAW_TRUE_DESCRIPTOR, called_by_framework=True)
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.createwallet(wallet_name="watch", disable_private_keys=True, blank=True)
+        watch = node.get_wallet_rpc("watch")
+
+        sk_seed = bytes.fromhex("11" * 32)
+        _, pk_script = build_pq_keypair(sk_seed)
+        witness_script = CScript([pk_script, OP_CHECKSIG])
+        address = script_to_p2wsh(witness_script)
+        descriptor = descsum_create(f"pq({pk_script.hex()})")
+
+        self.log.info("Import a fixed watch-only pq(...) descriptor")
+        result = watch.importdescriptors([{"desc": descriptor, "timestamp": "now"}])
+        assert_equal(result[0]["success"], True)
+        assert_equal(watch.getwalletinfo()["keypoolsize"], 0)
+
+        self.log.info("Reject unsupported active/range/next_index combinations")
+        active_result = watch.importdescriptors([{"desc": descriptor, "timestamp": "now", "active": True}])
+        assert_equal(active_result[0]["success"], False)
+        assert_equal(active_result[0]["error"]["code"], -8)
+        assert_equal(active_result[0]["error"]["message"], "Active descriptors must be ranged")
+
+        range_result = watch.importdescriptors([{"desc": descriptor, "timestamp": "now", "range": 1}])
+        assert_equal(range_result[0]["success"], False)
+        assert_equal(range_result[0]["error"]["code"], -8)
+        assert_equal(range_result[0]["error"]["message"], "Range should not be specified for an un-ranged descriptor")
+
+        next_result = watch.importdescriptors([{"desc": descriptor, "timestamp": "now", "next_index": 0}])
+        assert_equal(next_result[0]["success"], False)
+        assert_equal(next_result[0]["error"]["code"], -8)
+        assert_equal(next_result[0]["error"]["message"], "next_index should not be specified for an un-ranged descriptor")
+
+        self.log.info("Round-trip pq(...) through listdescriptors and getaddressinfo")
+        descriptor_info = node.getdescriptorinfo(descriptor)
+        assert_equal(descriptor_info["descriptor"], descriptor)
+        assert_equal(descriptor_info["isrange"], False)
+        assert_equal(descriptor_info["issolvable"], True)
+        assert_equal(descriptor_info["hasprivatekeys"], False)
+        assert_equal(node.deriveaddresses(descriptor), [address])
+        assert_raises_rpc_error(
+            -8,
+            "Range should not be specified for an un-ranged descriptor",
+            node.deriveaddresses,
+            descriptor,
+            [0, 1],
+        )
+
+        listed = watch.listdescriptors()
+        assert_equal(listed["wallet_name"], "watch")
+        assert_equal(len(listed["descriptors"]), 1)
+        assert_equal(
+            listed["descriptors"][0],
+            {
+                "active": False,
+                "desc": descriptor,
+                "timestamp": listed["descriptors"][0]["timestamp"],
+            },
+        )
+        assert_raises_rpc_error(-4, "Can't get descriptor string", watch.listdescriptors, True)
+
+        info = watch.getaddressinfo(address)
+        assert_equal(info["desc"], descriptor)
+        assert_equal(info["ismine"], True)
+        assert_equal(info["solvable"], True)
+
+        self.log.info("Descriptor survives unload/load")
+        watch.unloadwallet()
+        node.loadwallet("watch")
+        watch = node.get_wallet_rpc("watch")
+        assert_equal(watch.listdescriptors()["descriptors"][0]["desc"], descriptor)
+        assert_equal(watch.getaddressinfo(address)["desc"], descriptor)
+
+        self.log.info("Imported pq(...) tracks funds to the standard PQ P2WSH output")
+        tx = create_wallet_funded_tx(node, bytes(script_to_p2wsh_script(witness_script)), 5 * COIN)
+        tx.vout[1].scriptPubKey = script_to_p2wsh_script(CScript([OP_TRUE]))
+        txid = node.sendrawtransaction(tx.serialize().hex())
+        self.mine_block()
+
+        unspent = watch.listunspent()
+        assert_equal(len(unspent), 1)
+        assert_equal(unspent[0]["txid"], txid)
+        assert_equal(unspent[0]["address"], address)
+        assert_equal(unspent[0]["amount"], Decimal("5.00000000"))
+        balances = watch.getbalances()
+        tracked_bucket = balances["watchonly"] if "watchonly" in balances else balances["mine"]
+        assert_equal(tracked_bucket["trusted"], Decimal("5.00000000"))
+
+
+if __name__ == "__main__":
+    WalletPQDescriptorsTest(__file__).main()


### PR DESCRIPTION
## Summary
- add fixed watch-only `pq(<33-byte PK_script hex>)` descriptors for standard single-sig PQ P2WSH outputs
- keep scope narrow: public-only, non-ranged, non-active, watch-only only
- do not add PQ derivation, PQ private material, keypool behavior, PSBT changes, or signing support

## What Changes
- extend descriptor parsing and inference to recognize top-level `pq(...)`
- expand `pq(...)` directly to `witnessScript = <PK_script> OP_CHECKSIG` and `scriptPubKey = P2WSH(witnessScript)`
- store the witnessScript in the signing provider so watch-only wallets can import, rescan, and track funds
- reject malformed `pq(...)` descriptors and unsupported nested usage
- reject `next_index` for un-ranged descriptors in wallet import RPC handling
- add descriptor unit coverage and a dedicated `wallet_pq_descriptors.py` functional test

## Scope Guardrails
- only `ALG_ID=0x01` is accepted
- no active PQ descriptors
- no ranged PQ descriptors
- no private `pq(...)` export path
- no consensus or wire-format changes

## Validation
- `cmake --build /Users/scott/quantum-proof-bitcoin/build -j8 --target test_pqbtc pqbtcd pqbtc-cli`
- `/Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=descriptor_tests/pq_descriptor_roundtrip_expand_and_infer --catch_system_error=no --log_level=test_suite`
- `/Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=descriptor_tests/pq_descriptor_rejects_invalid_inputs --catch_system_error=no --log_level=test_suite`
- `python3 /Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_descriptors.py --configfile=/Users/scott/quantum-proof-bitcoin/build/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/build/test/cache`
- `git diff --check`

## Notes
- the legacy `descriptor_tests/descriptor_test` case is already noisy in this repo and is not used as the acceptance gate for this PR
- this PR implements the first wallet slice of `#18`; active/ranged descriptors, keypool, recovery, and PSBT remain deferred

Refs #18
