### PR TITLE
pqsig: centralize PK_script parser classification

### DIFF
--- a/docs/ALG_ID_PARSER_COMPAT.md
+++ b/docs/ALG_ID_PARSER_COMPAT.md
@@ -1,0 +1,35 @@
+# ALG_ID Parser Compatibility Contract
+
+## Status: FROZEN
+## Spec-ID: ALG-ID-PARSER-COMPAT-v1
+## Frozen-By: issue-25-parser-compat-20260327
+## Consensus-Relevant: YES
+
+## Scope
+Current-release parser and version-handling rules for PQBTC `PK_script` inputs.
+
+## Current Contract
+- Parsing is `length -> registry classification -> active-profile structural parse`.
+- Classification is length-first and MUST NOT inspect `pk_script[0]` unless the input is exactly 33 bytes.
+- Only `ACTIVE` `ALG_ID` values are accepted in current releases.
+- `RESERVED_INVALID`, `ALLOCATED_FUTURE`, `RETIRED`, and `UNALLOCATED` values all reject deterministically.
+- There is no downgrade, fallback, or alternate signature-family probing.
+- Current version negotiation is explicit non-negotiation: unsupported `ALG_ID` values fail.
+
+## Registry-State Handling
+- `RESERVED_INVALID`: reject.
+- `ACTIVE`: permit active-profile structural parsing.
+- `ALLOCATED_FUTURE`: reject until a later activation tranche defines compatibility behavior.
+- `RETIRED`: reject permanently.
+- `UNALLOCATED`: reject.
+
+## Structural Parsing Boundary
+- Classification answers what kind of `PK_script` bytes were supplied.
+- Structural parsing remains profile-specific.
+- In current releases, only the active `rc2` profile may structurally parse and consume a classified `VALID_ACTIVE` `PK_script`.
+
+## Observable Behavior
+- This contract does not broaden acceptance.
+- Invalid `PK_script` encoding continues to fail script evaluation as invalid public-key encoding.
+- Wrong PQ signature length continues to fail independently as invalid signature encoding.
+- Descriptor, PSBT, and wallet cache paths remain strict rejectors for any non-active `ALG_ID`.

--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -40,9 +40,9 @@ and define the concrete work required for a full-and-complete post-v1 program.
 ### 4. Fixed rc2 wire/profile
 - rc2 state: `ALG_ID=0x01`, `PK_script` fixed at 33 bytes, signature fixed at 4480 bytes, and `PK.root` is exact-root bound.
 - post-v1 update: `ALG_ID` registry structure and governance rules are frozen.
-- deferred: parser compatibility contract and forward-compatible algorithm path.
+- post-v1 update: parser compatibility and explicit non-negotiation rules are frozen.
+- deferred: forward-compatible algorithm path.
 - full-complete delta:
-  - version negotiation and backward-compat parsing guarantees
   - forward-compatible algorithm test path and activation/interoperability rules
 
 ### 5. Fixed pre-taproot sighash mode
@@ -70,7 +70,7 @@ and define the concrete work required for a full-and-complete post-v1 program.
 ## Post-v1 Full-Complete Program (Execution Order)
 1. Wallet completeness and PSBT parity.
 2. Taproot/PQ coexistence design + deployment path.
-3. Multi-alg parser compatibility and forward-compatible algorithm path.
+3. Multi-alg forward-compatible algorithm path.
 4. CI completion (full migration or permanent dual-profile contract).
 5. Operational SLO hardening and adversarial throughput validation.
 6. Bench instrumentation hardening from fixed-envelope mode to measured accounting.

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -20,8 +20,8 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 - Exit criteria: decision-complete consensus plan with cross-version test matrix.
 
 3. Multi-algorithm evolution (`ALG_ID` registry)
-- Scope: `#24` registry definition and governance rules, `#25` parser compatibility contract, and `#26` forward-compatible algorithm version path.
-- Exit criteria: frozen registry plus at least one forward-compatible algorithm version test path.
+- Scope: frozen `#24` registry rules and `#25` parser compatibility contract, plus the remaining `#26` forward-compatible algorithm version path.
+- Exit criteria: frozen registry/parser contract plus at least one forward-compatible algorithm version test path.
 
 4. CI completeness strategy
 - Scope: full PQ migration of legacy suites or explicit durable dual-profile guarantees.

--- a/docs/PQSIG_INTERNALS.md
+++ b/docs/PQSIG_INTERNALS.md
@@ -40,5 +40,5 @@ Consensus-locked internal parameterization for the PQSig rc2 profile in PQBTC.
 ## Safety Properties
 - Parser treats signature and key inputs as hostile.
 - Parameter values are immutable consensus constants.
