### PR TITLE
pqsig: freeze ALG_ID registry scaffolding

### DIFF
--- a/docs/ALG_ID_REGISTRY.md
+++ b/docs/ALG_ID_REGISTRY.md
@@ -1,0 +1,33 @@
+# ALG_ID Registry
+
+## Status: FROZEN
+## Spec-ID: ALG-ID-REGISTRY-v1
+## Frozen-By: issue-24-alg-id-registry-20260326
+## Consensus-Relevant: YES
+
+## Purpose
+Define the assigned script-layer `ALG_ID` values, their lifecycle states, and the change-control rules for future allocations.
+
+## Lifecycle States
+- `RESERVED_INVALID`: permanently invalid sentinel value; MUST fail in current releases.
+- `ACTIVE`: valid for current releases and bound to a frozen wire/internal spec set.
+- `ALLOCATED_FUTURE`: allocated for future work but not valid until a later consensus/deployment decision activates it.
+- `RETIRED`: no longer valid and MUST NOT be reused for different semantics.
+- `UNALLOCATED`: no assignment exists; value is invalid.
+
+## Current Registry
+
+| ALG_ID | Profile | State | Owning Specs | Activation Notes |
+| --- | --- | --- | --- | --- |
+| `0x00` | none | `RESERVED_INVALID` | none | Permanent invalid sentinel; MUST fail. |
+| `0x01` | `rc2` | `ACTIVE` | `PQSIG_WIRE_FORMAT.md`, `PQSIG_INTERNALS.md`, `Spec.md` | Current GA PQSig profile. |
+| `0x02-0xff` | none | `UNALLOCATED` | none | Invalid until a future allocation freezes the profile and activates it later. |
+
+## Allocation and Governance Rules
+- Only `ACTIVE` `ALG_ID` values are valid in current releases.
+- A new `ALG_ID` requires a dedicated child issue under epic [#14](https://github.com/scottdhughes/quantum-proof-bitcoin/issues/14).
+- Before allocation, the new profile MUST have a frozen wire-format spec and a frozen internal-parameter spec.
+- Allocation moves an entry to `ALLOCATED_FUTURE`; it does not make that value valid in running releases.
+- Moving an entry from `ALLOCATED_FUTURE` to `ACTIVE` requires a separate consensus/deployment decision and implementation tranche.
+- `RETIRED` values remain permanently reserved and MUST NOT be reassigned to different wire semantics.
+- `UNALLOCATED` values are invalid and MUST fail parser and script validation until a later frozen allocation exists.

--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -39,11 +39,11 @@ and define the concrete work required for a full-and-complete post-v1 program.
 
 ### 4. Fixed rc2 wire/profile
 - rc2 state: `ALG_ID=0x01`, `PK_script` fixed at 33 bytes, signature fixed at 4480 bytes, and `PK.root` is exact-root bound.
-- deferred: multi-algorithm evolution path.
+- post-v1 update: `ALG_ID` registry structure and governance rules are frozen.
+- deferred: parser compatibility contract and forward-compatible algorithm path.
 - full-complete delta:
-  - `ALG_ID` registry and governance
   - version negotiation and backward-compat parsing guarantees
-  - activation policy and interop tests for new formats
+  - forward-compatible algorithm test path and activation/interoperability rules
 
 ### 5. Fixed pre-taproot sighash mode
 - v1 state: pre-taproot PQ paths are fixed to `SIGHASH_ALL`.
@@ -70,7 +70,7 @@ and define the concrete work required for a full-and-complete post-v1 program.
 ## Post-v1 Full-Complete Program (Execution Order)
 1. Wallet completeness and PSBT parity.
 2. Taproot/PQ coexistence design + deployment path.
-3. Multi-alg registry and forward-compat parser strategy.
+3. Multi-alg parser compatibility and forward-compatible algorithm path.
 4. CI completion (full migration or permanent dual-profile contract).
 5. Operational SLO hardening and adversarial throughput validation.
 6. Bench instrumentation hardening from fixed-envelope mode to measured accounting.

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -20,8 +20,8 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 - Exit criteria: decision-complete consensus plan with cross-version test matrix.
 
 3. Multi-algorithm evolution (`ALG_ID` registry)
-- Scope: version registry, parser compatibility contract, governance and rollout semantics.
-- Exit criteria: at least one forward-compatible algorithm version test path.
+- Scope: `#24` registry definition and governance rules, `#25` parser compatibility contract, and `#26` forward-compatible algorithm version path.
+- Exit criteria: frozen registry plus at least one forward-compatible algorithm version test path.
 
 4. CI completeness strategy
 - Scope: full PQ migration of legacy suites or explicit durable dual-profile guarantees.

--- a/docs/PQSIG_INTERNALS.md
+++ b/docs/PQSIG_INTERNALS.md
@@ -40,5 +40,5 @@ Consensus-locked internal parameterization for the PQSig rc2 profile in PQBTC.
 ## Safety Properties
 - Parser treats signature and key inputs as hostile.
 - Parameter values are immutable consensus constants.
-- Unknown `ALG_ID` is invalid.
+- Unknown `ALG_ID` is invalid; assigned values and lifecycle state are governed by `ALG_ID_REGISTRY.md`.
 - Any nonzero count field is invalid.

--- a/docs/PQSIG_WIRE_FORMAT.md
+++ b/docs/PQSIG_WIRE_FORMAT.md
@@ -8,7 +8,7 @@
 ## Script-Layer Public Key
 - `PK_script` length is exactly 33 bytes.
 - Layout: `ALG_ID(1 byte) || PK_core(32 bytes)`.
-- For rc2: `ALG_ID = 0x01`.
+- For rc2: `ALG_ID = 0x01`; assigned values and lifecycle state are governed by `ALG_ID_REGISTRY.md`.
 - Any other length or unknown algorithm id is invalid.
 
 ## Signature Encoding

--- a/docs/Spec.md
+++ b/docs/Spec.md
@@ -208,10 +208,9 @@ Policy SHOULD enforce:
 
 ## 9. Upgrade and Versioning (Plan)
 - ALG_ID byte in PK_script provides a clean hook for future signature versions.
-- The active GA profile is PQSig rc2 with `ALG_ID = 0x01`.
-- Retired ALG_ID values MUST NOT be reused for different wire semantics.
-- New ALG_ID values MUST be introduced via a consensus upgrade process.
-- Any future ALG_ID allocation MUST ship with a frozen wire-format spec and explicit change-control review before activation.
+- The active GA profile is PQSig rc2 with `ALG_ID = 0x01`; see `ALG_ID_REGISTRY.md`.
+- Assigned values, lifecycle state, allocation rules, and reuse prohibitions are defined in `ALG_ID_REGISTRY.md`.
+- Parser/version-negotiation work and forward-compatible algorithm test paths remain post-v1 work tracked separately.
 
 ---
 

--- a/src/crypto/pqsig/params.h
+++ b/src/crypto/pqsig/params.h
@@ -64,7 +64,9 @@ static_assert(L == 32);
 static_assert(SWN == 240);
 static_assert(pqsig::PK_SCRIPT_SIZE == 33);
 static_assert(pqsig::SIG_SIZE == 4480);
-static_assert(pqsig::ALG_ID_RC2 == 0x01);
+static_assert(pqsig::GetALGIDInfo(pqsig::ALG_ID_RC2).state == pqsig::ALGIDState::ACTIVE);
+static_assert(pqsig::GetALGIDInfo(pqsig::ALG_ID_RC2).pk_script_size == pqsig::PK_SCRIPT_SIZE);
+static_assert(pqsig::GetALGIDInfo(pqsig::ALG_ID_RC2).sig_size == pqsig::SIG_SIZE);
 static_assert(SIGN_COUNTER_MAX == 1048576);
 
 } // namespace params

