### PR TITLE
docs: freeze taproot activation model

### DIFF
--- a/docs/CONSENSUS_DIFFS.md
+++ b/docs/CONSENSUS_DIFFS.md
@@ -17,6 +17,7 @@
 Every merged consensus diff must reference this document and corresponding tests.
 
 ## Post-v1 Boundary
-Future witness-v1 replacement posture is frozen in `TAPROOT_POSTURE.md`. This v1
+Future witness-v1 replacement posture is frozen in `TAPROOT_POSTURE.md`, and the
+replacement activation/rollback model is frozen in `TAPROOT_ACTIVATION.md`. This v1
 ledger records only the shipped v1 consensus diffs and does not approve inherited
 Taproot activation semantics for a later tranche.

--- a/docs/CONSENSUS_SURFACE.md
+++ b/docs/CONSENSUS_SURFACE.md
@@ -21,6 +21,7 @@
 
 ## Post-v1 Boundary
 - Future witness-v1 posture is frozen in `TAPROOT_POSTURE.md`.
+- Activation/deployment/rollback model is frozen in `TAPROOT_ACTIVATION.md`.
 - Inherited Taproot semantics are not the future activation target as-is.
 
 ## Out of Scope for v1

--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -25,8 +25,9 @@ and define the concrete work required for a full-and-complete post-v1 program.
 ### 2. Taproot disabled for v1
 - v1 state: taproot activation remains `NEVER_ACTIVE` on PQBTC deployment tracks.
 - post-v1 update: taproot posture is frozen to explicit replacement in `TAPROOT_POSTURE.md`.
+- post-v1 update: replacement activation family, parameter schema, and rollback envelope are frozen in `TAPROOT_ACTIVATION.md`.
 - full-complete delta:
-  - activation/deployment process and rollback rules for the replacement path
+  - concrete deployment values and code wiring for the replacement path
   - cross-version compatibility and migration functional suites for the replacement path
 
 ### 3. PQ-first CI profile
@@ -67,7 +68,7 @@ and define the concrete work required for a full-and-complete post-v1 program.
 
 ## Post-v1 Full-Complete Program (Execution Order)
 1. Wallet completeness and PSBT parity.
-2. Taproot replacement posture + deployment path.
+2. Taproot replacement activation wiring + migration path.
 3. CI completion (full migration or permanent dual-profile contract).
 4. Operational SLO hardening and adversarial throughput validation.
 5. Bench instrumentation hardening from fixed-envelope mode to measured accounting.

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -16,8 +16,8 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 - Exit criteria: node+wallet end-to-end PQ signing and recovery with CI coverage.
 
 2. Taproot posture beyond v1
-- Scope: frozen explicit-replacement posture, deployment/activation path, and migration tests.
-- Exit criteria: frozen replacement posture, decision-complete deployment plan, and cross-version test matrix.
+- Scope: frozen explicit-replacement posture, frozen replacement activation/rollback model, and migration tests.
+- Exit criteria: frozen replacement posture, decision-complete activation/deployment plan, and cross-version test matrix.
 
 3. Multi-algorithm evolution (`ALG_ID` registry)
 - Scope: frozen `#24` registry rules, `#25` parser compatibility contract, and `#26` neutral `future-0x02` forward-compatible algorithm version path.

