### PR TITLE
test: validate PQ descriptor backup and recovery invariants

### DIFF
--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -14,10 +14,12 @@ and define the concrete work required for a full-and-complete post-v1 program.
 ### 1. Node + consensus first
 - v1 state: node validation, script semantics, policy/relay, fuzz/bench, and PQ-first CI are implemented.
 - post-v1 update: fixed watch-only `pq(<PK_script>)` descriptor import/list/inference is implemented for standard single-sig PQ P2WSH outputs.
+- post-v1 update: `#19` validates backup/recovery of statically imported bounded PQ descriptor batches only.
 - deferred: wallet/keypool UX and end-user signing flows.
 - full-complete delta:
-  - active/ranged PQ descriptor support for keypool-driven address generation
-  - wallet keypool generation/backup/recovery invariants
+  - real PQ keypool generation/backup/recovery invariants
+  - private ranged descriptors (`pqpriv(...)`)
+  - active managers and PQ address generation
   - PSBT construction/finalization for PQ scripts
   - wallet RPC parity and wallet functional coverage
 

--- a/test/functional/test_framework/pq_wallet_helper.py
+++ b/test/functional/test_framework/pq_wallet_helper.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Helpers for deterministic PQ wallet descriptor batches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+
+from test_framework.address import script_to_p2wsh
+from test_framework.descriptors import descsum_create
+from test_framework.pqsig import build_pq_keypair
+from test_framework.script import CScript, OP_CHECKSIG
+from test_framework.script_util import script_to_p2wsh_script
+
+
+@dataclass(frozen=True)
+class PQDescriptorEntry:
+    index: int
+    internal: bool
+    sk_seed: bytes
+    pk_script: bytes
+    witness_script: CScript
+    script_pub_key: CScript
+    address: str
+    descriptor: str
+    label: str | None
+
+    def import_request(self, timestamp: int | str) -> dict[str, object]:
+        request: dict[str, object] = {
+            "desc": self.descriptor,
+            "timestamp": timestamp,
+        }
+        if self.internal:
+            request["internal"] = True
+        elif self.label is not None:
+            request["label"] = self.label
+        return request
+
+
+def _derive_test_seed(root_seed: bytes, internal: bool, index: int) -> bytes:
+    return hashlib.sha256(
+        b"PQSIG-WALLET-POOL-v1"
+        + root_seed
+        + (b"\x01" if internal else b"\x00")
+        + index.to_bytes(4, "little")
+    ).digest()
+
+
+def _build_entry(root_seed: bytes, internal: bool, index: int, label_prefix: str) -> PQDescriptorEntry:
+    sk_seed = _derive_test_seed(root_seed, internal, index)
+    _, pk_script = build_pq_keypair(sk_seed)
+    witness_script = CScript([pk_script, OP_CHECKSIG])
+    return PQDescriptorEntry(
+        index=index,
+        internal=internal,
+        sk_seed=sk_seed,
+        pk_script=pk_script,
+        witness_script=witness_script,
+        script_pub_key=script_to_p2wsh_script(witness_script),
+        address=script_to_p2wsh(witness_script),
+        descriptor=descsum_create(f"pq({pk_script.hex()})"),
+        label=None if internal else f"{label_prefix}-{index}",
+    )
+
+
+def build_bounded_pq_descriptor_batch(
+    root_seed: bytes,
+    *,
+    external_count: int,
+    internal_count: int,
+    label_prefix: str = "pq-external",
+) -> tuple[list[PQDescriptorEntry], list[PQDescriptorEntry]]:
+    external_entries = [
+        _build_entry(root_seed=root_seed, internal=False, index=index, label_prefix=label_prefix)
+        for index in range(external_count)
+    ]
+    internal_entries = [
+        _build_entry(root_seed=root_seed, internal=True, index=index, label_prefix=label_prefix)
+        for index in range(internal_count)
+    ]
+    return external_entries, internal_entries
+

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -285,6 +285,7 @@ BASE_SCRIPTS = [
     'mempool_expiry.py',
     'wallet_importdescriptors.py',
     'wallet_pq_descriptors.py',
+    'wallet_pq_backup_recovery.py',
     'wallet_crosschain.py',
     'mining_basic.py',
     'mining_mainnet.py',

--- a/test/functional/wallet_pq_backup_recovery.py
+++ b/test/functional/wallet_pq_backup_recovery.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test PQ descriptor backup/restore invariants for bounded imported batches."""
+
+from decimal import Decimal
+
+from test_framework.descriptors import descsum_create
+from test_framework.messages import COIN
+from test_framework.pqsig import create_wallet_funded_tx
+from test_framework.pq_wallet_helper import build_bounded_pq_descriptor_batch
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+RAW_TRUE_DESCRIPTOR = descsum_create("raw(51)")
+
+
+class WalletPQBackupRecoveryTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-acceptnonstdtxn=1"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def mine_block(self):
+        self.nodes[0].generatetodescriptor(1, RAW_TRUE_DESCRIPTOR, called_by_framework=True)
+
+    def ensure_wallet_loaded(self, wallet_name):
+        node = self.nodes[0]
+        if wallet_name not in node.listwallets():
+            node.loadwallet(wallet_name)
+        return node.get_wallet_rpc(wallet_name)
+
+    def fund_entry(self, entry, amount_sat: int) -> str:
+        tx = create_wallet_funded_tx(self.nodes[0], bytes(entry.script_pub_key), amount_sat)
+        return self.nodes[0].sendrawtransaction(tx.serialize().hex())
+
+    def descriptor_snapshot(self, wallet):
+        return [
+            {
+                "active": item["active"],
+                "desc": item["desc"],
+                "timestamp": item["timestamp"],
+            }
+            for item in wallet.listdescriptors()["descriptors"]
+        ]
+
+    def assert_entry_metadata(self, wallet, entry):
+        info = wallet.getaddressinfo(entry.address)
+        assert_equal(info["desc"], entry.descriptor)
+        assert_equal(info["ismine"], True)
+        assert_equal(info["solvable"], True)
+        assert_equal(info["ischange"], entry.internal)
+        if entry.internal:
+            assert_equal(info.get("labels", []), [])
+        else:
+            assert_equal(info["labels"], [entry.label])
+
+    def assert_tracked_outputs(self, wallet, expected_amounts):
+        observed = {item["address"]: item["amount"] for item in wallet.listunspent()}
+        assert_equal(observed, expected_amounts)
+
+    def run_test(self):
+        node = self.nodes[0]
+        root_seed = bytes.fromhex("42" * 32)
+        external_entries, internal_entries = build_bounded_pq_descriptor_batch(
+            root_seed,
+            external_count=3,
+            internal_count=2,
+        )
+        all_entries = external_entries + internal_entries
+
+        self.log.info("Create a blank watch-only wallet and import a bounded PQ descriptor batch")
+        node.createwallet(wallet_name="pqpool", disable_private_keys=True, blank=True)
+        watch = node.get_wallet_rpc("pqpool")
+        import_result = watch.importdescriptors([entry.import_request(0) for entry in all_entries])
+        assert all(result["success"] for result in import_result)
+        assert_equal(watch.getwalletinfo()["keypoolsize"], 0)
+
+        initial_snapshot = self.descriptor_snapshot(watch)
+        assert_equal(len(initial_snapshot), len(all_entries))
+        for entry in all_entries:
+            self.assert_entry_metadata(watch, entry)
+
+        self.log.info("Back up the wallet before any PQ funding so restore must recover from the watch set")
+        backup_path = node.datadir_path / "pqpool_pre_funding.bak"
+        watch.backupwallet(str(backup_path))
+
+        self.log.info("Fund sparse external/internal entries from the imported batch")
+        funded_amounts = {
+            external_entries[1].address: Decimal("3.00000000"),
+            internal_entries[1].address: Decimal("5.00000000"),
+        }
+        self.fund_entry(external_entries[1], 3 * COIN)
+        self.fund_entry(internal_entries[1], 5 * COIN)
+        self.mine_block()
+        self.assert_tracked_outputs(watch, funded_amounts)
+
+        self.log.info("Restart the node and confirm descriptor inventory and tracked outputs persist")
+        self.restart_node(0, self.extra_args[0])
+        node = self.nodes[0]
+        watch = self.ensure_wallet_loaded("pqpool")
+        assert_equal(self.descriptor_snapshot(watch), initial_snapshot)
+        for entry in all_entries:
+            self.assert_entry_metadata(watch, entry)
+        self.assert_tracked_outputs(watch, funded_amounts)
+
+        self.log.info("Restore the pre-funding backup into a fresh wallet and confirm funded outputs are rediscovered")
+        node.restorewallet("pqpool_restored", str(backup_path))
+        restored = node.get_wallet_rpc("pqpool_restored")
+        assert_equal(self.descriptor_snapshot(restored), initial_snapshot)
+        for entry in all_entries:
+            self.assert_entry_metadata(restored, entry)
+        self.assert_tracked_outputs(restored, funded_amounts)
+
+        self.log.info("Fund a previously unused PQ descriptor after restore and confirm it is tracked after reload")
+        post_restore_amounts = dict(funded_amounts)
+        post_restore_amounts[external_entries[0].address] = Decimal("7.00000000")
+        self.fund_entry(external_entries[0], 7 * COIN)
+        self.mine_block()
+        self.assert_tracked_outputs(restored, post_restore_amounts)
+
+        restored.unloadwallet()
+        node.loadwallet("pqpool_restored")
+        restored = node.get_wallet_rpc("pqpool_restored")
+        assert_equal(self.descriptor_snapshot(restored), initial_snapshot)
+        for entry in all_entries:
+            self.assert_entry_metadata(restored, entry)
+        self.assert_tracked_outputs(restored, post_restore_amounts)
+
+
+if __name__ == "__main__":
+    WalletPQBackupRecoveryTest(__file__).main()
+


### PR DESCRIPTION
## Summary
- add a deterministic PQ wallet helper for bounded imported descriptor batches
- add wallet_pq_backup_recovery.py to validate PQ backup/restore/reload/rescan invariants
- document that #19 is limited to bounded imported PQ batches and defers active/ranged PQ generation

## What this does
- keeps `pq(<PK_script>)` unchanged
- adds no new descriptor syntax, wallet RPCs, active managers, or signing paths
- proves that a restored wallet recovers the full imported PQ watch set, not just previously funded scripts

## Validation
- `python3 test/functional/wallet_pq_backup_recovery.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `python3 test/functional/wallet_pq_descriptors.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `python3 -m py_compile test/functional/test_framework/pq_wallet_helper.py test/functional/wallet_pq_backup_recovery.py test/functional/wallet_pq_descriptors.py test/functional/test_runner.py`
- `git diff --check`

## Issue
- progress toward #19