-- Unknown `ALG_ID` is invalid; assigned values and lifecycle state are governed by `ALG_ID_REGISTRY.md`.
+- `ALG_ID` classification and parser/version-handling rules are defined in `ALG_ID_PARSER_COMPAT.md`; assigned values and lifecycle state are governed by `ALG_ID_REGISTRY.md`.
 - Any nonzero count field is invalid.

--- a/docs/PQSIG_WIRE_FORMAT.md
+++ b/docs/PQSIG_WIRE_FORMAT.md
@@ -9,7 +9,7 @@
 - `PK_script` length is exactly 33 bytes.
 - Layout: `ALG_ID(1 byte) || PK_core(32 bytes)`.
 - For rc2: `ALG_ID = 0x01`; assigned values and lifecycle state are governed by `ALG_ID_REGISTRY.md`.
-- Any other length or unknown algorithm id is invalid.
+- Any other length or non-active algorithm id is invalid; parser handling is defined in `ALG_ID_PARSER_COMPAT.md`.
 
 ## Signature Encoding
 - Signature length is exactly 4480 bytes.

--- a/docs/SCRIPT_SEMANTICS.md
+++ b/docs/SCRIPT_SEMANTICS.md
@@ -10,7 +10,7 @@
 - `OP_CHECKMULTISIG` verifies multiple PQSig signatures under existing stack mechanics.
 
 ## Validation Rules
-- Unknown `ALG_ID` fails.
+- Non-active `ALG_ID` fails; parser handling is defined in `ALG_ID_PARSER_COMPAT.md`.
 - Wrong public key size fails.
 - Wrong signature size fails.
 - Failed PQSig verification fails.

--- a/docs/Spec.md
+++ b/docs/Spec.md
@@ -210,7 +210,8 @@ Policy SHOULD enforce:
 - ALG_ID byte in PK_script provides a clean hook for future signature versions.
 - The active GA profile is PQSig rc2 with `ALG_ID = 0x01`; see `ALG_ID_REGISTRY.md`.
 - Assigned values, lifecycle state, allocation rules, and reuse prohibitions are defined in `ALG_ID_REGISTRY.md`.
-- Parser/version-negotiation work and forward-compatible algorithm test paths remain post-v1 work tracked separately.
+- Current parser compatibility and explicit non-negotiation rules are frozen in `ALG_ID_PARSER_COMPAT.md`.
+- Forward-compatible algorithm test paths remain post-v1 work tracked separately.
 
 ---
 

--- a/src/crypto/pqsig/pqsig.cpp
+++ b/src/crypto/pqsig/pqsig.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -227,9 +228,32 @@ bool VerifySignatureStructure(
 
 } // namespace
 
+PkScriptParseStatus ClassifyPkScript(const std::span<const uint8_t> pk_script33)
+{
+    if (pk_script33.size() != PK_SCRIPT_SIZE) {
+        return PkScriptParseStatus::INVALID_LENGTH;
+    }
+
+    switch (GetALGIDInfo(pk_script33[0]).state) {
+    case ALGIDState::ACTIVE:
+        return PkScriptParseStatus::VALID_ACTIVE;
+    case ALGIDState::RESERVED_INVALID:
+        return PkScriptParseStatus::RESERVED_INVALID_ALG_ID;
+    case ALGIDState::ALLOCATED_FUTURE:
+        return PkScriptParseStatus::ALLOCATED_FUTURE_ALG_ID;
+    case ALGIDState::RETIRED:
+        return PkScriptParseStatus::RETIRED_ALG_ID;
+    case ALGIDState::UNALLOCATED:
+        return PkScriptParseStatus::UNALLOCATED_ALG_ID;
+    }
+
+    assert(false);
+    return PkScriptParseStatus::UNALLOCATED_ALG_ID;
+}
+
 bool IsValidPkScript(const std::span<const uint8_t> pk_script33)
 {
-    return pk_script33.size() == PK_SCRIPT_SIZE && IsValidALGID(pk_script33[0]);
+    return ClassifyPkScript(pk_script33) == PkScriptParseStatus::VALID_ACTIVE;
 }
 
 bool DerivePkScript(const std::span<uint8_t> out_pk_script33, const std::span<const uint8_t> sk_seed)