--- a/docs/TAPROOT_ACTIVATION.md
+++ b/docs/TAPROOT_ACTIVATION.md
@@ -1,0 +1,223 @@
+# Taproot Replacement Activation and Rollback
+
+## Status: FROZEN
+## Spec-ID: TAPROOT-ACTIVATION-v1
+## Frozen-By: issue-22-activation-20260331
+## Consensus-Relevant: YES
+
+## Purpose
+
+Freeze the activation/deployment model for the explicit-replacement Taproot path
+before any code constants, deployment wiring, or migration tests are chosen.
+
+This document is the canonical future-facing authority for replacement activation,
+deployment parameter shape, and rollback/abort semantics on PQBTC. It does not
+change current runtime behavior.
+
+## Current Baseline
+
+The live repo remains in `DORMANT_BASELINE`:
+
+1. `DEPLOYMENT_TAPROOT` is `NEVER_ACTIVE` on PQBTC deployment tracks.
+2. Pre-taproot `OP_CHECKSIG` and `OP_CHECKMULTISIG` remain PQ-only.
+3. Pre-taproot sighash remains fixed `SIGHASH_ALL`.
+4. No dormant Taproot-facing surface is approved for use merely because code exists.
+
+The future active path, if ever deployed, is a PQ-native replacement path. It is
+not inherited BIP341/BIP342 Taproot semantics switched on as-is.
+
+## Mechanism Family Decision
+
+### Chosen Mechanism Family
+
+PQBTC freezes the future replacement activation family as **BIP9/versionbits**.
+
+This choice freezes the deployment/reporting model already present in the repo,
+including:
+
+- `Consensus::BIP9Deployment` in `src/consensus/params.h`
+- `DEPLOYMENT_TAPROOT` deployment slots in `src/kernel/chainparams.cpp`
+- deployment reporting via `deploymentinfo.cpp` and `getdeploymentinfo`
+- versionbits threshold state reporting in `versionbits.cpp`
+
+### Rejected Alternative
+
+The rejected alternative is a mechanism-agnostic or later-defined activation family.
+
+### Why a Mechanism-Agnostic Model Was Rejected
+
+The repo already exposes a concrete deployment family in consensus params, chainparams,
+and RPC reporting. Leaving the mechanism family unresolved here would keep the main
+`#22` design question open and force downstream migration work to reason about an
+unknown activation substrate.
+
+Freezing BIP9/versionbits now is the narrowest decision-complete move because it
+resolves the family choice without prematurely choosing concrete network values.
+
+## Two-Layer Activation Model
+
+This document uses two layers:
+
+- **Operator/governance phases**: planning and release-facing states used to describe
+  whether the replacement path is dormant, deployable, signaling, active, or aborted.
+- **Code-facing BIP9 states**: `defined`, `started`, `locked_in`, `active`, and
+  `failed`, as exposed by the existing versionbits deployment model.
+
+The crosswalk below is descriptive only. It is not an identity claim that every
+operator phase is a distinct code state.
+
+| Operator/governance phase | Meaning | Code-facing BIP9 state relationship |
+|---|---|---|
+| `DORMANT_BASELINE` | Current shipped v1 posture with Taproot disabled and no approved replacement behavior | No active deployment instance is in use; `DEPLOYMENT_TAPROOT` remains `NEVER_ACTIVE` |
+| `SPEC_FROZEN_NOT_DEPLOYING` | Posture and activation model are frozen in docs, but no live deployment instance is configured for signaling | No deployment attempt is active yet |
+| `DEPLOYMENT_DEFINED_NOT_SIGNALING` | A future BIP9 deployment instance exists in code/config terms, but the start condition is not yet met | `defined` |
+| `SIGNALING` | A deployment attempt is collecting BIP9 signaling and has not yet locked in | `started` |
+| `LOCKED_IN_PRE_ACTIVE` | Threshold rules are satisfied, but replacement behavior is not active yet | `locked_in` |
+| `ACTIVE_REPLACEMENT` | The PQ-native replacement path is active according to the frozen deployment rules | `active` |
+| `ABORTED_PRE_ACTIVATION` | Operator/governance outcome for an abandoned pre-activation attempt | For a started deployment instance, the terminal code-facing state is `failed`; for withdrawal before signaling, the repo returns to a non-deploying posture |
+
+## Phase Semantics
+
+### `DORMANT_BASELINE`
+- This is the current repo state.
+- `DEPLOYMENT_TAPROOT` remains `NEVER_ACTIVE`.
+- Witness-v1 code and Taproot-facing wallet/RPC/descriptor/PSBT surfaces are dormant inventory only.
+- No operator should treat existing dormant surfaces as approved for use.
+
+### `SPEC_FROZEN_NOT_DEPLOYING`
+- The replacement posture and activation model are frozen in docs.
+- No deployment instance is configured for signaling.
+- This phase is documentation/governance only and does not imply a live deployment object.
+
+### `DEPLOYMENT_DEFINED_NOT_SIGNALING`
+- A future BIP9 deployment instance may exist, but start conditions are not yet met.
+- Replacement behavior remains dormant.
+- Wallet, RPC, PSBT, descriptor, address, and witness-v1 behavior remain unchanged.
+
+### `SIGNALING`
+- BIP9 signaling has started.
+- The replacement path is still not active.
+- No surface behavior changes are approved in this phase.
+- This phase exists to collect signaling only.
+
+### `LOCKED_IN_PRE_ACTIVE`
+- BIP9 threshold conditions are satisfied.
+- Replacement behavior is still not active until the activation delay/height rule is reached.
+- No ordinary rollback is defined in this phase.
+
+### `ACTIVE_REPLACEMENT`
+- The PQ-native replacement path becomes active.
+- Only at this phase may downstream implementation tranches activate replacement-specific
+  witness-v1/address/wallet/descriptor/PSBT/RPC behavior.
+- This tranche does not define those active semantics; it only defines when such semantics
+  become eligible for later implementation.
+
+### `ABORTED_PRE_ACTIVATION`
+- This is an operator/governance outcome, not a standalone BIP9 state.
+- During signaling, the code-facing terminal state for an abandoned or expired deployment
+  attempt is `failed`.
+- Before signaling starts, withdrawal returns the repo to a dormant/non-deploying posture
+  without requiring a `failed` steady-state interpretation.
+
+## Deployment-Parameter Schema
+
+The mechanism family is frozen as BIP9/versionbits. Any later code tranche must fill in
+this parameter schema explicitly.
+
+| Field | Meaning | Frozen in this tranche |
+|---|---|---|
+| Deployment mechanism family | Activation/reporting family used for the replacement path | BIP9/versionbits |
+| Deployment identifier / reporting surface | Human-readable deployment name exposed through deployment reporting | Field required; concrete name/value not chosen here |
+| Signaling bit | Versionbits bit used for miner signaling | Field required; concrete value not chosen here |
+| Start condition | Condition that moves a deployment instance from non-signaling into `started` | Field required; concrete value not chosen here |
+| Timeout / expiry condition | Condition after which an unsuccessful deployment attempt terminates | Field required; concrete value not chosen here |
+| Threshold rule | Confirmation/signaling threshold required for lock-in | Field required; concrete value not chosen here |
+| Period window | Retarget/signaling window used for threshold evaluation | Field required; concrete value not chosen here |
+| Minimum activation delay / height | Delay between lock-in and active enforcement | Field required; concrete value not chosen here |
+| Network-specific override surface | Where per-network values may differ | Field required; concrete values not chosen here |
+| Operator-visible status names | Release/operator-facing names for deployment status reporting | Frozen by this document |
+| Release-gating prerequisites | Preconditions for even permitting a deployment attempt | Field required; concrete checklist may be extended later |
+
+### Frozen Operator-Visible Status Vocabulary
+
+The operator-facing vocabulary is:
+
+- `DORMANT_BASELINE`
+- `SPEC_FROZEN_NOT_DEPLOYING`
+- `DEPLOYMENT_DEFINED_NOT_SIGNALING`
+- `SIGNALING`
+- `LOCKED_IN_PRE_ACTIVE`
+- `ACTIVE_REPLACEMENT`
+- `ABORTED_PRE_ACTIVATION`
+
+The code-facing BIP9 reporting vocabulary remains:
+
+- `defined`
+- `started`
+- `locked_in`
+- `active`
+- `failed`
+
+Future implementation and release docs must preserve this two-layer distinction.
+
+## Rollback and Abort Envelope
+
+Rollback and abort are defined conservatively by phase.
+
+| Phase | Ordinary withdrawal / rollback rule | Outcome |
+|---|---|---|
+| `DORMANT_BASELINE` | Ordinary planning withdrawal is allowed | Remains dormant |
+| `SPEC_FROZEN_NOT_DEPLOYING` | Ordinary planning withdrawal is allowed | Returns to dormant/non-deploying posture |
+| `DEPLOYMENT_DEFINED_NOT_SIGNALING` | Ordinary withdrawal is allowed before signaling begins | Returns to dormant/non-deploying posture |
+| `SIGNALING` | Abort is allowed before lock-in | Operator outcome is `ABORTED_PRE_ACTIVATION`; code-facing deployment attempt terminates as `failed` |
+| `LOCKED_IN_PRE_ACTIVE` | **No ordinary rollback is defined** | Any retreat requires a separate exceptional recovery decision outside this tranche |
+| `ACTIVE_REPLACEMENT` | **No routine rollback is defined** | Post-activation retreat is outside this tranche |
+
+The `failed` BIP9 state is meaningful only as a pre-activation abort/expiry outcome for a
+started deployment instance. It is not a post-activation rollback concept.
+
+## Phase-by-Surface Activation Matrix
+
+| Surface | `DORMANT_BASELINE` / `SPEC_FROZEN_NOT_DEPLOYING` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` / `SIGNALING` / `LOCKED_IN_PRE_ACTIVE` | `ACTIVE_REPLACEMENT` | Downstream owner |
+|---|---|---|---|---|
+| Deployment state / `getdeploymentinfo` posture | Current v1 deployment remains dormant; no approved replacement deployment behavior | Deployment reporting may reflect BIP9 lifecycle, but no replacement semantics are active | Eligible for later implementation under the replacement rules | `#22` |
+| Witness-v1 output acceptance | Dormant inventory only | Unchanged; no approved activation during pre-active phases | Eligible only after replacement activation rules are implemented | `#22` |
+| Address encoding and reporting | Dormant inventory only | Unchanged; existing code is not approval for use | Eligible only after replacement-specific address/output rules are implemented | `#22` |
+| Wallet capability surfaces such as `taprootEnabled()` | Dormant inventory only | Unchanged; no approved wallet activation during pre-active phases | Eligible only after replacement-specific wallet behavior is defined | `#22` then `#23` |
+| Descriptor `tr(...)` | Legacy-only inventory surface | Unchanged; not approved for use during pre-active phases | Still deferred pending compatibility/migration decisions | `#23` |
+| PSBT Taproot fields | Legacy-only inventory surface | Unchanged; not approved for replacement use during pre-active phases | Still deferred pending compatibility/migration decisions | `#23` |
+| RPC create/decode/reporting surfaces | Dormant or legacy-only inventory surfaces | Unchanged; reporting does not imply approved replacement semantics | Eligible only after replacement-specific RPC behavior is defined | `#22` then `#23` |
+| Functional Taproot suites | Legacy-only coverage | Unchanged | Still deferred pending migration-matrix decisions | `#23` |
+| CI classification posture | `legacy_only` remains frozen | Unchanged | Still deferred pending migration-matrix decisions | `#23` |
+
+## Release-Gating Baseline
+
+This tranche freezes that a future deployment attempt must not be defined as deployable
+until all of the following exist in a later follow-up:
+
+- frozen posture doc (`TAPROOT_POSTURE.md`)
+- frozen activation/rollback doc (this document)
+- concrete network parameter values
+- code plumbing for the chosen deployment instance
+- operator/release guidance for interpreting deployment status
+- migration/compatibility validation plan in `#23`
+
+This tranche does not define the full checklist contents beyond those baseline categories.
+
+## Explicit Non-Goals
+
+This document does **not** define:
+
+- concrete mainnet/testnet/regtest deployment values
+- modifications to `chainparams` or deployment wiring
+- the replacement-path witness-v1 script/address semantics themselves
+- migration or compatibility behavior across pre/post-activation nodes
+- CI reclassification or conversion of Taproot-specific suites
+- routine rollback after lock-in or after activation
+
+## Downstream Issue Boundaries
+
+- `#22`: freeze activation/deployment mechanism family, state machine, parameter schema,
+  and rollback envelope for the explicit-replacement path
+- `#23`: define migration and compatibility behavior spanning pre/post-activation states
+

