### PR TITLE
wallet: add PQ spendability and PSBT/signing parity (#20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,8 +476,36 @@ configure_file(cmake/script/CoverageInclude.cmake.in CoverageInclude.cmake USE_S
 configure_file(cmake/script/cov_tool_wrapper.sh.in cov_tool_wrapper.sh.in USE_SOURCE_PERMISSIONS COPYONLY)
 configure_file(contrib/filter-lcov.py filter-lcov.py USE_SOURCE_PERMISSIONS COPYONLY)
 
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_SYSTEM_PROCESSOR_LOWER)
+set(BUILD_SYSTEM_IS_DARWIN FALSE)
+set(BUILD_SYSTEM_IS_DARWIN_ARM64 FALSE)
+set(BUILD_SYSTEM_IS_X86 FALSE)
+set(BUILD_SYSTEM_IS_GNU FALSE)
+set(BUILD_SYSTEM_IS_MINGW_PE FALSE)
+set(BUILD_SYSTEM_IS_ELF FALSE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(BUILD_SYSTEM_IS_DARWIN TRUE)
+endif()
+if(CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "^(arm64|aarch64)$" AND BUILD_SYSTEM_IS_DARWIN)
+  set(BUILD_SYSTEM_IS_DARWIN_ARM64 TRUE)
+endif()
+if(CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "^(x86_64|amd64|i[3-6]86|x86)$")
+  set(BUILD_SYSTEM_IS_X86 TRUE)
+endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(BUILD_SYSTEM_IS_GNU TRUE)
+endif()
+if(MINGW)
+  set(BUILD_SYSTEM_IS_MINGW_PE TRUE)
+endif()
+if(UNIX AND NOT BUILD_SYSTEM_IS_DARWIN AND NOT BUILD_SYSTEM_IS_MINGW_PE)
+  set(BUILD_SYSTEM_IS_ELF TRUE)
+endif()
+
 # Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
-try_append_cxx_flags("-fno-extended-identifiers" TARGET core_interface SKIP_LINK)
+if(NOT BUILD_SYSTEM_IS_DARWIN_ARM64)
+  try_append_cxx_flags("-fno-extended-identifiers" TARGET core_interface SKIP_LINK)
+endif()
 
 # Avoiding the `-ffile-prefix-map` compiler option because it implies
 # `-fcoverage-prefix-map` on Clang or `-fprofile-prefix-map` on GCC,
@@ -495,7 +523,9 @@ try_append_cxx_flags("-fmacro-prefix-map=A=B" TARGET core_interface SKIP_LINK
 # gccbug_90348 test case (only reproduces on GCC 11 and earlier) and
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111843. To work around that, set
 # -fstack-reuse=none for all gcc builds. (Only gcc understands this flag).
-try_append_cxx_flags("-fstack-reuse=none" TARGET core_interface)
+if(BUILD_SYSTEM_IS_GNU)
+  try_append_cxx_flags("-fstack-reuse=none" TARGET core_interface)
+endif()
 
 if(MSVC)
   try_append_linker_flag("/DYNAMICBASE" TARGET core_interface)
@@ -523,12 +553,14 @@ else()
 
   try_append_cxx_flags("-Wstack-protector" TARGET core_interface SKIP_LINK)
   try_append_cxx_flags("-fstack-protector-all" TARGET core_interface)
-  try_append_cxx_flags("-fcf-protection=full" TARGET core_interface)
+  if(BUILD_SYSTEM_IS_X86)
+    try_append_cxx_flags("-fcf-protection=full" TARGET core_interface)
+  endif()
 
-  if(MINGW)
+  if(BUILD_SYSTEM_IS_MINGW_PE)
     # stack-clash-protection is a no-op for Windows.
     # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458 for more details.
-  else()
+  elseif(NOT BUILD_SYSTEM_IS_DARWIN)
     try_append_cxx_flags("-fstack-clash-protection" TARGET core_interface)
   endif()
 
@@ -540,33 +572,39 @@ else()
     endif()
   endif()
 
-  try_append_linker_flag("-Wl,--enable-reloc-section" TARGET core_interface)
-  try_append_linker_flag("-Wl,--dynamicbase" TARGET core_interface)
-  try_append_linker_flag("-Wl,--nxcompat" TARGET core_interface)
-  try_append_linker_flag("-Wl,--high-entropy-va" TARGET core_interface)
-  try_append_linker_flag("-Wl,-z,relro" TARGET core_interface)
-  try_append_linker_flag("-Wl,-z,now" TARGET core_interface)
-  # TODO: This can be dropped once Bitcoin Core no longer supports
-  #       NetBSD 10.0 or if upstream fix is backported.
-  # NetBSD's dynamic linker ld.elf_so < 11.0 supports exactly 2
-  # `PT_LOAD` segments and binaries linked with `-z separate-code`
-  # have 4 `PT_LOAD` segments.
-  # Relevant discussions:
-  # - https://github.com/bitcoin/bitcoin/pull/28724#issuecomment-2589347934
-  # - https://mail-index.netbsd.org/tech-userlevel/2023/01/05/msg013666.html
-  if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD" AND CMAKE_SYSTEM_VERSION VERSION_LESS 11.0)
-    try_append_linker_flag("-Wl,-z,noseparate-code" TARGET core_interface)
-  else()
-    try_append_linker_flag("-Wl,-z,separate-code" TARGET core_interface)
+  if(BUILD_SYSTEM_IS_MINGW_PE)
+    try_append_linker_flag("-Wl,--enable-reloc-section" TARGET core_interface)
+    try_append_linker_flag("-Wl,--dynamicbase" TARGET core_interface)
+    try_append_linker_flag("-Wl,--nxcompat" TARGET core_interface)
+    try_append_linker_flag("-Wl,--high-entropy-va" TARGET core_interface)
   endif()
-  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  if(BUILD_SYSTEM_IS_ELF)
+    try_append_linker_flag("-Wl,-z,relro" TARGET core_interface)
+    try_append_linker_flag("-Wl,-z,now" TARGET core_interface)
+    # TODO: This can be dropped once Bitcoin Core no longer supports
+    #       NetBSD 10.0 or if upstream fix is backported.
+    # NetBSD's dynamic linker ld.elf_so < 11.0 supports exactly 2
+    # `PT_LOAD` segments and binaries linked with `-z separate-code`
+    # have 4 `PT_LOAD` segments.
+    # Relevant discussions:
+    # - https://github.com/bitcoin/bitcoin/pull/28724#issuecomment-2589347934
+    # - https://mail-index.netbsd.org/tech-userlevel/2023/01/05/msg013666.html
+    if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD" AND CMAKE_SYSTEM_VERSION VERSION_LESS 11.0)
+      try_append_linker_flag("-Wl,-z,noseparate-code" TARGET core_interface)
+    else()
+      try_append_linker_flag("-Wl,-z,separate-code" TARGET core_interface)
+    endif()
+  endif()
+  if(BUILD_SYSTEM_IS_DARWIN)
     try_append_linker_flag("-Wl,-fixup_chains" TARGET core_interface)
   endif()
 endif()
 
 if(REDUCE_EXPORTS)
   set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-  try_append_linker_flag("-Wl,--exclude-libs,ALL" TARGET core_interface)
+  if(BUILD_SYSTEM_IS_ELF)
+    try_append_linker_flag("-Wl,--exclude-libs,ALL" TARGET core_interface)
+  endif()
   try_append_linker_flag("-Wl,-no_exported_symbols" VAR CMAKE_EXE_LINKER_FLAGS)
 endif()
 

--- a/ci/test/check_pqsig_bench.py
+++ b/ci/test/check_pqsig_bench.py
@@ -63,6 +63,15 @@ def run_bench(bench_exe: str) -> tuple[dict[str, float | int], str]:
     ns_match = NS_PER_OP_RE.search(output)
     if ns_match:
         envelope["ns_per_op"] = float(ns_match.group("ns").replace(",", ""))
+    else:
+        for line in output.splitlines():
+            if "PQSigBenchEnvelope" not in line or "PQSIG_BENCH_ENVELOPE" in line:
+                continue
+            numbers = re.findall(r"[0-9][0-9,]*(?:\.[0-9]+)?", line)
+            if not numbers:
+                continue
+            envelope["ns_per_op"] = float(numbers[0].replace(",", ""))
+            break
     return envelope, output
 
 

--- a/cmake/crc32c.cmake
+++ b/cmake/crc32c.cmake
@@ -9,6 +9,16 @@
 include(CheckCXXSourceCompiles)
 include(CheckSourceCompilesWithFlags)
 
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _crc32c_processor_lower)
+set(_crc32c_is_x86 FALSE)
+set(_crc32c_is_arm64 FALSE)
+if(_crc32c_processor_lower MATCHES "^(x86_64|amd64|i[3-6]86|x86)$")
+  set(_crc32c_is_x86 TRUE)
+endif()
+if(_crc32c_processor_lower MATCHES "^(arm64|aarch64)$")
+  set(_crc32c_is_arm64 TRUE)
+endif()
+
 # Check for __builtin_prefetch support in the compiler.
 check_cxx_source_compiles("
   int main() {
@@ -20,66 +30,78 @@ check_cxx_source_compiles("
   " HAVE_BUILTIN_PREFETCH
 )
 
-# Check for _mm_prefetch support in the compiler.
-check_cxx_source_compiles("
-  #if defined(_MSC_VER)
-  #include <intrin.h>
-  #else
-  #include <xmmintrin.h>
-  #endif
+if(_crc32c_is_x86)
+  # Check for _mm_prefetch support in the compiler.
+  check_cxx_source_compiles("
+    #if defined(_MSC_VER)
+    #include <intrin.h>
+    #else
+    #include <xmmintrin.h>
+    #endif
 
-  int main() {
-    char data = 0;
-    const char* address = &data;
-    _mm_prefetch(address, _MM_HINT_NTA);
-    return 0;
-  }
-  " HAVE_MM_PREFETCH
-)
-
-# Check for SSE4.2 support in the compiler.
-if(MSVC)
-  set(SSE42_CXXFLAGS /arch:AVX)
+    int main() {
+      char data = 0;
+      const char* address = &data;
+      _mm_prefetch(address, _MM_HINT_NTA);
+      return 0;
+    }
+    " HAVE_MM_PREFETCH
+  )
 else()
-  set(SSE42_CXXFLAGS -msse4.2)
+  set(HAVE_MM_PREFETCH FALSE)
 endif()
-check_cxx_source_compiles_with_flags("
-  #include <cstdint>
-  #if defined(_MSC_VER)
-  #include <intrin.h>
-  #elif defined(__GNUC__) && defined(__SSE4_2__)
-  #include <nmmintrin.h>
-  #endif
 
-  int main() {
-    uint64_t l = 0;
-    l = _mm_crc32_u8(l, 0);
-    l = _mm_crc32_u32(l, 0);
-    l = _mm_crc32_u64(l, 0);
-    return l;
-  }
-  " HAVE_SSE42
-  CXXFLAGS ${SSE42_CXXFLAGS}
-)
+if(_crc32c_is_x86)
+  # Check for SSE4.2 support in the compiler.
+  if(MSVC)
+    set(SSE42_CXXFLAGS /arch:AVX)
+  else()
+    set(SSE42_CXXFLAGS -msse4.2)
+  endif()
+  check_cxx_source_compiles_with_flags("
+    #include <cstdint>
+    #if defined(_MSC_VER)
+    #include <intrin.h>
+    #elif defined(__GNUC__) && defined(__SSE4_2__)
+    #include <nmmintrin.h>
+    #endif
+
+    int main() {
+      uint64_t l = 0;
+      l = _mm_crc32_u8(l, 0);
+      l = _mm_crc32_u32(l, 0);
+      l = _mm_crc32_u64(l, 0);
+      return l;
+    }
+    " HAVE_SSE42
+    CXXFLAGS ${SSE42_CXXFLAGS}
+  )
+else()
+  set(HAVE_SSE42 FALSE)
+endif()
 
 # Check for ARMv8 w/ CRC and CRYPTO extensions support in the compiler.
-set(ARM64_CRC_CXXFLAGS -march=armv8-a+crc+crypto)
-check_cxx_source_compiles_with_flags("
-  #include <arm_acle.h>
-  #include <arm_neon.h>
+if(_crc32c_is_arm64)
+  set(ARM64_CRC_CXXFLAGS -march=armv8-a+crc+crypto)
+  check_cxx_source_compiles_with_flags("
+    #include <arm_acle.h>
+    #include <arm_neon.h>
 
-  int main() {
-  #ifdef __aarch64__
-    __crc32cb(0, 0); __crc32ch(0, 0); __crc32cw(0, 0); __crc32cd(0, 0);
-    vmull_p64(0, 0);
-  #else
-  #error crc32c library does not support hardware acceleration on 32-bit ARM
-  #endif
-    return 0;
-  }
-  " HAVE_ARM64_CRC32C
-  CXXFLAGS ${ARM64_CRC_CXXFLAGS}
-)
+    int main() {
+    #ifdef __aarch64__
+      __crc32cb(0, 0); __crc32ch(0, 0); __crc32cw(0, 0); __crc32cd(0, 0);
+      vmull_p64(0, 0);
+    #else
+    #error crc32c library does not support hardware acceleration on 32-bit ARM
+    #endif
+      return 0;
+    }
+    " HAVE_ARM64_CRC32C
+    CXXFLAGS ${ARM64_CRC_CXXFLAGS}
+  )
+else()
+  set(HAVE_ARM64_CRC32C FALSE)
+endif()
 
 add_library(crc32c STATIC EXCLUDE_FROM_ALL
   ${PROJECT_SOURCE_DIR}/src/crc32c/src/crc32c.cc
@@ -113,3 +135,6 @@ if(HAVE_ARM64_CRC32C)
 endif()
 
 unset(_crc32_src)
+unset(_crc32c_is_arm64)
+unset(_crc32c_is_x86)
+unset(_crc32c_processor_lower)

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -147,67 +147,90 @@ check_cxx_source_compiles("
 
 if(NOT MSVC)
   include(CheckSourceCompilesWithFlags)
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _introspection_processor_lower)
+  set(_introspection_is_x86 FALSE)
+  set(_introspection_is_arm64 FALSE)
+  if(_introspection_processor_lower MATCHES "^(x86_64|amd64|i[3-6]86|x86)$")
+    set(_introspection_is_x86 TRUE)
+  endif()
+  if(_introspection_processor_lower MATCHES "^(arm64|aarch64)$")
+    set(_introspection_is_arm64 TRUE)
+  endif()
 
-  # Check for SSE4.1 intrinsics.
-  set(SSE41_CXXFLAGS -msse4.1)
-  check_cxx_source_compiles_with_flags("
-    #include <immintrin.h>
+  if(_introspection_is_x86)
+    # Check for SSE4.1 intrinsics.
+    set(SSE41_CXXFLAGS -msse4.1)
+    check_cxx_source_compiles_with_flags("
+      #include <immintrin.h>
 
-    int main()
-    {
-      __m128i a = _mm_set1_epi32(0);
-      __m128i b = _mm_set1_epi32(1);
-      __m128i r = _mm_blend_epi16(a, b, 0xFF);
-      return _mm_extract_epi32(r, 3);
-    }
-    " HAVE_SSE41
-    CXXFLAGS ${SSE41_CXXFLAGS}
-  )
+      int main()
+      {
+        __m128i a = _mm_set1_epi32(0);
+        __m128i b = _mm_set1_epi32(1);
+        __m128i r = _mm_blend_epi16(a, b, 0xFF);
+        return _mm_extract_epi32(r, 3);
+      }
+      " HAVE_SSE41
+      CXXFLAGS ${SSE41_CXXFLAGS}
+    )
 
-  # Check for AVX2 intrinsics.
-  set(AVX2_CXXFLAGS -mavx -mavx2)
-  check_cxx_source_compiles_with_flags("
-    #include <immintrin.h>
+    # Check for AVX2 intrinsics.
+    set(AVX2_CXXFLAGS -mavx -mavx2)
+    check_cxx_source_compiles_with_flags("
+      #include <immintrin.h>
 
-    int main()
-    {
-      __m256i l = _mm256_set1_epi32(0);
-      return _mm256_extract_epi32(l, 7);
-    }
-    " HAVE_AVX2
-    CXXFLAGS ${AVX2_CXXFLAGS}
-  )
+      int main()
+      {
+        __m256i l = _mm256_set1_epi32(0);
+        return _mm256_extract_epi32(l, 7);
+      }
+      " HAVE_AVX2
+      CXXFLAGS ${AVX2_CXXFLAGS}
+    )
 
-  # Check for x86 SHA-NI intrinsics.
-  set(X86_SHANI_CXXFLAGS -msse4 -msha)
-  check_cxx_source_compiles_with_flags("
-    #include <immintrin.h>
+    # Check for x86 SHA-NI intrinsics.
+    set(X86_SHANI_CXXFLAGS -msse4 -msha)
+    check_cxx_source_compiles_with_flags("
+      #include <immintrin.h>
 
-    int main()
-    {
-      __m128i i = _mm_set1_epi32(0);
-      __m128i j = _mm_set1_epi32(1);
-      __m128i k = _mm_set1_epi32(2);
-      return _mm_extract_epi32(_mm_sha256rnds2_epu32(i, j, k), 0);
-    }
-    " HAVE_X86_SHANI
-    CXXFLAGS ${X86_SHANI_CXXFLAGS}
-  )
+      int main()
+      {
+        __m128i i = _mm_set1_epi32(0);
+        __m128i j = _mm_set1_epi32(1);
+        __m128i k = _mm_set1_epi32(2);
+        return _mm_extract_epi32(_mm_sha256rnds2_epu32(i, j, k), 0);
+      }
+      " HAVE_X86_SHANI
+      CXXFLAGS ${X86_SHANI_CXXFLAGS}
+    )
+  else()
+    set(HAVE_SSE41 FALSE)
+    set(HAVE_AVX2 FALSE)
+    set(HAVE_X86_SHANI FALSE)
+  endif()
 
-  # Check for ARMv8 SHA-NI intrinsics.
-  set(ARM_SHANI_CXXFLAGS -march=armv8-a+crypto)
-  check_cxx_source_compiles_with_flags("
-    #include <arm_neon.h>
+  if(_introspection_is_arm64)
+    # Check for ARMv8 SHA-NI intrinsics.
+    set(ARM_SHANI_CXXFLAGS -march=armv8-a+crypto)
+    check_cxx_source_compiles_with_flags("
+      #include <arm_neon.h>
 
-    int main()
-    {
-      uint32x4_t a, b, c;
-      vsha256h2q_u32(a, b, c);
-      vsha256hq_u32(a, b, c);
-      vsha256su0q_u32(a, b);
-      vsha256su1q_u32(a, b, c);
-    }
-    " HAVE_ARM_SHANI
-    CXXFLAGS ${ARM_SHANI_CXXFLAGS}
-  )
+      int main()
+      {
+        uint32x4_t a, b, c;
+        vsha256h2q_u32(a, b, c);
+        vsha256hq_u32(a, b, c);
+        vsha256su0q_u32(a, b);
+        vsha256su1q_u32(a, b, c);
+      }
+      " HAVE_ARM_SHANI
+      CXXFLAGS ${ARM_SHANI_CXXFLAGS}
+    )
+  else()
+    set(HAVE_ARM_SHANI FALSE)
+  endif()
+
+  unset(_introspection_is_arm64)
+  unset(_introspection_is_x86)
+  unset(_introspection_processor_lower)
 endif()

--- a/cmake/libmultiprocess.cmake
+++ b/cmake/libmultiprocess.cmake
@@ -7,6 +7,12 @@ function(add_libmultiprocess subdir)
   # option that controls whether enable_testing() is called, but in the bitcoin
   # build a BUILD_TESTS option is used instead.
   set(BUILD_TESTING "${BUILD_TESTS}")
+  if(NOT CMAKE_SYSTEM_NAME MATCHES "^(FreeBSD|OpenBSD|DragonFly)$")
+    set(HAVE_PTHREAD_GETTHREADID_NP FALSE CACHE INTERNAL
+      "Skip the BSD-only pthread_getthreadid_np probe on non-BSD platforms."
+      FORCE
+    )
+  endif()
   add_subdirectory(${subdir} EXCLUDE_FROM_ALL)
   # Apply core_interface compile options to libmultiprocess runtime library.
   target_link_libraries(multiprocess PUBLIC $<BUILD_INTERFACE:core_interface>)

--- a/cmake/minisketch.cmake
+++ b/cmake/minisketch.cmake
@@ -4,28 +4,38 @@
 
 include(CheckSourceCompilesWithFlags)
 
-# Check for clmul instructions support.
-if(MSVC)
-  set(CLMUL_CXXFLAGS "")
-else()
-  set(CLMUL_CXXFLAGS -mpclmul)
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _minisketch_processor_lower)
+set(_minisketch_is_x86 FALSE)
+if(_minisketch_processor_lower MATCHES "^(x86_64|amd64|i[3-6]86|x86)$")
+  set(_minisketch_is_x86 TRUE)
 endif()
-check_cxx_source_compiles_with_flags("
-  #include <immintrin.h>
-  #include <cstdint>
 
-  int main()
-  {
-    __m128i a = _mm_cvtsi64_si128((uint64_t)7);
-    __m128i b = _mm_clmulepi64_si128(a, a, 37);
-    __m128i c = _mm_srli_epi64(b, 41);
-    __m128i d = _mm_xor_si128(b, c);
-    uint64_t e = _mm_cvtsi128_si64(d);
-    return e == 0;
-  }
-  " HAVE_CLMUL
-  CXXFLAGS ${CLMUL_CXXFLAGS}
-)
+# Check for clmul instructions support.
+if(_minisketch_is_x86)
+  if(MSVC)
+    set(CLMUL_CXXFLAGS "")
+  else()
+    set(CLMUL_CXXFLAGS -mpclmul)
+  endif()
+  check_cxx_source_compiles_with_flags("
+    #include <immintrin.h>
+    #include <cstdint>
+
+    int main()
+    {
+      __m128i a = _mm_cvtsi64_si128((uint64_t)7);
+      __m128i b = _mm_clmulepi64_si128(a, a, 37);
+      __m128i c = _mm_srli_epi64(b, 41);
+      __m128i d = _mm_xor_si128(b, c);
+      uint64_t e = _mm_cvtsi128_si64(d);
+      return e == 0;
+    }
+    " HAVE_CLMUL
+    CXXFLAGS ${CLMUL_CXXFLAGS}
+  )
+else()
+  set(HAVE_CLMUL FALSE)
+endif()
 
 add_library(minisketch_common INTERFACE)
 if(MSVC)
@@ -87,3 +97,6 @@ if(HAVE_CLMUL)
   target_compile_definitions(minisketch PRIVATE HAVE_CLMUL)
   unset(_minisketch_clmul_src)
 endif()
+
+unset(_minisketch_is_x86)
+unset(_minisketch_processor_lower)

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -7,6 +7,16 @@ enable_language(C)
 function(add_secp256k1 subdir)
   message("")
   message("Configuring secp256k1 subtree...")
+  if(NOT CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    string(MAKE_C_IDENTIFIER "-Wcast-align=strict" secp256k1_cast_align_strict_var)
+    string(TOUPPER "${secp256k1_cast_align_strict_var}" secp256k1_cast_align_strict_var)
+    set(secp256k1_cast_align_strict_var "C_SUPPORTS_${secp256k1_cast_align_strict_var}")
+    set(${secp256k1_cast_align_strict_var} FALSE CACHE INTERNAL
+      "Skip the GNU-only -Wcast-align=strict secp256k1 probe on non-GNU toolchains."
+      FORCE
+    )
+    unset(secp256k1_cast_align_strict_var)
+  endif()
   set(BUILD_SHARED_LIBS OFF)
   set(CMAKE_EXPORT_COMPILE_COMMANDS OFF)
   set(SECP256K1_ENABLE_MODULE_ECDH OFF CACHE BOOL "" FORCE)

--- a/src/crypto/pqsig/pqsig.cpp
+++ b/src/crypto/pqsig/pqsig.cpp
@@ -248,14 +248,22 @@ bool DerivePkScript(const std::span<uint8_t> out_pk_script33, const std::span<co
 
 bool DeriveWalletPkScript(const std::span<uint8_t> out_pk_script33, const std::span<const uint8_t> root_seed, const bool internal, const uint32_t index)
 {
-    if (!ConsensusProfileLocked() || out_pk_script33.size() != PK_SCRIPT_SIZE || root_seed.size() != MSG32_SIZE) {
+    std::array<unsigned char, MSG32_SIZE> child_seed{};
+    if (!DeriveWalletSkSeed(child_seed, root_seed, internal, index)) {
+        return false;
+    }
+    return DerivePkScript(out_pk_script33, child_seed);
+}
+
+bool DeriveWalletSkSeed(const std::span<uint8_t> out_sk_seed32, const std::span<const uint8_t> root_seed, const bool internal, const uint32_t index)
+{
+    if (!ConsensusProfileLocked() || out_sk_seed32.size() != MSG32_SIZE || root_seed.size() != MSG32_SIZE) {
         return false;
     }
 
     CHKDF_HMAC_SHA256_L32 hkdf(root_seed.data(), root_seed.size(), "PQSIG-WALLET-ROOT-v1");
-    unsigned char child_seed[MSG32_SIZE];
-    hkdf.Expand32(strprintf("branch=%u;index=%u", internal ? 1U : 0U, index), child_seed);
-    return DerivePkScript(out_pk_script33, child_seed);
+    hkdf.Expand32(strprintf("branch=%u;index=%u", internal ? 1U : 0U, index), out_sk_seed32.data());
+    return true;
 }
 
 bool PQSigVerify(

--- a/src/crypto/pqsig/pqsig.h
+++ b/src/crypto/pqsig/pqsig.h
@@ -20,6 +20,7 @@ inline constexpr uint8_t ALG_ID_RC2{0x01};
 
 bool IsValidPkScript(std::span<const uint8_t> pk_script33);
 bool DerivePkScript(std::span<uint8_t> out_pk_script33, std::span<const uint8_t> sk_seed);
+bool DeriveWalletSkSeed(std::span<uint8_t> out_sk_seed32, std::span<const uint8_t> root_seed, bool internal, uint32_t index);
 bool DeriveWalletPkScript(std::span<uint8_t> out_pk_script33, std::span<const uint8_t> root_seed, bool internal, uint32_t index);
 
 bool PQSigVerify(std::span<const uint8_t> sig4480,

--- a/src/ipc/libmultiprocess/cmake/pthread_checks.cmake
+++ b/src/ipc/libmultiprocess/cmake/pthread_checks.cmake
@@ -30,12 +30,16 @@ check_cxx_source_compiles("
   }"
   HAVE_PTHREAD_THREADID_NP)
 
-check_cxx_source_compiles("
-  #include <pthread.h>
-  #include <pthread_np.h>
-  int main(int argc, char** argv)
-  {
-    return pthread_getthreadid_np();
-  }"
-  HAVE_PTHREAD_GETTHREADID_NP)
+if(CMAKE_SYSTEM_NAME MATCHES "^(FreeBSD|OpenBSD|DragonFly)$")
+  check_cxx_source_compiles("
+    #include <pthread.h>
+    #include <pthread_np.h>
+    int main(int argc, char** argv)
+    {
+      return pthread_getthreadid_np();
+    }"
+    HAVE_PTHREAD_GETTHREADID_NP)
+else()
+  set(HAVE_PTHREAD_GETTHREADID_NP FALSE)
+endif()
 cmake_pop_check_state()

--- a/src/ipc/libmultiprocess/cmake/pthread_checks.cmake
+++ b/src/ipc/libmultiprocess/cmake/pthread_checks.cmake
@@ -30,16 +30,12 @@ check_cxx_source_compiles("
   }"
   HAVE_PTHREAD_THREADID_NP)
 
-if(CMAKE_SYSTEM_NAME MATCHES "^(FreeBSD|OpenBSD|DragonFly)$")
-  check_cxx_source_compiles("
-    #include <pthread.h>
-    #include <pthread_np.h>
-    int main(int argc, char** argv)
-    {
-      return pthread_getthreadid_np();
-    }"
-    HAVE_PTHREAD_GETTHREADID_NP)
-else()
-  set(HAVE_PTHREAD_GETTHREADID_NP FALSE)
-endif()
+check_cxx_source_compiles("
+  #include <pthread.h>
+  #include <pthread_np.h>
+  int main(int argc, char** argv)
+  {
+    return pthread_getthreadid_np();
+  }"
+  HAVE_PTHREAD_GETTHREADID_NP)
 cmake_pop_check_state()

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -5,6 +5,7 @@
 #include <psbt.h>
 
 #include <common/types.h>
+#include <crypto/pqsig/pqsig.h>
 #include <node/types.h>
 #include <policy/policy.h>
 #include <script/signingprovider.h>
@@ -12,6 +13,70 @@
 #include <util/strencodings.h>
 
 using common::PSBTError;
+
+namespace {
+
+constexpr uint64_t PSBT_PQBTC_IN_PARTIAL_SIG{0x01};
+constexpr std::array<unsigned char, 5> PSBT_PQBTC_IDENTIFIER{{'p', 'q', 'b', 't', 'c'}};
+
+bool IsPQPartialSig(const PSBTProprietary& prop)
+{
+    return prop.subtype == PSBT_PQBTC_IN_PARTIAL_SIG && prop.identifier == std::vector<unsigned char>(PSBT_PQBTC_IDENTIFIER.begin(), PSBT_PQBTC_IDENTIFIER.end());
+}
+
+bool DecodePQPartialSigProp(const PSBTProprietary& prop, PQPkScript& pk_script, std::vector<unsigned char>& sig)
+{
+    if (!IsPQPartialSig(prop)) {
+        return false;
+    }
+
+    SpanReader key_reader{prop.key};
+    uint8_t type;
+    key_reader >> type;
+    if (type != PSBT_IN_PROPRIETARY) {
+        return false;
+    }
+    std::vector<unsigned char> identifier;
+    key_reader >> identifier;
+    const uint64_t subtype = ReadCompactSize(key_reader);
+    if (identifier != prop.identifier || subtype != prop.subtype || key_reader.size() != pqsig::PK_SCRIPT_SIZE) {
+        return false;
+    }
+    key_reader >> std::as_writable_bytes(std::span{pk_script});
+    if (!pqsig::IsValidPkScript(pk_script) || prop.value.size() != pqsig::SIG_SIZE) {
+        return false;
+    }
+    sig = prop.value;
+    return true;
+}
+
+PSBTProprietary MakePQPartialSigProp(const PQPkScript& pk_script, const std::vector<unsigned char>& sig)
+{
+    PSBTProprietary prop;
+    prop.subtype = PSBT_PQBTC_IN_PARTIAL_SIG;
+    prop.identifier.assign(PSBT_PQBTC_IDENTIFIER.begin(), PSBT_PQBTC_IDENTIFIER.end());
+    prop.value = sig;
+
+    VectorWriter key_writer{prop.key, 0};
+    key_writer << CompactSizeWriter(PSBT_IN_PROPRIETARY);
+    key_writer << prop.identifier;
+    WriteCompactSize(key_writer, prop.subtype);
+    key_writer << std::span{pk_script};
+    return prop;
+}
+
+void ErasePQPartialSigProps(std::set<PSBTProprietary>& props)
+{
+    for (auto it = props.begin(); it != props.end();) {
+        if (IsPQPartialSig(*it)) {
+            it = props.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+} // namespace
 
 PartiallySignedTransaction::PartiallySignedTransaction(const CMutableTransaction& tx) : tx(tx)
 {
@@ -91,7 +156,7 @@ bool PartiallySignedTransaction::GetInputUTXO(CTxOut& utxo, int input_index) con
 
 bool PSBTInput::IsNull() const
 {
-    return !non_witness_utxo && witness_utxo.IsNull() && partial_sigs.empty() && unknown.empty() && hd_keypaths.empty() && redeem_script.empty() && witness_script.empty();
+    return !non_witness_utxo && witness_utxo.IsNull() && partial_sigs.empty() && unknown.empty() && m_proprietary.empty() && hd_keypaths.empty() && redeem_script.empty() && witness_script.empty();
 }
 
 void PSBTInput::FillSignatureData(SignatureData& sigdata) const
@@ -109,6 +174,13 @@ void PSBTInput::FillSignatureData(SignatureData& sigdata) const
     }
 
     sigdata.signatures.insert(partial_sigs.begin(), partial_sigs.end());
+    for (const auto& prop : m_proprietary) {
+        PQPkScript pk_script{};
+        std::vector<unsigned char> sig;
+        if (DecodePQPartialSigProp(prop, pk_script, sig)) {
+            sigdata.pq_signatures.emplace(pk_script, std::move(sig));
+        }
+    }
     if (!redeem_script.empty()) {
         sigdata.redeem_script = redeem_script;
     }
@@ -158,6 +230,7 @@ void PSBTInput::FromSignatureData(const SignatureData& sigdata)
         hd_keypaths.clear();
         redeem_script.clear();
         witness_script.clear();
+        ErasePQPartialSigProps(m_proprietary);
 
         if (!sigdata.scriptSig.empty()) {
             final_script_sig = sigdata.scriptSig;
@@ -169,6 +242,10 @@ void PSBTInput::FromSignatureData(const SignatureData& sigdata)
     }
 
     partial_sigs.insert(sigdata.signatures.begin(), sigdata.signatures.end());
+    ErasePQPartialSigProps(m_proprietary);
+    for (const auto& [pk_script, sig] : sigdata.pq_signatures) {
+        m_proprietary.insert(MakePQPartialSigProp(pk_script, sig));
+    }
     if (redeem_script.empty() && !sigdata.redeem_script.empty()) {
         redeem_script = sigdata.redeem_script;
     }
@@ -206,6 +283,7 @@ void PSBTInput::Merge(const PSBTInput& input)
     }
 
     partial_sigs.insert(input.partial_sigs.begin(), input.partial_sigs.end());
+    m_proprietary.insert(input.m_proprietary.begin(), input.m_proprietary.end());
     ripemd160_preimages.insert(input.ripemd160_preimages.begin(), input.ripemd160_preimages.end());
     sha256_preimages.insert(input.sha256_preimages.begin(), input.sha256_preimages.end());
     hash160_preimages.insert(input.hash160_preimages.begin(), input.hash160_preimages.end());
@@ -450,6 +528,9 @@ PSBTError SignPSBTInput(const SigningProvider& provider, PartiallySignedTransact
         for (const auto& [_, sig] : input.partial_sigs) {
             if (sig.second.back() != *sighash) return PSBTError::SIGHASH_MISMATCH;
         }
+    }
+    if (!sigdata.pq_signatures.empty() && *sighash != SIGHASH_DEFAULT && *sighash != SIGHASH_ALL) {
+        return PSBTError::SIGHASH_MISMATCH;
     }
 
     sigdata.witness = false;

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -829,6 +829,28 @@ struct PSBTInput
                         throw std::ios_base::failure("Duplicate Key, proprietary key already found");
                     }
                     s >> this_prop.value;
+                    if (this_prop.identifier == std::vector<unsigned char>{'p', 'q', 'b', 't', 'c'} && this_prop.subtype == 0x01) {
+                        SpanReader prop_key{this_prop.key};
+                        uint8_t type;
+                        prop_key >> type;
+                        if (type != PSBT_IN_PROPRIETARY) {
+                            throw std::ios_base::failure("Invalid PQ proprietary key type");
+                        }
+                        std::vector<unsigned char> identifier;
+                        prop_key >> identifier;
+                        const uint64_t subtype = ReadCompactSize(prop_key);
+                        if (identifier != this_prop.identifier || subtype != this_prop.subtype || prop_key.size() != pqsig::PK_SCRIPT_SIZE) {
+                            throw std::ios_base::failure("Invalid PQ proprietary key payload");
+                        }
+                        PQPkScript pk_script{};
+                        prop_key >> std::as_writable_bytes(std::span{pk_script});
+                        if (!pqsig::IsValidPkScript(pk_script)) {
+                            throw std::ios_base::failure("Invalid PQ PK_script in proprietary key");
+                        }
+                        if (this_prop.value.size() != pqsig::SIG_SIZE) {
+                            throw std::ios_base::failure("Invalid PQ proprietary signature size");
+                        }
+                    }
                     m_proprietary.insert(this_prop);
                     break;
                 }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -59,6 +59,27 @@ bool MutableTransactionSignatureCreator::CreateSig(const SigningProvider& provid
     return true;
 }
 
+bool MutableTransactionSignatureCreator::CreatePQSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const PQPkScript& pk_script, const CScript& scriptCode, SigVersion sigversion) const
+{
+    assert(sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0);
+
+    PQSeed seed;
+    if (!provider.GetPQKey(pk_script, seed)) {
+        return false;
+    }
+
+    if (sigversion == SigVersion::WITNESS_V0 && !MoneyRange(amount)) return false;
+
+    const int hashtype = nHashType == SIGHASH_DEFAULT ? SIGHASH_ALL : nHashType;
+    if (hashtype != SIGHASH_ALL) {
+        return false;
+    }
+
+    const uint256 hash = SignatureHash(scriptCode, m_txto, nIn, hashtype, amount, sigversion, m_txdata);
+    sig.resize(pqsig::SIG_SIZE);
+    return pqsig::PQSigSign(sig, std::span<const uint8_t>{hash.begin(), hash.size()}, seed, pk_script);
+}
+
 bool MutableTransactionSignatureCreator::CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const
 {
     assert(sigversion == SigVersion::TAPROOT || sigversion == SigVersion::TAPSCRIPT);
@@ -148,6 +169,21 @@ static bool CreateSig(const BaseSignatureCreator& creator, SignatureData& sigdat
     }
     // Could not make signature or signature not found, add keyid to missing
     sigdata.missing_sigs.push_back(keyid);
+    return false;
+}
+
+static bool CreatePQSig(const BaseSignatureCreator& creator, SignatureData& sigdata, const SigningProvider& provider, std::vector<unsigned char>& sig_out, const PQPkScript& pk_script, const CScript& scriptcode, SigVersion sigversion)
+{
+    const auto it = sigdata.pq_signatures.find(pk_script);
+    if (it != sigdata.pq_signatures.end()) {
+        sig_out = it->second;
+        return true;
+    }
+    if (creator.CreatePQSig(provider, sig_out, pk_script, scriptcode, sigversion)) {
+        auto inserted = sigdata.pq_signatures.emplace(pk_script, sig_out);
+        assert(inserted.second);
+        return true;
+    }
     return false;
 }
 
@@ -413,10 +449,20 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
     case TxoutType::NULL_DATA:
     case TxoutType::WITNESS_UNKNOWN:
         return false;
-    case TxoutType::PUBKEY:
+    case TxoutType::PUBKEY: {
+        if (vSolutions[0].size() == pqsig::PK_SCRIPT_SIZE) {
+            PQPkScript pk_script{};
+            std::copy(vSolutions[0].begin(), vSolutions[0].end(), pk_script.begin());
+            if (pqsig::IsValidPkScript(pk_script)) {
+                if (!CreatePQSig(creator, sigdata, provider, sig, pk_script, scriptPubKey, sigversion)) return false;
+                ret.push_back(std::move(sig));
+                return true;
+            }
+        }
         if (!CreateSig(creator, sigdata, provider, sig, CPubKey(vSolutions[0]), scriptPubKey, sigversion)) return false;
         ret.push_back(std::move(sig));
         return true;
+    }
     case TxoutType::PUBKEYHASH: {
         CKeyID keyID = CKeyID(uint160(vSolutions[0]));
         CPubKey pubkey;
@@ -692,6 +738,7 @@ void SignatureData::MergeSignatureData(SignatureData sigdata)
         witness_script = sigdata.witness_script;
     }
     signatures.insert(std::make_move_iterator(sigdata.signatures.begin()), std::make_move_iterator(sigdata.signatures.end()));
+    pq_signatures.insert(std::make_move_iterator(sigdata.pq_signatures.begin()), std::make_move_iterator(sigdata.pq_signatures.end()));
 }
 
 namespace {
@@ -730,6 +777,11 @@ public:
         vchSig[5 + m_r_len] = m_s_len;
         vchSig[6 + m_r_len] = 0x01;
         vchSig[6 + m_r_len + m_s_len] = SIGHASH_ALL;
+        return true;
+    }
+    bool CreatePQSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const PQPkScript& pk_script, const CScript& scriptCode, SigVersion sigversion) const override
+    {
+        sig.assign(pqsig::SIG_SIZE, 0x00);
         return true;
     }
     bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* tweak, SigVersion sigversion) const override

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -32,6 +32,7 @@ public:
 
     /** Create a singular (non-script) signature. */
     virtual bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
+    virtual bool CreatePQSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const PQPkScript& pk_script, const CScript& scriptCode, SigVersion sigversion) const =0;
     virtual bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const =0;
 };
 
