### PR TITLE
wallet: add active ranged pqpriv descriptor foundation

### DIFF
--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -15,13 +15,12 @@ and define the concrete work required for a full-and-complete post-v1 program.
 - v1 state: node validation, script semantics, policy/relay, fuzz/bench, and PQ-first CI are implemented.
 - post-v1 update: fixed watch-only `pq(<PK_script>)` descriptor import/list/inference is implemented for standard single-sig PQ P2WSH outputs.
 - post-v1 update: `#19` validates backup/recovery of statically imported bounded PQ descriptor batches only.
+- post-v1 update: active ranged private `pqpriv(...)` receive/change managers are implemented with dedicated PQ address generation and private export.
 - deferred: wallet/keypool UX and end-user signing flows.
 - full-complete delta:
-  - real PQ keypool generation/backup/recovery invariants
-  - private ranged descriptors (`pqpriv(...)`)
-  - active managers and PQ address generation
   - PSBT construction/finalization for PQ scripts
   - wallet RPC parity and wallet functional coverage
+  - spendability/signing parity for generated PQ outputs
 
 ### 2. Taproot disabled for v1
 - v1 state: taproot activation remains `NEVER_ACTIVE` on PQBTC deployment tracks.

--- a/src/crypto/pqsig/pqsig.cpp
+++ b/src/crypto/pqsig/pqsig.cpp
@@ -5,6 +5,7 @@
 #include <crypto/pqsig/pqsig.h>
 
 #include <crypto/pqsig/domains.h>
+#include <crypto/hkdf_sha256_32.h>
 #include <crypto/pqsig/hypertree.h>
 #include <crypto/pqsig/octopus.h>
 #include <crypto/pqsig/params.h>
