### PR TITLE
Freeze taproot migration matrix inventory

### DIFF
--- a/ci/test/check_ci_inventory.py
+++ b/ci/test/check_ci_inventory.py
@@ -15,6 +15,18 @@ PQ_TESTS_PATH = REPO_ROOT / "ci" / "test" / "pq_functional_tests.txt"
 INVENTORY_PATH = REPO_ROOT / "ci" / "test" / "functional_suite_inventory.json"
 HELPERS = {"combine_logs.py", "create_cache.py", "test_runner.py"}
 VALID_POLICY_CLASSES = {"pq_required", "pq_backlog", "dual_profile", "legacy_only"}
+VALID_TAPROOT_MATRIX_BUCKETS = {"legacy_only", "replacement_migration", "deferred"}
+REQUIRED_TAPROOT_MATRIX_BUCKETS = {
+    "feature_taproot.py": "legacy_only",
+    "feature_taproot_replacement_deployment.py": "replacement_migration",
+    "rpc_createmultisig.py": "deferred",
+    "rpc_psbt.py": "deferred",
+    "wallet_address_types.py": "deferred",
+    "wallet_createwalletdescriptor.py": "deferred",
+    "wallet_miniscript.py": "deferred",
+    "wallet_miniscript_decaying_multisig_descriptor_psbt.py": "deferred",
+    "wallet_taproot.py": "legacy_only",
+}
 
 
 def fail(message: str) -> None:
@@ -59,6 +71,7 @@ def main() -> int:
         name = entry.get("name")
         policy_class = entry.get("policy_class")
         owner = entry.get("owner")
+        taproot_matrix_bucket = entry.get("taproot_matrix_bucket")
 
         if not isinstance(name, str) or not name:
             fail("inventory entries must contain a non-empty string 'name'")
@@ -72,6 +85,21 @@ def main() -> int:
             fail(f"{name} has unknown policy_class {policy_class!r}")
         if not isinstance(owner, str) or not owner.strip():
             fail(f"{name} has an empty owner")
+        if name in REQUIRED_TAPROOT_MATRIX_BUCKETS:
+            expected_bucket = REQUIRED_TAPROOT_MATRIX_BUCKETS[name]
+            if taproot_matrix_bucket != expected_bucket:
+                fail(
+                    f"{name} must set taproot_matrix_bucket to {expected_bucket!r}, "
+                    f"got {taproot_matrix_bucket!r}"
+                )
+        elif taproot_matrix_bucket is not None:
+            fail(
+                f"{name} unexpectedly sets taproot_matrix_bucket; this field is reserved "
+                "for the curated Taproot migration subset"
+            )
+
+        if taproot_matrix_bucket is not None and taproot_matrix_bucket not in VALID_TAPROOT_MATRIX_BUCKETS:
+            fail(f"{name} has unknown taproot_matrix_bucket {taproot_matrix_bucket!r}")
 
         if policy_class == "pq_required":
             pq_required.append(name)
@@ -91,9 +119,16 @@ def main() -> int:
         )
 
     counts = Counter(entry["policy_class"] for entry in inventory)
+    taproot_bucket_counts = Counter(
+        entry["taproot_matrix_bucket"]
+        for entry in inventory
+        if "taproot_matrix_bucket" in entry
+    )
     print("CI inventory validation passed")
     for label in sorted(VALID_POLICY_CLASSES):
         print(f"{label}: {counts[label]}")
+    for label in sorted(VALID_TAPROOT_MATRIX_BUCKETS):
+        print(f"taproot_matrix_bucket:{label}: {taproot_bucket_counts[label]}")
     return 0
 
 