@@ -50,6 +51,7 @@ public:
     MutableTransactionSignatureCreator(const CMutableTransaction& tx LIFETIMEBOUND, unsigned int input_idx, const CAmount& amount, const PrecomputedTransactionData* txdata, int hash_type);
     const BaseSignatureChecker& Checker() const override { return checker; }
     bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
+    bool CreatePQSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const PQPkScript& pk_script, const CScript& scriptCode, SigVersion sigversion) const override;
     bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const override;
 };
 
@@ -75,6 +77,7 @@ struct SignatureData {
     TaprootSpendData tr_spenddata; ///< Taproot spending data.
     std::optional<TaprootBuilder> tr_builder; ///< Taproot tree used to build tr_spenddata.
     std::map<CKeyID, SigPair> signatures; ///< BIP 174 style partial signatures for the input. May contain all signatures necessary for producing a final scriptSig or scriptWitness.
+    std::map<PQPkScript, std::vector<unsigned char>> pq_signatures; ///< PQBTC proprietary partial signatures keyed by raw PK_script.
     std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>> misc_pubkeys;
     std::vector<unsigned char> taproot_key_path_sig; /// Schnorr signature for key path spending
     std::map<std::pair<XOnlyPubKey, uint256>, std::vector<unsigned char>> taproot_script_sigs; ///< (Partial) schnorr signatures, indexed by XOnlyPubKey and leaf_hash.

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -44,6 +44,12 @@ bool HidingSigningProvider::GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& inf
     return m_provider->GetKeyOrigin(keyid, info);
 }
 
