### PR TITLE
ops: freeze SLO evidence bundle and operator signals

### DIFF
--- a/contrib/soak/capture_ops_slo_evidence.sh
+++ b/contrib/soak/capture_ops_slo_evidence.sh
@@ -13,6 +13,7 @@ RAW_OUT="${RAW_OUT:-${ROOT_DIR}/build/ops-slo/${STAMP}}"
 TEST_RUNNER="${ROOT_DIR}/build/test/functional/test_runner.py"
 SOAK_OUT="${RAW_OUT}/soak"
 SOAK_RUNS="${SOAK_RUNS:-10}"
+SPEC_ID="OPS-SLO-v1"
 
 mkdir -p "${DOC_OUT}" "${RAW_OUT}"
 
@@ -38,19 +39,44 @@ if compgen -G "${SOAK_OUT}/summaries/*.json" > /dev/null; then
   cp "${SOAK_OUT}/summaries/"*.json "${DOC_OUT}/soak-summaries/"
 fi
 
+cat > "${DOC_OUT}/manifest.json" <<EOF
+{
+  "spec_id": "${SPEC_ID}",
+  "stamp": "${STAMP}",
+  "capture_script": "contrib/soak/capture_ops_slo_evidence.sh",
+  "soak_runs": ${SOAK_RUNS},
+  "artifacts": [
+    "README.md",
+    "mempool-pq-limits-summary.json",
+    "mempool-pq-stress-summary.json",
+    "feature-pq-reorg-summary.json",
+    "pq-mempool-soak-summary.json",
+    "pq-mempool-soak-results.tsv"
+  ]
+}
+EOF
+
 cat > "${DOC_OUT}/README.md" <<EOF
 # PQBTC Ops/SLO Evidence (${STAMP})
 