--- a/src/crypto/pqsig/pqsig.cpp
+++ b/src/crypto/pqsig/pqsig.cpp
@@ -31,7 +31,9 @@ constexpr bool ConsensusProfileLocked()
            PK_CORE_SIZE == 32 &&
            MSG32_SIZE == 32 &&
            SIG_SIZE == 4480 &&
-           ALG_ID_RC2 == 0x01 &&
+           GetALGIDInfo(ALG_ID_RC2).state == ALGIDState::ACTIVE &&
+           GetALGIDInfo(ALG_ID_RC2).pk_script_size == PK_SCRIPT_SIZE &&
+           GetALGIDInfo(ALG_ID_RC2).sig_size == SIG_SIZE &&
            params::N == 16 &&
            params::QS_LOG2 == 40 &&
            params::H == 44 &&
@@ -227,7 +229,7 @@ bool VerifySignatureStructure(
 
 bool IsValidPkScript(const std::span<const uint8_t> pk_script33)
 {
-    return pk_script33.size() == PK_SCRIPT_SIZE && pk_script33[0] == ALG_ID_RC2;
+    return pk_script33.size() == PK_SCRIPT_SIZE && IsValidALGID(pk_script33[0]);
 }
 
 bool DerivePkScript(const std::span<uint8_t> out_pk_script33, const std::span<const uint8_t> sk_seed)

--- a/src/crypto/pqsig/pqsig.h
+++ b/src/crypto/pqsig/pqsig.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CRYPTO_PQSIG_PQSIG_H
 #define BITCOIN_CRYPTO_PQSIG_PQSIG_H
 
+#include <crypto/pqsig/pqsig_registry.h>
+
 #include <cstddef>
 #include <cstdint>
 
@@ -16,7 +18,10 @@ inline constexpr size_t PK_SCRIPT_SIZE{33};
 inline constexpr size_t PK_CORE_SIZE{32};
 inline constexpr size_t MSG32_SIZE{32};
 inline constexpr size_t SIG_SIZE{4480};
-inline constexpr uint8_t ALG_ID_RC2{0x01};
+
+static_assert(GetALGIDInfo(ALG_ID_RC2).state == ALGIDState::ACTIVE);
+static_assert(GetALGIDInfo(ALG_ID_RC2).pk_script_size == PK_SCRIPT_SIZE);
+static_assert(GetALGIDInfo(ALG_ID_RC2).sig_size == SIG_SIZE);
 
 bool IsValidPkScript(std::span<const uint8_t> pk_script33);
 bool DerivePkScript(std::span<uint8_t> out_pk_script33, std::span<const uint8_t> sk_seed);

--- a/src/crypto/pqsig/pqsig_registry.h
+++ b/src/crypto/pqsig/pqsig_registry.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_PQSIG_PQSIG_REGISTRY_H
+#define BITCOIN_CRYPTO_PQSIG_PQSIG_REGISTRY_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace pqsig {
+
+// This registry is frozen for the current release.
+// Only ALG_ID=0x01 (rc2) is ACTIVE. All other ids are invalid.
+inline constexpr uint8_t ALG_ID_RC2{0x01};
+
+enum class ALGIDState : uint8_t {
+    RESERVED_INVALID,
+    ACTIVE,
+    ALLOCATED_FUTURE,
+    RETIRED,
+    UNALLOCATED,
+};
+
+struct ALGIDInfo {
+    uint8_t alg_id;
+    ALGIDState state;
+    size_t sig_size;
+    size_t pk_script_size;
+};
+
+constexpr ALGIDInfo GetALGIDInfo(const uint8_t alg_id)
+{
+    switch (alg_id) {
+    case 0x00:
+        return {alg_id, ALGIDState::RESERVED_INVALID, 0, 0};
+    case ALG_ID_RC2:
+        return {alg_id, ALGIDState::ACTIVE, 4480, 33};
+    default:
+        return {alg_id, ALGIDState::UNALLOCATED, 0, 0};
+    }
+}
+
+constexpr bool IsValidALGID(const uint8_t alg_id)
+{
+    return GetALGIDInfo(alg_id).state == ALGIDState::ACTIVE;
+}
+
+} // namespace pqsig
+
+#endif // BITCOIN_CRYPTO_PQSIG_PQSIG_REGISTRY_H

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -19,7 +19,9 @@ namespace {
 
 static_assert(pqsig::PK_SCRIPT_SIZE == 33, "PQSIG rc2 pubkey script size drifted");
 static_assert(pqsig::SIG_SIZE == 4480, "PQSIG rc2 signature size drifted");
-static_assert(pqsig::ALG_ID_RC2 == 0x01, "PQSIG rc2 ALG_ID drifted");
+static_assert(pqsig::GetALGIDInfo(pqsig::ALG_ID_RC2).state == pqsig::ALGIDState::ACTIVE, "PQSIG active ALG_ID drifted");
+static_assert(pqsig::GetALGIDInfo(pqsig::ALG_ID_RC2).pk_script_size == pqsig::PK_SCRIPT_SIZE, "PQSIG registry pubkey size drifted");
+static_assert(pqsig::GetALGIDInfo(pqsig::ALG_ID_RC2).sig_size == pqsig::SIG_SIZE, "PQSIG registry signature size drifted");
 
 constexpr bool IsPreTaprootPQSigVersion(const SigVersion sigversion)
 {

--- a/src/test/pqsig_script_tests.cpp
+++ b/src/test/pqsig_script_tests.cpp
@@ -88,6 +88,30 @@ FlatSigningProvider MakePQSigningProvider(const std::array<uint8_t, pqsig::PK_SC
 
 BOOST_AUTO_TEST_SUITE(pqsig_script_tests)
 
+BOOST_AUTO_TEST_CASE(alg_id_registry_is_frozen_for_current_release)
+{
+    const auto reserved = pqsig::GetALGIDInfo(0x00);
+    BOOST_CHECK_EQUAL(reserved.alg_id, 0x00);
+    BOOST_CHECK(reserved.state == pqsig::ALGIDState::RESERVED_INVALID);
+    BOOST_CHECK(!pqsig::IsValidALGID(0x00));
+    BOOST_CHECK_EQUAL(reserved.sig_size, 0U);
+    BOOST_CHECK_EQUAL(reserved.pk_script_size, 0U);
+
+    const auto active = pqsig::GetALGIDInfo(pqsig::ALG_ID_RC2);
+    BOOST_CHECK_EQUAL(active.alg_id, pqsig::ALG_ID_RC2);
+    BOOST_CHECK(active.state == pqsig::ALGIDState::ACTIVE);
+    BOOST_CHECK(pqsig::IsValidALGID(pqsig::ALG_ID_RC2));
+    BOOST_CHECK_EQUAL(active.sig_size, pqsig::SIG_SIZE);
+    BOOST_CHECK_EQUAL(active.pk_script_size, pqsig::PK_SCRIPT_SIZE);
+
+    const auto unallocated = pqsig::GetALGIDInfo(0x02);
+    BOOST_CHECK_EQUAL(unallocated.alg_id, 0x02);
+    BOOST_CHECK(unallocated.state == pqsig::ALGIDState::UNALLOCATED);
+    BOOST_CHECK(!pqsig::IsValidALGID(0x02));
+    BOOST_CHECK_EQUAL(unallocated.sig_size, 0U);
+    BOOST_CHECK_EQUAL(unallocated.pk_script_size, 0U);
+}
+
 BOOST_AUTO_TEST_CASE(checksig_accepts_valid_pqsig)
 {
     const auto pk_script = MakePkScript();


### PR DESCRIPTION
## Summary
- add a frozen ALG_ID registry spec and governance rules
- add a minimal constexpr PQSig ALG_ID registry in code
- centralize current validity checks without changing runtime behavior

## Testing
- cmake --build /Users/scott/quantum-proof-bitcoin/build -j8 --target test_pqbtc pqbtcd pqbtc-cli
- /Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=pqsig_script_tests --catch_system_error=no --log_level=test_suite
- /Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=pq_descriptor_tests --catch_system_error=no --log_level=test_suite
- git diff --check

Closes #24