@@ -16,6 +17,8 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <tinyformat.h>
 
 namespace pqsig {
 namespace {
@@ -241,6 +244,18 @@ bool DerivePkScript(const std::span<uint8_t> out_pk_script33, const std::span<co
     std::copy(pk_seed.begin(), pk_seed.end(), out_pk_script33.begin() + 1);
     std::copy(pk_root.begin(), pk_root.end(), out_pk_script33.begin() + 1 + pk_seed.size());
     return true;
+}
+
+bool DeriveWalletPkScript(const std::span<uint8_t> out_pk_script33, const std::span<const uint8_t> root_seed, const bool internal, const uint32_t index)
+{
+    if (!ConsensusProfileLocked() || out_pk_script33.size() != PK_SCRIPT_SIZE || root_seed.size() != MSG32_SIZE) {
+        return false;
+    }
+
+    CHKDF_HMAC_SHA256_L32 hkdf(root_seed.data(), root_seed.size(), "PQSIG-WALLET-ROOT-v1");
+    unsigned char child_seed[MSG32_SIZE];
+    hkdf.Expand32(strprintf("branch=%u;index=%u", internal ? 1U : 0U, index), child_seed);
+    return DerivePkScript(out_pk_script33, child_seed);
 }
 
 bool PQSigVerify(

--- a/src/crypto/pqsig/pqsig.h
+++ b/src/crypto/pqsig/pqsig.h
@@ -20,6 +20,7 @@ inline constexpr uint8_t ALG_ID_RC2{0x01};
 
 bool IsValidPkScript(std::span<const uint8_t> pk_script33);
 bool DerivePkScript(std::span<uint8_t> out_pk_script33, std::span<const uint8_t> sk_seed);
+bool DeriveWalletPkScript(std::span<uint8_t> out_pk_script33, std::span<const uint8_t> root_seed, bool internal, uint32_t index);
 
 bool PQSigVerify(std::span<const uint8_t> sig4480,
                  std::span<const uint8_t> msg32,

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1020,6 +1020,45 @@ static bool ParsePqPkScript(std::span<const char> expr, std::array<unsigned char
     return true;
 }
 
+static std::string MakePQPrivateDescriptorString(std::span<const unsigned char> root_seed, const bool internal)
+{
+    return strprintf("pqpriv(%s/%u/*)", HexStr(root_seed), internal ? 1 : 0);
+}
+
+static bool ParsePQPrivateDescriptor(std::span<const char> expr, PQPrivateDescriptorInfo& out_info, std::string& error)
+{
+    const std::string descriptor(expr.begin(), expr.end());
+    const size_t slash = descriptor.find('/');
+    if (slash == std::string::npos) {
+        error = "descriptor must end with /0/* or /1/*";
+        return false;
+    }
+
+    const std::string root_hex = descriptor.substr(0, slash);
+    if (!IsHex(root_hex)) {
+        error = "root seed must be valid hex";
+        return false;
+    }
+    const auto root_seed = ParseHex(root_hex);
+    if (root_seed.size() != 32) {
+        error = "root seed must be exactly 32 bytes";
+        return false;
+    }
+
+    const std::string suffix = descriptor.substr(slash);
+    if (suffix == "/0/*") {
+        out_info.internal = false;
+    } else if (suffix == "/1/*") {
+        out_info.internal = true;
+    } else {
+        error = "descriptor must end with /0/* or /1/*";
+        return false;
+    }
+
+    std::copy(root_seed.begin(), root_seed.end(), out_info.root_seed.begin());
+    return true;
+}
+
 static bool MatchPQSingleSigWitnessScript(const CScript& script, std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& out_pk_script)
 {
     if (script.size() != 1 + pqsig::PK_SCRIPT_SIZE + 1) return false;
@@ -1170,6 +1209,63 @@ public:
     {
         return std::make_unique<PQDescriptor>(m_pk_script);
     }
+};
+
+class PQPrivDescriptor final : public Descriptor
+{
+private:
+    const std::array<unsigned char, 32> m_root_seed;
+    const bool m_internal;
+
+    CScript MakeWitnessScript(const int pos) const
+    {
+        std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script{};
+        const bool derived = pqsig::DeriveWalletPkScript(pk_script, m_root_seed, m_internal, pos);
+        assert(derived);
+        return CScript() << std::vector<unsigned char>(pk_script.begin(), pk_script.end()) << OP_CHECKSIG;
+    }
+
+    bool ExpandImpl(const int pos, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const
+    {
+        const CScript witness_script = MakeWitnessScript(pos);
+        out.scripts.emplace(CScriptID(witness_script), witness_script);
+        output_scripts = Vector(GetScriptForDestination(WitnessV0ScriptHash(witness_script)));
+        return true;
+    }
+
+public:
+    explicit PQPrivDescriptor(std::array<unsigned char, 32> root_seed, bool internal) : m_root_seed(root_seed), m_internal(internal) {}
+
+    bool IsRange() const override { return true; }
+    bool IsSolvable() const override { return true; }
+    std::string ToString(bool) const override { return AddChecksum(MakePQPrivateDescriptorString(m_root_seed, m_internal)); }
+    bool IsSingleType() const override { return true; }
+    bool ToPrivateString(const SigningProvider&, std::string& out) const override
+    {
+        out = ToString(/*compat_format=*/false);
+        return true;
+    }
+    bool ToNormalizedString(const SigningProvider&, std::string&, const DescriptorCache*) const override { return false; }
+    bool Expand(int pos, const SigningProvider&, std::vector<CScript>& output_scripts, FlatSigningProvider& out, DescriptorCache*) const override
+    {
+        return ExpandImpl(pos, output_scripts, out);
+    }
+    bool ExpandFromCache(int pos, const DescriptorCache&, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const override
+    {
+        return ExpandImpl(pos, output_scripts, out);
+    }
+    void ExpandPrivate(int, const SigningProvider&, FlatSigningProvider&) const override {}
+    std::optional<OutputType> GetOutputType() const override { return OutputType::BECH32; }
+    std::optional<int64_t> ScriptSize() const override { return 34; }
+    std::optional<int64_t> MaxSatisfactionWeight(bool) const override
+    {
+        const auto witness_script_size = MakeWitnessScript(0).size();
+        return GetSizeOfCompactSize(pqsig::SIG_SIZE) + pqsig::SIG_SIZE + GetSizeOfCompactSize(witness_script_size) + witness_script_size;
+    }
+    std::optional<int64_t> MaxSatisfactionElems() const override { return 2; }
+    void GetPubKeys(std::set<CPubKey>&, std::set<CExtPubKey>&) const override {}
+
+    PQPrivateDescriptorInfo GetInfo() const { return PQPrivateDescriptorInfo{m_root_seed, m_internal}; }
 };
 
 /** A parsed pkh(P) descriptor. */
@@ -2378,6 +2474,10 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
         error = "Can only have pq() at top level";
         return {};
     }
+    if (Func("pqpriv", expr)) {
+        error = "Can only have pqpriv() at top level";
+        return {};
+    }
     if (ctx == ParseScriptContext::TOP && Func("sh", expr)) {
         auto descs = ParseScript(key_exp_index, expr, ParseScriptContext::P2SH, out, error);
         if (descs.empty() || expr.size()) return {};
@@ -2838,6 +2938,17 @@ std::vector<std::unique_ptr<Descriptor>> Parse(const std::string& descriptor, Fl
 {
     std::span<const char> sp{descriptor};
     if (!CheckChecksum(sp, require_checksum, error)) return {};
+    std::span<const char> pqpriv_expr = sp;
+    if (script::Func("pqpriv", pqpriv_expr)) {
+        PQPrivateDescriptorInfo info{};
+        if (!ParsePQPrivateDescriptor(pqpriv_expr, info, error)) {
+            error = strprintf("pqpriv(): %s", error);
+            return {};
+        }
+        std::vector<std::unique_ptr<Descriptor>> descs;
+        descs.emplace_back(std::make_unique<PQPrivDescriptor>(info.root_seed, info.internal));
+        return descs;
+    }
     uint32_t key_exp_index = 0;
     auto ret = ParseScript(key_exp_index, sp, ParseScriptContext::TOP, out, error);
     if (sp.size() == 0 && !ret.empty()) {
@@ -2863,6 +2974,19 @@ std::string GetDescriptorChecksum(const std::string& descriptor)
 std::unique_ptr<Descriptor> InferDescriptor(const CScript& script, const SigningProvider& provider)
 {
     return InferScript(script, ParseScriptContext::TOP, provider);
+}
+
+std::optional<PQPrivateDescriptorInfo> GetPQPrivateDescriptorInfo(const Descriptor& descriptor)
+{
+    const auto* pqpriv = dynamic_cast<const PQPrivDescriptor*>(&descriptor);
+    if (!pqpriv) return std::nullopt;
+    return pqpriv->GetInfo();
+}
+
+std::string GetPQPrivateDescriptorString(const std::array<unsigned char, 32>& root_seed, const bool internal, const bool with_checksum)
+{
+    const std::string descriptor = MakePQPrivateDescriptorString(root_seed, internal);
+    return with_checksum ? AddChecksum(descriptor) : descriptor;
 }
 
 uint256 DescriptorID(const Descriptor& desc)

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -10,10 +10,17 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 
+#include <array>
 #include <optional>
+#include <string>
 #include <vector>
 
 using ExtPubKeyMap = std::unordered_map<uint32_t, CExtPubKey>;
+
+struct PQPrivateDescriptorInfo {
+    std::array<unsigned char, 32> root_seed;
+    bool internal;
+};
 
 /** Cache for single descriptor's derived extended pubkeys */
 class DescriptorCache {
@@ -200,6 +207,9 @@ std::string GetDescriptorChecksum(const std::string& descriptor);
  * - Failing that, a "raw()" descriptor is returned.
  */
 std::unique_ptr<Descriptor> InferDescriptor(const CScript& script, const SigningProvider& provider);
+
+std::optional<PQPrivateDescriptorInfo> GetPQPrivateDescriptorInfo(const Descriptor& descriptor);
+std::string GetPQPrivateDescriptorString(const std::array<unsigned char, 32>& root_seed, bool internal, bool with_checksum = true);
 
 /** Unique identifier that may not change over time, unless explicitly marked as not backwards compatible.
 *   This is not part of BIP 380, not guaranteed to be interoperable and should not be exposed to the user.

--- a/src/test/pq_descriptor_tests.cpp
+++ b/src/test/pq_descriptor_tests.cpp
@@ -91,4 +91,66 @@ BOOST_AUTO_TEST_CASE(rejects_invalid_inputs)
     CheckUnparsable("wsh(pq(" + valid_hex + "))", "Can only have pq() at top level");
 }
 
+BOOST_AUTO_TEST_CASE(pqpriv_roundtrip_expand_and_public_infer)
+{
+    std::array<unsigned char, 32> root_seed{};
+    root_seed.fill(0x42);
+    const std::string desc = GetPQPrivateDescriptorString(root_seed, /*internal=*/false);
+
+    FlatSigningProvider provider;
+    std::string error;
+    auto parsed = Parse(desc, provider, error, /*require_checksum=*/true);
+    BOOST_REQUIRE_MESSAGE(!parsed.empty(), error);
+    BOOST_REQUIRE_EQUAL(parsed.size(), 1U);
+    BOOST_CHECK_EQUAL(parsed[0]->ToString(), desc);
+    BOOST_CHECK(parsed[0]->IsSolvable());
+    BOOST_CHECK(parsed[0]->IsRange());
+    BOOST_CHECK_EQUAL(parsed[0]->GetOutputType(), OutputType::BECH32);
+    BOOST_CHECK_EQUAL(parsed[0]->ScriptSize(), 34);
+    BOOST_CHECK_EQUAL(parsed[0]->MaxSatisfactionElems(), 2);
+
+    const auto info = GetPQPrivateDescriptorInfo(*parsed[0]);
+    BOOST_REQUIRE(info.has_value());
+    BOOST_CHECK(info->root_seed == root_seed);
+    BOOST_CHECK(!info->internal);
+
+    std::string priv_desc;
+    BOOST_CHECK(parsed[0]->ToPrivateString(DUMMY_SIGNING_PROVIDER, priv_desc));
+    BOOST_CHECK_EQUAL(priv_desc, desc);
+
+    std::string normalized;
+    BOOST_CHECK(!parsed[0]->ToNormalizedString(DUMMY_SIGNING_PROVIDER, normalized, /*cache=*/nullptr));
+
+    constexpr int DERIVE_POS = 3;
+    FlatSigningProvider expand_out;
+    std::vector<CScript> output_scripts;
+    BOOST_REQUIRE(parsed[0]->Expand(DERIVE_POS, DUMMY_SIGNING_PROVIDER, output_scripts, expand_out));
+    BOOST_REQUIRE_EQUAL(output_scripts.size(), 1U);
+
+    std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script{};
+    BOOST_REQUIRE(pqsig::DeriveWalletPkScript(pk_script, root_seed, /*internal=*/false, DERIVE_POS));
+    const CScript witness_script = MakePqWitnessScript(std::vector<unsigned char>(pk_script.begin(), pk_script.end()));
+    const CScript script_pubkey = GetScriptForDestination(WitnessV0ScriptHash(witness_script));
+    BOOST_CHECK_EQUAL(HexStr(output_scripts[0]), HexStr(script_pubkey));
+    BOOST_CHECK(expand_out.scripts.contains(CScriptID(witness_script)));
+    BOOST_CHECK_EQUAL(HexStr(expand_out.scripts.at(CScriptID(witness_script))), HexStr(witness_script));
+
+    FlatSigningProvider infer_provider;
+    infer_provider.scripts.emplace(CScriptID(witness_script), witness_script);
+    auto inferred = InferDescriptor(script_pubkey, infer_provider);
+    BOOST_REQUIRE(inferred);
+    BOOST_CHECK_EQUAL(inferred->ToString(), WithChecksum("pq(" + HexStr(std::span{pk_script}) + ")"));
+}
+
+BOOST_AUTO_TEST_CASE(pqpriv_rejects_invalid_inputs)
+{
+    const std::string valid_seed = std::string(64, '4');
+
+    CheckUnparsable("pqpriv(zz/0/*)", "pqpriv(): root seed must be valid hex");
+    CheckUnparsable("pqpriv(42/0/*)", "pqpriv(): root seed must be exactly 32 bytes");
+    CheckUnparsable("pqpriv(" + valid_seed + "/2/*)", "pqpriv(): descriptor must end with /0/* or /1/*");
+    CheckUnparsable("pqpriv(" + valid_seed + "/0)", "pqpriv(): descriptor must end with /0/* or /1/*");
+    CheckUnparsable("wsh(pqpriv(" + valid_seed + "/0/*))", "Can only have pqpriv() at top level");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(bitcoin_wallet STATIC EXCLUDE_FROM_ALL
   interfaces.cpp
   load.cpp
   migrate.cpp
+  pq_scriptpubkeyman.cpp
   receive.cpp
   rpc/addresses.cpp
   rpc/backup.cpp

--- a/src/wallet/pq_scriptpubkeyman.cpp
+++ b/src/wallet/pq_scriptpubkeyman.cpp
@@ -1,0 +1,456 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/pq_scriptpubkeyman.h>
+
+#include <crypto/sha256.h>
+#include <script/script.h>
+#include <script/solver.h>
+#include <tinyformat.h>
+#include <util/check.h>
+#include <util/strencodings.h>
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace wallet {
+namespace {
+
+std::vector<unsigned char> ToVector(const std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& pk_script)
+{
+    return std::vector<unsigned char>(pk_script.begin(), pk_script.end());
+}
+
+} // namespace
+
+PQDescriptorScriptPubKeyMan::PQDescriptorScriptPubKeyMan(WalletStorage& storage, const uint256 id, const PQWalletDescriptor& descriptor, const int64_t keypool_size)
+    : ScriptPubKeyMan(storage),
+      m_id(id),
+      m_wallet_descriptor(descriptor),
+      m_keypool_size(keypool_size)
+{
+}
+
+PQDescriptorScriptPubKeyMan::PQDescriptorScriptPubKeyMan(WalletStorage& storage,
+                                                         const uint256 id,
+                                                         const std::array<unsigned char, 32>& root_seed,
+                                                         const bool internal,
+                                                         const uint64_t creation_time,
+                                                         const int32_t range_start,
+                                                         const int32_t range_end,
+                                                         const int32_t next_index,
+                                                         const int64_t keypool_size)
+    : ScriptPubKeyMan(storage),
+      m_id(id),
+      m_wallet_descriptor{creation_time, range_start, range_end, next_index, static_cast<uint8_t>(internal ? 1 : 0)},
+      m_keypool_size(keypool_size)
+{
+    m_root_seed.assign(root_seed.begin(), root_seed.end());
+}
+
+uint256 PQDescriptorScriptPubKeyMan::DeriveID(const std::array<unsigned char, 32>& root_seed, const bool internal)
+{
+    const std::string desc = GetPQPrivateDescriptorString(root_seed, internal);
+    uint256 id;
+    CSHA256().Write(UCharCast(desc.data()), desc.size()).Finalize(id.begin());
+    return id;
+}
+
+CScript PQDescriptorScriptPubKeyMan::MakeWitnessScript(const std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& pk_script)
+{
+    return CScript() << ToVector(pk_script) << OP_CHECKSIG;
+}
+
+CScript PQDescriptorScriptPubKeyMan::MakeScriptPubKey(const std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& pk_script)
+{
+    return GetScriptForDestination(WitnessV0ScriptHash(MakeWitnessScript(pk_script)));
+}
+
+bool PQDescriptorScriptPubKeyMan::GetRootSeed(CKeyingMaterial& root_seed) const
+{
+    AssertLockHeld(cs_pq_man);
+    if (!m_root_seed.empty()) {
+        root_seed = m_root_seed;
+        return root_seed.size() == pqsig::MSG32_SIZE;
+    }
+    if (m_crypted_root_seed.empty()) {
+        return false;
+    }
+    const std::vector<unsigned char> crypted_root_seed{m_crypted_root_seed};
+    return m_storage.WithEncryptionKey([&](const CKeyingMaterial& master_key) {
+        return DecryptSecret(master_key, crypted_root_seed, m_id, root_seed) && root_seed.size() == pqsig::MSG32_SIZE;
+    });
+}
+
+bool PQDescriptorScriptPubKeyMan::GetDestinationForIndex(const int32_t index, CTxDestination& dest) const
+{
+    AssertLockHeld(cs_pq_man);
+    const auto it = m_map_pk_scripts.find(index);
+    if (it == m_map_pk_scripts.end()) {
+        return false;
+    }
+    dest = WitnessV0ScriptHash(MakeWitnessScript(it->second));
+    return true;
+}
+
+bool PQDescriptorScriptPubKeyMan::WriteMetadata(WalletBatch& batch)
+{
+    AssertLockHeld(cs_pq_man);
+    if (!batch.WritePQDescriptor(GetID(), m_wallet_descriptor)) {
+        return false;
+    }
+    if (!m_crypted_root_seed.empty()) {
+        return batch.WriteCryptedPQDescriptorSeed(GetID(), m_crypted_root_seed);
+    }
+    if (!m_root_seed.empty()) {
+        return batch.WritePQDescriptorSeed(GetID(), std::vector<unsigned char>(m_root_seed.begin(), m_root_seed.end()));
+    }
+    return true;
+}
+
+util::Result<CTxDestination> PQDescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
+{
+    LOCK(cs_pq_man);
+    if (type != OutputType::BECH32) {
+        return util::Error{Untranslated("PQSIG descriptors only support bech32 destinations")};
+    }
+    TopUp();
+    if (m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end && !TopUp(1)) {
+        return util::Error{Untranslated("Error: Keypool ran out, please unlock the wallet or expand the PQ range")};
+    }
+
+    CTxDestination dest;
+    if (!GetDestinationForIndex(m_wallet_descriptor.next_index, dest)) {
+        return util::Error{Untranslated("Error: Cannot extract destination from the generated PQ scriptpubkey")};
+    }
+    ++m_wallet_descriptor.next_index;
+    if (!WalletBatch(m_storage.GetDatabase()).WritePQDescriptor(GetID(), m_wallet_descriptor)) {
+        return util::Error{Untranslated("Error: writing PQ descriptor state failed")};
+    }
+    NotifyCanGetAddressesChanged();
+    return dest;
+}
+
+util::Result<CTxDestination> PQDescriptorScriptPubKeyMan::GetReservedDestination(const OutputType type, const bool internal, int64_t& index)
+{
+    LOCK(cs_pq_man);
+    if (internal != IsInternal()) {
+        return util::Error{Untranslated("Reserved PQ destination requested from the wrong branch")};
+    }
+    auto op_dest = GetNewDestination(type);
+    index = m_wallet_descriptor.next_index - 1;
+    return op_dest;
+}
+
+void PQDescriptorScriptPubKeyMan::ReturnDestination(const int64_t index, const bool internal, const CTxDestination&)
+{
+    LOCK(cs_pq_man);
+    if (internal != IsInternal()) return;
+    if (m_wallet_descriptor.next_index - 1 == index) {
+        --m_wallet_descriptor.next_index;
+    }
+    WalletBatch(m_storage.GetDatabase()).WritePQDescriptor(GetID(), m_wallet_descriptor);
+    NotifyCanGetAddressesChanged();
+}
+
+bool PQDescriptorScriptPubKeyMan::TopUp(const unsigned int size)
+{
+    WalletBatch batch(m_storage.GetDatabase());
+    LOCK(cs_pq_man);
+
+    const unsigned int target_size = size > 0 ? size : m_keypool_size;
+    const int32_t new_range_end = std::max(m_wallet_descriptor.next_index + static_cast<int32_t>(target_size), m_wallet_descriptor.range_end);
+    std::set<CScript> new_spks;
+
+    for (int32_t index = m_max_cached_index + 1; index < new_range_end; ++index) {
+        std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script{};
+        const auto cached = m_map_pk_scripts.find(index);
+        if (cached != m_map_pk_scripts.end()) {
+            pk_script = cached->second;
+        } else {
+            CKeyingMaterial root_seed;
+            if (!GetRootSeed(root_seed)) {
+                return false;
+            }
+            if (!pqsig::DeriveWalletPkScript(pk_script, root_seed, IsInternal(), index)) {
+                return false;
+            }
+            if (!batch.WritePQDescriptorCache(GetID(), index, ToVector(pk_script))) {
+                throw std::runtime_error(std::string(__func__) + ": writing PQ descriptor cache failed");
+            }
+            m_map_pk_scripts[index] = pk_script;
+        }
+
+        const CScript script_pub_key = MakeScriptPubKey(pk_script);
+        m_map_script_pub_keys[script_pub_key] = index;
+        new_spks.insert(script_pub_key);
+        m_max_cached_index = index;
+    }
+
+    m_wallet_descriptor.range_end = new_range_end;
+    if (!WriteMetadata(batch)) {
+        throw std::runtime_error(std::string(__func__) + ": writing PQ descriptor metadata failed");
+    }
+
+    m_storage.TopUpCallback(new_spks, this);
+    NotifyCanGetAddressesChanged();
+    return true;
+}
+
+std::vector<WalletDestination> PQDescriptorScriptPubKeyMan::MarkUnusedAddresses(const CScript& script)
+{
+    LOCK(cs_pq_man);
+    std::vector<WalletDestination> result;
+    const auto it = m_map_script_pub_keys.find(script);
+    if (it == m_map_script_pub_keys.end()) {
+        return result;
+    }
+    const int32_t used_index = it->second;
+    while (used_index >= m_wallet_descriptor.next_index) {
+        CTxDestination dest;
+        if (!GetDestinationForIndex(m_wallet_descriptor.next_index, dest)) {
+            break;
+        }
+        result.push_back({dest, IsInternal()});
+        ++m_wallet_descriptor.next_index;
+    }
+    if (!TopUp()) {
+        WalletLogPrintf("%s: Topping up PQ keypool failed (locked wallet)\n", __func__);
+    }
+    return result;
+}
+
+bool PQDescriptorScriptPubKeyMan::CanGetAddresses(const bool internal) const
+{
+    LOCK(cs_pq_man);
+    if (internal != IsInternal()) {
+        return false;
+    }
+    if (m_wallet_descriptor.next_index < m_wallet_descriptor.range_end) {
+        return true;
+    }
+    if (m_crypted_root_seed.empty()) {
+        return !m_root_seed.empty();
+    }
+    return !m_storage.IsLocked();
+}
+
+bool PQDescriptorScriptPubKeyMan::HavePrivateKeys() const
+{
+    LOCK(cs_pq_man);
+    return !m_root_seed.empty() || !m_crypted_root_seed.empty();
+}
+
+bool PQDescriptorScriptPubKeyMan::HaveCryptedKeys() const
+{
+    LOCK(cs_pq_man);
+    return !m_crypted_root_seed.empty();
+}
+
+bool PQDescriptorScriptPubKeyMan::IsMine(const CScript& script) const
+{
+    LOCK(cs_pq_man);
+    return m_map_script_pub_keys.contains(script);
+}
+
+bool PQDescriptorScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key)
+{
+    LOCK(cs_pq_man);
+    if (!m_root_seed.empty()) {
+        return false;
+    }
+    if (m_crypted_root_seed.empty()) {
+        return true;
+    }
+
+    CKeyingMaterial root_seed;
+    if (!DecryptSecret(master_key, m_crypted_root_seed, m_id, root_seed) || root_seed.size() != pqsig::MSG32_SIZE) {
+        return false;
+    }
+
+    bool pass = true;
+    if (!m_map_pk_scripts.empty()) {
+        const auto& [index, expected_pk_script] = *m_map_pk_scripts.begin();
+        std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> derived_pk_script{};
+        if (!pqsig::DeriveWalletPkScript(derived_pk_script, root_seed, IsInternal(), index)) {
+            return false;
+        }
+        pass = derived_pk_script == expected_pk_script;
+    }
+    if (pass) {
+        m_decryption_thoroughly_checked = true;
+    }
+    return pass;
+}
+
+bool PQDescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch)
+{
+    LOCK(cs_pq_man);
+    if (!m_crypted_root_seed.empty() || m_root_seed.empty() || batch == nullptr) {
+        return false;
+    }
+
+    std::vector<unsigned char> crypted_root_seed;
+    if (!EncryptSecret(master_key, m_root_seed, m_id, crypted_root_seed)) {
+        return false;
+    }
+    m_crypted_root_seed = crypted_root_seed;
+    m_root_seed.clear();
+    m_root_seed.shrink_to_fit();
+    return WriteMetadata(*batch);
+}
+
+unsigned int PQDescriptorScriptPubKeyMan::GetKeyPoolSize() const
+{
+    LOCK(cs_pq_man);
+    return m_wallet_descriptor.range_end - m_wallet_descriptor.next_index;
+}
+
+int64_t PQDescriptorScriptPubKeyMan::GetTimeFirstKey() const
+{
+    LOCK(cs_pq_man);
+    return m_wallet_descriptor.creation_time;
+}
+
+std::unique_ptr<CKeyMetadata> PQDescriptorScriptPubKeyMan::GetMetadata(const CTxDestination& dest) const
+{
+    LOCK(cs_pq_man);
+    const auto it = m_map_script_pub_keys.find(GetScriptForDestination(dest));
+    if (it == m_map_script_pub_keys.end()) {
+        return nullptr;
+    }
+    auto metadata = std::make_unique<CKeyMetadata>(m_wallet_descriptor.creation_time);
+    metadata->hdKeypath = strprintf("m/%u/%d", static_cast<unsigned int>(m_wallet_descriptor.branch), it->second);
+    return metadata;
+}
+
+std::unique_ptr<SigningProvider> PQDescriptorScriptPubKeyMan::GetSolvingProvider(const CScript& script) const
+{
+    LOCK(cs_pq_man);
+    const auto it = m_map_script_pub_keys.find(script);
+    if (it == m_map_script_pub_keys.end()) {
+        return nullptr;
+    }
+    const auto pk_it = m_map_pk_scripts.find(it->second);
+    if (pk_it == m_map_pk_scripts.end()) {
+        return nullptr;
+    }
+    auto provider = std::make_unique<FlatSigningProvider>();
+    const CScript witness_script = MakeWitnessScript(pk_it->second);
+    provider->scripts.emplace(CScriptID(witness_script), witness_script);
+    return provider;
+}
+
+bool PQDescriptorScriptPubKeyMan::CanProvide(const CScript& script, SignatureData&)
+{
+    return IsMine(script);
+}
+
+uint256 PQDescriptorScriptPubKeyMan::GetID() const
+{
+    return m_id;
+}
+
+std::unordered_set<CScript, SaltedSipHasher> PQDescriptorScriptPubKeyMan::GetScriptPubKeys() const
+{
+    LOCK(cs_pq_man);
+    return GetScriptPubKeys(m_wallet_descriptor.range_start);
+}
+
+std::unordered_set<CScript, SaltedSipHasher> PQDescriptorScriptPubKeyMan::GetScriptPubKeys(const int32_t minimum_index) const
+{
+    LOCK(cs_pq_man);
+    std::unordered_set<CScript, SaltedSipHasher> scripts;
+    for (const auto& [script, index] : m_map_script_pub_keys) {
+        if (index >= minimum_index) {
+            scripts.insert(script);
+        }
+    }
+    return scripts;
+}
+
+bool PQDescriptorScriptPubKeyMan::GetDescriptorString(std::string& out, const bool priv) const
+{
+    LOCK(cs_pq_man);
+    if (!priv) {
+        return false;
+    }
+    CKeyingMaterial root_seed;
+    if (!GetRootSeed(root_seed)) {
+        return false;
+    }
+    std::array<unsigned char, 32> seed{};
+    std::copy(root_seed.begin(), root_seed.end(), seed.begin());
+    out = GetPQPrivateDescriptorString(seed, IsInternal());
+    return true;
+}
+
+PQWalletDescriptor PQDescriptorScriptPubKeyMan::GetWalletDescriptor() const
+{
+    LOCK(cs_pq_man);
+    return m_wallet_descriptor;
+}
+
+bool PQDescriptorScriptPubKeyMan::IsInternal() const
+{
+    LOCK(cs_pq_man);
+    return m_wallet_descriptor.IsInternal();
+}
+
+int32_t PQDescriptorScriptPubKeyMan::GetEndRange() const
+{
+    LOCK(cs_pq_man);
+    return m_wallet_descriptor.range_end;
+}
+
+bool PQDescriptorScriptPubKeyMan::UpdateWalletDescriptor(const PQWalletDescriptor& descriptor)
+{
+    LOCK(cs_pq_man);
+    if (descriptor.branch != m_wallet_descriptor.branch) {
+        return false;
+    }
+    m_wallet_descriptor.creation_time = std::min(m_wallet_descriptor.creation_time, descriptor.creation_time);
+    m_wallet_descriptor.range_start = std::min(m_wallet_descriptor.range_start, descriptor.range_start);
+    m_wallet_descriptor.range_end = std::max(m_wallet_descriptor.range_end, descriptor.range_end);
+    m_wallet_descriptor.next_index = std::max(m_wallet_descriptor.next_index, descriptor.next_index);
+    return WalletBatch(m_storage.GetDatabase()).WritePQDescriptor(GetID(), m_wallet_descriptor);
+}
+
+bool PQDescriptorScriptPubKeyMan::LoadRootSeed(const std::vector<unsigned char>& root_seed)
+{
+    LOCK(cs_pq_man);
+    if (root_seed.size() != pqsig::MSG32_SIZE) {
+        return false;
+    }
+    m_root_seed.assign(root_seed.begin(), root_seed.end());
+    return true;
+}
+
+bool PQDescriptorScriptPubKeyMan::LoadCryptedRootSeed(const std::vector<unsigned char>& crypted_root_seed)
+{
+    LOCK(cs_pq_man);
+    m_crypted_root_seed = crypted_root_seed;
+    return true;
+}
+
+bool PQDescriptorScriptPubKeyMan::LoadCachedPkScript(const int32_t index, const std::vector<unsigned char>& pk_script)
+{
+    LOCK(cs_pq_man);
+    if (pk_script.size() != pqsig::PK_SCRIPT_SIZE) {
+        return false;
+    }
+    std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script_array{};
+    std::copy(pk_script.begin(), pk_script.end(), pk_script_array.begin());
+    if (!pqsig::IsValidPkScript(pk_script_array)) {
+        return false;
+    }
+    m_map_pk_scripts[index] = pk_script_array;
+    m_map_script_pub_keys[MakeScriptPubKey(pk_script_array)] = index;
+    m_max_cached_index = std::max(m_max_cached_index, index);
+    return true;
+}
+
+} // namespace wallet

--- a/src/wallet/pq_scriptpubkeyman.h
+++ b/src/wallet/pq_scriptpubkeyman.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_PQ_SCRIPTPUBKEYMAN_H
+#define BITCOIN_WALLET_PQ_SCRIPTPUBKEYMAN_H
+
+#include <crypto/pqsig/pqsig.h>
+#include <wallet/scriptpubkeyman.h>
+
+#include <array>
+#include <map>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace wallet {
+
+class PQDescriptorScriptPubKeyMan final : public ScriptPubKeyMan
+{
+private:
+    using ScriptPubKeyMap = std::map<CScript, int32_t>;
+    using PkScriptMap = std::map<int32_t, std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>>;
+
+    mutable RecursiveMutex cs_pq_man;
+
+    uint256 m_id;
+    PQWalletDescriptor m_wallet_descriptor GUARDED_BY(cs_pq_man);
+    CKeyingMaterial m_root_seed GUARDED_BY(cs_pq_man);
+    std::vector<unsigned char> m_crypted_root_seed GUARDED_BY(cs_pq_man);
+    ScriptPubKeyMap m_map_script_pub_keys GUARDED_BY(cs_pq_man);
+    PkScriptMap m_map_pk_scripts GUARDED_BY(cs_pq_man);
+    int32_t m_max_cached_index GUARDED_BY(cs_pq_man){-1};
+    int64_t m_keypool_size GUARDED_BY(cs_pq_man){DEFAULT_KEYPOOL_SIZE};
+    bool m_decryption_thoroughly_checked GUARDED_BY(cs_pq_man){false};
+
+    bool GetRootSeed(CKeyingMaterial& root_seed) const EXCLUSIVE_LOCKS_REQUIRED(cs_pq_man);
+    static CScript MakeWitnessScript(const std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& pk_script);
+    static CScript MakeScriptPubKey(const std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& pk_script);
+    bool GetDestinationForIndex(int32_t index, CTxDestination& dest) const EXCLUSIVE_LOCKS_REQUIRED(cs_pq_man);
+    bool WriteMetadata(WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_pq_man);
+
+public:
+    PQDescriptorScriptPubKeyMan(WalletStorage& storage, uint256 id, const PQWalletDescriptor& descriptor, int64_t keypool_size);
+    PQDescriptorScriptPubKeyMan(WalletStorage& storage,
+                                uint256 id,
+                                const std::array<unsigned char, 32>& root_seed,
+                                bool internal,
+                                uint64_t creation_time,
+                                int32_t range_start,
+                                int32_t range_end,
+                                int32_t next_index,
+                                int64_t keypool_size);
+
+    static uint256 DeriveID(const std::array<unsigned char, 32>& root_seed, bool internal);
+
+    util::Result<CTxDestination> GetNewDestination(OutputType type) override;
+    util::Result<CTxDestination> GetReservedDestination(OutputType type, bool internal, int64_t& index) override;
+    void ReturnDestination(int64_t index, bool internal, const CTxDestination& addr) override;
+    bool TopUp(unsigned int size = 0) override;
+    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) override;
+    bool IsHDEnabled() const override { return true; }
+    bool CanGetAddresses(bool internal = false) const override;
+    bool HavePrivateKeys() const override;
+    bool HaveCryptedKeys() const override;
+    bool IsMine(const CScript& script) const override;
+    bool CheckDecryptionKey(const CKeyingMaterial& master_key) override;
+    bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch) override;
+    unsigned int GetKeyPoolSize() const override;
+    int64_t GetTimeFirstKey() const override;
+    std::unique_ptr<CKeyMetadata> GetMetadata(const CTxDestination& dest) const override;
+    std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const override;
+    bool IsSpendable(const CScript& script) const override { return false; }
+    bool CanProvide(const CScript& script, SignatureData& sigdata) override;
+    uint256 GetID() const override;
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override;
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const;
+
+    bool GetDescriptorString(std::string& out, bool priv) const;
+    PQWalletDescriptor GetWalletDescriptor() const;
+    bool IsInternal() const;
+    int32_t GetEndRange() const;
+
+    bool UpdateWalletDescriptor(const PQWalletDescriptor& descriptor);
+    bool LoadRootSeed(const std::vector<unsigned char>& root_seed);
+    bool LoadCryptedRootSeed(const std::vector<unsigned char>& crypted_root_seed);
+    bool LoadCachedPkScript(int32_t index, const std::vector<unsigned char>& pk_script);
+};
+
+} // namespace wallet
+
+#endif // BITCOIN_WALLET_PQ_SCRIPTPUBKEYMAN_H

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -114,6 +114,64 @@ RPCHelpMan getrawchangeaddress()
     };
 }
 
+RPCHelpMan getnewpqaddress()
+{
+    return RPCHelpMan{
+        "getnewpqaddress",
+        "Returns a new active PQ receive address.\n",
+                {
+                    {"label", RPCArg::Type::STR, RPCArg::Default{""}, "The label name for the address to be linked to."},
+                },
+                RPCResult{
+                    RPCResult::Type::STR, "address", "The new PQ receive address"
+                },
+                RPCExamples{
+                    HelpExampleCli("getnewpqaddress", "")
+            + HelpExampleRpc("getnewpqaddress", "")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!pwallet) return UniValue::VNULL;
+
+    const std::string label{LabelFromValue(request.params[0])};
+    auto op_dest = pwallet->GetNewPQDestination(label);
+    if (!op_dest) {
+        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
+    }
+    return EncodeDestination(*op_dest);
+},
+    };
+}
+
+RPCHelpMan getrawpqchangeaddress()
+{
+    return RPCHelpMan{
+        "getrawpqchangeaddress",
+        "Returns a new active PQ change address.\n"
+                "This is for use with raw transactions, NOT normal use.\n",
+                {},
+                RPCResult{
+                    RPCResult::Type::STR, "address", "The PQ change address"
+                },
+                RPCExamples{
+                    HelpExampleCli("getrawpqchangeaddress", "")
+            + HelpExampleRpc("getrawpqchangeaddress", "")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!pwallet) return UniValue::VNULL;
+
+    auto op_dest = pwallet->GetNewPQChangeDestination();
+    if (!op_dest) {
+        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
+    }
+    return EncodeDestination(*op_dest);
+},
+    };
+}
+
 
 RPCHelpMan setlabel()
 {

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -20,6 +20,7 @@
 #include <util/time.h>
 #include <util/translation.h>
 #include <wallet/rpc/util.h>
+#include <wallet/pq_scriptpubkeyman.h>
 #include <wallet/wallet.h>
 
 #include <cstdint>
@@ -216,6 +217,30 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
         // Combo descriptor check
         if (active && !parsed_descs.at(0)->IsSingleType()) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Combo descriptors cannot be set to active");
+        }
+
+        if (parsed_descs.size() == 1) {
+            if (const auto pq_info = GetPQPrivateDescriptorInfo(*parsed_descs.at(0))) {
+                if (internal.has_value() && internal.value() != pq_info->internal) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "internal must match the pqpriv() branch");
+                }
+
+                auto spk_manager_res = wallet.AddWalletPQDescriptor(*pq_info, timestamp, range_start, range_end, next_index);
+                if (!spk_manager_res) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Could not add descriptor '%s': %s", descriptor, util::ErrorString(spk_manager_res).original));
+                }
+
+                auto& spk_manager = spk_manager_res.value().get();
+                if (active) {
+                    wallet.AddActivePQScriptPubKeyMan(spk_manager.GetID(), pq_info->internal);
+                } else {
+                    wallet.DeactivateActivePQScriptPubKeyMan(spk_manager.GetID(), pq_info->internal);
+                }
+
+                result.pushKV("success", UniValue(true));
+                PushWarnings(warnings, result);
+                return result;
+            }
         }
 
         // If the wallet disabled private keys, abort if private keys exist
