### PR TITLE
ci: optimize required-path runtime budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,62 +46,6 @@ jobs:
             echo "::notice title=Runner Selection::Using GitHub-hosted runners"
           fi
 
-  test-each-commit:
-    name: 'test each commit'
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request' && github.event.pull_request.commits != 1
-    timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes. Assuming a worst case time of 1 hour per commit, this leads to a --max-count=6 below.
-    env:
-      MAX_COUNT: 6
-    steps:
-      - name: Determine fetch depth
-        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ env.FETCH_DEPTH }}
-      - name: Determine commit range
-        run: |
-          # Checkout HEAD~ and find the test base commit
-          # Checkout HEAD~ because it would be wasteful to rerun tests on the PR
-          # head commit that are already run by other jobs.
-          git checkout HEAD~
-          # Figure out test base commit by listing ancestors of HEAD, excluding
-          # ancestors of the most recent merge commit, limiting the list to the
-          # newest MAX_COUNT ancestors, ordering it from oldest to newest, and
-          # taking the first one.
-          #
-          # If the branch contains up to MAX_COUNT ancestor commits after the
-          # most recent merge commit, all of those commits will be tested. If it
-          # contains more, only the most recent MAX_COUNT commits will be
-          # tested.
-          #
-          # In the command below, the ^@ suffix is used to refer to all parents
-          # of the merge commit as described in:
-          # https://git-scm.com/docs/git-rev-parse#_other_rev_parent_shorthand_notations
-          # and the ^ prefix is used to exclude these parents and all their
-          # ancestors from the rev-list output as described in:
-          # https://git-scm.com/docs/git-rev-list
-          MERGE_BASE=$(git rev-list -n1 --merges HEAD)
-          EXCLUDE_MERGE_BASE_ANCESTORS=
-          # MERGE_BASE can be empty due to limited fetch-depth
-          if test -n "$MERGE_BASE"; then
-            EXCLUDE_MERGE_BASE_ANCESTORS=^${MERGE_BASE}^@
-          fi
-          echo "TEST_BASE=$(git rev-list -n$((${{ env.MAX_COUNT }} + 1)) --reverse HEAD $EXCLUDE_MERGE_BASE_ANCESTORS | head -1)" >> "$GITHUB_ENV"
-      - run: |
-          git fetch origin "${GITHUB_BASE_REF}"
-          git config user.email "ci@example.com"
-          git config user.name "CI"
-      - run: |
-          sudo apt-get update
-          sudo apt-get install clang mold ccache build-essential cmake ninja-build pkgconf python3-zmq libevent-dev libboost-dev libsqlite3-dev systemtap-sdt-dev libzmq3-dev qt6-base-dev qt6-tools-dev qt6-l10n-tools libqrencode-dev capnproto libcapnp-dev -y
-          sudo pip3 install --break-system-packages pycapnp
-      - name: Compile and run tests
-        run: |
-          # Run tests on commits after the last merge commit and before the PR head commit
-          git rebase --exec "git merge --no-commit origin/${GITHUB_BASE_REF} && python3 ./.github/ci-test-each-commit-exec.py && git reset --hard" ${{ env.TEST_BASE }}
-
   ci-inventory:
     name: 'CI inventory'
     runs-on: ubuntu-24.04
@@ -112,7 +56,95 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.ref || '' }}
       - name: Validate CI inventory