--- a/src/crypto/pqsig/pqsig.h
+++ b/src/crypto/pqsig/pqsig.h
@@ -23,6 +23,16 @@ static_assert(GetALGIDInfo(ALG_ID_RC2).state == ALGIDState::ACTIVE);
 static_assert(GetALGIDInfo(ALG_ID_RC2).pk_script_size == PK_SCRIPT_SIZE);
 static_assert(GetALGIDInfo(ALG_ID_RC2).sig_size == SIG_SIZE);
 
+enum class PkScriptParseStatus : uint8_t {
+    VALID_ACTIVE,
+    INVALID_LENGTH,
+    RESERVED_INVALID_ALG_ID,
+    ALLOCATED_FUTURE_ALG_ID,
+    RETIRED_ALG_ID,
+    UNALLOCATED_ALG_ID,
+};
+
+PkScriptParseStatus ClassifyPkScript(std::span<const uint8_t> pk_script33);
 bool IsValidPkScript(std::span<const uint8_t> pk_script33);
 bool DerivePkScript(std::span<uint8_t> out_pk_script33, std::span<const uint8_t> sk_seed);
 bool DeriveWalletSkSeed(std::span<uint8_t> out_sk_seed32, std::span<const uint8_t> root_seed, bool internal, uint32_t index);

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -43,7 +43,7 @@ bool DecodePQPartialSigProp(const PSBTProprietary& prop, PQPkScript& pk_script, 
         return false;
     }
     key_reader >> std::as_writable_bytes(std::span{pk_script});
-    if (!pqsig::IsValidPkScript(pk_script) || prop.value.size() != pqsig::SIG_SIZE) {
+    if (pqsig::ClassifyPkScript(pk_script) != pqsig::PkScriptParseStatus::VALID_ACTIVE || prop.value.size() != pqsig::SIG_SIZE) {
         return false;
     }
     sig = prop.value;

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -844,7 +844,7 @@ struct PSBTInput
                         }
                         PQPkScript pk_script{};
                         prop_key >> std::as_writable_bytes(std::span{pk_script});