-- Functional summaries:
-  - \`mempool-pq-limits-summary.json\`
-  - \`mempool-pq-stress-summary.json\`
-  - \`feature-pq-reorg-summary.json\`
-- Soak summaries:
-  - \`pq-mempool-soak-summary.json\`
-  - \`pq-mempool-soak-results.tsv\`
-  - \`soak-summaries/\`
-- Raw logs:
-  - \`build/ops-slo/${STAMP}\`
+- Spec: \`${SPEC_ID}\`
+- Capture script: \`contrib/soak/capture_ops_slo_evidence.sh\`
+- Validator: \`contrib/soak/validate_ops_slo_evidence.py --signoff <bundle-root>\`
+- Raw logs: \`build/ops-slo/${STAMP}\`
+
+## Artifacts
+
+- \`README.md\`
+- \`manifest.json\`
+- \`mempool-pq-limits-summary.json\`
+- \`mempool-pq-stress-summary.json\`
+- \`feature-pq-reorg-summary.json\`
+- \`pq-mempool-soak-summary.json\`
+- \`pq-mempool-soak-results.tsv\`
+
+## Optional Supplemental Artifacts
+
+- \`soak-summaries/\`
 EOF
 
 echo "Ops/SLO evidence written to: ${DOC_OUT}"

--- a/contrib/soak/test_validate_ops_slo_evidence.py
+++ b/contrib/soak/test_validate_ops_slo_evidence.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import validate_ops_slo_evidence as target  # noqa: E402
+
+
+FIXTURE_BUNDLE = REPO_ROOT / "docs" / "artifacts" / "ops-slo" / "2026-03-23"
+
+
+class ValidateOpsSLOEvidenceTest(unittest.TestCase):
+    def copy_fixture_bundle(self) -> Path:
+        tmpdir = Path(tempfile.mkdtemp(prefix="ops-slo-bundle-"))
+        bundle_root = tmpdir / FIXTURE_BUNDLE.name
+        shutil.copytree(FIXTURE_BUNDLE, bundle_root)
+        return bundle_root
+
+    def test_fixture_bundle_passes_signoff(self) -> None:
+        bundle_root = self.copy_fixture_bundle()
+        self.addCleanup(shutil.rmtree, bundle_root.parent)
+        target.validate_bundle(bundle_root, signoff=True)
+
+    def test_missing_summary_file_fails(self) -> None:
+        bundle_root = self.copy_fixture_bundle()
+        self.addCleanup(shutil.rmtree, bundle_root.parent)
+        (bundle_root / "mempool-pq-stress-summary.json").unlink()
+
+        with self.assertRaisesRegex(target.ValidationError, "mempool-pq-stress-summary.json: missing file"):
+            target.validate_bundle(bundle_root)
+
+    def test_malformed_json_fails(self) -> None:
+        bundle_root = self.copy_fixture_bundle()
+        self.addCleanup(shutil.rmtree, bundle_root.parent)
+        (bundle_root / "feature-pq-reorg-summary.json").write_text("{bad json\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(target.ValidationError, "feature-pq-reorg-summary.json: malformed JSON"):
+            target.validate_bundle(bundle_root)
+
+    def test_wrong_scenario_fails(self) -> None:
+        bundle_root = self.copy_fixture_bundle()
+        self.addCleanup(shutil.rmtree, bundle_root.parent)
+        summary_path = bundle_root / "mempool-pq-limits-summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        summary["scenario"] = "wrong_scenario"
+        summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(target.ValidationError, "mempool-pq-limits-summary.json: unexpected scenario"):
+            target.validate_bundle(bundle_root)
+
+    def test_missing_required_field_fails(self) -> None:
+        bundle_root = self.copy_fixture_bundle()
+        self.addCleanup(shutil.rmtree, bundle_root.parent)
+        summary_path = bundle_root / "mempool-pq-stress-summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        del summary["notes"]
+        summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(target.ValidationError, "missing fields: notes"):
+            target.validate_bundle(bundle_root)
+
+    def test_non_signoff_soak_result_fails_in_signoff_mode(self) -> None:
+        bundle_root = self.copy_fixture_bundle()
+        self.addCleanup(shutil.rmtree, bundle_root.parent)
+        summary_path = bundle_root / "pq-mempool-soak-summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        summary["passed"] = 9
+        summary["failed"] = 1
+        summary["pass"] = False
+        summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(target.ValidationError, "pq_mempool_soak: signoff requires"):
+            target.validate_bundle(bundle_root, signoff=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/soak/validate_ops_slo_evidence.py
+++ b/contrib/soak/validate_ops_slo_evidence.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Validate checked-in or freshly captured PQBTC ops/SLO evidence bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+SPEC_ID = "OPS-SLO-v1"
+CAPTURE_SCRIPT = "contrib/soak/capture_ops_slo_evidence.sh"
+REQUIRED_ARTIFACTS = [
+    "README.md",
+    "mempool-pq-limits-summary.json",
+    "mempool-pq-stress-summary.json",
+    "feature-pq-reorg-summary.json",
+    "pq-mempool-soak-summary.json",
+    "pq-mempool-soak-results.tsv",
+]
+SUMMARY_REQUIRED_FIELDS = [
+    "scenario",
+    "pass",
+    "duration_s",
+    "mempool_before_restart",
+    "mempool_after_restart",
+    "reorg_result",
+    "crash_assert_hang",
+    "notes",
+]
+SOAK_REQUIRED_FIELDS = SUMMARY_REQUIRED_FIELDS + [
+    "runs",
+    "passed",
+    "failed",
+    "jobs",
+    "test",
+    "results_tsv",
+]
+SUMMARY_SCENARIOS = {
+    "mempool-pq-limits-summary.json": "mempool_pq_limits",
+    "mempool-pq-stress-summary.json": "mempool_pq_stress",
+    "feature-pq-reorg-summary.json": "feature_pq_reorg",
+}
+SOAK_SUMMARY = "pq-mempool-soak-summary.json"
+SOAK_SCENARIO = "pq_mempool_soak"
+
+
+class ValidationError(ValueError):
+    """Raised when an evidence bundle does not satisfy the frozen contract."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def _load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"{path.name}: malformed JSON: {exc.msg}") from exc
+
+
+def _validate_manifest(bundle_root: Path) -> dict[str, object]:
+    manifest_path = bundle_root / "manifest.json"
+    _require(manifest_path.is_file(), "manifest.json: missing file")
+    manifest = _load_json(manifest_path)
+    _require(isinstance(manifest, dict), "manifest.json: top-level object required")
+    expected_keys = {"spec_id", "stamp", "capture_script", "soak_runs", "artifacts"}
+    _require(set(manifest.keys()) == expected_keys, "manifest.json: unexpected schema")
+    _require(manifest["spec_id"] == SPEC_ID, "manifest.json: unexpected spec_id")
+    _require(manifest["stamp"] == bundle_root.name, "manifest.json: stamp must match bundle directory name")
+    _require(manifest["capture_script"] == CAPTURE_SCRIPT, "manifest.json: unexpected capture_script")
+    _require(isinstance(manifest["soak_runs"], int), "manifest.json: soak_runs must be an integer")
+    _require(isinstance(manifest["artifacts"], list), "manifest.json: artifacts must be a list")
+    _require(sorted(manifest["artifacts"]) == sorted(REQUIRED_ARTIFACTS), "manifest.json: artifacts list drifted")
+    return manifest
+
+
+def _validate_readme(bundle_root: Path) -> None:
+    readme_path = bundle_root / "README.md"
+    _require(readme_path.is_file(), "README.md: missing file")
+    readme = readme_path.read_text(encoding="utf-8")
+    required_fragments = [
+        f"# PQBTC Ops/SLO Evidence ({bundle_root.name})",
+        f"- Spec: `{SPEC_ID}`",
+        f"- Capture script: `{CAPTURE_SCRIPT}`",
+        "- Validator: `contrib/soak/validate_ops_slo_evidence.py --signoff <bundle-root>`",
+        f"- Raw logs: `build/ops-slo/{bundle_root.name}`",
+        "## Artifacts",
+        "## Optional Supplemental Artifacts",
+    ]
+    for artifact in REQUIRED_ARTIFACTS:
+        required_fragments.append(f"- `{artifact}`")
+    required_fragments.append("- `soak-summaries/`")
+    for fragment in required_fragments:
+        _require(fragment in readme, f"README.md: missing required text: {fragment}")
+
+
+def _validate_summary_fields(path: Path, expected_scenario: str, required_fields: list[str]) -> dict[str, object]:
+    summary = _load_json(path)
+    _require(isinstance(summary, dict), f"{path.name}: top-level object required")
+    missing = [field for field in required_fields if field not in summary]
+    _require(not missing, f"{path.name}: missing fields: {', '.join(missing)}")
+    _require(summary["scenario"] == expected_scenario, f"{path.name}: unexpected scenario")
+    return summary
+
+
+def validate_bundle(bundle_root: Path, *, signoff: bool = False) -> None:
+    bundle_root = bundle_root.resolve()
+    _require(bundle_root.is_dir(), f"{bundle_root}: bundle directory not found")
+
+    manifest = _validate_manifest(bundle_root)
+    _validate_readme(bundle_root)
+
+    for artifact in REQUIRED_ARTIFACTS:
+        _require((bundle_root / artifact).is_file(), f"{artifact}: missing file")
+
+    summaries = []
+    for filename, scenario in SUMMARY_SCENARIOS.items():
+        summary = _validate_summary_fields(bundle_root / filename, scenario, SUMMARY_REQUIRED_FIELDS)
+        summaries.append(summary)
+
+    soak_summary = _validate_summary_fields(bundle_root / SOAK_SUMMARY, SOAK_SCENARIO, SOAK_REQUIRED_FIELDS)
+    _require(isinstance(soak_summary["runs"], int), f"{SOAK_SUMMARY}: runs must be an integer")
+    _require(isinstance(soak_summary["passed"], int), f"{SOAK_SUMMARY}: passed must be an integer")
+    _require(isinstance(soak_summary["failed"], int), f"{SOAK_SUMMARY}: failed must be an integer")
+    _require(isinstance(soak_summary["jobs"], int), f"{SOAK_SUMMARY}: jobs must be an integer")
+    _require(isinstance(soak_summary["test"], str) and soak_summary["test"], f"{SOAK_SUMMARY}: test must be a non-empty string")
+    _require(isinstance(soak_summary["results_tsv"], str) and soak_summary["results_tsv"], f"{SOAK_SUMMARY}: results_tsv must be a non-empty string")
+    _require(soak_summary["runs"] == manifest["soak_runs"], f"{SOAK_SUMMARY}: runs must match manifest soak_runs")
+    _require(soak_summary["passed"] + soak_summary["failed"] == soak_summary["runs"], f"{SOAK_SUMMARY}: passed + failed must equal runs")
+    _require((soak_summary["failed"] == 0) == (soak_summary["pass"] is True), f"{SOAK_SUMMARY}: pass must match failed count")
+
+    if signoff:
+        _require(manifest["soak_runs"] == 10, "manifest.json: signoff requires soak_runs == 10")
+        for summary in summaries:
+            _require(summary["pass"] is True, f"{summary['scenario']}: signoff requires pass=true")
+            _require(summary["crash_assert_hang"] is False, f"{summary['scenario']}: signoff requires crash_assert_hang=false")
+        _require(soak_summary["pass"] is True, f"{SOAK_SCENARIO}: signoff requires pass=true")
+        _require(soak_summary["crash_assert_hang"] is False, f"{SOAK_SCENARIO}: signoff requires crash_assert_hang=false")
+        _require(soak_summary["runs"] == 10, f"{SOAK_SCENARIO}: signoff requires runs == 10")
+        _require(soak_summary["passed"] == 10, f"{SOAK_SCENARIO}: signoff requires passed == 10")
+        _require(soak_summary["failed"] == 0, f"{SOAK_SCENARIO}: signoff requires failed == 0")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle_root", help="Path to docs/artifacts/ops-slo/<stamp>")
+    parser.add_argument("--signoff", action="store_true", help="Enforce frozen sign-off thresholds")
+    args = parser.parse_args()
+
+    try:
+        validate_bundle(Path(args.bundle_root), signoff=args.signoff)
+    except ValidationError as exc:
+        print(f"OPS/SLO validation failed: {exc}")
+        return 1
+
+    print(f"OPS/SLO evidence bundle validated: {Path(args.bundle_root).resolve()}")
+    if args.signoff:
+        print("Sign-off thresholds satisfied.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -235,12 +235,19 @@ Operator/local capture:
 contrib/soak/capture_ops_slo_evidence.sh
 ```
 