@@ -511,25 +536,44 @@ RPCHelpMan listdescriptors()
 
     std::vector<WalletDescInfo> wallet_descriptors;
     for (const auto& spk_man : wallet->GetAllScriptPubKeyMans()) {
-        const auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
-        if (!desc_spk_man) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Unexpected ScriptPubKey manager type.");
+        if (const auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
+            LOCK(desc_spk_man->cs_desc_man);
+            const auto& wallet_descriptor = desc_spk_man->GetWalletDescriptor();
+            std::string descriptor;
+            if (!desc_spk_man->GetDescriptorString(descriptor, priv)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Can't get descriptor string.");
+            }
+            const bool is_range = wallet_descriptor.descriptor->IsRange();
+            wallet_descriptors.push_back({
+                descriptor,
+                wallet_descriptor.creation_time,
+                active_spk_mans.count(desc_spk_man) != 0,
+                wallet->IsInternalScriptPubKeyMan(desc_spk_man),
+                is_range ? std::optional(std::make_pair(wallet_descriptor.range_start, wallet_descriptor.range_end)) : std::nullopt,
+                wallet_descriptor.next_index
+            });
+            continue;
         }
-        LOCK(desc_spk_man->cs_desc_man);
-        const auto& wallet_descriptor = desc_spk_man->GetWalletDescriptor();
-        std::string descriptor;
-        if (!desc_spk_man->GetDescriptorString(descriptor, priv)) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Can't get descriptor string.");
+        if (const auto pq_spk_man = dynamic_cast<PQDescriptorScriptPubKeyMan*>(spk_man)) {
+            if (!priv) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Public export for ranged pqpriv() descriptors is not available.");
+            }
+            std::string descriptor;
+            if (!pq_spk_man->GetDescriptorString(descriptor, /*priv=*/true)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Can't get PQ descriptor string.");
+            }
+            const auto wallet_descriptor = pq_spk_man->GetWalletDescriptor();
+            wallet_descriptors.push_back({
+                descriptor,
+                wallet_descriptor.creation_time,
+                active_spk_mans.count(pq_spk_man) != 0,
+                wallet->IsInternalScriptPubKeyMan(pq_spk_man),
+                std::optional(std::make_pair(wallet_descriptor.range_start, wallet_descriptor.range_end)),
+                wallet_descriptor.next_index
+            });
+            continue;
         }