-                        if (!pqsig::IsValidPkScript(pk_script)) {
+                        if (pqsig::ClassifyPkScript(pk_script) != pqsig::PkScriptParseStatus::VALID_ACTIVE) {
                             throw std::ios_base::failure("Invalid PQ PK_script in proprietary key");
                         }
                         if (this_prop.value.size() != pqsig::SIG_SIZE) {

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1013,7 +1013,7 @@ static bool ParsePqPkScript(std::span<const char> expr, std::array<unsigned char
         return false;
     }
     std::copy(pk_script.begin(), pk_script.end(), out_pk_script.begin());
-    if (!pqsig::IsValidPkScript(out_pk_script)) {
+    if (pqsig::ClassifyPkScript(out_pk_script) != pqsig::PkScriptParseStatus::VALID_ACTIVE) {
         error = strprintf("PK_script must use ALG_ID=0x%02x", pqsig::ALG_ID_RC2);
         return false;
     }
@@ -1064,7 +1064,7 @@ static bool MatchPQSingleSigWitnessScript(const CScript& script, std::array<unsi
     if (script.size() != 1 + pqsig::PK_SCRIPT_SIZE + 1) return false;
     if (script[0] != pqsig::PK_SCRIPT_SIZE || script.back() != OP_CHECKSIG) return false;
     std::copy(script.begin() + 1, script.begin() + 1 + pqsig::PK_SCRIPT_SIZE, out_pk_script.begin());
-    return pqsig::IsValidPkScript(out_pk_script);
+    return pqsig::ClassifyPkScript(out_pk_script) == pqsig::PkScriptParseStatus::VALID_ACTIVE;
 }
 
 /** A parsed addr(A) descriptor. */

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -88,7 +88,7 @@ bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned i
 bool static CheckPubKeyEncoding(const valtype &vchPubKey, unsigned int flags, const SigVersion &sigversion, ScriptError* serror) {
     (void)flags;
     (void)sigversion;
-    if (!pqsig::IsValidPkScript(vchPubKey)) {
+    if (pqsig::ClassifyPkScript(vchPubKey) != pqsig::PkScriptParseStatus::VALID_ACTIVE) {
         return set_error(serror, SCRIPT_ERR_PUBKEYTYPE);
     }
     return true;
@@ -1559,7 +1559,7 @@ bool GenericTransactionSignatureChecker<T>::CheckECDSASignature(const std::vecto
     if (!IsPreTaprootPQSigVersion(sigversion)) return false;
     if (vchSigIn.empty()) return false;
     if (vchSigIn.size() != pqsig::SIG_SIZE) return false;
-    if (!pqsig::IsValidPkScript(vchPubKey)) return false;
+    if (pqsig::ClassifyPkScript(vchPubKey) != pqsig::PkScriptParseStatus::VALID_ACTIVE) return false;
 
     // Witness sighashes need the amount.
     if (sigversion == SigVersion::WITNESS_V0 && amount < 0) return HandleMissingData(m_mdb);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -453,7 +453,7 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
         if (vSolutions[0].size() == pqsig::PK_SCRIPT_SIZE) {
             PQPkScript pk_script{};
             std::copy(vSolutions[0].begin(), vSolutions[0].end(), pk_script.begin());
-            if (pqsig::IsValidPkScript(pk_script)) {
+            if (pqsig::ClassifyPkScript(pk_script) == pqsig::PkScriptParseStatus::VALID_ACTIVE) {
                 if (!CreatePQSig(creator, sigdata, provider, sig, pk_script, scriptPubKey, sigversion)) return false;
                 ret.push_back(std::move(sig));
                 return true;

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -42,7 +42,7 @@ static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
     }
     if (script.size() == CPubKey::COMPRESSED_SIZE + 2 && script[0] == CPubKey::COMPRESSED_SIZE && script.back() == OP_CHECKSIG) {
         pubkey = valtype(script.begin() + 1, script.begin() + CPubKey::COMPRESSED_SIZE + 1);
-        return CPubKey::ValidSize(pubkey) || pqsig::IsValidPkScript(pubkey);
+        return CPubKey::ValidSize(pubkey) || pqsig::ClassifyPkScript(pubkey) == pqsig::PkScriptParseStatus::VALID_ACTIVE;
     }
     return false;
 }

--- a/src/test/pqsig_script_tests.cpp
+++ b/src/test/pqsig_script_tests.cpp
@@ -112,6 +112,35 @@ BOOST_AUTO_TEST_CASE(alg_id_registry_is_frozen_for_current_release)
     BOOST_CHECK_EQUAL(unallocated.pk_script_size, 0U);
 }
 
+BOOST_AUTO_TEST_CASE(pk_script_classification_is_length_first_and_matches_validity)
+{
+    const auto active_pk_script = MakePkScript();
+    auto reserved_pk_script = active_pk_script;
+    reserved_pk_script[0] = 0x00;
+    auto unallocated_pk_script = active_pk_script;
+    unallocated_pk_script[0] = 0x02;
+
+    struct ClassificationCase {
+        std::vector<uint8_t> pk_script;
+        pqsig::PkScriptParseStatus expected;
+    };
+
+    const std::vector<ClassificationCase> cases{
+        {{}, pqsig::PkScriptParseStatus::INVALID_LENGTH},
+        {std::vector<uint8_t>(pqsig::PK_SCRIPT_SIZE - 1, 0x11), pqsig::PkScriptParseStatus::INVALID_LENGTH},
+        {std::vector<uint8_t>(reserved_pk_script.begin(), reserved_pk_script.end()), pqsig::PkScriptParseStatus::RESERVED_INVALID_ALG_ID},
+        {std::vector<uint8_t>(active_pk_script.begin(), active_pk_script.end()), pqsig::PkScriptParseStatus::VALID_ACTIVE},
+        {std::vector<uint8_t>(unallocated_pk_script.begin(), unallocated_pk_script.end()), pqsig::PkScriptParseStatus::UNALLOCATED_ALG_ID},
+        {std::vector<uint8_t>(pqsig::PK_SCRIPT_SIZE + 1, 0x11), pqsig::PkScriptParseStatus::INVALID_LENGTH},
+    };
+
+    for (const auto& test_case : cases) {
+        const auto status = pqsig::ClassifyPkScript(test_case.pk_script);
+        BOOST_CHECK(status == test_case.expected);
+        BOOST_CHECK_EQUAL(pqsig::IsValidPkScript(test_case.pk_script), status == pqsig::PkScriptParseStatus::VALID_ACTIVE);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(checksig_accepts_valid_pqsig)
 {
     const auto pk_script = MakePkScript();
@@ -154,12 +183,20 @@ BOOST_AUTO_TEST_CASE(checksig_rejects_wrong_sig_size_and_alg_id)
     BOOST_CHECK(!VerifyScript(tx.vin[0].scriptSig, short_pk_script_pubkey, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_PUBKEYTYPE);
 
-    // Wrong algorithm identifier in the pubkey script is rejected deterministically.
-    auto bad_pk_script = pk_script;
-    bad_pk_script[0] = 0x00;
-    const CScript bad_script_pubkey = CScript{} << std::vector<unsigned char>{bad_pk_script.begin(), bad_pk_script.end()} << OP_CHECKSIG;
+    // Reserved-invalid algorithm identifiers are rejected deterministically.
+    auto reserved_pk_script = pk_script;
+    reserved_pk_script[0] = 0x00;
+    const CScript reserved_script_pubkey = CScript{} << std::vector<unsigned char>{reserved_pk_script.begin(), reserved_pk_script.end()} << OP_CHECKSIG;
     tx.vin[0].scriptSig = CScript{} << std::vector<unsigned char>{good_sig.begin(), good_sig.end()};
-    BOOST_CHECK(!VerifyScript(tx.vin[0].scriptSig, bad_script_pubkey, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
+    BOOST_CHECK(!VerifyScript(tx.vin[0].scriptSig, reserved_script_pubkey, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_PUBKEYTYPE);
+
+    // Unallocated algorithm identifiers are rejected with the same public-key encoding error.
+    auto unallocated_pk_script = pk_script;
+    unallocated_pk_script[0] = 0x02;
+    const CScript unallocated_script_pubkey = CScript{} << std::vector<unsigned char>{unallocated_pk_script.begin(), unallocated_pk_script.end()} << OP_CHECKSIG;
+    tx.vin[0].scriptSig = CScript{} << std::vector<unsigned char>{good_sig.begin(), good_sig.end()};
+    BOOST_CHECK(!VerifyScript(tx.vin[0].scriptSig, unallocated_script_pubkey, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, checker, &err));
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_PUBKEYTYPE);
 }
 
@@ -276,6 +313,36 @@ BOOST_AUTO_TEST_CASE(psbt_roundtrips_pq_proprietary_partial_sig_and_finalizes)
     BOOST_REQUIRE_EQUAL(roundtrip.inputs[0].final_script_witness.stack.size(), 2U);
     BOOST_CHECK_EQUAL(roundtrip.inputs[0].final_script_witness.stack[0].size(), pqsig::SIG_SIZE);
     BOOST_CHECK(roundtrip.inputs[0].final_script_witness.stack[1] == std::vector<unsigned char>(witness_script.begin(), witness_script.end()));
+}
+
+BOOST_AUTO_TEST_CASE(psbt_rejects_non_active_pq_pk_script_in_proprietary_partial_sig)
+{
+    const auto pk_script = MakePkScript();
+
+    CMutableTransaction tx = BuildSpendingTx();
+    PartiallySignedTransaction psbt(tx);
+
+    auto invalid_pk_script = pk_script;
+    invalid_pk_script[0] = 0x02;
+
+    PSBTProprietary prop;
+    prop.subtype = 1;
+    prop.identifier = {'p', 'q', 'b', 't', 'c'};
+    prop.value.assign(pqsig::SIG_SIZE, 0x5a);
+
+    VectorWriter key_writer{prop.key, 0};
+    key_writer << CompactSizeWriter(PSBT_IN_PROPRIETARY);
+    key_writer << prop.identifier;
+    WriteCompactSize(key_writer, prop.subtype);
+    key_writer << std::span{invalid_pk_script};
+
+    psbt.inputs[0].m_proprietary.insert(prop);
+
+    DataStream ss{};
+    ss << psbt;
+
+    PartiallySignedTransaction roundtrip;
+    BOOST_CHECK_THROW(ss >> roundtrip, std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/pq_scriptpubkeyman.cpp
+++ b/src/wallet/pq_scriptpubkeyman.cpp
@@ -539,7 +539,7 @@ bool PQDescriptorScriptPubKeyMan::LoadCachedPkScript(const int32_t index, const 
     }
     std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script_array{};
     std::copy(pk_script.begin(), pk_script.end(), pk_script_array.begin());
-    if (!pqsig::IsValidPkScript(pk_script_array)) {
+    if (pqsig::ClassifyPkScript(pk_script_array) != pqsig::PkScriptParseStatus::VALID_ACTIVE) {
         return false;
     }
     m_map_pk_scripts[index] = pk_script_array;


### PR DESCRIPTION
## Summary
- centralize PK_script classification in the parser layer and keep pqsig_registry.h registry-only
- freeze the ALG_ID parser compatibility contract in docs and narrow the remaining multi-alg deferral to #26
- add classifier, script, and PSBT rejection coverage while preserving existing observable behavior

## Testing
- cmake --build /Users/scott/quantum-proof-bitcoin/build -j8 --target test_pqbtc pqbtcd pqbtc-cli
- /Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=pqsig_script_tests --catch_system_error=no --log_level=test_suite
- /Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=pq_descriptor_tests --catch_system_error=no --log_level=test_suite
- git diff --check

Closes #25