-The helper writes tracked summaries under `docs/artifacts/ops-slo/<date>/` and raw logs under `build/ops-slo/<date>/`.
+The helper writes tracked summaries under `docs/artifacts/ops-slo/<date>/`, emits a fixed
+`manifest.json` and `README.md`, and stores raw logs under `build/ops-slo/<date>/`.
 
 CI-runner style invocation:
 
 ```bash
 STAMP=$(date -u +%Y-%m-%d) contrib/soak/capture_ops_slo_evidence.sh
+```
+
+Bundle validation:
+
+```bash
+contrib/soak/validate_ops_slo_evidence.py --signoff docs/artifacts/ops-slo/2026-03-23
 ```
 
 Expected local wall-clock time for the full capture is roughly 5-10 minutes on current developer hardware, depending on soak durations.
@@ -251,3 +258,6 @@ The capture includes:
 2. `mempool_pq_stress.py`
 3. `feature_pq_reorg.py`
 4. `RUNS=10 JOBS=1 contrib/soak/run_pq_mempool_soak.sh`
+
+This capture and validation path is an operator/local evidence surface. It is not a separate
+required PR status in the current CI contract.

--- a/docs/GA_ACCEPTANCE_CHECKLIST.md
+++ b/docs/GA_ACCEPTANCE_CHECKLIST.md
@@ -106,3 +106,10 @@ Rules:
   - [ ] No
   - [x] Yes (CFC verdict and accepted-set impact statement attached)
 - Notes: `2026-03-06` posture change for issue `#48`: old profile held, rc2 exact-root reprofile active, and fresh burn-in evidence required before any blocker closure. `2026-03-09`: merge-commit CI and Gatekeeper are green on the shipped rc2 path, issue `#48` is closed, and the GA call is promote from current `main`.