--- a/docs/TAPROOT_POSTURE.md
+++ b/docs/TAPROOT_POSTURE.md
@@ -8,7 +8,8 @@
 ## Purpose
 
 Freeze the post-v1 Taproot posture decision before activation, deployment, rollback,
-or migration mechanics are specified.
+or migration mechanics are implemented. Activation/deployment/rollback semantics are
+now frozen in `TAPROOT_ACTIVATION.md`.
 
 This document is the canonical future-facing authority for Taproot posture on PQBTC.
 It does not change current runtime behavior.
@@ -73,12 +74,12 @@ model that the current implementation and docs do not define.
 
 | Surface | Current v1 state | Explicit-replacement posture | Expected treatment | Downstream owner |
 |---|---|---|---|---|
-| Deployment state in `src/kernel/chainparams.cpp` | `DEPLOYMENT_TAPROOT` is `NEVER_ACTIVE` on PQBTC tracks | Current deployment settings are baseline only, not the future activation design | Retained dormant until a replacement activation spec exists | `#22` |
-| Script semantics | Pre-taproot `CHECKSIG` / `CHECKMULTISIG` are PQ-only | Future witness-v1+ semantics must be defined as a new PQ-native replacement, not inherited Taproot semantics | Superseded later by replacement-specific script rules | `#21` then `#22` |
-| Sighash posture | Pre-taproot paths are fixed to `SIGHASH_ALL` | This doc does not define any witness-v1+ replacement sighash rules | Downstream-defined only | `#21` then `#22` |
-| Witness-v1 / Taproot address encoding in `src/key_io.cpp` | Bech32m/Taproot encoding and decoding code exists | Existing witness-v1 address code is not a commitment to activate inherited Taproot semantics | Retained dormant until a replacement address/output spec exists | `#21` then `#22` |
+| Deployment state in `src/kernel/chainparams.cpp` | `DEPLOYMENT_TAPROOT` is `NEVER_ACTIVE` on PQBTC tracks | Current deployment settings are baseline only; replacement activation model is frozen in `TAPROOT_ACTIVATION.md` | Retained dormant until a later code tranche defines concrete deployment values | `#22` |
+| Script semantics | Pre-taproot `CHECKSIG` / `CHECKMULTISIG` are PQ-only | Future witness-v1+ semantics must be defined as a new PQ-native replacement, not inherited Taproot semantics | Superseded later by replacement-specific script rules | `#22` |
+| Sighash posture | Pre-taproot paths are fixed to `SIGHASH_ALL` | This doc does not define any witness-v1+ replacement sighash rules | Downstream-defined only | `#22` |
+| Witness-v1 / Taproot address encoding in `src/key_io.cpp` | Bech32m/Taproot encoding and decoding code exists | Existing witness-v1 address code is not a commitment to activate inherited Taproot semantics | Retained dormant until a replacement address/output spec exists | `#22` |
 | Wallet Taproot capability surfaces such as `taprootEnabled()` | Interfaces and output-type plumbing exist | Existing wallet surfaces are inherited implementation artifacts, not approved future posture | Retained dormant and out of current sign-off scope | `#22` and `#23` |
