### PR TITLE
docs: freeze taproot explicit-replacement posture

### DIFF
--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -62,6 +62,9 @@ Explicit legacy-only coverage in this tranche includes:
 2. SegWit/pre-SegWit transition tests
 3. legacy message-signing flows
 
+Taproot-specific tests remain `legacy_only` in the current CI contract. Their future
+status is governed by `TAPROOT_POSTURE.md` and remains outside this tranche.
+
 ## Ownership
 
 Until a separate ownership model or `CODEOWNERS` file exists, all current workflow and gate ownership is assigned to `@scottdhughes`.

--- a/docs/CONSENSUS_DIFFS.md
+++ b/docs/CONSENSUS_DIFFS.md
@@ -15,3 +15,8 @@
 
 ## Audit Requirement
 Every merged consensus diff must reference this document and corresponding tests.
+
+## Post-v1 Boundary
+Future witness-v1 replacement posture is frozen in `TAPROOT_POSTURE.md`. This v1
+ledger records only the shipped v1 consensus diffs and does not approve inherited
+Taproot activation semantics for a later tranche.

--- a/docs/CONSENSUS_SURFACE.md
+++ b/docs/CONSENSUS_SURFACE.md
@@ -19,6 +19,10 @@
 - Max block weight is 16,000,000 WU.
 - Max script element size is at least 10,000 bytes.
 
+## Post-v1 Boundary
+- Future witness-v1 posture is frozen in `TAPROOT_POSTURE.md`.
+- Inherited Taproot semantics are not the future activation target as-is.
+
 ## Out of Scope for v1
 - Wallet UX for keypool batching and recovery flows.
 - New RPCs for legacy-compatible signing surfaces.

--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -24,11 +24,10 @@ and define the concrete work required for a full-and-complete post-v1 program.
 
 ### 2. Taproot disabled for v1
 - v1 state: taproot activation remains `NEVER_ACTIVE` on PQBTC deployment tracks.
-- deferred: coexistence/migration with PQ signature semantics.
+- post-v1 update: taproot posture is frozen to explicit replacement in `TAPROOT_POSTURE.md`.
 - full-complete delta:
-  - frozen taproot coexistence spec set
-  - activation/deployment process and rollback rules
-  - cross-version compatibility and migration functional suites
+  - activation/deployment process and rollback rules for the replacement path
+  - cross-version compatibility and migration functional suites for the replacement path
 
 ### 3. PQ-first CI profile
 - v1 state: default CI gates PQ suites; legacy profile is explicit opt-in.
@@ -68,7 +67,7 @@ and define the concrete work required for a full-and-complete post-v1 program.
 
 ## Post-v1 Full-Complete Program (Execution Order)
 1. Wallet completeness and PSBT parity.
-2. Taproot/PQ coexistence design + deployment path.
+2. Taproot replacement posture + deployment path.
 3. CI completion (full migration or permanent dual-profile contract).
 4. Operational SLO hardening and adversarial throughput validation.
 5. Bench instrumentation hardening from fixed-envelope mode to measured accounting.

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -16,8 +16,8 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 - Exit criteria: node+wallet end-to-end PQ signing and recovery with CI coverage.
 
 2. Taproot posture beyond v1
-- Scope: coexistence or replacement design, frozen spec set, deployment/activation path, migration tests.
-- Exit criteria: decision-complete consensus plan with cross-version test matrix.
+- Scope: frozen explicit-replacement posture, deployment/activation path, and migration tests.
+- Exit criteria: frozen replacement posture, decision-complete deployment plan, and cross-version test matrix.
 
 3. Multi-algorithm evolution (`ALG_ID` registry)
 - Scope: frozen `#24` registry rules, `#25` parser compatibility contract, and `#26` neutral `future-0x02` forward-compatible algorithm version path.

--- a/docs/RELEASE_V1_RC1.md
+++ b/docs/RELEASE_V1_RC1.md
@@ -54,6 +54,7 @@ Use `/Users/scott/quantum-proof-bitcoin/contrib/release/cut_v1_rc1.sh` to run RC
 ## Deferred from v1 (Tracked)
 
 See `/Users/scott/quantum-proof-bitcoin/docs/DECISION_DEFERRAL_LEDGER.md` and `/Users/scott/quantum-proof-bitcoin/docs/POST_RC_EPICS.md`.