-        run: python3 ci/test/check_ci_inventory.py
+        run: |
+          python3 ci/test/check_ci_inventory.py
+          python3 -m unittest discover -s ci/test -p 'test_*.py'
+
+  linux-fuzz-build:
+    name: 'fuzzer,address,undefined,integer, no depends (build)'
+    needs: runners
+    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg' || 'ubuntu-24.04' }}
+    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+    timeout-minutes: 120
+
+    env:
+      DANGER_CI_ON_HOST_FOLDERS: 1
+      FILE_ENV: './ci/test/00_setup_env_native_fuzz_build.sh'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.ref || '' }}
+
+      - name: Configure environment
+        uses: ./.github/actions/configure-environment
+
+      - name: Restore caches
+        id: restore-cache
+        uses: ./.github/actions/restore-caches
+
+      - name: Configure Docker
+        uses: ./.github/actions/configure-docker
+        with:
+          cache-provider: ${{ needs.runners.outputs.provider }}
+
+      - name: CI script
+        run: ./ci/test_run_all.sh
+
+      - name: Save caches
+        uses: ./.github/actions/save-caches
+
+      - name: Upload fuzz binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-fuzz-binary-${{ github.run_id }}
+          path: ${{ env.BASE_BUILD_DIR }}/bin/fuzz
+
+  linux-fuzz-shards:
+    name: 'fuzzer,address,undefined,integer, no depends (shard ${{ matrix.shard_index + 1 }}/${{ matrix.shard_count }})'
+    needs: [runners, linux-fuzz-build]
+    runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg' || 'ubuntu-24.04' }}
+    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard_index: 0
+            shard_count: 2
+          - shard_index: 1
+            shard_count: 2
+
+    env:
+      DANGER_CI_ON_HOST_FOLDERS: 1
+      FILE_ENV: './ci/test/00_setup_env_native_fuzz_shard.sh'
+      FUZZ_SHARD_INDEX: ${{ matrix.shard_index }}
+      FUZZ_SHARD_COUNT: ${{ matrix.shard_count }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.ref || '' }}
+
+      - name: Configure environment
+        uses: ./.github/actions/configure-environment
+
+      - name: Configure Docker
+        uses: ./.github/actions/configure-docker
+        with:
+          cache-provider: ${{ needs.runners.outputs.provider }}
+
+      - name: Download fuzz binary
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-fuzz-binary-${{ github.run_id }}
+          path: ${{ env.BASE_BUILD_DIR }}/bin
+
+      - name: Run fuzz shard
+        run: ./ci/test_run_all.sh
 
   macos-native-arm64:
     name: ${{ matrix.job-name }}
@@ -231,7 +263,7 @@ jobs:
         job-type: [standard, fuzz]
         include:
           - job-type: standard
-            generate-options: '-DBUILD_GUI=ON -DWITH_ZMQ=ON -DBUILD_BENCH=ON -DWERROR=ON'
+            generate-options: '-DBUILD_GUI=ON -DWITH_ZMQ=ON -DWERROR=ON'
             job-name: 'Windows native, VS 2022'
           - job-type: fuzz
             generate-options: '-DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES="wallet" -DBUILD_GUI=OFF -DBUILD_FOR_FUZZING=ON -DWERROR=ON'
@@ -521,12 +553,6 @@ jobs:
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 120
             file-env: './ci/test/00_setup_env_i686_no_ipc.sh'
-
-          - name: 'fuzzer,address,undefined,integer, no depends'
-            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
-            fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 240
-            file-env: './ci/test/00_setup_env_native_fuzz.sh'
 
           - name: 'previous releases, depends DEBUG'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,9 @@ jobs:
           name: linux-fuzz-binary-${{ github.run_id }}
           path: ${{ env.BASE_BUILD_DIR }}/bin
 
+      - name: Restore fuzz execute bit
+        run: chmod +x "${BASE_BUILD_DIR}/bin/fuzz"
+
       - name: Run fuzz shard
         run: ./ci/test_run_all.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,22 @@ jobs:
       - name: Run fuzz shard
         run: ./ci/test_run_all.sh
 