-        const bool is_range = wallet_descriptor.descriptor->IsRange();
-        wallet_descriptors.push_back({
-            descriptor,
-            wallet_descriptor.creation_time,
-            active_spk_mans.count(desc_spk_man) != 0,
-            wallet->IsInternalScriptPubKeyMan(desc_spk_man),
-            is_range ? std::optional(std::make_pair(wallet_descriptor.range_start, wallet_descriptor.range_end)) : std::nullopt,
-            wallet_descriptor.next_index
-        });
+        throw JSONRPCError(RPC_WALLET_ERROR, "Unexpected ScriptPubKey manager type.");
     }
 
     std::sort(wallet_descriptors.begin(), wallet_descriptors.end(), [](const auto& a, const auto& b) {

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -699,7 +699,7 @@ RPCHelpMan gethdkeys()
             std::map<CExtPubKey, CExtKey> wallet_xprvs;
             for (auto* spkm : spkms) {
                 auto* desc_spkm{dynamic_cast<DescriptorScriptPubKeyMan*>(spkm)};
-                CHECK_NONFATAL(desc_spkm);
+                if (!desc_spkm) continue;
                 LOCK(desc_spkm->cs_desc_man);
                 WalletDescriptor w_desc = desc_spkm->GetWalletDescriptor();
 
@@ -847,7 +847,9 @@ static RPCHelpMan createwalletdescriptor()
 // addresses
 RPCHelpMan getaddressinfo();
 RPCHelpMan getnewaddress();
+RPCHelpMan getnewpqaddress();
 RPCHelpMan getrawchangeaddress();
+RPCHelpMan getrawpqchangeaddress();
 RPCHelpMan setlabel();
 RPCHelpMan listaddressgroupings();
 RPCHelpMan keypoolrefill();
@@ -924,7 +926,9 @@ std::span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &getbalance},
         {"wallet", &gethdkeys},
         {"wallet", &getnewaddress},
+        {"wallet", &getnewpqaddress},
         {"wallet", &getrawchangeaddress},
+        {"wallet", &getrawpqchangeaddress},
         {"wallet", &getreceivedbyaddress},
         {"wallet", &getreceivedbylabel},
         {"wallet", &gettransaction},

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -129,6 +129,7 @@ public:
     virtual std::unique_ptr<CKeyMetadata> GetMetadata(const CTxDestination& dest) const { return nullptr; }
 
     virtual std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const { return nullptr; }
+    virtual bool IsSpendable(const CScript& script) const { return IsMine(script); }
 
     /** Whether this ScriptPubKeyMan can provide a SigningProvider (via GetSolvingProvider) that, combined with
       * sigdata, can produce solving data.

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -446,6 +446,14 @@ CoinsResult AvailableCoins(const CWallet& wallet,
             continue;
         }
 
+        bool spendable = false;
+        for (const auto* spk_man : wallet.GetScriptPubKeyMans(output.scriptPubKey)) {
+            spendable |= spk_man->IsSpendable(output.scriptPubKey);
+        }
+        if (!spendable) {
+            continue;
+        }
+
         bool tx_from_me = CachedTxIsFromMe(wallet, wtx);
 
         std::unique_ptr<SigningProvider> provider = wallet.GetSolvingProvider(output.scriptPubKey);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -65,6 +65,7 @@
 #include <wallet/crypter.h>
 #include <wallet/db.h>
 #include <wallet/external_signer_scriptpubkeyman.h>
+#include <wallet/pq_scriptpubkeyman.h>
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/transaction.h>
 #include <wallet/types.h>
@@ -311,12 +312,18 @@ public:
     {
         // create initial filter with scripts from all ScriptPubKeyMans
         for (auto spkm : m_wallet.GetAllScriptPubKeyMans()) {
-            auto desc_spkm{dynamic_cast<DescriptorScriptPubKeyMan*>(spkm)};
-            assert(desc_spkm != nullptr);
-            AddScriptPubKeys(desc_spkm);
-            // save each range descriptor's end for possible future filter updates
-            if (desc_spkm->IsHDEnabled()) {
-                m_last_range_ends.emplace(desc_spkm->GetID(), desc_spkm->GetEndRange());
+            if (auto* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm)) {
+                AddScriptPubKeys(desc_spkm);
+                if (desc_spkm->IsHDEnabled()) {
+                    m_last_range_ends.emplace(desc_spkm->GetID(), desc_spkm->GetEndRange());
+                }
+            } else if (auto* pq_spkm = dynamic_cast<PQDescriptorScriptPubKeyMan*>(spkm)) {
+                AddScriptPubKeys(*pq_spkm);
+                m_last_range_ends.emplace(pq_spkm->GetID(), pq_spkm->GetEndRange());
+            } else {
+                for (const auto& script_pub_key : spkm->GetScriptPubKeys()) {
+                    m_filter_set.emplace(script_pub_key.begin(), script_pub_key.end());
+                }
             }
         }
     }
@@ -325,12 +332,19 @@ public:
     {
         // repopulate filter with new scripts if top-up has happened since last iteration
         for (const auto& [desc_spkm_id, last_range_end] : m_last_range_ends) {
-            auto desc_spkm{dynamic_cast<DescriptorScriptPubKeyMan*>(m_wallet.GetScriptPubKeyMan(desc_spkm_id))};
-            assert(desc_spkm != nullptr);
-            int32_t current_range_end{desc_spkm->GetEndRange()};
-            if (current_range_end > last_range_end) {
-                AddScriptPubKeys(desc_spkm, last_range_end);
-                m_last_range_ends.at(desc_spkm->GetID()) = current_range_end;
+            auto* spkm = m_wallet.GetScriptPubKeyMan(desc_spkm_id);
+            if (auto* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm)) {
+                int32_t current_range_end{desc_spkm->GetEndRange()};
+                if (current_range_end > last_range_end) {
+                    AddScriptPubKeys(desc_spkm, last_range_end);
+                    m_last_range_ends.at(desc_spkm->GetID()) = current_range_end;
+                }
+            } else if (auto* pq_spkm = dynamic_cast<PQDescriptorScriptPubKeyMan*>(spkm)) {
+                int32_t current_range_end{pq_spkm->GetEndRange()};
+                if (current_range_end > last_range_end) {
+                    AddScriptPubKeys(*pq_spkm, last_range_end);
+                    m_last_range_ends.at(pq_spkm->GetID()) = current_range_end;
+                }
             }
         }
     }
@@ -354,6 +368,13 @@ private:
     void AddScriptPubKeys(const DescriptorScriptPubKeyMan* desc_spkm, int32_t last_range_end = 0)
     {
         for (const auto& script_pub_key : desc_spkm->GetScriptPubKeys(last_range_end)) {
+            m_filter_set.emplace(script_pub_key.begin(), script_pub_key.end());
+        }
+    }
+
+    void AddScriptPubKeys(const PQDescriptorScriptPubKeyMan& pq_spkm, int32_t last_range_end = 0)
+    {
+        for (const auto& script_pub_key : pq_spkm.GetScriptPubKeys(last_range_end)) {
             m_filter_set.emplace(script_pub_key.begin(), script_pub_key.end());
         }
     }
@@ -552,8 +573,9 @@ void CWallet::UpgradeDescriptorCache()
     }
 
     for (ScriptPubKeyMan* spkm : GetAllScriptPubKeyMans()) {
-        DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
-        desc_spkm->UpgradeDescriptorCache();
+        if (auto* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm)) {
+            desc_spkm->UpgradeDescriptorCache();
+        }
     }
     SetWalletFlag(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED);
 }
@@ -2494,6 +2516,9 @@ size_t CWallet::KeypoolCountExternalKeys() const
     for (auto spk_man : m_external_spk_managers) {
         count += spk_man.second->GetKeyPoolSize();
     }
+    if (m_external_pq_spk_manager) {
+        count += m_external_pq_spk_manager->GetKeyPoolSize();
+    }
 
     return count;
 }
@@ -2544,6 +2569,30 @@ util::Result<CTxDestination> CWallet::GetNewChangeDestination(const OutputType t
     if (op_dest) reservedest.KeepDestination();
 
     return op_dest;
+}
+
+util::Result<CTxDestination> CWallet::GetNewPQDestination(const std::string& label)
+{
+    LOCK(cs_wallet);
+    auto* pq_spk_man = dynamic_cast<PQDescriptorScriptPubKeyMan*>(m_external_pq_spk_manager);
+    if (!pq_spk_man) {
+        return util::Error{_("Error: No active PQ receiving descriptor is available.")};
+    }
+    auto op_dest = pq_spk_man->GetNewDestination(OutputType::BECH32);
+    if (op_dest) {
+        SetAddressBook(*op_dest, label, AddressPurpose::RECEIVE);
+    }
+    return op_dest;
+}
+
+util::Result<CTxDestination> CWallet::GetNewPQChangeDestination()
+{
+    LOCK(cs_wallet);
+    auto* pq_spk_man = dynamic_cast<PQDescriptorScriptPubKeyMan*>(m_internal_pq_spk_manager);
+    if (!pq_spk_man) {
+        return util::Error{_("Error: No active PQ change descriptor is available.")};
+    }
+    return pq_spk_man->GetNewDestination(OutputType::BECH32);
 }
 
 void CWallet::MarkDestinationsDirty(const std::set<CTxDestination>& destinations) {
@@ -3365,6 +3414,8 @@ std::set<ScriptPubKeyMan*> CWallet::GetActiveScriptPubKeyMans() const
             }
         }
     }
+    if (m_external_pq_spk_manager) spk_mans.insert(m_external_pq_spk_manager);
+    if (m_internal_pq_spk_manager) spk_mans.insert(m_internal_pq_spk_manager);
     return spk_mans;
 }
 
@@ -3376,6 +3427,7 @@ bool CWallet::IsActiveScriptPubKeyMan(const ScriptPubKeyMan& spkm) const
     for (const auto& [_, int_spkm] : m_internal_spk_managers) {
         if (int_spkm == &spkm) return true;
     }
+    if (m_external_pq_spk_manager == &spkm || m_internal_pq_spk_manager == &spkm) return true;
     return false;
 }
 
@@ -3534,6 +3586,35 @@ DescriptorScriptPubKeyMan& CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, Wa
     return *spk_manager;
 }
 
+PQDescriptorScriptPubKeyMan& CWallet::LoadPQDescriptorScriptPubKeyMan(uint256 id, PQWalletDescriptor& desc)
+{
+    auto spk_manager = std::make_unique<PQDescriptorScriptPubKeyMan>(*this, id, desc, m_keypool_size);
+    auto* out = spk_manager.get();
+    AddScriptPubKeyMan(id, std::move(spk_manager));
+    return *out;
+}
+
+bool CWallet::LoadPQDescriptorRootSeed(uint256 id, const std::vector<unsigned char>& root_seed) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+{
+    AssertLockHeld(cs_wallet);
+    auto* spk_man = dynamic_cast<PQDescriptorScriptPubKeyMan*>(GetScriptPubKeyMan(id));
+    return spk_man != nullptr && spk_man->LoadRootSeed(root_seed);
+}
+
+bool CWallet::LoadCryptedPQDescriptorRootSeed(uint256 id, const std::vector<unsigned char>& crypted_root_seed) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+{
+    AssertLockHeld(cs_wallet);
+    auto* spk_man = dynamic_cast<PQDescriptorScriptPubKeyMan*>(GetScriptPubKeyMan(id));
+    return spk_man != nullptr && spk_man->LoadCryptedRootSeed(crypted_root_seed);
+}
+
+bool CWallet::LoadPQDescriptorCacheEntry(uint256 id, const int32_t index, const std::vector<unsigned char>& pk_script) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+{
+    AssertLockHeld(cs_wallet);
+    auto* spk_man = dynamic_cast<PQDescriptorScriptPubKeyMan*>(GetScriptPubKeyMan(id));
+    return spk_man != nullptr && spk_man->LoadCachedPkScript(index, pk_script);
+}
+
 DescriptorScriptPubKeyMan& CWallet::SetupDescriptorScriptPubKeyMan(WalletBatch& batch, const CExtKey& master_key, const OutputType& output_type, bool internal)
 {
     AssertLockHeld(cs_wallet);
@@ -3637,6 +3718,15 @@ void CWallet::AddActiveScriptPubKeyMan(uint256 id, OutputType type, bool interna
     return AddActiveScriptPubKeyManWithDb(batch, id, type, internal);
 }
 
+void CWallet::AddActivePQScriptPubKeyMan(uint256 id, bool internal)
+{
+    WalletBatch batch(GetDatabase());
+    if (!batch.WriteActivePQScriptPubKeyMan(id, internal)) {
+        throw std::runtime_error(std::string(__func__) + ": writing active PQ ScriptPubKeyMan id failed");
+    }
+    LoadActivePQScriptPubKeyMan(id, internal);
+}
+
 void CWallet::AddActiveScriptPubKeyManWithDb(WalletBatch& batch, uint256 id, OutputType type, bool internal)
 {
     if (!batch.WriteActiveScriptPubKeyMan(static_cast<uint8_t>(type), id, internal)) {
@@ -3665,6 +3755,21 @@ void CWallet::LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool intern
     NotifyCanGetAddressesChanged();
 }
 
+void CWallet::LoadActivePQScriptPubKeyMan(uint256 id, bool internal)
+{
+    Assert(IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
+
+    WalletLogPrintf("Setting PQ spkMan to active: id = %s, internal = %s\n", id.ToString(), internal ? "true" : "false");
+    auto* spk_man = m_spk_managers.at(id).get();
+    if (internal) {
+        m_internal_pq_spk_manager = spk_man;
+    } else {
+        m_external_pq_spk_manager = spk_man;
+    }
+
+    NotifyCanGetAddressesChanged();
+}
+
 void CWallet::DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool internal)
 {
     auto spk_man = GetScriptPubKeyMan(type, internal);
@@ -3679,6 +3784,20 @@ void CWallet::DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool intern
         spk_mans.erase(type);
     }
 
+    NotifyCanGetAddressesChanged();
+}
+
+void CWallet::DeactivateActivePQScriptPubKeyMan(uint256 id, bool internal)
+{
+    auto*& spk_man = internal ? m_internal_pq_spk_manager : m_external_pq_spk_manager;
+    if (spk_man != nullptr && spk_man->GetID() == id) {
+        WalletLogPrintf("Deactivate PQ spkMan: id = %s, internal = %s\n", id.ToString(), internal ? "true" : "false");
+        WalletBatch batch(GetDatabase());
+        if (!batch.EraseActivePQScriptPubKeyMan(internal)) {
+            throw std::runtime_error(std::string(__func__) + ": erasing active PQ ScriptPubKeyMan id failed");
+        }
+        spk_man = nullptr;
+    }
     NotifyCanGetAddressesChanged();
 }
 
@@ -3705,15 +3824,16 @@ std::optional<bool> CWallet::IsInternalScriptPubKeyMan(ScriptPubKeyMan* spk_man)
     }
 
     const auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
-    if (!desc_spk_man) {
-        throw std::runtime_error(std::string(__func__) + ": unexpected ScriptPubKeyMan type.");
+    if (desc_spk_man) {
+        LOCK(desc_spk_man->cs_desc_man);
+        const auto& type = desc_spk_man->GetWalletDescriptor().descriptor->GetOutputType();
+        assert(type.has_value());
+
+        return GetScriptPubKeyMan(*type, /* internal= */ true) == desc_spk_man;
     }