+Future Taproot posture is tracked separately in `/Users/scott/quantum-proof-bitcoin/docs/TAPROOT_POSTURE.md`.
 
 - Wallet/keypool UX and signing parity.
 - Taproot coexistence/replacement design and deployment path.

--- a/docs/RUNBOOK_V1_RC1.md
+++ b/docs/RUNBOOK_V1_RC1.md
@@ -136,3 +136,5 @@ Use the following immutable state machine for GA operations:
 - Wallet keypool and signing UX.
 - Taproot coexistence migration.
 - Multi-alg version negotiation.
+
+Future Taproot posture is tracked separately in `/Users/scott/quantum-proof-bitcoin/docs/TAPROOT_POSTURE.md`.

--- a/docs/SCRIPT_SEMANTICS.md
+++ b/docs/SCRIPT_SEMANTICS.md
@@ -18,3 +18,7 @@
 
 ## Legacy Behavior
 - Active PQ consensus paths do not accept DER/secp legacy signature encodings.
+
+## Post-v1 Boundary
+- Future witness-v1 replacement posture is frozen in `TAPROOT_POSTURE.md`.
+- This document defines only shipped v1 pre-taproot PQ semantics.

--- a/docs/SIGHASH.md
+++ b/docs/SIGHASH.md
@@ -15,3 +15,7 @@ Reusing the existing sighash construction minimizes migration risk and preserves
 ## Constraints
 - Digest computation must remain byte-for-byte stable for equivalent transaction contexts.
 - Any future sighash redesign requires a new Spec-ID version and explicit consensus activation process.
+
+## Post-v1 Boundary
+Future witness-v1 replacement posture is frozen in `TAPROOT_POSTURE.md`. This document
+defines only the shipped pre-taproot PQ sighash rule.