-| Descriptor `tr(...)` posture | Descriptor/test surfaces for Taproot exist in inherited wallet code and tests | `tr(...)` is not part of the approved future PQBTC posture as-is | Legacy-only until a replacement descriptor decision exists | `#21` then `#23` |
+| Descriptor `tr(...)` posture | Descriptor/test surfaces for Taproot exist in inherited wallet code and tests | `tr(...)` is not part of the approved future PQBTC posture as-is | Legacy-only until a replacement descriptor decision exists | `#23` |
 | PSBT Taproot fields | Taproot PSBT fields still exist in inherited code and tests | Existing PSBT Taproot field support is not approved future interoperability behavior | Retained dormant and classified as legacy-only for now | `#23` |
 | RPC reporting and creation surfaces | RPC decode/create/reporting surfaces still expose Taproot-related fields and address types | Existing RPC exposure is not an approval of future activated semantics | Retained dormant; future replacement behavior must be specified explicitly | `#22` and `#23` |
 | Functional Taproot suites | Taproot-specific functional tests remain in the repo | These tests are inventory surfaces, not future activation commitments | Retained as legacy-only coverage until migration decisions exist | `#23` |
@@ -88,8 +89,8 @@ model that the current implementation and docs do not define.
 
 This document does **not** define:
 