+  linux-fuzz-compat:
+    name: 'fuzzer,address,undefined,integer, no depends'
+    needs: [linux-fuzz-build, linux-fuzz-shards]
+    runs-on: ubuntu-24.04
+    if: ${{ always() && (vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request') }}
+    steps:
+      - name: Validate split fuzz results
+        env:
+          BUILD_RESULT: ${{ needs.linux-fuzz-build.result }}
+          SHARDS_RESULT: ${{ needs.linux-fuzz-shards.result }}
+        run: |
+          echo "linux-fuzz-build: ${BUILD_RESULT}"
+          echo "linux-fuzz-shards: ${SHARDS_RESULT}"
+          test "${BUILD_RESULT}" = "success"
+          test "${SHARDS_RESULT}" = "success"
+
   macos-native-arm64:
     name: ${{ matrix.job-name }}
     # Use any image to support the xcode-select below, but hardcode version to avoid silent upgrades (and breaks).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           path: ${{ env.BASE_BUILD_DIR }}/bin/fuzz
 
   linux-fuzz-shards:
-    name: 'fuzzer,address,undefined,integer, no depends (shard ${{ matrix.shard_index + 1 }}/${{ matrix.shard_count }})'
+    name: 'fuzzer,address,undefined,integer, no depends (shard ${{ matrix.shard_label }})'
     needs: [runners, linux-fuzz-build]
     runs-on: ${{ needs.runners.outputs.provider == 'cirrus' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg' || 'ubuntu-24.04' }}
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
@@ -114,8 +114,10 @@ jobs:
         include:
           - shard_index: 0
             shard_count: 2
+            shard_label: '1/2'
           - shard_index: 1
             shard_count: 2
+            shard_label: '2/2'
 
     env:
       DANGER_CI_ON_HOST_FOLDERS: 1

--- a/.github/workflows/test-each-commit.yml
+++ b/.github/workflows/test-each-commit.yml
@@ -1,0 +1,49 @@
+name: test each commit
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-each-commit:
+    name: 'test each commit'
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request' && github.event.pull_request.commits != 1
+    timeout-minutes: 360
+    env:
+      MAX_COUNT: 6
+    steps:
+      - name: Determine fetch depth
+        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+
+      - name: Determine commit range
+        run: |
+          git checkout HEAD~
+          MERGE_BASE=$(git rev-list -n1 --merges HEAD)
+          EXCLUDE_MERGE_BASE_ANCESTORS=
+          if test -n "$MERGE_BASE"; then
+            EXCLUDE_MERGE_BASE_ANCESTORS=^${MERGE_BASE}^@
+          fi
+          echo "TEST_BASE=$(git rev-list -n$((${{ env.MAX_COUNT }} + 1)) --reverse HEAD $EXCLUDE_MERGE_BASE_ANCESTORS | head -1)" >> "$GITHUB_ENV"
+
+      - name: Prepare merge base and toolchain
+        run: |
+          git fetch origin "${GITHUB_BASE_REF}"
+          git config user.email "ci@example.com"
+          git config user.name "CI"
+          sudo apt-get update
+          sudo apt-get install clang mold ccache build-essential cmake ninja-build pkgconf python3-zmq libevent-dev libboost-dev libsqlite3-dev systemtap-sdt-dev libzmq3-dev qt6-base-dev qt6-tools-dev qt6-l10n-tools libqrencode-dev capnproto libcapnp-dev -y
+          sudo pip3 install --break-system-packages pycapnp
+
+      - name: Compile and run tests
+        run: |
+          git rebase --exec "git merge --no-commit origin/${GITHUB_BASE_REF} && python3 ./.github/ci-test-each-commit-exec.py && git reset --hard" ${{ env.TEST_BASE }}

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -52,6 +52,11 @@ export RUN_PQSIG_FUZZ_SMOKE=${RUN_PQSIG_FUZZ_SMOKE:-true}
 export PQSIG_FUZZ_SMOKE_MAX_TOTAL_TIME=${PQSIG_FUZZ_SMOKE_MAX_TOTAL_TIME:-30}
 export PQSIG_FUZZ_SMOKE_MAX_RUNS=${PQSIG_FUZZ_SMOKE_MAX_RUNS:-100000}
 export PQSIG_BENCH_REPEATS=${PQSIG_BENCH_REPEATS:-3}
+export BUILD_BENCH_BINARIES=${BUILD_BENCH_BINARIES:-$RUN_UNIT_TESTS}
+export BUILD_FUZZ_BINARY=${BUILD_FUZZ_BINARY:-$RUN_FUZZ_TESTS}
+export CI_TEST_SCRIPT=${CI_TEST_SCRIPT:-$BASE_ROOT_DIR/ci/test/03_test_script.sh}
+export FUZZ_SHARD_INDEX=${FUZZ_SHARD_INDEX:-0}
+export FUZZ_SHARD_COUNT=${FUZZ_SHARD_COUNT:-2}
 
 # Randomize test order.
 # See https://www.boost.org/doc/libs/1_71_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/random.html

--- a/ci/test/00_setup_env_native_fuzz_build.sh
+++ b/ci/test/00_setup_env_native_fuzz_build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026-present The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+# shellcheck disable=SC1090
+source "${BASE_ROOT_DIR}/ci/test/00_setup_env_native_fuzz.sh"
+
+export RUN_FUZZ_TESTS=false
+export RUN_PQSIG_FUZZ_SMOKE=false
+export BUILD_BENCH_BINARIES=false
+export BUILD_FUZZ_BINARY=true

--- a/ci/test/00_setup_env_native_fuzz_build.sh
+++ b/ci/test/00_setup_env_native_fuzz_build.sh
@@ -6,8 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
-# shellcheck disable=SC1090
-source "${BASE_ROOT_DIR}/ci/test/00_setup_env_native_fuzz.sh"
+# shellcheck disable=SC1091
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/00_setup_env_native_fuzz.sh"
 
 export RUN_FUZZ_TESTS=false
 export RUN_PQSIG_FUZZ_SMOKE=false

--- a/ci/test/00_setup_env_native_fuzz_shard.sh
+++ b/ci/test/00_setup_env_native_fuzz_shard.sh
@@ -6,8 +6,8 @@
 
 export LC_ALL=C.UTF-8
 
-# shellcheck disable=SC1090
-source "${BASE_ROOT_DIR}/ci/test/00_setup_env_native_fuzz.sh"
+# shellcheck disable=SC1091
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/00_setup_env_native_fuzz.sh"
 
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/00_setup_env_native_fuzz_shard.sh
+++ b/ci/test/00_setup_env_native_fuzz_shard.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026-present The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+# shellcheck disable=SC1090
+source "${BASE_ROOT_DIR}/ci/test/00_setup_env_native_fuzz.sh"
+
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false
+export RUN_FUZZ_TESTS=false
+export RUN_PQSIG_FUZZ_SMOKE=false
+export BUILD_BENCH_BINARIES=false
+export BUILD_FUZZ_BINARY=false
+export CI_TEST_SCRIPT="${BASE_ROOT_DIR}/ci/test/04_run_fuzz_shard.sh"

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -12,6 +12,9 @@ export HOST=x86_64-w64-mingw32
 export PACKAGES="g++-mingw-w64-x86-64-posix nsis"
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
+export RUN_PQSIG_FUZZ_SMOKE=false
+export BUILD_BENCH_BINARIES=true
+export BUILD_FUZZ_BINARY=true
 export GOAL="deploy"
 export BITCOIN_CONFIG="-DREDUCE_EXPORTS=ON -DBUILD_GUI_TESTS=OFF \
 -DCMAKE_CXX_FLAGS='-Wno-error=maybe-uninitialized'"

--- a/ci/test/02_run_container.sh
+++ b/ci/test/02_run_container.sh
@@ -123,7 +123,7 @@ CI_EXEC "${BASE_ROOT_DIR}/ci/test/01_base_install.sh"
 
 CI_EXEC mkdir -p "${BINS_SCRATCH_DIR}"
 
-CI_EXEC "${BASE_ROOT_DIR}/ci/test/03_test_script.sh"
+CI_EXEC "${CI_TEST_SCRIPT}"
 
 if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   echo "Stop and remove CI container by ID"

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -110,7 +110,13 @@ if [ "$DOWNLOAD_PREVIOUS_RELEASES" = "true" ]; then
   test/get_previous_releases.py --target-dir "$PREVIOUS_RELEASES_DIR"
 fi
 
-BITCOIN_CONFIG_ALL="-DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON"
+BITCOIN_CONFIG_ALL=""
+if [ "${BUILD_BENCH_BINARIES}" = "true" ]; then
+  BITCOIN_CONFIG_ALL="${BITCOIN_CONFIG_ALL} -DBUILD_BENCH=ON"
+fi
+if [ "${BUILD_FUZZ_BINARY}" = "true" ]; then
+  BITCOIN_CONFIG_ALL="${BITCOIN_CONFIG_ALL} -DBUILD_FUZZ_BINARY=ON"
+fi
 if [ -z "$NO_DEPENDS" ]; then
   BITCOIN_CONFIG_ALL="${BITCOIN_CONFIG_ALL} -DCMAKE_TOOLCHAIN_FILE=$DEPENDS_DIR/$HOST/toolchain.cmake"
 fi
@@ -270,7 +276,7 @@ if [ "$RUN_FUNCTIONAL_TESTS" = "true" ]; then
   fi
 fi
 
-if [ "${RUN_PQSIG_FUZZ_SMOKE}" = "true" ]; then
+if [ "${RUN_PQSIG_FUZZ_SMOKE}" = "true" ] && [ "${BUILD_FUZZ_BINARY}" = "true" ]; then
   build_for_fuzzing=""
   if [ -f "${BASE_BUILD_DIR}/CMakeCache.txt" ]; then
     build_for_fuzzing="$(sed -n 's/^BUILD_FOR_FUZZING:BOOL=//p' "${BASE_BUILD_DIR}/CMakeCache.txt" | tail -1)"

--- a/ci/test/04_run_fuzz_shard.sh
+++ b/ci/test/04_run_fuzz_shard.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026-present The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+set -ex
+
+export HOST=${HOST:-$("${BASE_ROOT_DIR}/depends/config.guess")}
+export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_corpora/
+
+if [ ! -x "${BASE_BUILD_DIR}/bin/fuzz" ]; then
+  echo "Missing fuzz binary at ${BASE_BUILD_DIR}/bin/fuzz"
+  exit 1
+fi
+
+if [ ! -d "${DIR_FUZZ_IN}" ]; then
+  ${CI_RETRY_EXE} git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
+fi
+(
+  cd "${DIR_QA_ASSETS}"
+  echo "Using qa-assets repo from commit ..."
+  git log -1
+)
+
+LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" \
+python3 "${BASE_ROOT_DIR}/ci/test/fuzz_shard.py" run \
+  --fuzz-bin "${BASE_BUILD_DIR}/bin/fuzz" \
+  --source-dir "${BASE_ROOT_DIR}" \
+  --corpus-dir "${DIR_FUZZ_IN}" \
+  --shard-index "${FUZZ_SHARD_INDEX}" \
+  --shard-count "${FUZZ_SHARD_COUNT}" \
+  --par "$(nproc)" \
+  --empty-min-time 60 \
+  --loglevel DEBUG

--- a/ci/test/ci_runtime_budget.json
+++ b/ci/test/ci_runtime_budget.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "wall_clock_definition": "earliest_required_job_start_to_latest_required_job_completion",
+  "linux_fuzz_shard_count": 2,
+  "workflows": {
+    "CI": {
+      "wall_clock_minutes_max": 60
+    },
+    "Gatekeeper": {
+      "wall_clock_minutes_max": 5
+    },
+    "measured-bench": {
+      "wall_clock_minutes_max": 15
+    }
+  }
+}

--- a/ci/test/fuzz_shard.py
+++ b/ci/test/fuzz_shard.py
@@ -9,7 +9,6 @@ import argparse
 import logging
 import os
 import subprocess
-import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Iterable, Optional

--- a/ci/test/fuzz_shard.py
+++ b/ci/test/fuzz_shard.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+SYMBOLIZER_PATH = os.environ.get("LLVM_SYMBOLIZER_PATH", "/usr/bin/llvm-symbolizer")
+
+
+def fuzz_env(*, target: str, source_dir: Path) -> dict[str, str]:
+    return os.environ | {
+        "FUZZ": target,
+        "UBSAN_OPTIONS": f"suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1",
+        "UBSAN_SYMBOLIZER_PATH": SYMBOLIZER_PATH,
+        "ASAN_OPTIONS": "detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1",
+        "ASAN_SYMBOLIZER_PATH": SYMBOLIZER_PATH,
+        "MSAN_SYMBOLIZER_PATH": SYMBOLIZER_PATH,
+    }
+
+
+def list_targets(*, fuzz_bin: Path, source_dir: Path) -> list[str]:
+    output = subprocess.run(
+        [str(fuzz_bin)],
+        env={"PRINT_ALL_FUZZ_TARGETS_AND_ABORT": "", **fuzz_env(target="", source_dir=source_dir)},
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.splitlines()
+    return sorted(output)
+
+
+def shard_targets(targets: Iterable[str], shard_index: int, shard_count: int) -> list[str]:
+    if shard_count <= 0:
+        raise ValueError("shard_count must be positive")
+    if shard_index < 0 or shard_index >= shard_count:
+        raise ValueError("shard_index must be within shard_count")
+    sorted_targets = sorted(targets)
+    return [target for idx, target in enumerate(sorted_targets) if idx % shard_count == shard_index]
+
+
+def using_libfuzzer(*, fuzz_bin: Path, source_dir: Path, sample_target: str) -> bool:
+    help_output = subprocess.run(
+        [str(fuzz_bin), "-help=1"],
+        env=fuzz_env(target=sample_target, source_dir=source_dir),
+        check=False,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stderr
+    return "libFuzzer" in help_output
+
+
+def run_targets(*, fuzz_bin: Path, source_dir: Path, corpus_dir: Path, targets: list[str], par: int, empty_min_time: Optional[int]) -> None:
+    if not targets:
+        raise ValueError("no fuzz targets selected for shard")
+
+    is_libfuzzer = using_libfuzzer(fuzz_bin=fuzz_bin, source_dir=source_dir, sample_target=targets[0])
+    stats: list[tuple[str, str]] = []
+
+    def job(target: str) -> tuple[str, subprocess.CompletedProcess[str]]:
+        target_corpus = corpus_dir / target
+        target_corpus.mkdir(parents=True, exist_ok=True)
+        args = [str(fuzz_bin)]
+        empty_dir = not any(target_corpus.iterdir())
+        if is_libfuzzer:
+            if empty_min_time and empty_dir:
+                args.append(f"-max_total_time={empty_min_time}")
+            else:
+                args.extend(["-runs=1", str(target_corpus)])
+        else:
+            args.append(str(target_corpus))
+        result = subprocess.run(
+            args,
+            env=fuzz_env(target=target, source_dir=source_dir),
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return target, result
+
+    with ThreadPoolExecutor(max_workers=par) as pool:
+        futures = [pool.submit(job, target) for target in targets]
+        for future in as_completed(futures):
+            target, result = future.result()
+            logging.debug("Run %s\n%s", target, result.stderr)
+            try:
+                result.check_returncode()
+            except subprocess.CalledProcessError:
+                if result.stderr:
+                    logging.error(result.stderr)
+                raise
+            if is_libfuzzer:
+                done_lines = [line for line in result.stderr.splitlines() if "DONE" in line]
+                if len(done_lines) != 1:
+                    raise RuntimeError(f"expected one libFuzzer DONE line for target {target}")
+                stats.append((target, done_lines[0]))
+
+    if is_libfuzzer:
+        print("Summary:")
+        width = max(len(target) for target, _ in stats)
+        for target, stat in sorted(stats):
+            print(f"{target.ljust(width + 1)}{stat}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="List or run a deterministic shard of fuzz targets.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--fuzz-bin", required=True)
+    common.add_argument("--source-dir", required=True)
+    common.add_argument("--shard-index", type=int, required=True)
+    common.add_argument("--shard-count", type=int, required=True)
+
+    list_parser = subparsers.add_parser("list", parents=[common])
+    list_parser.add_argument("--format", choices=("lines", "space"), default="lines")
+
+    run_parser = subparsers.add_parser("run", parents=[common])
+    run_parser.add_argument("--corpus-dir", required=True)
+    run_parser.add_argument("--par", type=int, default=4)
+    run_parser.add_argument("--empty-min-time", type=int)
+    run_parser.add_argument("--loglevel", default="INFO")
+
+    args = parser.parse_args()
+    fuzz_bin = Path(args.fuzz_bin)
+    source_dir = Path(args.source_dir)
+    targets = shard_targets(
+        list_targets(fuzz_bin=fuzz_bin, source_dir=source_dir),
+        shard_index=args.shard_index,
+        shard_count=args.shard_count,
+    )
+
+    if args.command == "list":
+        if args.format == "space":
+            print(" ".join(targets))
+        else:
+            print("\n".join(targets))
+        return 0
+
+    logging.basicConfig(
+        format="%(message)s",
+        level=int(args.loglevel) if str(args.loglevel).isdigit() else str(args.loglevel).upper(),
+    )
+    run_targets(
+        fuzz_bin=fuzz_bin,
+        source_dir=source_dir,
+        corpus_dir=Path(args.corpus_dir),
+        targets=targets,
+        par=args.par,
+        empty_min_time=args.empty_min_time,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test/report_ci_runtime.py
+++ b/ci/test/report_ci_runtime.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+DEFAULT_BUDGET_PATH = Path(__file__).with_name("ci_runtime_budget.json")
+
+
+def load_json_stream(path: Optional[str]) -> dict[str, Any]:
+    if path:
+        with open(path, encoding="utf8") as fh:
+            return json.load(fh)
+    return json.load(sys.stdin)
+
+
+def load_budget(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf8") as fh:
+        return json.load(fh)
+
+
+def infer_workflow_name(run_data: dict[str, Any]) -> Optional[str]:
+    for key in ("workflowName", "name"):
+        value = run_data.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def parse_timestamp(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    return datetime.strptime(value, TIME_FORMAT)
+
+
+def completed_job_windows(run_data: dict[str, Any]) -> list[tuple[datetime, datetime, str]]:
+    jobs = []
+    for job in run_data.get("jobs", []):
+        started = parse_timestamp(job.get("startedAt"))
+        completed = parse_timestamp(job.get("completedAt"))
+        if not started or not completed:
+            continue
+        jobs.append((started, completed, job.get("name", "<unnamed>")))
+    if not jobs:
+        raise ValueError("run data did not contain any completed jobs")
+    return jobs
+
+
+def compute_wall_clock_minutes(run_data: dict[str, Any]) -> float:
+    jobs = completed_job_windows(run_data)
+    started = min(start for start, _, _ in jobs)
+    completed = max(end for _, end, _ in jobs)
+    return (completed - started).total_seconds() / 60.0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Report workflow wall-clock runtime against checked-in CI budgets.")
+    parser.add_argument("--workflow", help="Workflow name to evaluate, for example 'CI'. If omitted, infer from JSON when possible.")
+    parser.add_argument("--input", help="Saved gh run view JSON file. Reads stdin when omitted.")
+    parser.add_argument("--budget", default=str(DEFAULT_BUDGET_PATH), help="Path to ci_runtime_budget.json.")
+    args = parser.parse_args()
+
+    run_data = load_json_stream(args.input)
+    budget_data = load_budget(args.budget)
+    workflow = args.workflow or infer_workflow_name(run_data)
+    if not workflow:
+        raise SystemExit("workflow name is required via --workflow when the JSON does not include one")
+
+    workflow_budget = budget_data["workflows"].get(workflow)
+    if workflow_budget is None:
+        raise SystemExit(f"no runtime budget defined for workflow '{workflow}'")
+
+    wall_clock_minutes = compute_wall_clock_minutes(run_data)
+    budget_minutes = float(workflow_budget["wall_clock_minutes_max"])
+    passed = wall_clock_minutes < budget_minutes
+    status = "PASS" if passed else "FAIL"
+
+    print(f"workflow={workflow}")
+    print(f"wall_clock_definition={budget_data['wall_clock_definition']}")
+    print(f"wall_clock_minutes={wall_clock_minutes:.2f}")
+    print(f"budget_minutes_max={budget_minutes:.2f}")
+    print(f"status={status}")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test/test_ci_runtime_helpers.py
+++ b/ci/test/test_ci_runtime_helpers.py
@@ -1,0 +1,109 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+CI_TEST_DIR = Path(__file__).resolve().parent
+REPORT_PATH = CI_TEST_DIR / "report_ci_runtime.py"
+FUZZ_SHARD_PATH = CI_TEST_DIR / "fuzz_shard.py"
+BUDGET_PATH = CI_TEST_DIR / "ci_runtime_budget.json"
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+report_ci_runtime = load_module(REPORT_PATH, "report_ci_runtime")
+fuzz_shard = load_module(FUZZ_SHARD_PATH, "fuzz_shard")
+
+
+class ReportRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.run_json = {
+            "jobs": [
+                {
+                    "name": "job-a",
+                    "startedAt": "2026-03-28T12:10:00Z",
+                    "completedAt": "2026-03-28T12:25:00Z",
+                },
+                {
+                    "name": "job-b",
+                    "startedAt": "2026-03-28T12:12:00Z",
+                    "completedAt": "2026-03-28T12:40:00Z",
+                },
+            ]
+        }
+
+    def test_wall_clock_uses_earliest_start_and_latest_finish(self):
+        minutes = report_ci_runtime.compute_wall_clock_minutes(self.run_json)
+        self.assertEqual(minutes, 30.0)
+
+    def test_cli_accepts_saved_json_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_path = Path(tmpdir) / "run.json"
+            run_path.write_text(json.dumps(self.run_json), encoding="utf8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPORT_PATH),
+                    "--workflow",
+                    "CI",
+                    "--budget",
+                    str(BUDGET_PATH),
+                    "--input",
+                    str(run_path),
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("status=PASS", result.stdout)
+
+    def test_cli_accepts_stdin(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPORT_PATH),
+                "--workflow",
+                "Gatekeeper",
+                "--budget",
+                str(BUDGET_PATH),
+            ],
+            input=json.dumps(self.run_json),
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("status=FAIL", result.stdout)
+
+
+class FuzzShardTests(unittest.TestCase):
+    def test_shard_assignment_is_deterministic(self):
+        targets = ["zeta", "alpha", "gamma", "beta", "delta"]
+        shard0 = fuzz_shard.shard_targets(targets, shard_index=0, shard_count=2)
+        shard1 = fuzz_shard.shard_targets(targets, shard_index=1, shard_count=2)
+        self.assertEqual(shard0, ["alpha", "delta", "zeta"])
+        self.assertEqual(shard1, ["beta", "gamma"])
+
+    def test_shard_union_matches_full_target_set(self):
+        targets = ["delta", "alpha", "gamma", "beta", "zeta", "eta"]
+        shard_count = 2
+        shards = [fuzz_shard.shard_targets(targets, shard_index=i, shard_count=shard_count) for i in range(shard_count)]
+        flattened = [target for shard in shards for target in shard]
+        self.assertEqual(sorted(flattened), sorted(targets))
+        self.assertEqual(len(flattened), len(set(flattened)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/test_imagefile
+++ b/ci/test_imagefile
@@ -15,6 +15,6 @@ ARG BASE_ROOT_DIR
 ENV BASE_ROOT_DIR=${BASE_ROOT_DIR}
 
 COPY ./ci/retry/retry /usr/bin/retry
-COPY ./ci/test/00_setup_env.sh ./${FILE_ENV} ./ci/test/01_base_install.sh /ci_container_base/ci/test/
+COPY ./ci/test/00_setup_env.sh ./ci/test/00_setup_env_native_fuzz.sh ./${FILE_ENV} ./ci/test/01_base_install.sh /ci_container_base/ci/test/
 
 RUN ["bash", "-c", "cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh"]

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -11,6 +11,7 @@ PQC-facing CI enforcement is split across two workflows:
 | `ci.yml` | Build, tests, benchmarks, fuzz, and PQ gating across platforms |
 | `measured-bench.yml` | Dedicated runtime variance gate for PQSig bench performance |
 | `gatekeeper.yml` | Docs-first freeze-gate checks against the selected base ref |
+| `test-each-commit.yml` | Non-required per-commit replay coverage for multi-commit pull requests |
 
 ## RC Stabilization Controls
 
@@ -58,6 +59,40 @@ Current workflow and gate ownership remains maintainer-owned:
 | `measured-bench` | `@scottdhughes` | Dedicated runtime variance gate. |
 | PQ functional default list | `@scottdhughes` | Canonical file: `ci/test/pq_functional_tests.txt`. |
 | Legacy opt-in profile | `@scottdhughes` | Controlled by `PQBTC_ENABLE_LEGACY_FUNCTIONAL_TESTS=true`. |
+| `test each commit` workflow | `@scottdhughes` | Non-required long-tail coverage outside the required `CI` wall-clock path. |
+
+## Runtime Budget Contract
+
+Checked-in runtime budget file:
+
+- `ci/test/ci_runtime_budget.json`
+
+Current required-path budgets:
+
+| Workflow | Budget |
+|---|---|
+| `CI` | under `60` minutes |
+| `Gatekeeper` | under `5` minutes |
+| `measured-bench` | under `15` minutes |
+
+Wall-clock semantics are frozen as:
+
+- earliest required job start to latest required job completion for that workflow run
+- not the sum of job runtimes
+
+Runtime reporting helper:
+
+```bash
+gh run view <run-id> --json jobs,createdAt,updatedAt > /tmp/ci-run.json
+python3 ci/test/report_ci_runtime.py --workflow CI --input /tmp/ci-run.json
+```
+
+or from stdin:
+
+```bash
+gh run view <run-id> --json jobs,createdAt,updatedAt | \
+  python3 ci/test/report_ci_runtime.py --workflow CI
+```
 
 ## CI Inventory Contract
 

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -71,4 +71,3 @@ Until a separate ownership model or `CODEOWNERS` file exists, all current workfl
 Still deferred after this tranche:
 
 1. converting `pq_backlog` suites into required PQ gates or documenting permanent dual-profile boundaries for them
-2. runtime and matrix optimization work in issue `#29`


### PR DESCRIPTION
## Summary
- add the checked-in CI runtime budget contract and reporting helper
- move `test each commit` out of the required `CI` workflow path
- split the long Linux fuzz lane into a producer plus deterministic shards
- stop building bench/fuzz artifacts in jobs that do not consume them

## Testing
- python3 -m py_compile ci/test/report_ci_runtime.py ci/test/fuzz_shard.py ci/test/test_ci_runtime_helpers.py ci/test/check_ci_inventory.py
- python3 -m unittest discover -s ci/test -p "test_*.py"
- bash -n ci/test/03_test_script.sh ci/test/04_run_fuzz_shard.sh ci/test/00_setup_env_native_fuzz_build.sh ci/test/00_setup_env_native_fuzz_shard.sh
- python3 ci/test/check_ci_inventory.py
- python3 ci/test/report_ci_runtime.py --workflow CI --input <(gh run view -R scottdhughes/quantum-proof-bitcoin 23684919465 --json jobs,createdAt,updatedAt)
- python3 ci/test/fuzz_shard.py list --fuzz-bin build/bin/fuzz --source-dir . --shard-index 0 --shard-count 2
- python3 ci/test/fuzz_shard.py list --fuzz-bin build/bin/fuzz --source-dir . --shard-index 1 --shard-count 2
- git diff --check

Closes #29