-
-    LOCK(desc_spk_man->cs_desc_man);
-    const auto& type = desc_spk_man->GetWalletDescriptor().descriptor->GetOutputType();
-    assert(type.has_value());
-
-    return GetScriptPubKeyMan(*type, /* internal= */ true) == desc_spk_man;
+    if (spk_man == m_internal_pq_spk_manager) return true;
+    if (spk_man == m_external_pq_spk_manager) return false;
+    throw std::runtime_error(std::string(__func__) + ": unexpected ScriptPubKeyMan type.");
 }
 
 util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWalletDescriptor(WalletDescriptor& desc, const FlatSigningProvider& signing_provider, const std::string& label, bool internal)
@@ -3774,6 +3894,52 @@ util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWall
     // Break balance caches so that outputs that are now IsMine in already known txs will be included in the balance
     MarkDirty();
 
+    return std::reference_wrapper(*spk_man);
+}
+
+util::Result<std::reference_wrapper<PQDescriptorScriptPubKeyMan>> CWallet::AddWalletPQDescriptor(const PQPrivateDescriptorInfo& info, const uint64_t creation_time, const int32_t range_start, const int32_t range_end, const int32_t next_index)
+{
+    AssertLockHeld(cs_wallet);
+
+    if (!IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+        return util::Error{_("Cannot add PQ descriptors to a non-descriptor wallet")};
+    }
+    if (IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+        return util::Error{_("Cannot import pqpriv() to a wallet with private keys disabled")};
+    }
+
+    const uint256 id = PQDescriptorScriptPubKeyMan::DeriveID(info.root_seed, info.internal);
+    PQWalletDescriptor descriptor{creation_time, range_start, range_end, next_index, static_cast<uint8_t>(info.internal ? 1 : 0)};
+
+    PQDescriptorScriptPubKeyMan* spk_man = nullptr;
+    if (auto* existing = GetScriptPubKeyMan(id)) {
+        spk_man = dynamic_cast<PQDescriptorScriptPubKeyMan*>(existing);
+        if (!spk_man) {
+            return util::Error{_("ScriptPubKey manager id collision for pqpriv() descriptor")};
+        }
+        if (!spk_man->UpdateWalletDescriptor(descriptor)) {
+            return util::Error{_("Could not update PQ descriptor state")};
+        }
+    } else {
+        auto new_spk_man = std::make_unique<PQDescriptorScriptPubKeyMan>(*this, id, info.root_seed, info.internal, creation_time, range_start, range_end, next_index, m_keypool_size);
+        if (IsCrypted()) {
+            if (IsLocked()) {
+                return util::Error{_("Cannot import pqpriv() into a locked encrypted wallet")};
+            }
+            WalletBatch batch(GetDatabase());
+            if (!new_spk_man->Encrypt(vMasterKey, &batch)) {
+                return util::Error{_("Could not encrypt pqpriv() root seed")};
+            }
+        }
+        spk_man = new_spk_man.get();
+        AddScriptPubKeyMan(id, std::move(new_spk_man));
+    }
+
+    if (!spk_man->TopUp()) {
+        return util::Error{_("Could not top up PQ scriptPubKeys")};
+    }
+
+    MarkDirty();
     return std::reference_wrapper(*spk_man);
 }
 