-- activation state machine or deployment parameters
-- rollback or abort rules for a future replacement path
+- concrete activation parameter values or code wiring
+- runtime rollback machinery for a future replacement path
 - migration or compatibility matrix across pre/post-activation states
 - CI reclassification or conversion of Taproot-specific suites
 - runtime code changes, removals, or enablement
@@ -97,5 +98,5 @@ This document does **not** define:
 ## Downstream Issue Boundaries
 
 - `#21`: freeze posture choice and surface boundary map
-- `#22`: define activation/deployment mechanism and rollback rules for the chosen posture
+- `#22`: freeze activation/deployment mechanism family, parameter schema, and rollback rules for the chosen posture
 - `#23`: define cross-version migration and compatibility validation for the chosen posture


### PR DESCRIPTION
## Summary
- add `docs/TAPROOT_ACTIVATION.md` as the canonical replacement activation/deployment/rollback spec
- freeze the BIP9/versionbits family, two-layer activation model, parameter schema, and rollback envelope
- align Taproot and post-RC docs to point activation/deployment questions at the new spec

## Testing
- `git diff --check`
- docs consistency review across `TAPROOT_ACTIVATION.md`, `TAPROOT_POSTURE.md`, `DECISION_DEFERRAL_LEDGER.md`, `POST_RC_EPICS.md`, `CONSENSUS_SURFACE.md`, and `CONSENSUS_DIFFS.md`

Refs #22
Refs #13