--- a/docs/TAPROOT_POSTURE.md
+++ b/docs/TAPROOT_POSTURE.md
@@ -1,0 +1,101 @@
+# Taproot Posture Beyond v1
+
+## Status: FROZEN
+## Spec-ID: TAPROOT-POSTURE-v1
+## Frozen-By: issue-21-posture-20260330
+## Consensus-Relevant: YES
+
+## Purpose
+
+Freeze the post-v1 Taproot posture decision before activation, deployment, rollback,
+or migration mechanics are specified.
+
+This document is the canonical future-facing authority for Taproot posture on PQBTC.
+It does not change current runtime behavior.
+
+## Current v1 Baseline
+
+The live v1 baseline remains:
+
+1. Taproot deployment is `NEVER_ACTIVE` on PQBTC deployment tracks.
+2. Pre-taproot `OP_CHECKSIG` and `OP_CHECKMULTISIG` are PQ-only semantics.
+3. Pre-taproot sighash is fixed to `SIGHASH_ALL`.
+
+These baseline facts are frozen in:
+
+- `CONSENSUS_SURFACE.md`
+- `CONSENSUS_DIFFS.md`
+- `SCRIPT_SEMANTICS.md`
+- `SIGHASH.md`
+- `RELEASE_V1_RC1.md`
+- `RUNBOOK_V1_RC1.md`
+
+## Decision Record
+
+### Chosen Posture
+
+PQBTC future Taproot posture is **explicit replacement**.
+
+The future witness-v1+ path, if activated later, must be specified as a PQ-native
+replacement design. PQBTC will not define its future posture by simply turning on the
+currently dormant inherited Bitcoin Taproot stack.
+
+### Rejected Alternative
+
+The rejected alternative is **coexistence**.
+
+### Why Coexistence Was Rejected
+
+Coexistence was not chosen because it would preserve or reintroduce an unresolved dual
+semantic surface across:
+
+- consensus deployment and witness-v1 validation
+- address encoding and `bech32m` output handling
+- descriptor and wallet output-type behavior
+- PSBT and RPC Taproot reporting fields
+- functional test and CI classification boundaries
+
+The live repo is already frozen around a PQ-only pre-taproot consensus posture and still
+treats Taproot-specific suites as non-PQ-gated legacy coverage. Freezing coexistence now
+would force downstream activation and migration work to carry an open-ended mixed semantic
+model that the current implementation and docs do not define.
+
+## Normative Future Posture
+
+1. Inherited Bitcoin Taproot/BIP341/BIP342 semantics are **not** the future activation
+   target as-is on PQBTC.
+2. Any future witness-v1+ replacement path must be specified as a PQ-native design.
+3. Existing Taproot-related code and tests in the repo are implementation surfaces to
+   classify, not proof of planned activation semantics.
+4. No current dormant Taproot surface becomes active merely because it exists in the codebase.
+
+## Surface Boundary Matrix
+
+| Surface | Current v1 state | Explicit-replacement posture | Expected treatment | Downstream owner |
+|---|---|---|---|---|
+| Deployment state in `src/kernel/chainparams.cpp` | `DEPLOYMENT_TAPROOT` is `NEVER_ACTIVE` on PQBTC tracks | Current deployment settings are baseline only, not the future activation design | Retained dormant until a replacement activation spec exists | `#22` |
+| Script semantics | Pre-taproot `CHECKSIG` / `CHECKMULTISIG` are PQ-only | Future witness-v1+ semantics must be defined as a new PQ-native replacement, not inherited Taproot semantics | Superseded later by replacement-specific script rules | `#21` then `#22` |
+| Sighash posture | Pre-taproot paths are fixed to `SIGHASH_ALL` | This doc does not define any witness-v1+ replacement sighash rules | Downstream-defined only | `#21` then `#22` |
+| Witness-v1 / Taproot address encoding in `src/key_io.cpp` | Bech32m/Taproot encoding and decoding code exists | Existing witness-v1 address code is not a commitment to activate inherited Taproot semantics | Retained dormant until a replacement address/output spec exists | `#21` then `#22` |
+| Wallet Taproot capability surfaces such as `taprootEnabled()` | Interfaces and output-type plumbing exist | Existing wallet surfaces are inherited implementation artifacts, not approved future posture | Retained dormant and out of current sign-off scope | `#22` and `#23` |
+| Descriptor `tr(...)` posture | Descriptor/test surfaces for Taproot exist in inherited wallet code and tests | `tr(...)` is not part of the approved future PQBTC posture as-is | Legacy-only until a replacement descriptor decision exists | `#21` then `#23` |
+| PSBT Taproot fields | Taproot PSBT fields still exist in inherited code and tests | Existing PSBT Taproot field support is not approved future interoperability behavior | Retained dormant and classified as legacy-only for now | `#23` |
+| RPC reporting and creation surfaces | RPC decode/create/reporting surfaces still expose Taproot-related fields and address types | Existing RPC exposure is not an approval of future activated semantics | Retained dormant; future replacement behavior must be specified explicitly | `#22` and `#23` |
+| Functional Taproot suites | Taproot-specific functional tests remain in the repo | These tests are inventory surfaces, not future activation commitments | Retained as legacy-only coverage until migration decisions exist | `#23` |
+| CI classification posture | `CI_COMPLETENESS.md` classifies Taproot-specific tests as `legacy_only` | This tranche does not reclassify them | Legacy-only remains frozen for now | `#23` |
+
+## Explicit Non-Goals
+
+This document does **not** define:
+
+- activation state machine or deployment parameters
+- rollback or abort rules for a future replacement path
+- migration or compatibility matrix across pre/post-activation states
+- CI reclassification or conversion of Taproot-specific suites
+- runtime code changes, removals, or enablement
+
+## Downstream Issue Boundaries
+
+- `#21`: freeze posture choice and surface boundary map
+- `#22`: define activation/deployment mechanism and rollback rules for the chosen posture
+- `#23`: define cross-version migration and compatibility validation for the chosen posture


### PR DESCRIPTION
## Summary
- add `docs/TAPROOT_POSTURE.md` as the canonical future-facing Taproot posture spec
- freeze explicit replacement as the chosen posture and record coexistence as the rejected alternative with rationale
- align the current deferred/consensus/CI docs to that canonical posture while keeping the RC release/runbook docs historical

## Testing
- `git diff --check`
- reviewed canonical cross-references and boundary-matrix coverage for the already-present Taproot-facing surfaces

Refs #21
Refs #13