@@ -4469,7 +4635,7 @@ std::set<CExtPubKey> CWallet::GetActiveHDPubKeys() const
     std::set<CExtPubKey> active_xpubs;
     for (const auto& spkm : GetActiveScriptPubKeyMans()) {
         const DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
-        assert(desc_spkm);
+        if (!desc_spkm) continue;
         LOCK(desc_spkm->cs_desc_man);
         WalletDescriptor w_desc = desc_spkm->GetWalletDescriptor();
 
@@ -4487,7 +4653,7 @@ std::optional<CKey> CWallet::GetKey(const CKeyID& keyid) const
 
     for (const auto& spkm : GetAllScriptPubKeyMans()) {
         const DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
-        assert(desc_spkm);
+        if (!desc_spkm) continue;
         LOCK(desc_spkm->cs_desc_man);
         if (std::optional<CKey> key = desc_spkm->GetKey(keyid)) {
             return key;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -67,6 +67,7 @@ class Wallet;
 }
 namespace wallet {
 class CWallet;
+class PQDescriptorScriptPubKeyMan;
 class WalletBatch;
 enum class DBErrors : int;
 } // namespace wallet
@@ -417,6 +418,8 @@ private:
 
     std::map<OutputType, ScriptPubKeyMan*> m_external_spk_managers;
     std::map<OutputType, ScriptPubKeyMan*> m_internal_spk_managers;
+    ScriptPubKeyMan* m_external_pq_spk_manager{nullptr};
+    ScriptPubKeyMan* m_internal_pq_spk_manager{nullptr};
 
     // Indexed by a unique identifier produced by each ScriptPubKeyMan using
     // ScriptPubKeyMan::GetID. In many cases it will be the hash of an internal structure
@@ -785,6 +788,8 @@ public:
 
     util::Result<CTxDestination> GetNewDestination(const OutputType type, const std::string label);
     util::Result<CTxDestination> GetNewChangeDestination(const OutputType type);
+    util::Result<CTxDestination> GetNewPQDestination(const std::string& label);
+    util::Result<CTxDestination> GetNewPQChangeDestination();
 
     bool IsMine(const CTxDestination& dest) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool IsMine(const CScript& script) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -995,24 +1000,31 @@ public:
 
     //! Instantiate a descriptor ScriptPubKeyMan from the WalletDescriptor and load it
     DescriptorScriptPubKeyMan& LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc);
+    PQDescriptorScriptPubKeyMan& LoadPQDescriptorScriptPubKeyMan(uint256 id, PQWalletDescriptor& desc);
+    bool LoadPQDescriptorRootSeed(uint256 id, const std::vector<unsigned char>& root_seed);
+    bool LoadCryptedPQDescriptorRootSeed(uint256 id, const std::vector<unsigned char>& crypted_root_seed);
+    bool LoadPQDescriptorCacheEntry(uint256 id, int32_t index, const std::vector<unsigned char>& pk_script);
 
     //! Adds the active ScriptPubKeyMan for the specified type and internal. Writes it to the wallet file
     //! @param[in] id The unique id for the ScriptPubKeyMan
     //! @param[in] type The OutputType this ScriptPubKeyMan provides addresses for
     //! @param[in] internal Whether this ScriptPubKeyMan provides change addresses
     void AddActiveScriptPubKeyMan(uint256 id, OutputType type, bool internal);
+    void AddActivePQScriptPubKeyMan(uint256 id, bool internal);
 
     //! Loads an active ScriptPubKeyMan for the specified type and internal. (used by LoadWallet)
     //! @param[in] id The unique id for the ScriptPubKeyMan
     //! @param[in] type The OutputType this ScriptPubKeyMan provides addresses for
     //! @param[in] internal Whether this ScriptPubKeyMan provides change addresses
     void LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool internal);
+    void LoadActivePQScriptPubKeyMan(uint256 id, bool internal);
 
     //! Remove specified ScriptPubKeyMan from set of active SPK managers. Writes the change to the wallet file.
     //! @param[in] id The unique id for the ScriptPubKeyMan
     //! @param[in] type The OutputType this ScriptPubKeyMan provides addresses for
     //! @param[in] internal Whether this ScriptPubKeyMan provides change addresses
     void DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool internal);
+    void DeactivateActivePQScriptPubKeyMan(uint256 id, bool internal);
 
     //! Create new DescriptorScriptPubKeyMan and add it to the wallet
     DescriptorScriptPubKeyMan& SetupDescriptorScriptPubKeyMan(WalletBatch& batch, const CExtKey& master_key, const OutputType& output_type, bool internal) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -1033,6 +1045,7 @@ public:
 
     //! Add a descriptor to the wallet, return a ScriptPubKeyMan & associated output type
     util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> AddWalletDescriptor(WalletDescriptor& desc, const FlatSigningProvider& signing_provider, const std::string& label, bool internal) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    util::Result<std::reference_wrapper<PQDescriptorScriptPubKeyMan>> AddWalletPQDescriptor(const PQPrivateDescriptorInfo& info, uint64_t creation_time, int32_t range_start, int32_t range_end, int32_t next_index) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Move all records from the BDB database to a new SQLite database for storage.
      * The original BDB file will be deleted and replaced with a new SQLite file.

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -25,13 +25,16 @@
 
 #include <atomic>
 #include <optional>