--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -415,16 +415,18 @@
   {
     "name": "feature_taproot.py",
     "policy_class": "legacy_only",
+    "taproot_matrix_bucket": "legacy_only",
     "owner": "@scottdhughes",
-    "tracking_issue": "#13",
-    "notes": "Explicit Taproot coverage; retained for the separate Taproot posture epic."
+    "tracking_issue": "#23",
+    "notes": "Explicit inherited Taproot functional coverage; classified as legacy_only in the #23 migration matrix."
   },
   {
     "name": "feature_taproot_replacement_deployment.py",
     "policy_class": "pq_backlog",
+    "taproot_matrix_bucket": "replacement_migration",
     "owner": "@scottdhughes",
-    "tracking_issue": "#13",
-    "notes": "Concrete dormant replacement deployment reporting and regtest BIP9 override coverage; kept out of the PQ gate while Taproot migration work remains in #23."
+    "tracking_issue": "#23",
+    "notes": "Concrete dormant replacement deployment reporting and regtest BIP9 override coverage; classified as replacement_migration while remaining out of the PQ gate."
   },
   {
     "name": "feature_uacomment.py",
@@ -1108,9 +1110,10 @@
   {
     "name": "rpc_createmultisig.py",
     "policy_class": "dual_profile",
+    "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Retained under the current non-gating dual-profile contract."
+    "tracking_issue": "#23",
+    "notes": "Includes bech32m/Taproot-adjacent RPC coverage; retained under the current non-gating dual-profile contract and classified as deferred in the #23 migration matrix."
   },
   {
     "name": "rpc_decodescript.py",
@@ -1269,9 +1272,10 @@
   {
     "name": "rpc_psbt.py",
     "policy_class": "dual_profile",
+    "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Retained under the current non-gating dual-profile contract."
+    "tracking_issue": "#23",
+    "notes": "Includes Taproot-facing PSBT surfaces; retained under the current non-gating dual-profile contract and classified as deferred in the #23 migration matrix."
   },
   {
     "name": "rpc_rawtransaction.py",
@@ -1416,9 +1420,10 @@
   {
     "name": "wallet_address_types.py",
     "policy_class": "dual_profile",
+    "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Retained under the current non-gating dual-profile contract."
+    "tracking_issue": "#23",
+    "notes": "Includes bech32m/Taproot-facing address branches; retained under the current non-gating dual-profile contract and classified as deferred in the #23 migration matrix."
   },
   {
     "name": "wallet_anchor.py",
@@ -1528,9 +1533,10 @@
   {
     "name": "wallet_createwalletdescriptor.py",
     "policy_class": "pq_backlog",
+    "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#23",
+    "notes": "Includes tr()/bech32m descriptor creation paths; kept in pq_backlog and classified as deferred in the #23 migration matrix."
   },
   {
     "name": "wallet_crosschain.py",
@@ -1675,16 +1681,18 @@
   {
     "name": "wallet_miniscript.py",
     "policy_class": "dual_profile",
+    "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Retained under the current non-gating dual-profile contract."
+    "tracking_issue": "#23",
+    "notes": "Includes Taproot-facing descriptor/miniscript coverage; retained under the current non-gating dual-profile contract and classified as deferred in the #23 migration matrix."
   },
   {
     "name": "wallet_miniscript_decaying_multisig_descriptor_psbt.py",
     "policy_class": "dual_profile",
+    "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Retained under the current non-gating dual-profile contract."
+    "tracking_issue": "#23",
+    "notes": "Touches descriptor/PSBT surfaces that may intersect replacement compatibility later; retained under the current non-gating dual-profile contract and classified as deferred in the #23 migration matrix."
   },
   {
     "name": "wallet_multisig_descriptor_psbt.py",
@@ -1829,9 +1837,10 @@
   {
     "name": "wallet_taproot.py",
     "policy_class": "legacy_only",
+    "taproot_matrix_bucket": "legacy_only",
     "owner": "@scottdhughes",
-    "tracking_issue": "#13",
-    "notes": "Explicit Taproot coverage; retained for the separate Taproot posture epic."
+    "tracking_issue": "#23",
+    "notes": "Explicit inherited Taproot wallet coverage; classified as legacy_only in the #23 migration matrix."
   },
   {
     "name": "wallet_timelock.py",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -32,12 +32,12 @@ This tranche does not migrate legacy suites to PQ semantics and does not optimiz
 
 ## Current Inventory Summary
 
-The current functional corpus has `266` tracked test files, classified as:
+The current functional corpus has `267` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
 | `pq_required` | `6` |
-| `pq_backlog` | `104` |
+| `pq_backlog` | `105` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
 
@@ -62,8 +62,12 @@ Explicit legacy-only coverage in this tranche includes:
 2. SegWit/pre-SegWit transition tests
 3. legacy message-signing flows
 
-Taproot-specific tests remain `legacy_only` in the current CI contract. Their future
-status is governed by `TAPROOT_POSTURE.md` and remains outside this tranche.
+Inherited Taproot-specific suites remain `legacy_only` in the current CI contract,
+while `feature_taproot_replacement_deployment.py` remains `pq_backlog` as replacement-path
+deployment coverage. Their future status is governed by `TAPROOT_POSTURE.md` and
+`TAPROOT_MIGRATION_MATRIX.md`. `policy_class` remains the CI gating/ownership surface,
+while `taproot_matrix_bucket` is migration-matrix metadata only and does not change
+required CI behavior in this tranche.
 
 ## Ownership
 

--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -27,8 +27,9 @@ and define the concrete work required for a full-and-complete post-v1 program.
 - post-v1 update: taproot posture is frozen to explicit replacement in `TAPROOT_POSTURE.md`.
 - post-v1 update: replacement activation family, parameter schema, and rollback envelope are frozen in `TAPROOT_ACTIVATION.md`.
 - post-v1 update: concrete far-future dormant deployment values and the `taproot_replacement` reporting surface are wired into the repo.
+- post-v1 update: directional migration/compatibility matrix and Taproot suite classification are frozen in `TAPROOT_MIGRATION_MATRIX.md`.
 - full-complete delta:
-  - cross-version compatibility and migration functional suites for the replacement path
+  - implement the cross-version compatibility and migration functional suites for the replacement path
 
 ### 3. PQ-first CI profile
 - v1 state: default CI gates PQ suites; legacy profile is explicit opt-in.

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -16,8 +16,8 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 - Exit criteria: node+wallet end-to-end PQ signing and recovery with CI coverage.
 
 2. Taproot posture beyond v1
-- Scope: frozen explicit-replacement posture, concrete dormant replacement deployment/reporting path, and migration tests.
-- Exit criteria: frozen replacement posture, concrete dormant deployment/reporting path, and cross-version test matrix.
+- Scope: frozen explicit-replacement posture, concrete dormant replacement deployment/reporting path, frozen migration matrix, and compatibility tests.
+- Exit criteria: frozen replacement posture, concrete dormant deployment/reporting path, and implemented cross-version validation against the frozen matrix.
 
 3. Multi-algorithm evolution (`ALG_ID` registry)
 - Scope: frozen `#24` registry rules, `#25` parser compatibility contract, and `#26` neutral `future-0x02` forward-compatible algorithm version path.

--- a/docs/TAPROOT_ACTIVATION.md
+++ b/docs/TAPROOT_ACTIVATION.md
@@ -213,11 +213,11 @@ started deployment instance. It is not a post-activation rollback concept.
 | Witness-v1 output acceptance | Dormant inventory only | Unchanged; no approved activation during pre-active phases | Eligible only after replacement activation rules are implemented | `#22` |
 | Address encoding and reporting | Dormant inventory only | Unchanged; existing code is not approval for use | Eligible only after replacement-specific address/output rules are implemented | `#22` |
 | Wallet capability surfaces such as `taprootEnabled()` | Dormant inventory only | Unchanged; no approved wallet activation during pre-active phases | Eligible only after replacement-specific wallet behavior is defined | `#22` then `#23` |
-| Descriptor `tr(...)` | Legacy-only inventory surface | Unchanged; not approved for use during pre-active phases | Still deferred pending compatibility/migration decisions | `#23` |
-| PSBT Taproot fields | Legacy-only inventory surface | Unchanged; not approved for replacement use during pre-active phases | Still deferred pending compatibility/migration decisions | `#23` |
-| RPC create/decode/reporting surfaces | Dormant or legacy-only inventory surfaces | Unchanged; reporting does not imply approved replacement semantics | Eligible only after replacement-specific RPC behavior is defined | `#22` then `#23` |
-| Functional Taproot suites | Legacy-only coverage | Unchanged | Still deferred pending migration-matrix decisions | `#23` |
-| CI classification posture | `legacy_only` remains frozen | Unchanged | Still deferred pending migration-matrix decisions | `#23` |
+| Descriptor `tr(...)` | Legacy-only inventory surface | Unchanged; not approved for use during pre-active phases | Migration classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; replacement semantics remain deferred | `#23` |
+| PSBT Taproot fields | Legacy-only inventory surface | Unchanged; not approved for replacement use during pre-active phases | Migration classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; replacement semantics remain deferred | `#23` |
+| RPC create/decode/reporting surfaces | Dormant or legacy-only inventory surfaces | Unchanged; reporting does not imply approved replacement semantics | Migration classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; replacement-specific behavior remains deferred | `#22` then `#23` |
+| Functional Taproot suites | Legacy-only coverage | Unchanged | Migration relevance is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; implementation remains deferred | `#23` |
+| CI classification posture | Inherited Taproot suites remain `legacy_only`; replacement deployment reporting remains `pq_backlog` | Unchanged | `policy_class` remains frozen while `taproot_matrix_bucket` carries migration metadata only | `#23` |
 
 ## Release-Gating Baseline
 
@@ -227,7 +227,7 @@ the current dormant defined state until all of the following exist in a later fo
 - frozen posture doc (`TAPROOT_POSTURE.md`)
 - frozen activation/rollback doc (this document)
 - operator/release guidance for interpreting deployment status
-- migration/compatibility validation plan in `#23`
+- frozen migration/compatibility matrix in `TAPROOT_MIGRATION_MATRIX.md`
 - replacement-specific semantics and activation behavior for the affected surfaces
 
 This tranche does not define the full checklist contents beyond those baseline categories.
@@ -237,7 +237,7 @@ This tranche does not define the full checklist contents beyond those baseline c
 This document does **not** define:
 
 - the replacement-path witness-v1 script/address semantics themselves
-- migration or compatibility behavior across pre/post-activation nodes
+- migration or compatibility behavior implementation across pre/post-activation nodes; the frozen matrix lives in `TAPROOT_MIGRATION_MATRIX.md`
 - CI reclassification or conversion of Taproot-specific suites
 - routine rollback after lock-in or after activation
 
@@ -245,4 +245,4 @@ This document does **not** define:
 
 - `#22`: freeze activation/deployment mechanism family, state machine, parameter schema,
   and rollback envelope for the explicit-replacement path
-- `#23`: define migration and compatibility behavior spanning pre/post-activation states
+- `#23`: freeze the migration matrix and implement migration/compatibility behavior spanning pre/post-activation states

--- a/docs/TAPROOT_MIGRATION_MATRIX.md
+++ b/docs/TAPROOT_MIGRATION_MATRIX.md
@@ -1,0 +1,103 @@
+# Taproot Replacement Migration and Compatibility Matrix
+
+## Status: FROZEN
+## Spec-ID: TAPROOT-MIGRATION-MATRIX-v1
+## Frozen-By: issue-23-matrix-20260401
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the first migration and compatibility matrix for the explicit-replacement
+Taproot path.
+
+This document is the canonical future-facing authority for how PQBTC classifies
+Taproot-facing migration coverage across the already-frozen dormant and pre-active
+states. It does not define active replacement semantics and does not change runtime
+behavior.
+
+## Current Inputs
+
+This matrix builds on already-frozen inputs:
+
+1. `TAPROOT_POSTURE.md` freezes future Taproot posture as explicit replacement.
+2. `TAPROOT_ACTIVATION.md` freezes BIP9/versionbits as the activation family.
+3. The current repo state is `DEPLOYMENT_DEFINED_NOT_SIGNALING` with concrete but
+   far-future dormant `taproot_replacement` deployment values.
+4. No dormant Taproot-facing surface is approved merely because code or reporting exists.
+
+## Normative Bucket Definitions
+
+- `legacy_only`: inherited Taproot behavior that is not a PQBTC replacement target.
+- `replacement_migration`: directly relevant to the frozen PQBTC replacement path.
+- `deferred`: Taproot-facing surface exists, but replacement semantics are not yet
+  specific enough to test directly.
+
+These bucket meanings are inventory metadata only. They do not change CI gating,
+required status contexts, or runtime behavior.
+
+## Compatibility Classes
+
+This matrix freezes three compatibility outcome classes:
+
+- `same-consensus / reporting-only divergence`
+- `same-consensus / pre-active deployment divergence`
+- `future-active compatibility reserved`
+
+The matrix is directional. Each row is evaluated as `local state -> observed/compared state`.
+
+## Frozen Directed Migration Matrix
+
+| Local state | Observed/compared state | Compatibility class | Allowed interpretation | Coverage expectation |
+|---|---|---|---|---|
+| `DORMANT_BASELINE` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `same-consensus / reporting-only divergence` | One side exposes a concrete dormant deployment/reporting surface while the other reflects the historical shipped v1 baseline. No approved replacement semantics exist on either side. | Deployment/reporting assertions only. |
+| `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `DORMANT_BASELINE` | `same-consensus / reporting-only divergence` | Same consensus posture despite missing deployment reporting on the historical side. No approved replacement semantics exist on either side. | Deployment/reporting assertions only. |
+| `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `SIGNALING` | `same-consensus / pre-active deployment divergence` | BIP9 deployment status differs, but runtime semantics remain unchanged and no replacement behavior is active. | Regtest-only deployment-status coverage. |
+| `SIGNALING` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `same-consensus / pre-active deployment divergence` | Same as above from the opposite observation direction. | Regtest-only deployment-status coverage. |
+| `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `LOCKED_IN_PRE_ACTIVE` | `same-consensus / pre-active deployment divergence` | Lock-in visibility differs, but no replacement semantics are active yet. | Regtest-only deployment-status coverage. |
+| `LOCKED_IN_PRE_ACTIVE` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `same-consensus / pre-active deployment divergence` | Same as above from the opposite observation direction. | Regtest-only deployment-status coverage. |
+| `DORMANT_BASELINE` | `SIGNALING` | `same-consensus / pre-active deployment divergence` | Historical baseline and regtest signaling may disagree on deployment status only. No approved replacement semantics exist. | Regtest-only deployment-status coverage. |
+| `SIGNALING` | `DORMANT_BASELINE` | `same-consensus / pre-active deployment divergence` | Same as above from the opposite observation direction. | Regtest-only deployment-status coverage. |
+| `DORMANT_BASELINE` | `LOCKED_IN_PRE_ACTIVE` | `same-consensus / pre-active deployment divergence` | Historical baseline and regtest lock-in may disagree on deployment status only. No approved replacement semantics exist. | Regtest-only deployment-status coverage. |
+| `LOCKED_IN_PRE_ACTIVE` | `DORMANT_BASELINE` | `same-consensus / pre-active deployment divergence` | Same as above from the opposite observation direction. | Regtest-only deployment-status coverage. |
+| `*` | `ACTIVE_REPLACEMENT` | `future-active compatibility reserved` | Any pairing involving future active replacement is reserved for later implementation work. This document does not define active replacement semantics. | Bucket and inventory now; implementation later. |
+| `ACTIVE_REPLACEMENT` | `*` | `future-active compatibility reserved` | Any pairing involving future active replacement is reserved for later implementation work. This document does not define active replacement semantics. | Bucket and inventory now; implementation later. |
+
+## Coverage Guardrails
+
+1. Public-network defaults remain concrete but far-future dormant.
+2. `SIGNALING` and `LOCKED_IN_PRE_ACTIVE` are currently exercisable only through
+   regtest `-vbparams` override machinery.
+3. No wallet, RPC, descriptor, PSBT, address, or witness-v1 behavior becomes
+   approved merely because deployment reporting exists.
+4. This matrix freezes what is comparable today; it does not speculate about
+   active replacement semantics beyond reserving them for later work.
+
+## Frozen Suite Classification
+
+| Suite | Current `policy_class` | `taproot_matrix_bucket` | Rationale |
+|---|---|---|---|
+| `feature_taproot.py` | `legacy_only` | `legacy_only` | Explicit inherited BIP341/BIP342 functional coverage; not a PQBTC replacement target as-is. |
+| `wallet_taproot.py` | `legacy_only` | `legacy_only` | Explicit inherited Taproot wallet coverage; not a PQBTC replacement target as-is. |
+| `feature_taproot_replacement_deployment.py` | `pq_backlog` | `replacement_migration` | Directly exercises the frozen dormant replacement deployment/reporting path and regtest pre-active BIP9 transitions. |
+| `rpc_createmultisig.py` | `dual_profile` | `deferred` | Contains Taproot-adjacent bech32m coverage, but replacement-specific semantics are not yet defined. |
+| `rpc_psbt.py` | `dual_profile` | `deferred` | Contains Taproot-facing PSBT surfaces, but replacement-specific semantics are not yet defined. |
+| `wallet_address_types.py` | `dual_profile` | `deferred` | Contains bech32m/Taproot-facing address branches, but replacement-specific semantics are not yet defined. |
+| `wallet_createwalletdescriptor.py` | `pq_backlog` | `deferred` | Contains `tr(...)` descriptor creation paths, but replacement descriptor semantics are not yet defined. |
+| `wallet_miniscript.py` | `dual_profile` | `deferred` | Contains Taproot-facing descriptor/miniscript surfaces, but replacement semantics are not yet defined. |
+| `wallet_miniscript_decaying_multisig_descriptor_psbt.py` | `dual_profile` | `deferred` | Touches descriptor/PSBT surfaces that may intersect future replacement compatibility, but not yet specifically enough to test. |
+
+## Explicit Non-Goals
+
+This slice does **not** define:
+
+- active replacement witness-v1 semantics
+- migration behavior between active replacement and dormant nodes
+- CI reclassification of Taproot suites into PQ-required gates
+- wallet, RPC, descriptor, PSBT, address, or consensus implementation changes
+
+## Downstream Boundary
+
+This document is the opening slice of `#23`.
+
+Remaining `#23` work after this slice is the actual implementation of the focused
+migration and compatibility suites implied by this matrix.

--- a/docs/TAPROOT_POSTURE.md
+++ b/docs/TAPROOT_POSTURE.md
@@ -79,11 +79,11 @@ model that the current implementation and docs do not define.
 | Sighash posture | Pre-taproot paths are fixed to `SIGHASH_ALL` | This doc does not define any witness-v1+ replacement sighash rules | Downstream-defined only | `#22` |
 | Witness-v1 / Taproot address encoding in `src/key_io.cpp` | Bech32m/Taproot encoding and decoding code exists | Existing witness-v1 address code is not a commitment to activate inherited Taproot semantics | Retained dormant until a replacement address/output spec exists | `#22` |
 | Wallet Taproot capability surfaces such as `taprootEnabled()` | Interfaces and output-type plumbing exist | Existing wallet surfaces are inherited implementation artifacts, not approved future posture | Retained dormant and out of current sign-off scope | `#22` and `#23` |
-| Descriptor `tr(...)` posture | Descriptor/test surfaces for Taproot exist in inherited wallet code and tests | `tr(...)` is not part of the approved future PQBTC posture as-is | Legacy-only until a replacement descriptor decision exists | `#23` |
-| PSBT Taproot fields | Taproot PSBT fields still exist in inherited code and tests | Existing PSBT Taproot field support is not approved future interoperability behavior | Retained dormant and classified as legacy-only for now | `#23` |
-| RPC reporting and creation surfaces | RPC decode/create/reporting surfaces still expose Taproot-related fields and address types | Existing RPC exposure is not an approval of future activated semantics | Retained dormant; future replacement behavior must be specified explicitly | `#22` and `#23` |
-| Functional Taproot suites | Taproot-specific functional tests remain in the repo | These tests are inventory surfaces, not future activation commitments | Retained as legacy-only coverage until migration decisions exist | `#23` |
-| CI classification posture | `CI_COMPLETENESS.md` classifies Taproot-specific tests as `legacy_only` | This tranche does not reclassify them | Legacy-only remains frozen for now | `#23` |
+| Descriptor `tr(...)` posture | Descriptor/test surfaces for Taproot exist in inherited wallet code and tests | `tr(...)` is not part of the approved future PQBTC posture as-is | Inventory classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; replacement semantics remain deferred | `#23` |
+| PSBT Taproot fields | Taproot PSBT fields still exist in inherited code and tests | Existing PSBT Taproot field support is not approved future interoperability behavior | Inventory classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; replacement semantics remain deferred | `#23` |
+| RPC reporting and creation surfaces | RPC decode/create/reporting surfaces still expose Taproot-related fields and address types | Existing RPC exposure is not an approval of future activated semantics | Deployment reporting remains frozen in `#22`; compatibility coverage classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md` | `#22` and `#23` |
+| Functional Taproot suites | Taproot-specific functional tests remain in the repo | These tests are inventory surfaces, not future activation commitments | Migration relevance is now classified in `TAPROOT_MIGRATION_MATRIX.md` without changing CI gating | `#23` |
+| CI classification posture | `CI_COMPLETENESS.md` keeps inherited Taproot suites `legacy_only` and the replacement deployment test `pq_backlog` | This tranche does not reclassify them | `policy_class` remains frozen while `taproot_matrix_bucket` carries migration-matrix metadata only | `#23` |
 
 ## Explicit Non-Goals
 
@@ -91,7 +91,7 @@ This document does **not** define directly:
 
 - concrete activation parameter values or code wiring; see `TAPROOT_ACTIVATION.md`
 - runtime rollback machinery for a future replacement path
-- migration or compatibility matrix across pre/post-activation states
+- migration or compatibility implementation across pre/post-activation states; the frozen matrix now lives in `TAPROOT_MIGRATION_MATRIX.md`
 - CI reclassification or conversion of Taproot-specific suites
 - runtime code changes, removals, or enablement
 
@@ -99,4 +99,4 @@ This document does **not** define directly:
 
 - `#21`: freeze posture choice and surface boundary map
 - `#22`: freeze activation/deployment mechanism family, parameter schema, and rollback rules for the chosen posture
-- `#23`: define cross-version migration and compatibility validation for the chosen posture
+- `#23`: freeze the migration matrix and implement cross-version compatibility validation for the chosen posture


### PR DESCRIPTION
## Summary
- add `docs/TAPROOT_MIGRATION_MATRIX.md` as the canonical #23 migration/compatibility spec
- add orthogonal `taproot_matrix_bucket` inventory metadata for the curated Taproot-facing suite subset
- align Taproot and CI docs to the new frozen matrix without changing runtime behavior or CI gating

## Testing
- python3 ci/test/check_ci_inventory.py
- git diff --check

## Issues
- part of #23
- part of #13