+
+## Post-v1 Carry-Forward
+
+Post-v1 operational sign-off reuses the rollback-trigger vocabulary from `Required Evidence` item 7.
+The checked-in operator evidence contract lives in `docs/OPS_SLO.md`, the tracked bundles live under
+`docs/artifacts/ops-slo/<stamp>/`, and local integrity/sign-off validation runs via
+`contrib/soak/validate_ops_slo_evidence.py --signoff <bundle>`.

--- a/docs/GA_BURNIN_LOG.md
+++ b/docs/GA_BURNIN_LOG.md
@@ -11,6 +11,13 @@
 - End: 2026-03-09
 - Cadence: weekly checkpoints
 
+## Post-v1 Carry-Forward
+
+The checkpoint vocabulary for soak summary, SLO summary, and rollback-trigger review carries forward
+into the post-v1 operator bundle defined by `docs/OPS_SLO.md`. Checked-in operator bundles live under
+`docs/artifacts/ops-slo/<stamp>/` and validate with
+`contrib/soak/validate_ops_slo_evidence.py --signoff <bundle>`.
+
 ## RC2 Reset (2026-03-06)
 
 1. `v1.0.0` GA on the original `ALG_ID=0x00` profile is held.

--- a/docs/OPS_SLO.md
+++ b/docs/OPS_SLO.md
@@ -28,17 +28,11 @@ Define the operator-facing pass/fail thresholds for PQBTC post-v1 operational ha
 4. `run_pq_mempool_soak.sh`
    - repeats `mempool_pq_stress.py` under a fixed pass-rate target
 