+bool HidingSigningProvider::GetPQKey(const PQPkScript& pk_script, PQSeed& seed) const
+{
+    if (m_hide_secret) return false;
+    return m_provider->GetPQKey(pk_script, seed);
+}
+
 bool HidingSigningProvider::GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const
 {
     return m_provider->GetTaprootSpendData(output_key, spenddata);
@@ -73,6 +79,7 @@ bool FlatSigningProvider::HaveKey(const CKeyID &keyid) const
     return LookupHelper(keys, keyid, key);
 }
 bool FlatSigningProvider::GetKey(const CKeyID& keyid, CKey& key) const { return LookupHelper(keys, keyid, key); }
+bool FlatSigningProvider::GetPQKey(const PQPkScript& pk_script, PQSeed& seed) const { return LookupHelper(pq_keys, pk_script, seed); }
 bool FlatSigningProvider::GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const
 {
     TaprootBuilder builder;
@@ -100,6 +107,7 @@ FlatSigningProvider& FlatSigningProvider::Merge(FlatSigningProvider&& b)
     pubkeys.merge(b.pubkeys);
     keys.merge(b.keys);
     origins.merge(b.origins);
+    pq_keys.merge(b.pq_keys);
     tr_trees.merge(b.tr_trees);
     aggregate_pubkeys.merge(b.aggregate_pubkeys);
     return *this;
@@ -280,6 +288,14 @@ bool MultiSigningProvider::GetKey(const CKeyID& keyid, CKey& key) const
 {
     for (const auto& provider: m_providers) {
         if (provider->GetKey(keyid, key)) return true;
+    }
+    return false;
+}
+
+bool MultiSigningProvider::GetPQKey(const PQPkScript& pk_script, PQSeed& seed) const
+{
+    for (const auto& provider: m_providers) {
+        if (provider->GetPQKey(pk_script, seed)) return true;
     }
     return false;
 }

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -8,6 +8,7 @@
 
 #include <addresstype.h>
 #include <attributes.h>
+#include <crypto/pqsig/pqsig.h>
 #include <key.h>
 #include <pubkey.h>
 #include <script/keyorigin.h>
@@ -148,6 +149,9 @@ public:
  */
 std::optional<std::vector<std::tuple<int, std::vector<unsigned char>, int>>> InferTaprootTree(const TaprootSpendData& spenddata, const XOnlyPubKey& output);
 
+using PQPkScript = std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>;
+using PQSeed = std::array<unsigned char, pqsig::MSG32_SIZE>;
+
 /** An interface to be implemented by keystores that support signing. */
 class SigningProvider
 {
@@ -159,6 +163,7 @@ public:
     virtual bool GetKey(const CKeyID &address, CKey& key) const { return false; }
     virtual bool HaveKey(const CKeyID &address) const { return false; }
     virtual bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const { return false; }
+    virtual bool GetPQKey(const PQPkScript& pk_script, PQSeed& seed) const { return false; }
     virtual bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const { return false; }
     virtual bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const { return false; }
     virtual std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const { return {}; }
@@ -203,6 +208,7 @@ public:
     bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
     bool GetKey(const CKeyID& keyid, CKey& key) const override;
     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
+    bool GetPQKey(const PQPkScript& pk_script, PQSeed& seed) const override;
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
@@ -214,6 +220,7 @@ struct FlatSigningProvider final : public SigningProvider
     std::map<CKeyID, CPubKey> pubkeys;
     std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>> origins;
     std::map<CKeyID, CKey> keys;
+    std::map<PQPkScript, PQSeed> pq_keys;
     std::map<XOnlyPubKey, TaprootBuilder> tr_trees; /** Map from output key to Taproot tree (which can then make the TaprootSpendData */
     std::map<CPubKey, std::vector<CPubKey>> aggregate_pubkeys; /** MuSig2 aggregate pubkeys */
 
@@ -222,6 +229,7 @@ struct FlatSigningProvider final : public SigningProvider
     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
     bool HaveKey(const CKeyID &keyid) const override;
     bool GetKey(const CKeyID& keyid, CKey& key) const override;
+    bool GetPQKey(const PQPkScript& pk_script, PQSeed& seed) const override;
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
     std::vector<CPubKey> GetMuSig2ParticipantPubkeys(const CPubKey& pubkey) const override;
@@ -316,6 +324,7 @@ public:
     bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
     bool GetKey(const CKeyID& keyid, CKey& key) const override;
+    bool GetPQKey(const PQPkScript& pk_script, PQSeed& seed) const override;
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
 };

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <pubkey.h>
+#include <crypto/pqsig/pqsig.h>
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <script/solver.h>
@@ -41,7 +42,7 @@ static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
     }
     if (script.size() == CPubKey::COMPRESSED_SIZE + 2 && script[0] == CPubKey::COMPRESSED_SIZE && script.back() == OP_CHECKSIG) {
         pubkey = valtype(script.begin() + 1, script.begin() + CPubKey::COMPRESSED_SIZE + 1);
-        return CPubKey::ValidSize(pubkey);
+        return CPubKey::ValidSize(pubkey) || pqsig::IsValidPkScript(pubkey);
     }
     return false;
 }