+#include <set>
 #include <string>
 
 namespace wallet {
 namespace DBKeys {
 const std::string ACENTRY{"acentry"};
 const std::string ACTIVEEXTERNALSPK{"activeexternalspk"};
+const std::string ACTIVEEXTERNALPQSPK{"activeexternalpqspk"};
 const std::string ACTIVEINTERNALSPK{"activeinternalspk"};
+const std::string ACTIVEINTERNALPQSPK{"activeinternalpqspk"};
 const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
 const std::string BESTBLOCK{"bestblock"};
 const std::string CRYPTED_KEY{"ckey"};
@@ -58,6 +61,10 @@ const std::string WALLETDESCRIPTORCACHE{"walletdescriptorcache"};
 const std::string WALLETDESCRIPTORLHCACHE{"walletdescriptorlhcache"};
 const std::string WALLETDESCRIPTORCKEY{"walletdescriptorckey"};
 const std::string WALLETDESCRIPTORKEY{"walletdescriptorkey"};
+const std::string PQWALLETDESCRIPTOR{"pqwalletdescriptor"};
+const std::string PQWALLETDESCRIPTORCACHE{"pqwalletdescriptorcache"};
+const std::string PQWALLETDESCRIPTORCKEY{"pqwalletdescriptorckey"};
+const std::string PQWALLETDESCRIPTORKEY{"pqwalletdescriptorkey"};
 const std::string WATCHMETA{"watchmeta"};
 const std::string WATCHS{"watchs"};
 const std::unordered_set<std::string> LEGACY_TYPES{CRYPTED_KEY, CSCRIPT, DEFAULTKEY, HDCHAIN, KEYMETA, KEY, OLD_KEY, POOL, WATCHMETA, WATCHS};
@@ -211,6 +218,18 @@ bool WalletBatch::EraseActiveScriptPubKeyMan(uint8_t type, bool internal)
     return EraseIC(make_pair(key, type));
 }
 
+bool WalletBatch::WriteActivePQScriptPubKeyMan(const uint256& id, bool internal)
+{
+    const std::string key{internal ? DBKeys::ACTIVEINTERNALPQSPK : DBKeys::ACTIVEEXTERNALPQSPK};
+    return WriteIC(key, id);
+}
+
+bool WalletBatch::EraseActivePQScriptPubKeyMan(bool internal)
+{
+    const std::string key{internal ? DBKeys::ACTIVEINTERNALPQSPK : DBKeys::ACTIVEEXTERNALPQSPK};
+    return EraseIC(key);
+}
+
 bool WalletBatch::WriteDescriptorKey(const uint256& desc_id, const CPubKey& pubkey, const CPrivKey& privkey)
 {
     // hash pubkey/privkey to accelerate wallet load
@@ -234,6 +253,34 @@ bool WalletBatch::WriteCryptedDescriptorKey(const uint256& desc_id, const CPubKe
 bool WalletBatch::WriteDescriptor(const uint256& desc_id, const WalletDescriptor& descriptor)
 {
     return WriteIC(make_pair(DBKeys::WALLETDESCRIPTOR, desc_id), descriptor);
+}
+
+bool WalletBatch::WritePQDescriptor(const uint256& desc_id, const PQWalletDescriptor& descriptor)
+{
+    return WriteIC(make_pair(DBKeys::PQWALLETDESCRIPTOR, desc_id), descriptor);
+}
+
+bool WalletBatch::WritePQDescriptorSeed(const uint256& desc_id, const std::vector<unsigned char>& root_seed)
+{
+    if (!WriteIC(std::make_pair(DBKeys::PQWALLETDESCRIPTORKEY, desc_id), root_seed)) {
+        return false;
+    }
+    EraseIC(std::make_pair(DBKeys::PQWALLETDESCRIPTORCKEY, desc_id));
+    return true;
+}
+
+bool WalletBatch::WriteCryptedPQDescriptorSeed(const uint256& desc_id, const std::vector<unsigned char>& crypted_root_seed)
+{
+    if (!WriteIC(std::make_pair(DBKeys::PQWALLETDESCRIPTORCKEY, desc_id), crypted_root_seed)) {
+        return false;
+    }
+    EraseIC(std::make_pair(DBKeys::PQWALLETDESCRIPTORKEY, desc_id));
+    return true;
+}
+
+bool WalletBatch::WritePQDescriptorCache(const uint256& desc_id, int32_t index, const std::vector<unsigned char>& pk_script)
+{
+    return WriteIC(std::make_pair(std::make_pair(DBKeys::PQWALLETDESCRIPTORCACHE, desc_id), index), pk_script);
 }
 
 bool WalletBatch::WriteDescriptorDerivedCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index, uint32_t der_index)
@@ -926,6 +973,85 @@ static DBErrors LoadDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& bat
     return desc_res.m_result;
 }
 
+static DBErrors LoadPQDescriptorWalletRecords(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+{
+    AssertLockHeld(pwallet->cs_wallet);
+
+    LoadResult desc_res = LoadRecords(pwallet, batch, DBKeys::PQWALLETDESCRIPTOR,
+        [&batch] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& strErr) {
+        DBErrors result = DBErrors::LOAD_OK;
+
+        uint256 id;
+        key >> id;
+        PQWalletDescriptor desc;
+        value >> desc;
+
+        pwallet->LoadPQDescriptorScriptPubKeyMan(id, desc);
+
+        DataStream prefix = PrefixStream(DBKeys::PQWALLETDESCRIPTORCACHE, id);
+        LoadResult cache_res = LoadRecords(pwallet, batch, DBKeys::PQWALLETDESCRIPTORCACHE, prefix,
+            [&id] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) {
+            uint256 desc_id;
+            int32_t index;
+            key >> desc_id;
+            assert(desc_id == id);
+            key >> index;
+            std::vector<unsigned char> pk_script;
+            value >> pk_script;
+            if (!pwallet->LoadPQDescriptorCacheEntry(id, index, pk_script)) {
+                err = "Error reading wallet database: invalid PQ descriptor cache entry";
+                return DBErrors::CORRUPT;
+            }
+            return DBErrors::LOAD_OK;
+        });
+        result = std::max(result, cache_res.m_result);
+
+        prefix = PrefixStream(DBKeys::PQWALLETDESCRIPTORKEY, id);
+        LoadResult seed_res = LoadRecords(pwallet, batch, DBKeys::PQWALLETDESCRIPTORKEY, prefix,
+            [&id] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) {
+            uint256 desc_id;
+            key >> desc_id;
+            assert(desc_id == id);
+            std::vector<unsigned char> root_seed;
+            value >> root_seed;
+            if (!pwallet->LoadPQDescriptorRootSeed(id, root_seed)) {
+                err = "Error reading wallet database: invalid PQ descriptor root seed";
+                return DBErrors::CORRUPT;
+            }
+            return DBErrors::LOAD_OK;
+        });
+        result = std::max(result, seed_res.m_result);
+
+        prefix = PrefixStream(DBKeys::PQWALLETDESCRIPTORCKEY, id);
+        LoadResult cseed_res = LoadRecords(pwallet, batch, DBKeys::PQWALLETDESCRIPTORCKEY, prefix,
+            [&id] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) {
+            uint256 desc_id;
+            key >> desc_id;
+            assert(desc_id == id);
+            std::vector<unsigned char> crypted_root_seed;
+            value >> crypted_root_seed;
+            if (!pwallet->LoadCryptedPQDescriptorRootSeed(id, crypted_root_seed)) {
+                err = "Error reading wallet database: invalid encrypted PQ descriptor root seed";
+                return DBErrors::CORRUPT;
+            }
+            return DBErrors::LOAD_OK;
+        });
+        result = std::max(result, cseed_res.m_result);
+
+        ScriptPubKeyMan* spk_man = pwallet->GetScriptPubKeyMan(id);
+        if (spk_man == nullptr) {
+            strErr = "Error reading wallet database: missing PQ scriptpubkey manager";
+            return DBErrors::CORRUPT;
+        }
+        std::set<CScript> cached_spks;
+        for (const auto& spk : spk_man->GetScriptPubKeys()) cached_spks.insert(spk);
+        pwallet->CacheNewScriptPubKeys(cached_spks, spk_man);
+        return result;
+    });
+
+    return desc_res.m_result;
+}
+
 static DBErrors LoadAddressBookRecords(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
@@ -1091,6 +1217,25 @@ static DBErrors LoadActiveSPKMs(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIV
     return result;
 }
 
+static DBErrors LoadActivePQSPKMs(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+{
+    AssertLockHeld(pwallet->cs_wallet);
+    DBErrors result = DBErrors::LOAD_OK;
+
+    for (const auto& spk_key : {DBKeys::ACTIVEEXTERNALPQSPK, DBKeys::ACTIVEINTERNALPQSPK}) {
+        LoadResult spkm_res = LoadRecords(pwallet, batch, spk_key,
+            [&spk_key] (CWallet* pwallet, DataStream&, DataStream& value, std::string&) {
+            uint256 id;
+            value >> id;
+            const bool internal = spk_key == DBKeys::ACTIVEINTERNALPQSPK;
+            pwallet->LoadActivePQScriptPubKeyMan(id, internal);
+            return DBErrors::LOAD_OK;
+        });
+        result = std::max(result, spkm_res.m_result);
+    }
+    return result;
+}
+
 static DBErrors LoadDecryptionKeys(CWallet* pwallet, DatabaseBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
@@ -1135,6 +1280,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
         // Load descriptors
         result = std::max(LoadDescriptorWalletRecords(pwallet, *m_batch, last_client), result);
+        result = std::max(LoadPQDescriptorWalletRecords(pwallet, *m_batch), result);
         // Early return if there are unknown descriptors. Later loading of ACTIVEINTERNALSPK and ACTIVEEXTERNALEXPK
         // may reference the unknown descriptor's ID which can result in a misleading corruption error
         // when in reality the wallet is simply too new.
@@ -1145,6 +1291,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
         // Load SPKMs
         result = std::max(LoadActiveSPKMs(pwallet, *m_batch), result);
+        result = std::max(LoadActivePQSPKMs(pwallet, *m_batch), result);
 
         // Load decryption keys
         result = std::max(LoadDecryptionKeys(pwallet, *m_batch), result);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -55,7 +55,9 @@ enum class DBErrors : int
 namespace DBKeys {
 extern const std::string ACENTRY;
 extern const std::string ACTIVEEXTERNALSPK;
+extern const std::string ACTIVEEXTERNALPQSPK;
 extern const std::string ACTIVEINTERNALSPK;
+extern const std::string ACTIVEINTERNALPQSPK;
 extern const std::string BESTBLOCK;
 extern const std::string BESTBLOCK_NOMERKLE;
 extern const std::string CRYPTED_KEY;
@@ -80,6 +82,10 @@ extern const std::string VERSION;
 extern const std::string WALLETDESCRIPTOR;
 extern const std::string WALLETDESCRIPTORCKEY;
 extern const std::string WALLETDESCRIPTORKEY;
+extern const std::string PQWALLETDESCRIPTOR;
+extern const std::string PQWALLETDESCRIPTORCACHE;
+extern const std::string PQWALLETDESCRIPTORCKEY;
+extern const std::string PQWALLETDESCRIPTORKEY;
 extern const std::string WATCHMETA;
 extern const std::string WATCHS;
 
@@ -244,6 +250,10 @@ public:
     bool WriteDescriptorKey(const uint256& desc_id, const CPubKey& pubkey, const CPrivKey& privkey);
     bool WriteCryptedDescriptorKey(const uint256& desc_id, const CPubKey& pubkey, const std::vector<unsigned char>& secret);
     bool WriteDescriptor(const uint256& desc_id, const WalletDescriptor& descriptor);
+    bool WritePQDescriptor(const uint256& desc_id, const PQWalletDescriptor& descriptor);
+    bool WritePQDescriptorSeed(const uint256& desc_id, const std::vector<unsigned char>& root_seed);
+    bool WriteCryptedPQDescriptorSeed(const uint256& desc_id, const std::vector<unsigned char>& crypted_root_seed);
+    bool WritePQDescriptorCache(const uint256& desc_id, int32_t index, const std::vector<unsigned char>& pk_script);
     bool WriteDescriptorDerivedCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index, uint32_t der_index);
     bool WriteDescriptorParentCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index);
     bool WriteDescriptorLastHardenedCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index);
@@ -259,6 +269,8 @@ public:
 
     bool WriteActiveScriptPubKeyMan(uint8_t type, const uint256& id, bool internal);
     bool EraseActiveScriptPubKeyMan(uint8_t type, bool internal);
+    bool WriteActivePQScriptPubKeyMan(const uint256& id, bool internal);
+    bool EraseActivePQScriptPubKeyMan(bool internal);
 
     DBErrors LoadWallet(CWallet* pwallet);
 

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -8,6 +8,7 @@
 #include <script/descriptor.h>
 #include <util/fs.h>
 
+#include <array>
 #include <vector>
 
 namespace wallet {
@@ -96,6 +97,23 @@ public:
 
     WalletDescriptor() = default;
     WalletDescriptor(std::shared_ptr<Descriptor> descriptor, uint64_t creation_time, int32_t range_start, int32_t range_end, int32_t next_index) : descriptor(descriptor), id(DescriptorID(*descriptor)), creation_time(creation_time), range_start(range_start), range_end(range_end), next_index(next_index) { }
+};
+
+class PQWalletDescriptor
+{
+public:
+    uint64_t creation_time{0};
+    int32_t range_start{0};
+    int32_t range_end{0};
+    int32_t next_index{0};
+    uint8_t branch{0};
+
+    SERIALIZE_METHODS(PQWalletDescriptor, obj)
+    {
+        READWRITE(obj.creation_time, obj.range_start, obj.range_end, obj.next_index, obj.branch);
+    }
+
+    bool IsInternal() const { return branch == 1; }
 };
 
 WalletDescriptor GenerateWalletDescriptor(const CExtPubKey& master_key, const OutputType& output_type, bool internal);

--- a/test/functional/test_framework/pq_wallet_helper.py
+++ b/test/functional/test_framework/pq_wallet_helper.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import hashlib
+import hmac
 
 from test_framework.address import script_to_p2wsh
 from test_framework.descriptors import descsum_create
@@ -49,6 +50,12 @@ def _derive_test_seed(root_seed: bytes, internal: bool, index: int) -> bytes:
     ).digest()
 
 