-## Machine-Readable Evidence
+## Operator Signals
 
-Tracked evidence lives under `docs/artifacts/ops-slo/<date>/`.
-
-Required files:
-
-1. `mempool-pq-limits-summary.json`
-2. `mempool-pq-stress-summary.json`
-3. `feature-pq-reorg-summary.json`
-4. `pq-mempool-soak-summary.json`
-5. `pq-mempool-soak-results.tsv`
+For this repository, operator-facing "dashboard signals" are the checked-in machine-readable
+summary fields emitted by the required scenarios. This contract does not define or require a
+live telemetry or production dashboard system.
 
 Per-scenario JSON summaries use this fixed field set:
 
@@ -51,9 +45,55 @@ Per-scenario JSON summaries use this fixed field set:
 - `crash_assert_hang`
 - `notes`
 
+The soak aggregate summary extends the fixed field set with:
+
+- `runs`
+- `passed`
+- `failed`
+- `jobs`
+- `test`
+- `results_tsv`
+
+## Evidence Bundle Contract
+
+Tracked evidence lives under `docs/artifacts/ops-slo/<date>/`.
+
+Required top-level files:
+
+1. `README.md`
+2. `manifest.json`
+3. `mempool-pq-limits-summary.json`
+4. `mempool-pq-stress-summary.json`
+5. `feature-pq-reorg-summary.json`
+6. `pq-mempool-soak-summary.json`
+7. `pq-mempool-soak-results.tsv`
+
+Optional supplemental evidence:
+
+- `soak-summaries/`
+
+The bundle manifest uses this fixed schema:
+
+- `spec_id`
+- `stamp`
+- `capture_script`
+- `soak_runs`
+- `artifacts` (the required top-level payload files, excluding `manifest.json` itself)
+
 Raw logs remain untracked under `build/ops-slo/<date>/`.
 
-## Invocation
+## Sign-Off Interpretation
+
+Operator sign-off requires:
+
+1. Every required scenario summary has `pass=true`.
+2. Every required scenario summary has `crash_assert_hang=false`.
+3. The soak summary reports `runs=10`, `passed=10`, and `failed=0`.
+4. Restart and reorg reconciliation outcomes remain consistent with the scenario contract.
+5. Witness `10,001` byte rejection stability and large-witness RBF churn status remain captured in
+   the scenario summaries that produced `pass=true`.
+
+## Invocation And Validation
 
 Local capture:
 
@@ -67,6 +107,12 @@ CI-style runner invocation:
 STAMP=$(date -u +%Y-%m-%d) contrib/soak/capture_ops_slo_evidence.sh
 ```
 
+Bundle validation:
+
+```bash
+contrib/soak/validate_ops_slo_evidence.py --signoff docs/artifacts/ops-slo/2026-03-23
+```
+
 ## Reproduce Latest Evidence
 
 The latest checked-in evidence batch lives under `docs/artifacts/ops-slo/2026-03-23/`.
@@ -77,10 +123,14 @@ To reproduce a fresh batch locally:
 STAMP=$(date -u +%Y-%m-%d) contrib/soak/capture_ops_slo_evidence.sh
 ```
 
-Then review the emitted `*-summary.json` files under `docs/artifacts/ops-slo/$STAMP/`.
+Then validate the emitted bundle:
+
+```bash
+contrib/soak/validate_ops_slo_evidence.py --signoff docs/artifacts/ops-slo/$STAMP
+```
 
 ## Current Execution Order
 