--- a/src/secp256k1/CMakeLists.txt
+++ b/src/secp256k1/CMakeLists.txt
@@ -216,7 +216,9 @@ else()
   # Keep the following commands ordered lexicographically.
   try_append_c_flags(-pedantic)
   try_append_c_flags(-Wcast-align) # GCC >= 2.95.
-  try_append_c_flags(-Wcast-align=strict) # GCC >= 8.0.
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    try_append_c_flags(-Wcast-align=strict) # GCC >= 8.0.
+  endif()
   try_append_c_flags(-Wconditional-uninitialized) # Clang >= 3.0 only.
   try_append_c_flags(-Wextra) # GCC >= 3.4, this is the newer name of -W, which we don't use because older GCCs will warn about unused functions.
   try_append_c_flags(-Wnested-externs)

--- a/src/secp256k1/CMakeLists.txt
+++ b/src/secp256k1/CMakeLists.txt
@@ -216,9 +216,7 @@ else()
   # Keep the following commands ordered lexicographically.
   try_append_c_flags(-pedantic)
   try_append_c_flags(-Wcast-align) # GCC >= 2.95.
-  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    try_append_c_flags(-Wcast-align=strict) # GCC >= 8.0.
-  endif()
+  try_append_c_flags(-Wcast-align=strict) # GCC >= 8.0.
   try_append_c_flags(-Wconditional-uninitialized) # Clang >= 3.0 only.
   try_append_c_flags(-Wextra) # GCC >= 3.4, this is the newer name of -W, which we don't use because older GCCs will warn about unused functions.
   try_append_c_flags(-Wnested-externs)