+def _derive_wallet_seed(root_seed: bytes, internal: bool, index: int) -> bytes:
+    prk = hmac.new(b"PQSIG-WALLET-ROOT-v1", root_seed, hashlib.sha256).digest()
+    info = f"branch={1 if internal else 0};index={index}".encode()
+    return hmac.new(prk, info + b"\x01", hashlib.sha256).digest()
+
+
 def _build_entry(root_seed: bytes, internal: bool, index: int, label_prefix: str) -> PQDescriptorEntry:
     sk_seed = _derive_test_seed(root_seed, internal, index)
     _, pk_script = build_pq_keypair(sk_seed)
@@ -83,3 +90,44 @@ def build_bounded_pq_descriptor_batch(
     ]
     return external_entries, internal_entries
 
+
+def make_pqpriv_descriptor(root_seed: bytes, internal: bool) -> str:
+    return descsum_create(f"pqpriv({root_seed.hex()}/{1 if internal else 0}/*)")
+
+
+def make_pqpriv_import_request(
+    root_seed: bytes,
+    *,
+    internal: bool,
+    active: bool,
+    timestamp: int | str,
+    range_end: int,
+    next_index: int = 0,
+) -> dict[str, object]:
+    request: dict[str, object] = {
+        "desc": make_pqpriv_descriptor(root_seed, internal),
+        "active": active,
+        "timestamp": timestamp,
+        "range": [0, range_end],
+        "next_index": next_index,
+    }
+    if internal:
+        request["internal"] = True
+    return request
+
+
+def build_active_pq_descriptor_entry(root_seed: bytes, *, internal: bool, index: int, label: str | None = None) -> PQDescriptorEntry:
+    sk_seed = _derive_wallet_seed(root_seed, internal, index)
+    _, pk_script = build_pq_keypair(sk_seed)
+    witness_script = CScript([pk_script, OP_CHECKSIG])
+    return PQDescriptorEntry(
+        index=index,
+        internal=internal,
+        sk_seed=sk_seed,
+        pk_script=pk_script,
+        witness_script=witness_script,
+        script_pub_key=script_to_p2wsh_script(witness_script),
+        address=script_to_p2wsh(witness_script),
+        descriptor=descsum_create(f"pq({pk_script.hex()})"),
+        label=label,
+    )

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -195,6 +195,7 @@ BASE_SCRIPTS = [
     'wallet_createwallet.py',
     'wallet_reindex.py',
     'wallet_reorgsrestore.py',
+    'wallet_pq_active_ranged.py',
     'interface_http.py',
     'interface_rpc.py',
     'interface_usdt_coinselection.py',

--- a/test/functional/wallet_pq_active_ranged.py
+++ b/test/functional/wallet_pq_active_ranged.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test active ranged pqpriv() descriptor wallet managers."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from test_framework.descriptors import descsum_create
+from test_framework.messages import COIN
+from test_framework.pqsig import create_wallet_funded_tx
+from test_framework.pq_wallet_helper import (
+    build_active_pq_descriptor_entry,
+    make_pqpriv_descriptor,
+    make_pqpriv_import_request,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+RAW_TRUE_DESCRIPTOR = descsum_create("raw(51)")
+
+
+class WalletPQActiveRangedTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-acceptnonstdtxn=1"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def mine_block(self):
+        self.nodes[0].generatetodescriptor(1, RAW_TRUE_DESCRIPTOR, called_by_framework=True)
+
+    def ensure_wallet_loaded(self, wallet_name):
+        node = self.nodes[0]
+        if wallet_name not in node.listwallets():
+            node.loadwallet(wallet_name)
+        return node.get_wallet_rpc(wallet_name)
+
+    def descriptor_state(self, wallet):
+        descriptors = {}
+        for item in wallet.listdescriptors(True)["descriptors"]:
+            descriptors[item["desc"]] = {
+                "active": item["active"],
+                "internal": item["internal"],
+                "range": item["range"],
+                "next_index": item["next_index"],
+            }
+        return descriptors
+
+    def assert_descriptor_state(self, wallet, root_seed: bytes, *, external_next: int, internal_next: int):
+        descs = self.descriptor_state(wallet)
+        expected = {
+            make_pqpriv_descriptor(root_seed, False): {
+                "active": True,
+                "internal": False,
+                "range": [0, 9],
+                "next_index": external_next,
+            },
+            make_pqpriv_descriptor(root_seed, True): {
+                "active": True,
+                "internal": True,
+                "range": [0, 9],
+                "next_index": internal_next,
+            },
+        }
+        assert_equal(descs, expected)
+
+    def assert_address_info(self, wallet, entry, *, is_change: bool, label: str | None = None):
+        info = wallet.getaddressinfo(entry.address)
+        assert_equal(info["desc"], entry.descriptor)
+        assert_equal(info["ismine"], True)
+        assert_equal(info["solvable"], True)
+        assert_equal(info["ischange"], is_change)
+        assert "parent_desc" not in info
+        if label is not None:
+            assert_equal(info["labels"], [label])
+
+    def assert_tracked_output(self, wallet, txid: str, entry, amount: Decimal):
+        tx = wallet.gettransaction(txid)
+        assert_equal(tx["amount"], amount)
+        assert_equal(tx["details"][0]["address"], entry.address)
+        assert_equal(tx["details"][0]["category"], "receive")
+        assert_equal(wallet.getbalances()["mine"]["trusted"], amount)
+        assert_equal(wallet.listunspent(), [])
+
+    def fund_entry(self, entry, amount_sat: int) -> str:
+        tx = create_wallet_funded_tx(self.nodes[0], bytes(entry.script_pub_key), amount_sat)
+        return self.nodes[0].sendrawtransaction(tx.serialize().hex())
+
+    def run_test(self):
+        node = self.nodes[0]
+        root_seed = bytes.fromhex("24" * 32)
+        ext_entries = [build_active_pq_descriptor_entry(root_seed, internal=False, index=i) for i in range(6)]
+        int_entries = [build_active_pq_descriptor_entry(root_seed, internal=True, index=i) for i in range(4)]
+        node.createwallet(wallet_name="sink")
+        sink_addr = node.get_wallet_rpc("sink").getnewaddress()
+
+        self.log.info("Create a blank descriptor wallet and import active pqpriv() receive/change descriptors")
+        node.createwallet(wallet_name="pqactive", blank=True)
+        wallet = node.get_wallet_rpc("pqactive")
+        result = wallet.importdescriptors([
+            make_pqpriv_import_request(root_seed, internal=False, active=True, timestamp="now", range_end=9),
+            make_pqpriv_import_request(root_seed, internal=True, active=True, timestamp="now", range_end=9),
+        ])
+        assert all(item["success"] for item in result)
+
+        self.assert_descriptor_state(wallet, root_seed, external_next=0, internal_next=0)
+        assert_raises_rpc_error(-4, "Public export for ranged pqpriv() descriptors is not available.", wallet.listdescriptors, False)
+        assert_equal(wallet.gethdkeys(), [])
+        assert_raises_rpc_error(
+            -5,
+            "Unable to determine which HD key to use from active descriptors. Please specify with 'hdkey'",
+            wallet.createwalletdescriptor,
+            "bech32",
+        )
+
+        self.log.info("Generate receive/change PQ addresses from the active managers")
+        first_label = "pq receive"
+        assert_equal(wallet.getnewpqaddress(first_label), ext_entries[0].address)
+        assert_equal(wallet.getnewpqaddress(), ext_entries[1].address)
+        assert_equal(wallet.getnewpqaddress(), ext_entries[2].address)
+        assert_equal(wallet.getrawpqchangeaddress(), int_entries[0].address)
+
+        self.assert_address_info(wallet, ext_entries[0], is_change=False, label=first_label)
+        self.assert_address_info(wallet, ext_entries[2], is_change=False)
+        self.assert_address_info(wallet, int_entries[0], is_change=True)
+        self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=1)
+
+        self.log.info("Fund a later generated PQ address and confirm it is tracked but not spendable")
+        txid = self.fund_entry(ext_entries[2], 4 * COIN)
+        self.mine_block()
+        self.assert_tracked_output(wallet, txid, ext_entries[2], Decimal("4.00000000"))
+        assert_raises_rpc_error(-6, "Insufficient funds", wallet.sendtoaddress, sink_addr, 1)
+
+        self.log.info("Restart and confirm active manager state and tracked outputs persist")
+        self.restart_node(0, self.extra_args[0])
+        node = self.nodes[0]
+        wallet = self.ensure_wallet_loaded("pqactive")
+        self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=1)
+        self.assert_tracked_output(wallet, txid, ext_entries[2], Decimal("4.00000000"))
+
+        assert_equal(wallet.getnewpqaddress(), ext_entries[3].address)
+        assert_equal(wallet.getrawpqchangeaddress(), int_entries[1].address)
+        self.assert_descriptor_state(wallet, root_seed, external_next=4, internal_next=2)
+
+        self.log.info("Back up and restore the wallet with active PQ managers intact")
+        backup_path = node.datadir_path / "pqactive.bak"
+        wallet.backupwallet(str(backup_path))
+        node.restorewallet("pqactive_restored", str(backup_path))
+        restored = node.get_wallet_rpc("pqactive_restored")
+
+        self.assert_descriptor_state(restored, root_seed, external_next=4, internal_next=2)
+        self.assert_tracked_output(restored, txid, ext_entries[2], Decimal("4.00000000"))
+        self.assert_address_info(restored, ext_entries[2], is_change=False)
+        assert_equal(restored.gethdkeys(), [])
+        assert_raises_rpc_error(-4, "Public export for ranged pqpriv() descriptors is not available.", restored.listdescriptors, False)
+        assert_raises_rpc_error(
+            -5,
+            "Unable to determine which HD key to use from active descriptors. Please specify with 'hdkey'",
+            restored.createwalletdescriptor,
+            "bech32",
+        )
+
+        self.log.info("Generated addresses continue from the correct next index after restore")
+        assert_equal(restored.getnewpqaddress("restored receive"), ext_entries[4].address)
+        assert_equal(restored.getrawpqchangeaddress(), int_entries[2].address)
+        self.assert_descriptor_state(restored, root_seed, external_next=5, internal_next=3)
+
+        self.log.info("Reload the restored wallet and confirm watch set and next_index remain stable")
+        restored.unloadwallet()
+        node.loadwallet("pqactive_restored")
+        restored = node.get_wallet_rpc("pqactive_restored")
+        self.assert_descriptor_state(restored, root_seed, external_next=5, internal_next=3)
+        self.assert_tracked_output(restored, txid, ext_entries[2], Decimal("4.00000000"))
+        assert_equal(restored.getnewpqaddress(), ext_entries[5].address)
+        self.assert_descriptor_state(restored, root_seed, external_next=6, internal_next=3)
+
+
+if __name__ == "__main__":
+    WalletPQActiveRangedTest(__file__).main()


### PR DESCRIPTION
## Summary
- add top-level private ranged `pqpriv(<root-seed>/<0|1>/*)` descriptors and wallet derivation plumbing
- add dedicated `PQDescriptorScriptPubKeyMan` persistence, active receive/change managers, and `getnewpqaddress` / `getrawpqchangeaddress`
- keep generated PQ outputs tracked and solvable but non-spendable, with unit and functional coverage

## Validation
- `cmake --build build -j8 --target bitcoin_wallet pqbtcd pqbtc-cli test_pqbtc`
- `build/bin/test_pqbtc --run_test=pq_descriptor_tests --catch_system_error=no --log_level=test_suite`
- `python3 test/functional/wallet_pq_descriptors.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `python3 test/functional/wallet_pq_backup_recovery.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `python3 test/functional/wallet_pq_active_ranged.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `python3 -m py_compile test/functional/test_framework/pq_wallet_helper.py test/functional/wallet_pq_active_ranged.py`
- `git diff --check`

Closes #60