-1. Close issue `#31` by extending the existing stress and soak assets.
-2. Close issue `#32` by publishing this SLO contract and committing evidence artifacts from a clean capture run.
-3. Only then move to measured-bench work in issues `#33`, `#34`, and `#35`.
+1. Close issue `#32` by freezing this bundle contract, publishing the validator, and validating the
+   checked-in evidence bundle.
+2. Keep issue `#31` open for later adversarial throughput and scenario expansion.

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -28,8 +28,8 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 - Exit criteria: documented policy with stable gating and ownership.
 
 5. Operational hardening and SLOs
-- Scope: long-run soak, adversarial throughput tests, restart/reorg resilience under PQ load.
-- Exit criteria: agreed SLO dashboard and sign-off thresholds.
+- Scope: freeze `#32` checked-in operator signal and evidence-validation contract around the current soak/restart/reorg assets, then extend `#31` adversarial throughput and scenario coverage under PQ load.
+- Exit criteria: checked-in operator signal contract and sign-off thresholds are frozen for `#32`, and the remaining workload expansion under `#31` is complete.
 
 6. Bench instrumentation hardening
 - Scope: measured runtime counters replacing fixed-envelope telemetry mode.

--- a/docs/artifacts/ops-slo/2026-03-23/README.md
+++ b/docs/artifacts/ops-slo/2026-03-23/README.md
@@ -1,12 +1,20 @@
 # PQBTC Ops/SLO Evidence (2026-03-23)
 
-- Functional summaries:
-  - `mempool-pq-limits-summary.json`
-  - `mempool-pq-stress-summary.json`
-  - `feature-pq-reorg-summary.json`
-- Soak summaries:
-  - `pq-mempool-soak-summary.json`
-  - `pq-mempool-soak-results.tsv`
-  - `soak-summaries/`
-- Raw logs:
-  - `build/ops-slo/2026-03-23`
+- Spec: `OPS-SLO-v1`
+- Capture script: `contrib/soak/capture_ops_slo_evidence.sh`
+- Validator: `contrib/soak/validate_ops_slo_evidence.py --signoff <bundle-root>`
+- Raw logs: `build/ops-slo/2026-03-23`
+
+## Artifacts
+
+- `README.md`
+- `manifest.json`
+- `mempool-pq-limits-summary.json`
+- `mempool-pq-stress-summary.json`
+- `feature-pq-reorg-summary.json`
+- `pq-mempool-soak-summary.json`
+- `pq-mempool-soak-results.tsv`
+
+## Optional Supplemental Artifacts
+
+- `soak-summaries/`

--- a/docs/artifacts/ops-slo/2026-03-23/manifest.json
+++ b/docs/artifacts/ops-slo/2026-03-23/manifest.json
@@ -1,0 +1,14 @@
+{
+  "spec_id": "OPS-SLO-v1",
+  "stamp": "2026-03-23",
+  "capture_script": "contrib/soak/capture_ops_slo_evidence.sh",
+  "soak_runs": 10,
+  "artifacts": [
+    "README.md",
+    "mempool-pq-limits-summary.json",
+    "mempool-pq-stress-summary.json",
+    "feature-pq-reorg-summary.json",
+    "pq-mempool-soak-summary.json",
+    "pq-mempool-soak-results.tsv"
+  ]
+}


### PR DESCRIPTION
## Summary
- freeze the checked-in ops/SLO evidence bundle contract in docs/OPS_SLO.md
- add a local validator and negative coverage for checked-in and freshly captured bundles
- normalize the capture script and March 23 artifact bundle around a manifest-backed operator sign-off shape

## Validation
- python3 contrib/soak/validate_ops_slo_evidence.py --signoff docs/artifacts/ops-slo/2026-03-23
- python3 -m unittest discover -s contrib/soak -p "test_*.py"
- STAMP=ops-slo-validate-2026-03-29 DOC_OUT=<tmp>/<stamp> contrib/soak/capture_ops_slo_evidence.sh
- python3 contrib/soak/validate_ops_slo_evidence.py --signoff <tmp>/<stamp>
- git diff --check

Closes #32

Issue #31 remains open for later workload expansion under #16.