--- a/src/test/pqsig_script_tests.cpp
+++ b/src/test/pqsig_script_tests.cpp
@@ -2,12 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <addresstype.h>
 #include <consensus/amount.h>
 #include <crypto/pqsig/params.h>
 #include <crypto/pqsig/pqsig.h>
+#include <psbt.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
 #include <script/script.h>
 #include <script/script_error.h>
 
@@ -64,6 +68,20 @@ CMutableTransaction BuildSpendingTx()
     tx.vout[0].nValue = 50 * COIN;
     tx.vout[0].scriptPubKey = CScript{} << OP_TRUE;
     return tx;
+}
+
+CScript MakeWitnessScript(const std::array<uint8_t, pqsig::PK_SCRIPT_SIZE>& pk_script)
+{
+    return CScript{} << std::vector<unsigned char>{pk_script.begin(), pk_script.end()} << OP_CHECKSIG;
+}
+
+FlatSigningProvider MakePQSigningProvider(const std::array<uint8_t, pqsig::PK_SCRIPT_SIZE>& pk_script)
+{
+    FlatSigningProvider provider;
+    const CScript witness_script = MakeWitnessScript(pk_script);
+    provider.scripts.emplace(CScriptID(witness_script), witness_script);
+    provider.pq_keys.emplace(pk_script, TEST_SK_SEED);
+    return provider;
 }
 
 } // namespace
@@ -155,6 +173,85 @@ BOOST_AUTO_TEST_CASE(checkmultisig_accepts_valid_and_rejects_wrong_sighash)
 
     BOOST_CHECK(!VerifyScript(mutated_tx.vin[0].scriptSig, multisig_script, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, mutated_checker, &err));
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_EVAL_FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(produce_signature_builds_valid_p2wsh_pq_witness)
+{
+    const auto pk_script = MakePkScript();
+    const CScript witness_script = MakeWitnessScript(pk_script);
+    const CScript script_pubkey = GetScriptForDestination(WitnessV0ScriptHash(witness_script));
+    const CAmount amount = 50 * COIN;
+
+    CMutableTransaction tx = BuildSpendingTx();
+    SignatureData sigdata;
+    const auto provider = MakePQSigningProvider(pk_script);
+
+    BOOST_REQUIRE(ProduceSignature(provider, MutableTransactionSignatureCreator(tx, 0, amount, SIGHASH_ALL), script_pubkey, sigdata));
+    BOOST_REQUIRE_EQUAL(sigdata.scriptWitness.stack.size(), 2U);
+    BOOST_CHECK_EQUAL(sigdata.scriptWitness.stack[0].size(), pqsig::SIG_SIZE);
+    BOOST_CHECK(sigdata.scriptWitness.stack[1] == std::vector<unsigned char>(witness_script.begin(), witness_script.end()));
+
+    tx.vin[0].scriptWitness = sigdata.scriptWitness;
+    const CTransaction tx_const{tx};
+    const TransactionSignatureChecker checker(&tx_const, /*nInIn=*/0, amount, MissingDataBehavior::FAIL);
+
+    ScriptError err;
+    BOOST_CHECK(VerifyScript(CScript{}, script_pubkey, &tx.vin[0].scriptWitness, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+}
+
+BOOST_AUTO_TEST_CASE(dummy_and_non_all_pq_signing_paths)
+{
+    const auto pk_script = MakePkScript();
+    const CScript witness_script = MakeWitnessScript(pk_script);
+    const CScript script_pubkey = GetScriptForDestination(WitnessV0ScriptHash(witness_script));
+    const CAmount amount = 50 * COIN;
+    const auto provider = MakePQSigningProvider(pk_script);
+
+    SignatureData dummy_sigdata;
+    BOOST_REQUIRE(ProduceSignature(provider, DUMMY_SIGNATURE_CREATOR, script_pubkey, dummy_sigdata));
+    BOOST_REQUIRE_EQUAL(dummy_sigdata.scriptWitness.stack.size(), 2U);
+    BOOST_CHECK_EQUAL(dummy_sigdata.scriptWitness.stack[0].size(), pqsig::SIG_SIZE);
+    BOOST_CHECK(dummy_sigdata.scriptWitness.stack[1] == std::vector<unsigned char>(witness_script.begin(), witness_script.end()));
+
+    SignatureData rejected_sigdata;
+    CMutableTransaction tx = BuildSpendingTx();
+    BOOST_CHECK(!ProduceSignature(provider, MutableTransactionSignatureCreator(tx, 0, amount, SIGHASH_NONE), script_pubkey, rejected_sigdata));
+}
+
+BOOST_AUTO_TEST_CASE(psbt_roundtrips_pq_proprietary_partial_sig_and_finalizes)
+{
+    const auto pk_script = MakePkScript();
+    const CScript witness_script = MakeWitnessScript(pk_script);
+    const CScript script_pubkey = GetScriptForDestination(WitnessV0ScriptHash(witness_script));
+    const CAmount amount = 50 * COIN;
+
+    CMutableTransaction tx = BuildSpendingTx();
+    PartiallySignedTransaction psbt(tx);
+    psbt.inputs[0].witness_utxo = CTxOut(amount, script_pubkey);
+
+    const auto provider = MakePQSigningProvider(pk_script);
+    const PrecomputedTransactionData txdata = PrecomputePSBTData(psbt);
+
+    BOOST_CHECK(static_cast<int>(SignPSBTInput(provider, psbt, 0, &txdata, std::nullopt, nullptr, /*finalize=*/false)) == static_cast<int>(PSBTError::OK));
+    BOOST_CHECK(psbt.inputs[0].final_script_witness.IsNull());
+    BOOST_REQUIRE_EQUAL(psbt.inputs[0].m_proprietary.size(), 1U);
+
+    DataStream ss{};
+    ss << psbt;
+    PartiallySignedTransaction roundtrip;
+    ss >> roundtrip;
+
+    BOOST_REQUIRE_EQUAL(roundtrip.inputs[0].m_proprietary.size(), 1U);
+    const auto& prop = *roundtrip.inputs[0].m_proprietary.begin();
+    BOOST_CHECK(prop.identifier == std::vector<unsigned char>({'p', 'q', 'b', 't', 'c'}));
+    BOOST_CHECK_EQUAL(prop.subtype, 1U);
+    BOOST_CHECK_EQUAL(prop.value.size(), pqsig::SIG_SIZE);
+
+    BOOST_CHECK(FinalizePSBT(roundtrip));
+    BOOST_REQUIRE_EQUAL(roundtrip.inputs[0].final_script_witness.stack.size(), 2U);
+    BOOST_CHECK_EQUAL(roundtrip.inputs[0].final_script_witness.stack[0].size(), pqsig::SIG_SIZE);
+    BOOST_CHECK(roundtrip.inputs[0].final_script_witness.stack[1] == std::vector<unsigned char>(witness_script.begin(), witness_script.end()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(bitcoin_wallet
     core_interface
     bitcoin_common
     $<TARGET_NAME_IF_EXISTS:unofficial::sqlite3::sqlite3>
-    $<TARGET_NAME_IF_EXISTS:SQLite::SQLite3>
+    $<TARGET_NAME_IF_EXISTS:SQLite3::SQLite3>
     univalue
     Boost::headers
     $<TARGET_NAME_IF_EXISTS:USDT::headers>

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -35,13 +35,22 @@ add_library(bitcoin_wallet STATIC EXCLUDE_FROM_ALL
   walletdb.cpp
   walletutil.cpp
 )
+set(bitcoin_sqlite_target "")
+if(TARGET unofficial::sqlite3::sqlite3)
+  set(bitcoin_sqlite_target unofficial::sqlite3::sqlite3)
+elseif(TARGET SQLite3::SQLite3)
+  set(bitcoin_sqlite_target SQLite3::SQLite3)
+elseif(TARGET SQLite::SQLite3)
+  set(bitcoin_sqlite_target SQLite::SQLite3)
+endif()
 target_link_libraries(bitcoin_wallet
   PRIVATE
     core_interface
     bitcoin_common
-    $<TARGET_NAME_IF_EXISTS:unofficial::sqlite3::sqlite3>
-    $<TARGET_NAME_IF_EXISTS:SQLite3::SQLite3>
     univalue
     Boost::headers
     $<TARGET_NAME_IF_EXISTS:USDT::headers>
 )
+if(bitcoin_sqlite_target)
+  target_link_libraries(bitcoin_wallet PRIVATE ${bitcoin_sqlite_target})
+endif()

--- a/src/wallet/pq_scriptpubkeyman.cpp
+++ b/src/wallet/pq_scriptpubkeyman.cpp
@@ -5,6 +5,7 @@
 #include <wallet/pq_scriptpubkeyman.h>
 
 #include <crypto/sha256.h>
+#include <script/sign.h>
 #include <script/script.h>
 #include <script/solver.h>
 #include <tinyformat.h>
@@ -83,6 +84,16 @@ bool PQDescriptorScriptPubKeyMan::GetRootSeed(CKeyingMaterial& root_seed) const
     return m_storage.WithEncryptionKey([&](const CKeyingMaterial& master_key) {
         return DecryptSecret(master_key, crypted_root_seed, m_id, root_seed) && root_seed.size() == pqsig::MSG32_SIZE;
     });
+}
+
+bool PQDescriptorScriptPubKeyMan::GetChildSeedForIndex(const int32_t index, PQSeed& seed) const
+{
+    AssertLockHeld(cs_pq_man);
+    CKeyingMaterial root_seed;
+    if (!GetRootSeed(root_seed)) {
+        return false;
+    }
+    return pqsig::DeriveWalletSkSeed(seed, root_seed, IsInternal(), index);
 }
 
 bool PQDescriptorScriptPubKeyMan::GetDestinationForIndex(const int32_t index, CTxDestination& dest) const
@@ -256,6 +267,12 @@ bool PQDescriptorScriptPubKeyMan::IsMine(const CScript& script) const
     return m_map_script_pub_keys.contains(script);
 }
 
+bool PQDescriptorScriptPubKeyMan::IsSpendable(const CScript& script) const
+{
+    LOCK(cs_pq_man);
+    return m_map_script_pub_keys.contains(script) && (!m_root_seed.empty() || !m_crypted_root_seed.empty());
+}
+
 bool PQDescriptorScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key)
 {
     LOCK(cs_pq_man);
@@ -329,6 +346,11 @@ std::unique_ptr<CKeyMetadata> PQDescriptorScriptPubKeyMan::GetMetadata(const CTx
 
 std::unique_ptr<SigningProvider> PQDescriptorScriptPubKeyMan::GetSolvingProvider(const CScript& script) const
 {
+    return GetSigningProvider(script, /*include_private=*/false);
+}
+
+std::unique_ptr<FlatSigningProvider> PQDescriptorScriptPubKeyMan::GetSigningProvider(const CScript& script, const bool include_private) const
+{
     LOCK(cs_pq_man);
     const auto it = m_map_script_pub_keys.find(script);
     if (it == m_map_script_pub_keys.end()) {
@@ -341,12 +363,85 @@ std::unique_ptr<SigningProvider> PQDescriptorScriptPubKeyMan::GetSolvingProvider
     auto provider = std::make_unique<FlatSigningProvider>();
     const CScript witness_script = MakeWitnessScript(pk_it->second);
     provider->scripts.emplace(CScriptID(witness_script), witness_script);
+    if (include_private) {
+        PQSeed child_seed{};
+        if (!GetChildSeedForIndex(it->second, child_seed)) {
+            return nullptr;
+        }
+        provider->pq_keys.emplace(pk_it->second, child_seed);
+    }
     return provider;
 }
 
 bool PQDescriptorScriptPubKeyMan::CanProvide(const CScript& script, SignatureData&)
 {
     return IsMine(script);
+}
+
+bool PQDescriptorScriptPubKeyMan::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const
+{
+    const int effective_sighash = sighash == SIGHASH_DEFAULT ? SIGHASH_ALL : sighash;
+    if (effective_sighash != SIGHASH_ALL) {
+        return false;
+    }
+
+    std::unique_ptr<FlatSigningProvider> keys = std::make_unique<FlatSigningProvider>();
+    for (const auto& coin_pair : coins) {
+        std::unique_ptr<FlatSigningProvider> coin_keys = GetSigningProvider(coin_pair.second.out.scriptPubKey, /*include_private=*/true);
+        if (!coin_keys) {
+            continue;
+        }
+        keys->Merge(std::move(*coin_keys));
+    }
+
+    return ::SignTransaction(tx, keys.get(), coins, sighash, input_errors);
+}
+
+std::optional<common::PSBTError> PQDescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, std::optional<int> sighash_type, const bool sign, const bool bip32derivs, int* n_signed, const bool finalize) const
+{
+    if (n_signed) {
+        *n_signed = 0;
+    }
+    for (unsigned int i = 0; i < psbt.tx->vin.size(); ++i) {
+        const CTxIn& txin = psbt.tx->vin[i];
+        PSBTInput& input = psbt.inputs.at(i);
+
+        if (PSBTInputSigned(input)) {
+            continue;
+        }
+
+        CScript script;
+        if (!input.witness_utxo.IsNull()) {
+            script = input.witness_utxo.scriptPubKey;
+        } else if (input.non_witness_utxo) {
+            if (txin.prevout.n >= input.non_witness_utxo->vout.size()) {
+                return common::PSBTError::MISSING_INPUTS;
+            }
+            script = input.non_witness_utxo->vout[txin.prevout.n].scriptPubKey;
+        } else {
+            continue;
+        }
+
+        std::unique_ptr<FlatSigningProvider> keys = GetSigningProvider(script, /*include_private=*/sign);
+        if (!keys) {
+            continue;
+        }
+
+        const std::optional<int> input_sighash = input.sighash_type.has_value() ? input.sighash_type : sighash_type;
+        if (input_sighash.has_value() && *input_sighash != SIGHASH_DEFAULT && *input_sighash != SIGHASH_ALL) {
+            return common::PSBTError::SIGHASH_MISMATCH;
+        }
+
+        const auto res = SignPSBTInput(HidingSigningProvider(keys.get(), /*hide_secret=*/!sign, /*hide_origin=*/!bip32derivs), psbt, i, &txdata, sighash_type, nullptr, finalize);
+        if (res != common::PSBTError::OK && res != common::PSBTError::INCOMPLETE) {
+            return res;
+        }
+
+        if (n_signed && (PSBTInputSigned(input) || !sign)) {
+            ++(*n_signed);
+        }
+    }
+    return {};
 }
 
 uint256 PQDescriptorScriptPubKeyMan::GetID() const

--- a/src/wallet/pq_scriptpubkeyman.h
+++ b/src/wallet/pq_scriptpubkeyman.h
@@ -35,9 +35,11 @@ private:
     bool m_decryption_thoroughly_checked GUARDED_BY(cs_pq_man){false};
 
     bool GetRootSeed(CKeyingMaterial& root_seed) const EXCLUSIVE_LOCKS_REQUIRED(cs_pq_man);
+    bool GetChildSeedForIndex(int32_t index, PQSeed& seed) const EXCLUSIVE_LOCKS_REQUIRED(cs_pq_man);
     static CScript MakeWitnessScript(const std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& pk_script);
     static CScript MakeScriptPubKey(const std::array<unsigned char, pqsig::PK_SCRIPT_SIZE>& pk_script);
     bool GetDestinationForIndex(int32_t index, CTxDestination& dest) const EXCLUSIVE_LOCKS_REQUIRED(cs_pq_man);
+    std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CScript& script, bool include_private) const;
     bool WriteMetadata(WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_pq_man);
 
 public:
@@ -70,8 +72,10 @@ public:
     int64_t GetTimeFirstKey() const override;
     std::unique_ptr<CKeyMetadata> GetMetadata(const CTxDestination& dest) const override;
     std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const override;
-    bool IsSpendable(const CScript& script) const override { return false; }
+    bool IsSpendable(const CScript& script) const override;
     bool CanProvide(const CScript& script, SignatureData& sigdata) override;
+    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
+    std::optional<common::PSBTError> FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, std::optional<int> sighash_type = std::nullopt, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const override;
     uint256 GetID() const override;
     std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override;
     std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1719,6 +1719,9 @@ bool CWallet::CanGetAddresses(bool internal) const
 {
     LOCK(cs_wallet);
     if (m_spk_managers.empty()) return false;
+    if (internal && m_internal_pq_spk_manager && m_internal_pq_spk_manager->CanGetAddresses(/*internal=*/true)) {
+        return true;
+    }
     for (OutputType t : OUTPUT_TYPES) {
         auto spk_man = GetScriptPubKeyMan(t, internal);
         if (spk_man && spk_man->CanGetAddresses(internal)) {
@@ -2275,7 +2278,7 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
         // Currently tr is the only type supported by the BECH32M spkman
         return OutputType::BECH32M;
     }
-    const bool has_bech32_spkman(GetScriptPubKeyMan(OutputType::BECH32, /*internal=*/true));
+    const bool has_bech32_spkman(GetChangeScriptPubKeyMan(OutputType::BECH32));
     if (has_bech32_spkman && any_wpkh) {
         // Currently wpkh is the only type supported by the BECH32 spkman
         return OutputType::BECH32;
@@ -2571,6 +2574,17 @@ util::Result<CTxDestination> CWallet::GetNewChangeDestination(const OutputType t
     return op_dest;
 }
 
+ScriptPubKeyMan* CWallet::GetChangeScriptPubKeyMan(const OutputType& type) const
+{
+    if (auto* spk_man = GetScriptPubKeyMan(type, /*internal=*/true)) {
+        return spk_man;
+    }
+    if (type == OutputType::BECH32) {
+        return m_internal_pq_spk_manager;
+    }
+    return nullptr;
+}
+
 util::Result<CTxDestination> CWallet::GetNewPQDestination(const std::string& label)
 {
     LOCK(cs_wallet);
@@ -2650,7 +2664,7 @@ std::set<std::string> CWallet::ListAddrBookLabels(const std::optional<AddressPur
 
 util::Result<CTxDestination> ReserveDestination::GetReservedDestination(bool internal)
 {
-    m_spk_man = pwallet->GetScriptPubKeyMan(type, internal);
+    m_spk_man = internal ? pwallet->GetChangeScriptPubKeyMan(type) : pwallet->GetScriptPubKeyMan(type, internal);
     if (!m_spk_man) {
         return util::Error{strprintf(_("Error: No %s addresses available."), FormatOutputType(type))};
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -790,6 +790,7 @@ public:
     util::Result<CTxDestination> GetNewChangeDestination(const OutputType type);
     util::Result<CTxDestination> GetNewPQDestination(const std::string& label);
     util::Result<CTxDestination> GetNewPQChangeDestination();
+    ScriptPubKeyMan* GetChangeScriptPubKeyMan(const OutputType& type) const;
 
     bool IsMine(const CTxDestination& dest) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool IsMine(const CScript& script) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -287,6 +287,7 @@ BASE_SCRIPTS = [
     'wallet_importdescriptors.py',
     'wallet_pq_descriptors.py',
     'wallet_pq_backup_recovery.py',
+    'wallet_pq_psbt.py',
     'wallet_crosschain.py',
     'mining_basic.py',
     'mining_mainnet.py',

--- a/test/functional/wallet_pq_active_ranged.py
+++ b/test/functional/wallet_pq_active_ranged.py
@@ -33,7 +33,7 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def mine_block(self):
-        self.nodes[0].generatetodescriptor(1, RAW_TRUE_DESCRIPTOR, called_by_framework=True)
+        return self.nodes[0].generatetodescriptor(1, RAW_TRUE_DESCRIPTOR, called_by_framework=True)[0]
 
     def ensure_wallet_loaded(self, wallet_name):
         node = self.nodes[0]
@@ -80,13 +80,32 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         if label is not None:
             assert_equal(info["labels"], [label])
 
-    def assert_tracked_output(self, wallet, txid: str, entry, amount: Decimal):
-        tx = wallet.gettransaction(txid)
-        assert_equal(tx["amount"], amount)
-        assert_equal(tx["details"][0]["address"], entry.address)
-        assert_equal(tx["details"][0]["category"], "receive")
+    def assert_owned_unspent(self, wallet, txid: str, entry, amount: Decimal, *, category: str | None = "receive"):
+        if category is not None:
+            tx = wallet.gettransaction(txid)
+            details = [detail for detail in tx["details"] if detail["address"] == entry.address]
+            assert_equal(len(details), 1)
+            assert_equal(details[0]["category"], category)
+        unspent = wallet.listunspent()
+        assert_equal(len(unspent), 1)
+        assert_equal(unspent[0]["txid"], txid)
+        assert_equal(unspent[0]["address"], entry.address)
+        assert_equal(unspent[0]["amount"], amount)
+        assert_equal(unspent[0]["spendable"], True)
         assert_equal(wallet.getbalances()["mine"]["trusted"], amount)
-        assert_equal(wallet.listunspent(), [])
+
+    def find_output_amount(self, txid: str, address: str, *, blockhash: str) -> Decimal:
+        tx = self.nodes[0].getrawtransaction(txid, 2, blockhash)
+        for vout in tx["vout"]:
+            script_pub_key = vout["scriptPubKey"]
+            output_address = script_pub_key.get("address")
+            if output_address is None:
+                addresses = script_pub_key.get("addresses", [])
+                if addresses:
+                    output_address = addresses[0]
+            if output_address == address:
+                return Decimal(str(vout["value"]))
+        raise AssertionError(f"Unable to find output for {address} in {txid}")
 
     def fund_entry(self, entry, amount_sat: int) -> str:
         tx = create_wallet_funded_tx(self.nodes[0], bytes(entry.script_pub_key), amount_sat)
@@ -131,22 +150,25 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         self.assert_address_info(wallet, int_entries[0], is_change=True)
         self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=1)
 
-        self.log.info("Fund a later generated PQ address and confirm it is tracked but not spendable")
+        self.log.info("Fund a later generated PQ address and confirm it is tracked and spendable")
         txid = self.fund_entry(ext_entries[2], 4 * COIN)
         self.mine_block()
-        self.assert_tracked_output(wallet, txid, ext_entries[2], Decimal("4.00000000"))
-        assert_raises_rpc_error(-6, "Insufficient funds", wallet.sendtoaddress, sink_addr, 1)
+        self.assert_owned_unspent(wallet, txid, ext_entries[2], Decimal("4.00000000"))
+
+        self.log.info("Spend from the funded PQ output and confirm automatic PQ change uses the active internal manager")
+        spend_txid = wallet.sendtoaddress(sink_addr, 1)
+        spend_blockhash = self.mine_block()
+        change_amount = self.find_output_amount(spend_txid, int_entries[1].address, blockhash=spend_blockhash)
+        self.assert_owned_unspent(wallet, spend_txid, int_entries[1], change_amount, category=None)
+        self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=2)
+        self.assert_address_info(wallet, int_entries[1], is_change=True)
 
         self.log.info("Restart and confirm active manager state and tracked outputs persist")
         self.restart_node(0, self.extra_args[0])
         node = self.nodes[0]
         wallet = self.ensure_wallet_loaded("pqactive")
-        self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=1)
-        self.assert_tracked_output(wallet, txid, ext_entries[2], Decimal("4.00000000"))
-
-        assert_equal(wallet.getnewpqaddress(), ext_entries[3].address)
-        assert_equal(wallet.getrawpqchangeaddress(), int_entries[1].address)
-        self.assert_descriptor_state(wallet, root_seed, external_next=4, internal_next=2)
+        self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=2)
+        self.assert_owned_unspent(wallet, spend_txid, int_entries[1], change_amount, category=None)
 
         self.log.info("Back up and restore the wallet with active PQ managers intact")
         backup_path = node.datadir_path / "pqactive.bak"
@@ -154,9 +176,9 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         node.restorewallet("pqactive_restored", str(backup_path))
         restored = node.get_wallet_rpc("pqactive_restored")
 
-        self.assert_descriptor_state(restored, root_seed, external_next=4, internal_next=2)
-        self.assert_tracked_output(restored, txid, ext_entries[2], Decimal("4.00000000"))
-        self.assert_address_info(restored, ext_entries[2], is_change=False)
+        self.assert_descriptor_state(restored, root_seed, external_next=3, internal_next=2)
+        self.assert_owned_unspent(restored, spend_txid, int_entries[1], change_amount, category=None)
+        self.assert_address_info(restored, int_entries[1], is_change=True)
         assert_equal(restored.gethdkeys(), [])
         assert_raises_rpc_error(-4, "Public export for ranged pqpriv() descriptors is not available.", restored.listdescriptors, False)
         assert_raises_rpc_error(
@@ -167,18 +189,18 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         )
 
         self.log.info("Generated addresses continue from the correct next index after restore")
-        assert_equal(restored.getnewpqaddress("restored receive"), ext_entries[4].address)
+        assert_equal(restored.getnewpqaddress("restored receive"), ext_entries[3].address)
         assert_equal(restored.getrawpqchangeaddress(), int_entries[2].address)
-        self.assert_descriptor_state(restored, root_seed, external_next=5, internal_next=3)
+        self.assert_descriptor_state(restored, root_seed, external_next=4, internal_next=3)
 
         self.log.info("Reload the restored wallet and confirm watch set and next_index remain stable")
         restored.unloadwallet()
         node.loadwallet("pqactive_restored")
         restored = node.get_wallet_rpc("pqactive_restored")
+        self.assert_descriptor_state(restored, root_seed, external_next=4, internal_next=3)
+        self.assert_owned_unspent(restored, spend_txid, int_entries[1], change_amount, category=None)
+        assert_equal(restored.getnewpqaddress(), ext_entries[4].address)
         self.assert_descriptor_state(restored, root_seed, external_next=5, internal_next=3)
-        self.assert_tracked_output(restored, txid, ext_entries[2], Decimal("4.00000000"))
-        assert_equal(restored.getnewpqaddress(), ext_entries[5].address)
-        self.assert_descriptor_state(restored, root_seed, external_next=6, internal_next=3)
 
 
 if __name__ == "__main__":

--- a/test/functional/wallet_pq_psbt.py
+++ b/test/functional/wallet_pq_psbt.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test PQ wallet spendability and PSBT parity."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from test_framework.descriptors import descsum_create
+from test_framework.messages import COIN
+from test_framework.pqsig import create_wallet_funded_tx
+from test_framework.pq_wallet_helper import (
+    build_active_pq_descriptor_entry,
+    make_pqpriv_import_request,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+RAW_TRUE_DESCRIPTOR = descsum_create("raw(51)")
+PQ_PROP_IDENTIFIER = "7071627463"
+
+
+class WalletPQPSBTTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-acceptnonstdtxn=1"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def mine_block(self):
+        return self.nodes[0].generatetodescriptor(1, RAW_TRUE_DESCRIPTOR, called_by_framework=True)[0]
+
+    def ensure_wallet_loaded(self, wallet_name):
+        node = self.nodes[0]
+        if wallet_name not in node.listwallets():
+            node.loadwallet(wallet_name)
+        return node.get_wallet_rpc(wallet_name)
+
+    def fund_entry(self, entry, amount_sat: int) -> str:
+        tx = create_wallet_funded_tx(self.nodes[0], bytes(entry.script_pub_key), amount_sat)
+        return self.nodes[0].sendrawtransaction(tx.serialize().hex())
+
+    def find_unspent(self, wallet, address: str, txid: str | None = None):
+        matches = [u for u in wallet.listunspent() if u["address"] == address and (txid is None or u["txid"] == txid)]
+        assert_equal(len(matches), 1)
+        return matches[0]
+
+    def find_output_amount(self, txid: str, address: str, *, blockhash: str) -> Decimal:
+        tx = self.nodes[0].getrawtransaction(txid, 2, blockhash)
+        for vout in tx["vout"]:
+            script_pub_key = vout["scriptPubKey"]
+            output_address = script_pub_key.get("address")
+            if output_address is None:
+                addresses = script_pub_key.get("addresses", [])
+                if addresses:
+                    output_address = addresses[0]
+            if output_address == address:
+                return Decimal(str(vout["value"]))
+        raise AssertionError(f"Unable to find output for {address} in {txid}")
+
+    def find_pq_props(self, decoded_input):
+        return [
+            prop for prop in decoded_input.get("proprietary", [])
+            if prop["identifier"] == PQ_PROP_IDENTIFIER and prop["subtype"] == 1
+        ]
+
+    def run_test(self):
+        node = self.nodes[0]
+        root_seed = bytes.fromhex("36" * 32)
+        ext_entries = [build_active_pq_descriptor_entry(root_seed, internal=False, index=i) for i in range(4)]
+        int_entries = [build_active_pq_descriptor_entry(root_seed, internal=True, index=i) for i in range(4)]
+
+        node.createwallet(wallet_name="sink")
+        sink = node.get_wallet_rpc("sink")
+        sink_a = sink.getnewaddress()
+        sink_b = sink.getnewaddress()
+
+        self.log.info("Create a blank descriptor wallet with active pqpriv() receive/change managers")
+        node.createwallet(wallet_name="pqspend", blank=True)
+        wallet = node.get_wallet_rpc("pqspend")
+        result = wallet.importdescriptors([
+            make_pqpriv_import_request(root_seed, internal=False, active=True, timestamp="now", range_end=9),
+            make_pqpriv_import_request(root_seed, internal=True, active=True, timestamp="now", range_end=9),
+        ])
+        assert all(item["success"] for item in result)
+
+        self.log.info("Fund the first generated PQ address and spend it through sendmany")
+        assert_equal(wallet.getnewpqaddress("first receive"), ext_entries[0].address)
+        funding_txid = self.fund_entry(ext_entries[0], 6 * COIN)
+        self.mine_block()
+        funded = self.find_unspent(wallet, ext_entries[0].address, funding_txid)
+        assert_equal(funded["spendable"], True)
+        assert_equal(funded["amount"], Decimal("6.00000000"))
+
+        sendmany_txid = wallet.sendmany("", {sink_a: Decimal("1.00000000"), sink_b: Decimal("0.50000000")})
+        sendmany_blockhash = self.mine_block()
+        sendmany_change = self.find_output_amount(sendmany_txid, int_entries[0].address, blockhash=sendmany_blockhash)
+        assert self.find_unspent(wallet, int_entries[0].address, sendmany_txid)["amount"] == sendmany_change
+
+        self.log.info("Fund a second PQ address and spend it through walletcreatefundedpsbt/walletprocesspsbt/finalizepsbt")
+        assert_equal(wallet.getnewpqaddress("psbt receive"), ext_entries[1].address)
+        psbt_funding_txid = self.fund_entry(ext_entries[1], 4 * COIN)
+        self.mine_block()
+        psbt_utxo = self.find_unspent(wallet, ext_entries[1].address, psbt_funding_txid)
+
+        created = wallet.walletcreatefundedpsbt(
+            [{"txid": psbt_utxo["txid"], "vout": psbt_utxo["vout"]}],
+            {sink_a: Decimal("1.25000000")},
+            0,
+            {"add_inputs": False, "fee_rate": 1},
+        )
+        processed = wallet.walletprocesspsbt(psbt=created["psbt"], finalize=False)
+        assert "hex" not in processed
+
+        decoded = node.decodepsbt(processed["psbt"])
+        pq_props = self.find_pq_props(decoded["inputs"][0])
+        assert_equal(len(pq_props), 1)
+        assert pq_props[0]["key"].endswith(ext_entries[1].pk_script.hex())
+        assert_equal(len(pq_props[0]["value"]), 2 * 4480)
+
+        finalized = node.finalizepsbt(processed["psbt"])
+        assert_equal(finalized["complete"], True)
+        node.sendrawtransaction(finalized["hex"])
+        self.mine_block()
+
+        self.log.info("Restart, generate a later PQ address, then fund and spend it to confirm persisted next_index and spendability")
+        self.restart_node(0, self.extra_args[0])
+        node = self.nodes[0]
+        wallet = self.ensure_wallet_loaded("pqspend")
+        sink = self.ensure_wallet_loaded("sink")
+        sink_a = sink.getnewaddress()
+
+        assert_equal(wallet.getnewpqaddress("post-restart receive"), ext_entries[2].address)
+        restart_funding_txid = self.fund_entry(ext_entries[2], 3 * COIN)
+        self.mine_block()
+        restart_utxo = self.find_unspent(wallet, ext_entries[2].address, restart_funding_txid)
+        assert_equal(restart_utxo["spendable"], True)
+
+        direct_send_txid = wallet.sendtoaddress(sink_a, 1)
+        direct_send_blockhash = self.mine_block()
+        direct_change = self.find_output_amount(direct_send_txid, int_entries[2].address, blockhash=direct_send_blockhash)
+        assert self.find_unspent(wallet, int_entries[2].address, direct_send_txid)["amount"] == direct_change
+
+
+if __name__ == "__main__":
+    WalletPQPSBTTest(__file__).main()


### PR DESCRIPTION
Implements wallet tranche #20 for active `pqpriv(...)` outputs.

What landed:
- adds PQ signing-provider plumbing and P2WSH PQ witness production
- makes `PQDescriptorScriptPubKeyMan` inputs spendable via wallet send flows
- adds PQ PSBT proprietary partial-signature support (`pqbtc`, subtype `0x01`)
- enables `walletprocesspsbt` + `finalizepsbt` round-trip for PQ inputs
- keeps `pq(...)` / `pqpriv(...)` receive-path behavior unchanged
- keeps PQ signatures fixed to `SIGHASH_ALL` with no appended sighash byte

Validation:
- `cmake --build build -j8 --target bitcoin_wallet test_pqbtc pqbtcd pqbtc-cli`
- `./build/bin/test_pqbtc --run_test=pqsig_script_tests --catch_system_error=no --log_level=test_suite`
- `python3 test/functional/wallet_pq_active_ranged.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `python3 test/functional/wallet_pq_psbt.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `python3 test/functional/wallet_pq_descriptors.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `python3 test/functional/wallet_pq_backup_recovery.py --configfile=build/test/config.ini --cachedir=build/test/cache`
- `git diff --check`

Non-goals:
- no consensus or wire-format changes
- no descriptor syntax changes
- no PQ derivation/origin metadata expansion beyond the proprietary PSBT field required for wallet round-trip
