### PR TITLE
Close #12 with PQ wallet and PSBT confidence coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ This project implements a Bitcoin-like UTXO chain using hash-based post-quantum 
 
 ## Status
 
-**Early development** - Specification phase.
+**Active implementation** - frozen PQ-only consensus, descriptor-native PQ
+wallet flows, and PQ PSBT handling are in-tree. Current work is focused on CI
+completeness, Taproot replacement migration coverage, and operational
+hardening.
 
 ## License
 

--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1717,17 +1717,17 @@
   },
   {
     "name": "wallet_pq_active_ranged.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "PQ-specific coverage exists but is not yet part of the required CI gate set."
+    "tracking_issue": "#12",
+    "notes": "Required deterministic PQ wallet receive/change and ranged-descriptor spend coverage."
   },
   {
     "name": "wallet_pq_backup_recovery.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "PQ-specific coverage exists but is not yet part of the required CI gate set."
+    "tracking_issue": "#12",
+    "notes": "Required deterministic PQ wallet backup, restore, and recovery coverage."
   },
   {
     "name": "wallet_pq_descriptors.py",
@@ -1738,10 +1738,10 @@
   },
   {
     "name": "wallet_pq_psbt.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "PQ-specific coverage exists but is not yet part of the required CI gate set."
+    "tracking_issue": "#12",
+    "notes": "Required deterministic PQ PSBT creation, signing, and finalization coverage."
   },
   {
     "name": "wallet_reindex.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -4,3 +4,6 @@ feature_pqsig_basic.py
 feature_pqsig_multisig.py
 mempool_pq_limits.py
 mempool_pq_stress.py
+wallet_pq_active_ranged.py
+wallet_pq_backup_recovery.py
+wallet_pq_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `267` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `6` |
-| `pq_backlog` | `105` |
+| `pq_required` | `9` |
+| `pq_backlog` | `102` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
 
@@ -49,12 +49,18 @@ Current required PQ-first gates:
 4. `feature_pqsig_multisig.py`
 5. `mempool_pq_limits.py`
 6. `mempool_pq_stress.py`
+7. `wallet_pq_active_ranged.py`
+8. `wallet_pq_backup_recovery.py`
+9. `wallet_pq_psbt.py`
 
-Key backlog families in this tranche:
+The previous wallet-confidence gap is closed in this tranche by promoting the
+existing PQ wallet suites into the required gate and adding PQ-native wallet and
+PSBT unit coverage to the default `test_pqbtc` profile. The remaining key
+backlog families are:
 
-1. wallet functional coverage outside the current PQ-specific tests
-2. mempool and mining policy suites not yet given explicit PQ gating treatment
-3. chainstate and validation-facing feature tests that still need a later PQ migration decision
+1. mempool and mining policy suites not yet given explicit PQ gating treatment
+2. chainstate and validation-facing feature tests that still need a later PQ migration decision
+3. broader dual-profile and legacy-only coverage that still needs durable ownership and migration boundaries
 
 Explicit legacy-only coverage in this tranche includes:
 
@@ -78,3 +84,4 @@ Until a separate ownership model or `CODEOWNERS` file exists, all current workfl
 Still deferred after this tranche:
 
 1. converting `pq_backlog` suites into required PQ gates or documenting permanent dual-profile boundaries for them
+2. promoting high-value chainstate and validation suites from `pq_backlog` once the current wallet-confidence tranche is stable

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -12,8 +12,9 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 ## Epics
 
 1. Wallet completeness and signing parity
-- Scope: descriptors, keypool batching, restore/recovery invariants, PSBT finalization, wallet RPC parity, wallet functional coverage.
-- Exit criteria: node+wallet end-to-end PQ signing and recovery with CI coverage.
+- Status: completed by `#12` wallet confidence closure.
+- Delivered scope: descriptor-native PQ wallet managers, restore/recovery invariants, PQ PSBT signing/finalization coverage, and deterministic wallet functional coverage in the required PQ gate.
+- Exit criteria: met once node+wallet end-to-end PQ signing and recovery are covered by required CI and default PQ-native unit coverage.
 
 2. Taproot posture beyond v1
 - Scope: frozen explicit-replacement posture, concrete dormant replacement deployment/reporting path, frozen migration matrix, and compatibility tests.

--- a/docs/README_PQBTC.md
+++ b/docs/README_PQBTC.md
@@ -25,7 +25,14 @@ This project implements a Bitcoin-like UTXO chain using hash-based post-quantum 
 
 ## Status
 
-**`v1.0.0` held; `v1.0.0-rc2` active** - the project is on the rc2 mitigation track after retiring the old `ALG_ID=0x00` profile before GA.
+**`v1.0.0` held; `v1.0.0-rc2` active** - the project is on the rc2 mitigation
+track after retiring the old `ALG_ID=0x00` profile before GA.
+
+The repo already includes frozen PQ-only consensus, descriptor-native PQ wallet
+managers, PQ PSBT signing/finalization support, and deterministic wallet
+backup/recovery coverage. Current work is focused on confidence/gating
+completeness, Taproot replacement migration coverage, and operational
+hardening rather than first-pass wallet implementation.
 
 ## RC Documentation
 

--- a/docs/WALLET.md
+++ b/docs/WALLET.md
@@ -1,18 +1,35 @@
 # Wallet Plan for PQBTC
 
-## Status: FROZEN
-## Spec-ID: WALLET-v1-deferred
-## Frozen-By: gate-v1-bootstrap-20260222
+## Status: IMPLEMENTED
+## Spec-ID: WALLET-v1-implemented
+## Updated-By: issue-12-wallet-confidence-20260401
 ## Consensus-Relevant: NO
 
-## v1 Delivery Boundary
-Wallet keypool batching UX is deferred from node+consensus v1.
+## Current v1 Wallet Surface
 
-## Deferred Work Items
-- Hardened-only child derivation for hash-based signing seeds.
-- Public key batch export and replenishment workflow.
-- Restore and gap-limit scanning behavior for PQ keypools.
+The wallet surface is no longer deferred in the repo. Current `main` includes:
 
-## Interim Strategy
-Node validates PQ spends; test/tooling signer flows provide transaction generation during v1.
-Reference tooling path: `contrib/pqsign/pqsign.py`.
+- descriptor-native `pqpriv(...)` wallet managers for receive and change flows
+- deterministic PQ destination derivation with persisted `next_index`
+- PQ signing and PQ PSBT proprietary partial-signature handling under the current fixed `SIGHASH_ALL` rule
+- backup, restore, and ranged-descriptor recovery coverage
+- default PQ-native unit coverage for wallet bookkeeping and PSBT role/error handling
+
+## Confidence Closure In This Tranche
+
+This tranche closes the remaining wallet confidence gap by:
+
+- promoting the existing PQ wallet functional suites into the required PQ CI gate
+- adding PQ-native wallet bookkeeping tests to the default `test_pqbtc` profile
+- adding PQ-native PSBT negative/interoperability tests to the default `test_pqbtc` profile
+
+## Remaining Out Of Scope
+
+- broad rehabilitation of inherited legacy wallet tests under PQ mode
+- Taproot replacement behavior and migration work, which remains tracked separately under `#23`
+- broader CI completeness work outside the wallet-confidence surface
+
+## Tooling Note
+
+Reference tooling such as `contrib/pqsign/pqsign.py` remains useful for external
+workflows, but it is no longer the only exercised signing path in-tree.

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -4,15 +4,42 @@
 
 #include <coins.h>
 #include <consensus/amount.h>
+#include <crypto/pqsig/pqsig.h>
 #include <consensus/tx_verify.h>
 #include <node/psbt.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
+#include <script/script.h>
 #include <tinyformat.h>
 
+#include <algorithm>
 #include <numeric>
 
 namespace node {
+namespace {
+bool IsPQSingleSigWitnessScript(const CScript& script)
+{
+    if (script.size() != pqsig::PK_SCRIPT_SIZE + 2) return false;
+    if (script[0] != pqsig::PK_SCRIPT_SIZE || script.back() != OP_CHECKSIG) return false;
+
+    PQPkScript pk_script{};
+    std::copy_n(script.begin() + 1, pqsig::PK_SCRIPT_SIZE, pk_script.begin());
+    return pqsig::ClassifyPkScript(pk_script) == pqsig::PkScriptParseStatus::VALID_ACTIVE;
+}
+
+bool MissingOnlyPQSignature(const PSBTInput& input, const SignatureData& outdata)
+{
+    if (!outdata.missing_pubkeys.empty() || !outdata.missing_sigs.empty() ||
+        !outdata.missing_redeem_script.IsNull() || !outdata.missing_witness_script.IsNull()) {
+        return false;
+    }
+
+    SignatureData existing;
+    input.FillSignatureData(existing);
+    return existing.pq_signatures.empty() && IsPQSingleSigWitnessScript(input.witness_script);
+}
+} // namespace
+
 PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
 {
     // Go through each input and build status
@@ -74,7 +101,8 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
                 input_analysis.missing_sigs = outdata.missing_sigs;
 
                 // If we are only missing signatures and nothing else, then next is signer
-                if (outdata.missing_pubkeys.empty() && outdata.missing_redeem_script.IsNull() && outdata.missing_witness_script.IsNull() && !outdata.missing_sigs.empty()) {
+                if ((outdata.missing_pubkeys.empty() && outdata.missing_redeem_script.IsNull() && outdata.missing_witness_script.IsNull() && !outdata.missing_sigs.empty()) ||
+                    MissingOnlyPQSignature(input, outdata)) {
                     input_analysis.next = PSBTRole::SIGNER;
                 } else {
                     input_analysis.next = PSBTRole::UPDATER;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -193,6 +193,10 @@ target_link_libraries(test_pqbtc
 
 if(ENABLE_WALLET)
   add_subdirectory(${PROJECT_SOURCE_DIR}/src/wallet/test wallet)
+  target_sources(test_pqbtc
+    PRIVATE
+      pq_psbt_tests.cpp
+  )
 endif()
 
 if(ENABLE_IPC)

--- a/src/test/pq_psbt_tests.cpp
+++ b/src/test/pq_psbt_tests.cpp
@@ -1,0 +1,338 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/test/util.h>
+
+#include <addresstype.h>
+#include <common/types.h>
+#include <consensus/amount.h>
+#include <consensus/consensus.h>
+#include <crypto/pqsig/pqsig.h>
+#include <key.h>
+#include <key_io.h>
+#include <node/psbt.h>
+#include <node/types.h>
+#include <psbt.h>
+#include <script/descriptor.h>
+#include <script/interpreter.h>
+#include <script/sign.h>
+#include <script/solver.h>
+#include <streams.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <util/check.h>
+#include <validation.h>
+#include <wallet/coincontrol.h>
+#include <wallet/context.h>
+#include <wallet/pq_scriptpubkeyman.h>
+#include <wallet/spend.h>
+#include <wallet/test/wallet_test_fixture.h>
+#include <wallet/wallet.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using wallet::CWallet;
+using wallet::CreateMockableWalletDatabase;
+using wallet::TestLoadWallet;
+using wallet::TestUnloadWallet;
+using wallet::WalletContext;
+
+constexpr uint64_t BLANK_DESCRIPTOR_WALLET_FLAGS{wallet::WALLET_FLAG_DESCRIPTORS | wallet::WALLET_FLAG_BLANK_WALLET};
+constexpr int32_t PQ_RECEIVE_RANGE_END{1};
+constexpr int32_t PQ_CHANGE_RANGE_END{0};
+constexpr uint64_t PQBTC_IN_PARTIAL_SIG{0x01};
+constexpr std::array<unsigned char, 5> PQBTC_IDENTIFIER{{'p', 'q', 'b', 't', 'c'}};
+
+struct LoadedPQWallet {
+    std::unique_ptr<WalletContext> context;
+    std::shared_ptr<CWallet> wallet;
+
+    LoadedPQWallet() = default;
+    LoadedPQWallet(LoadedPQWallet&&) = default;
+    LoadedPQWallet(const LoadedPQWallet&) = delete;
+    LoadedPQWallet& operator=(const LoadedPQWallet&) = delete;
+
+    ~LoadedPQWallet()
+    {
+        if (wallet) TestUnloadWallet(std::move(wallet));
+    }
+
+    CWallet& operator*() const { return *wallet; }
+    CWallet* operator->() const { return wallet.get(); }
+};
+
+PQPrivateDescriptorInfo ParsePQDescriptorInfo(const std::array<unsigned char, 32>& root_seed, bool internal)
+{
+    FlatSigningProvider provider;
+    std::string error;
+    auto parsed = Parse(GetPQPrivateDescriptorString(root_seed, internal), provider, error, /*require_checksum=*/true);
+    if (parsed.empty()) {
+        throw std::runtime_error(error);
+    }
+    auto info = GetPQPrivateDescriptorInfo(*parsed.at(0));
+    if (!info.has_value()) {
+        throw std::runtime_error("missing pqpriv() descriptor info");
+    }
+    return *info;
+}
+
+LoadedPQWallet CreateActivePQWallet(TestChain100Setup& setup, const std::array<unsigned char, 32>& root_seed)
+{
+    LoadedPQWallet loaded;
+    setup.m_args.ForceSetArg("-keypool", "1");
+    loaded.context = std::make_unique<WalletContext>();
+    loaded.context->args = &setup.m_args;
+    loaded.context->chain = setup.m_node.chain.get();
+    loaded.wallet = TestLoadWallet(CreateMockableWalletDatabase(), *loaded.context, BLANK_DESCRIPTOR_WALLET_FLAGS);
+    loaded.wallet->m_keypool_size = 1;
+
+    LOCK(loaded.wallet->cs_wallet);
+    auto& receive_manager = Assert(loaded.wallet->AddWalletPQDescriptor(ParsePQDescriptorInfo(root_seed, /*internal=*/false), /*creation_time=*/0, /*range_start=*/0, PQ_RECEIVE_RANGE_END, /*next_index=*/0))->get();
+    loaded.wallet->AddActivePQScriptPubKeyMan(receive_manager.GetID(), /*internal=*/false);
+    auto& change_manager = Assert(loaded.wallet->AddWalletPQDescriptor(ParsePQDescriptorInfo(root_seed, /*internal=*/true), /*creation_time=*/0, /*range_start=*/0, PQ_CHANGE_RANGE_END, /*next_index=*/0))->get();
+    loaded.wallet->AddActivePQScriptPubKeyMan(change_manager.GetID(), /*internal=*/true);
+    return loaded;
+}
+
+CTxDestination MakePQDestination(const std::array<unsigned char, 32>& root_seed, bool internal, int32_t index)
+{
+    std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script{};
+    if (!pqsig::DeriveWalletPkScript(pk_script, root_seed, internal, index)) {
+        throw std::runtime_error("failed to derive deterministic PQ destination");
+    }
+    const CScript witness_script = CScript{} << std::vector<unsigned char>(pk_script.begin(), pk_script.end()) << OP_CHECKSIG;
+    return WitnessV0ScriptHash(witness_script);
+}
+
+void RescanWalletToTip(TestChain100Setup& setup, CWallet& wallet)
+{
+    const auto [genesis_hash, tip_hash, tip_height] = WITH_LOCK(Assert(setup.m_node.chainman)->GetMutex(), return std::make_tuple(
+        setup.m_node.chainman->ActiveChain().Genesis()->GetBlockHash(),
+        setup.m_node.chainman->ActiveChain().Tip()->GetBlockHash(),
+        setup.m_node.chainman->ActiveChain().Height()));
+    wallet::WalletRescanReserver reserver(wallet);
+    BOOST_REQUIRE(reserver.reserve());
+    const auto result = wallet.ScanForWalletTransactions(genesis_hash, /*start_height=*/0, /*max_height=*/tip_height, reserver, /*fUpdate=*/false, /*save_progress=*/false);
+    BOOST_CHECK_EQUAL(result.status, CWallet::ScanResult::SUCCESS);
+    BOOST_CHECK_EQUAL(result.last_scanned_block, tip_hash);
+}
+
+Txid FundWalletFromCoinbase(TestChain100Setup& setup, CWallet& wallet, const CTxDestination& dest)
+{
+    const auto funded_block = setup.CreateAndProcessBlock({}, GetScriptForDestination(dest));
+    const Txid funding_txid = funded_block.vtx.at(0)->GetHash();
+    for (int i = 0; i < COINBASE_MATURITY; ++i) {
+        setup.CreateAndProcessBlock({}, GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey()));
+    }
+    setup.m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    RescanWalletToTip(setup, wallet);
+    return funding_txid;
+}
+
+PartiallySignedTransaction CreateUnsignedPQSpendPSBT(CWallet& wallet)
+{
+    const CTxDestination sink = WitnessV0KeyHash(GenerateRandomKey().GetPubKey().GetID());
+    const wallet::CRecipient recipient{sink, 1 * COIN, /*subtract_fee=*/false};
+    wallet::CCoinControl coin_control;
+    coin_control.m_feerate = CFeeRate(1000);
+    auto tx_result = wallet::CreateTransaction(wallet, {recipient}, /*change_pos=*/std::nullopt, coin_control, /*sign=*/false);
+    BOOST_REQUIRE_MESSAGE(tx_result, util::ErrorString(tx_result).original);
+    return PartiallySignedTransaction(CMutableTransaction(*tx_result->tx));
+}
+
+PQPkScript MakePkScript(uint8_t seed_byte)
+{
+    std::array<unsigned char, 32> root_seed{};
+    root_seed.fill(seed_byte);
+    PQPkScript pk_script{};
+    if (!pqsig::DeriveWalletPkScript(pk_script, root_seed, /*internal=*/false, /*index=*/0)) {
+        throw std::runtime_error("failed to derive deterministic test pk script");
+    }
+    return pk_script;
+}
+
+std::vector<unsigned char> MakeSig(uint8_t fill, size_t size = pqsig::SIG_SIZE)
+{
+    return std::vector<unsigned char>(size, fill);
+}
+
+std::vector<unsigned char> SerializePQPropKey(uint8_t type, const std::vector<unsigned char>& identifier, uint64_t subtype, std::span<const unsigned char> trailing_key)
+{
+    std::vector<unsigned char> key;
+    VectorWriter writer{key, 0};
+    writer << CompactSizeWriter(type);
+    writer << identifier;
+    WriteCompactSize(writer, subtype);
+    writer << trailing_key;
+    return key;
+}
+
+PSBTProprietary MakePQPartialSigProp(const PQPkScript& pk_script, const std::vector<unsigned char>& sig)
+{
+    PSBTProprietary prop;
+    prop.subtype = PQBTC_IN_PARTIAL_SIG;
+    prop.identifier.assign(PQBTC_IDENTIFIER.begin(), PQBTC_IDENTIFIER.end());
+    prop.key = SerializePQPropKey(PSBT_IN_PROPRIETARY, prop.identifier, prop.subtype, std::span<const unsigned char>(pk_script.begin(), pk_script.end()));
+    prop.value = sig;
+    return prop;
+}
+
+bool IsPQPartialSigProp(const PSBTProprietary& prop)
+{
+    return prop.subtype == PQBTC_IN_PARTIAL_SIG &&
+           prop.identifier == std::vector<unsigned char>(PQBTC_IDENTIFIER.begin(), PQBTC_IDENTIFIER.end());
+}
+
+size_t CountPQPartialSigProps(const PSBTInput& input)
+{
+    size_t count{0};
+    for (const auto& prop : input.m_proprietary) {
+        if (IsPQPartialSigProp(prop)) ++count;
+    }
+    return count;
+}
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(pq_psbt_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(pq_psbt_malformed_proprietary_partial_sigs_are_ignored)
+{
+    const PQPkScript pk_script = MakePkScript(0x11);
+    const std::vector<unsigned char> valid_sig = MakeSig(0x44);
+
+    struct MalformedCase {
+        std::string name;
+        PSBTProprietary prop;
+    };
+
+    std::vector<MalformedCase> cases;
+
+    PSBTProprietary wrong_identifier = MakePQPartialSigProp(pk_script, valid_sig);
+    wrong_identifier.identifier = {'n', 'o', 'p', 'e'};
+    wrong_identifier.key = SerializePQPropKey(PSBT_IN_PROPRIETARY, wrong_identifier.identifier, wrong_identifier.subtype, std::span<const unsigned char>(pk_script.begin(), pk_script.end()));
+    cases.push_back({"wrong identifier", std::move(wrong_identifier)});
+
+    PSBTProprietary wrong_subtype = MakePQPartialSigProp(pk_script, valid_sig);
+    wrong_subtype.subtype = 0x02;
+    wrong_subtype.key = SerializePQPropKey(PSBT_IN_PROPRIETARY, wrong_subtype.identifier, wrong_subtype.subtype, std::span<const unsigned char>(pk_script.begin(), pk_script.end()));
+    cases.push_back({"wrong subtype", std::move(wrong_subtype)});
+
+    PSBTProprietary wrong_key_prefix = MakePQPartialSigProp(pk_script, valid_sig);
+    wrong_key_prefix.key = SerializePQPropKey(PSBT_IN_PARTIAL_SIG, wrong_key_prefix.identifier, wrong_key_prefix.subtype, std::span<const unsigned char>(pk_script.begin(), pk_script.end()));
+    cases.push_back({"wrong proprietary key prefix", std::move(wrong_key_prefix)});
+
+    PSBTProprietary wrong_pk_script_length = MakePQPartialSigProp(pk_script, valid_sig);
+    wrong_pk_script_length.key = SerializePQPropKey(PSBT_IN_PROPRIETARY, wrong_pk_script_length.identifier, wrong_pk_script_length.subtype, std::span<const unsigned char>(pk_script.begin(), pk_script.end() - 1));
+    cases.push_back({"wrong pk_script length", std::move(wrong_pk_script_length)});
+
+    PSBTProprietary wrong_sig_length = MakePQPartialSigProp(pk_script, MakeSig(0x44, pqsig::SIG_SIZE - 1));
+    cases.push_back({"wrong signature length", std::move(wrong_sig_length)});
+
+    for (const auto& test_case : cases) {
+        BOOST_TEST_CONTEXT(test_case.name) {
+            PSBTInput input;
+            input.m_proprietary.insert(test_case.prop);
+
+            SignatureData sigdata;
+            input.FillSignatureData(sigdata);
+            BOOST_CHECK(sigdata.pq_signatures.empty());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(pq_psbt_from_signature_data_rewrites_stale_proprietary_fields)
+{
+    const PQPkScript stale_pk_script = MakePkScript(0x21);
+    const PQPkScript fresh_pk_script = MakePkScript(0x22);
+
+    PSBTInput input;
+    input.m_proprietary.insert(MakePQPartialSigProp(stale_pk_script, MakeSig(0x51)));
+
+    PSBTProprietary unrelated_prop;
+    unrelated_prop.subtype = 0x07;
+    unrelated_prop.identifier = {'m', 'e', 't', 'a'};
+    unrelated_prop.key = SerializePQPropKey(PSBT_IN_PROPRIETARY, unrelated_prop.identifier, unrelated_prop.subtype, std::span<const unsigned char>());
+    unrelated_prop.value = {0x01, 0x02, 0x03};
+    input.m_proprietary.insert(unrelated_prop);
+
+    SignatureData sigdata;
+    sigdata.pq_signatures.emplace(fresh_pk_script, MakeSig(0x61));
+
+    input.FromSignatureData(sigdata);
+
+    BOOST_CHECK_EQUAL(CountPQPartialSigProps(input), 1U);
+    BOOST_CHECK_EQUAL(input.m_proprietary.count(unrelated_prop), 1U);
+
+    SignatureData roundtrip;
+    input.FillSignatureData(roundtrip);
+    BOOST_CHECK(roundtrip.pq_signatures == sigdata.pq_signatures);
+}
+
+BOOST_AUTO_TEST_CASE(pq_analyze_psbt_role_transitions_cover_updater_signer_and_finalizer)
+{
+    std::array<unsigned char, 32> root_seed{};
+    root_seed.fill(0x42);
+
+    auto loaded = CreateActivePQWallet(*this, root_seed);
+    const CTxDestination receive = MakePQDestination(root_seed, /*internal=*/false, /*index=*/0);
+    FundWalletFromCoinbase(*this, *loaded, receive);
+
+    PartiallySignedTransaction psbt = CreateUnsignedPQSpendPSBT(*loaded);
+
+    node::PSBTAnalysis analysis = node::AnalyzePSBT(psbt);
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1U);
+    BOOST_CHECK(!analysis.inputs[0].has_utxo);
+    BOOST_CHECK_EQUAL(analysis.inputs[0].next, PSBTRole::UPDATER);
+    BOOST_CHECK_EQUAL(analysis.next, PSBTRole::UPDATER);
+
+    bool complete{false};
+    BOOST_REQUIRE(!loaded->FillPSBT(psbt, complete, std::nullopt, /*sign=*/false, /*bip32derivs=*/true, nullptr, /*finalize=*/false));
+    BOOST_CHECK(!complete);
+
+    analysis = node::AnalyzePSBT(psbt);
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1U);
+    BOOST_CHECK(analysis.inputs[0].has_utxo);
+    BOOST_CHECK(!analysis.inputs[0].is_final);
+    BOOST_CHECK_EQUAL(analysis.inputs[0].next, PSBTRole::SIGNER);
+    BOOST_CHECK_EQUAL(analysis.next, PSBTRole::SIGNER);
+
+    BOOST_REQUIRE(!loaded->FillPSBT(psbt, complete, std::nullopt, /*sign=*/true, /*bip32derivs=*/false, nullptr, /*finalize=*/false));
+    BOOST_CHECK(!complete);
+
+    analysis = node::AnalyzePSBT(psbt);
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1U);
+    BOOST_CHECK(analysis.inputs[0].has_utxo);
+    BOOST_CHECK(!analysis.inputs[0].is_final);
+    BOOST_CHECK_EQUAL(analysis.inputs[0].next, PSBTRole::FINALIZER);
+    BOOST_CHECK_EQUAL(analysis.next, PSBTRole::FINALIZER);
+}
+
+BOOST_AUTO_TEST_CASE(pq_fillpsbt_rejects_non_default_sighash)
+{
+    std::array<unsigned char, 32> root_seed{};
+    root_seed.fill(0x33);
+
+    auto loaded = CreateActivePQWallet(*this, root_seed);
+    const CTxDestination receive = MakePQDestination(root_seed, /*internal=*/false, /*index=*/0);
+    FundWalletFromCoinbase(*this, *loaded, receive);
+
+    PartiallySignedTransaction psbt = CreateUnsignedPQSpendPSBT(*loaded);
+    bool complete{false};
+    const auto err = loaded->FillPSBT(psbt, complete, SIGHASH_NONE, /*sign=*/false, /*bip32derivs=*/true, nullptr, /*finalize=*/false);
+
+    BOOST_REQUIRE(err.has_value());
+    BOOST_CHECK(*err == common::PSBTError::SIGHASH_MISMATCH);
+    BOOST_CHECK(!complete);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/CMakeLists.txt
+++ b/src/wallet/test/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(test_pqbtc
     init_tests.cpp
     ismine_tests.cpp
     psbt_wallet_tests.cpp
+    pq_wallet_tests.cpp
     scriptpubkeyman_tests.cpp
     spend_tests.cpp
     wallet_crypto_tests.cpp

--- a/src/wallet/test/pq_wallet_tests.cpp
+++ b/src/wallet/test/pq_wallet_tests.cpp
@@ -1,0 +1,323 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/test/util.h>
+
+#include <addresstype.h>
+#include <consensus/consensus.h>
+#include <key.h>
+#include <key_io.h>
+#include <node/types.h>
+#include <script/descriptor.h>
+#include <script/solver.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <util/check.h>
+#include <validation.h>
+#include <wallet/coincontrol.h>
+#include <wallet/context.h>
+#include <wallet/pq_scriptpubkeyman.h>
+#include <wallet/receive.h>
+#include <wallet/spend.h>
+#include <wallet/test/wallet_test_fixture.h>
+#include <wallet/wallet.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace wallet {
+BOOST_FIXTURE_TEST_SUITE(pq_wallet_tests, TestChain100Setup)
+
+namespace {
+
+constexpr uint64_t BLANK_DESCRIPTOR_WALLET_FLAGS{WALLET_FLAG_DESCRIPTORS | WALLET_FLAG_BLANK_WALLET};
+constexpr int32_t PQ_RECEIVE_RANGE_END{1};
+constexpr int32_t PQ_CHANGE_RANGE_END{0};
+
+struct LoadedPQWallet {
+    std::unique_ptr<WalletContext> context;
+    std::shared_ptr<CWallet> wallet;
+
+    LoadedPQWallet() = default;
+    LoadedPQWallet(LoadedPQWallet&&) = default;
+    LoadedPQWallet(const LoadedPQWallet&) = delete;
+    LoadedPQWallet& operator=(const LoadedPQWallet&) = delete;
+
+    ~LoadedPQWallet()
+    {
+        if (wallet) TestUnloadWallet(std::move(wallet));
+    }
+
+    CWallet& operator*() const { return *wallet; }
+    CWallet* operator->() const { return wallet.get(); }
+};
+
+PQPrivateDescriptorInfo ParsePQDescriptorInfo(const std::array<unsigned char, 32>& root_seed, bool internal)
+{
+    FlatSigningProvider provider;
+    std::string error;
+    auto parsed = Parse(GetPQPrivateDescriptorString(root_seed, internal), provider, error, /*require_checksum=*/true);
+    if (parsed.empty()) {
+        throw std::runtime_error(error);
+    }
+    auto info = GetPQPrivateDescriptorInfo(*parsed.at(0));
+    if (!info.has_value()) {
+        throw std::runtime_error("missing pqpriv() descriptor info");
+    }
+    return *info;
+}
+
+CTxDestination DerivePQDestination(const std::array<unsigned char, 32>& root_seed, bool internal, int32_t index)
+{
+    std::array<unsigned char, pqsig::PK_SCRIPT_SIZE> pk_script{};
+    if (!pqsig::DeriveWalletPkScript(pk_script, root_seed, internal, index)) {
+        throw std::runtime_error("failed to derive deterministic PQ destination");
+    }
+    const CScript witness_script = CScript{} << std::vector<unsigned char>(pk_script.begin(), pk_script.end()) << OP_CHECKSIG;
+    return WitnessV0ScriptHash(witness_script);
+}
+
+LoadedPQWallet CreateActivePQWallet(TestChain100Setup& setup, const std::array<unsigned char, 32>& root_seed)
+{
+    LoadedPQWallet loaded;
+    setup.m_args.ForceSetArg("-keypool", "1");
+    loaded.context = std::make_unique<WalletContext>();
+    loaded.context->args = &setup.m_args;
+    loaded.context->chain = setup.m_node.chain.get();
+    loaded.wallet = TestLoadWallet(CreateMockableWalletDatabase(), *loaded.context, BLANK_DESCRIPTOR_WALLET_FLAGS);
+    loaded.wallet->m_keypool_size = 1;
+
+    LOCK(loaded.wallet->cs_wallet);
+    auto& receive_manager = Assert(loaded.wallet->AddWalletPQDescriptor(ParsePQDescriptorInfo(root_seed, /*internal=*/false), /*creation_time=*/0, /*range_start=*/0, PQ_RECEIVE_RANGE_END, /*next_index=*/0))->get();
+    loaded.wallet->AddActivePQScriptPubKeyMan(receive_manager.GetID(), /*internal=*/false);
+    auto& change_manager = Assert(loaded.wallet->AddWalletPQDescriptor(ParsePQDescriptorInfo(root_seed, /*internal=*/true), /*creation_time=*/0, /*range_start=*/0, PQ_CHANGE_RANGE_END, /*next_index=*/0))->get();
+    loaded.wallet->AddActivePQScriptPubKeyMan(change_manager.GetID(), /*internal=*/true);
+    return loaded;
+}
+
+void RescanWalletToTip(TestChain100Setup& setup, CWallet& wallet)
+{
+    const auto [genesis_hash, tip_hash, tip_height] = WITH_LOCK(Assert(setup.m_node.chainman)->GetMutex(), return std::make_tuple(
+        setup.m_node.chainman->ActiveChain().Genesis()->GetBlockHash(),
+        setup.m_node.chainman->ActiveChain().Tip()->GetBlockHash(),
+        setup.m_node.chainman->ActiveChain().Height()));
+    WalletRescanReserver reserver(wallet);
+    BOOST_REQUIRE(reserver.reserve());
+    const auto result = wallet.ScanForWalletTransactions(genesis_hash, /*start_height=*/0, /*max_height=*/tip_height, reserver, /*fUpdate=*/false, /*save_progress=*/false);
+    BOOST_CHECK_EQUAL(result.status, CWallet::ScanResult::SUCCESS);
+    BOOST_CHECK_EQUAL(result.last_scanned_block, tip_hash);
+    BOOST_REQUIRE(result.last_scanned_height.has_value());
+    BOOST_CHECK_EQUAL(*result.last_scanned_height, tip_height);
+}
+
+Txid MineMatureWalletCoinbase(TestChain100Setup& setup, const CTxDestination& dest)
+{
+    const auto funded_block = setup.CreateAndProcessBlock({}, GetScriptForDestination(dest));
+    const Txid funding_txid = funded_block.vtx.at(0)->GetHash();
+    for (int i = 0; i < COINBASE_MATURITY; ++i) {
+        setup.CreateAndProcessBlock({}, GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey()));
+    }
+    setup.m_node.validation_signals->SyncWithValidationInterfaceQueue();
+    return funding_txid;
+}
+
+Txid FundWalletFromCoinbase(TestChain100Setup& setup, CWallet& wallet, const CTxDestination& dest)
+{
+    const Txid funding_txid = MineMatureWalletCoinbase(setup, dest);
+    RescanWalletToTip(setup, wallet);
+    return funding_txid;
+}
+
+CWalletTx& CommitAndConfirm(TestChain100Setup& setup, CWallet& wallet, const CRecipient& recipient)
+{
+    CTransactionRef tx;
+    CCoinControl coin_control;
+    coin_control.m_feerate = CFeeRate(1000);
+    {
+        auto res = CreateTransaction(wallet, {recipient}, /*change_pos=*/std::nullopt, coin_control);
+        BOOST_REQUIRE_MESSAGE(res, util::ErrorString(res).original);
+        tx = res->tx;
+    }
+    wallet.CommitTransaction(tx, {}, {});
+
+    CMutableTransaction block_tx;
+    {
+        LOCK(wallet.cs_wallet);
+        block_tx = CMutableTransaction(*wallet.mapWallet.at(tx->GetHash()).tx);
+    }
+    setup.CreateAndProcessBlock({block_tx}, GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey()));
+    setup.m_node.validation_signals->SyncWithValidationInterfaceQueue();
+
+    LOCK(wallet.cs_wallet);
+    LOCK(Assert(setup.m_node.chainman)->GetMutex());
+    wallet.SetLastBlockProcessed(wallet.GetLastBlockHeight() + 1, setup.m_node.chainman->ActiveChain().Tip()->GetBlockHash());
+    auto it = wallet.mapWallet.find(tx->GetHash());
+    BOOST_REQUIRE(it != wallet.mapWallet.end());
+    it->second.m_state = TxStateConfirmed{setup.m_node.chainman->ActiveChain().Tip()->GetBlockHash(), setup.m_node.chainman->ActiveChain().Height(), /*index=*/1};
+    return it->second;
+}
+
+size_t CountListedCoins(const std::map<CTxDestination, std::vector<COutput>>& list)
+{
+    size_t count{0};
+    for (const auto& [_, coins] : list) count += coins.size();
+    return count;
+}
+
+std::set<COutPoint> CollectListedOutpoints(const std::map<CTxDestination, std::vector<COutput>>& list)
+{
+    std::set<COutPoint> outpoints;
+    for (const auto& [_, coins] : list) {
+        for (const auto& coin : coins) {
+            outpoints.insert(coin.outpoint);
+        }
+    }
+    return outpoints;
+}
+
+std::set<COutPoint> CollectOwnedOutpoints(const CWallet& wallet, const CWalletTx& tx)
+{
+    std::set<COutPoint> outpoints;
+    LOCK(wallet.cs_wallet);
+    for (uint32_t i = 0; i < tx.tx->vout.size(); ++i) {
+        if (wallet.IsMine(tx.tx->vout[i])) {
+            outpoints.emplace(tx.GetHash(), i);
+        }
+    }
+    return outpoints;
+}
+
+std::set<std::string> CollectOwnedDestinations(const CWallet& wallet, const CWalletTx& tx)
+{
+    std::set<std::string> destinations;
+    LOCK(wallet.cs_wallet);
+    for (const auto& txout : tx.tx->vout) {
+        if (!wallet.IsMine(txout)) continue;
+        CTxDestination dest;
+        BOOST_REQUIRE(ExtractDestination(txout.scriptPubKey, dest));
+        destinations.insert(EncodeDestination(dest));
+    }
+    return destinations;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(pq_wallet_listcoins_and_output_types_cover_receive_change_and_locked_outputs)
+{
+    std::array<unsigned char, 32> root_seed{};
+    root_seed.fill(0x24);
+
+    auto loaded = CreateActivePQWallet(*this, root_seed);
+    const CTxDestination first_receive = *Assert(loaded->GetNewPQDestination("first receive"));
+    const CTxDestination expected_change = DerivePQDestination(root_seed, /*internal=*/true, /*index=*/0);
+
+    const Txid funding_txid = FundWalletFromCoinbase(*this, *loaded, first_receive);
+    {
+        LOCK(loaded->cs_wallet);
+        BOOST_REQUIRE_EQUAL(loaded->mapWallet.count(funding_txid), 1U);
+    }
+
+    CWalletTx& spend_wtx = CommitAndConfirm(*this, *loaded, CRecipient{first_receive, 1 * COIN, /*subtract_fee=*/false});
+
+    std::map<CTxDestination, std::vector<COutput>> listed;
+    CoinsResult available;
+    {
+        LOCK(loaded->cs_wallet);
+        CoinFilterParams filter;
+        filter.skip_locked = false;
+        listed = ListCoins(*loaded);
+        available = AvailableCoins(*loaded, nullptr, std::nullopt, filter);
+    }
+
+    const std::set<COutPoint> expected_outpoints = CollectOwnedOutpoints(*loaded, spend_wtx);
+    const std::set<COutPoint> listed_outpoints = CollectListedOutpoints(listed);
+    const std::set<std::string> owned_destinations = CollectOwnedDestinations(*loaded, spend_wtx);
+
+    BOOST_CHECK_EQUAL(expected_outpoints.size(), 2U);
+    BOOST_CHECK_EQUAL(CountListedCoins(listed), 2U);
+    BOOST_CHECK(expected_outpoints == listed_outpoints);
+    BOOST_CHECK_EQUAL(available.Size(), 2U);
+    BOOST_CHECK_EQUAL(available.coins[OutputType::BECH32].size(), 2U);
+    BOOST_CHECK_EQUAL(available.coins[OutputType::UNKNOWN].size(), 0U);
+    BOOST_CHECK(owned_destinations.contains(EncodeDestination(first_receive)));
+    BOOST_CHECK(owned_destinations.contains(EncodeDestination(expected_change)));
+
+    for (const auto& [_, coins] : listed) {
+        for (const auto& coin : coins) {
+            LOCK(loaded->cs_wallet);
+            loaded->LockCoin(coin.outpoint, /*persist=*/false);
+        }
+    }
+
+    {
+        LOCK(loaded->cs_wallet);
+        BOOST_CHECK_EQUAL(AvailableCoins(*loaded).Size(), 0U);
+        BOOST_CHECK(CollectListedOutpoints(ListCoins(*loaded)) == expected_outpoints);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(pq_wallet_reload_persists_next_index_and_rescan_finds_funded_outputs)
+{
+    std::array<unsigned char, 32> root_seed{};
+    root_seed.fill(0x42);
+
+    auto loaded = CreateActivePQWallet(*this, root_seed);
+    const CTxDestination first_receive = *Assert(loaded->GetNewPQDestination("first receive"));
+    std::unique_ptr<WalletDatabase> duplicate_db = DuplicateMockDatabase(loaded->GetDatabase());
+    TestUnloadWallet(std::move(loaded.wallet));
+
+    const Txid funding_txid = MineMatureWalletCoinbase(*this, first_receive);
+
+    LoadedPQWallet reloaded;
+    reloaded.context = std::make_unique<WalletContext>();
+    reloaded.context->args = &m_args;
+    reloaded.context->chain = m_node.chain.get();
+    reloaded.wallet = TestLoadWallet(std::move(duplicate_db), *reloaded.context, BLANK_DESCRIPTOR_WALLET_FLAGS);
+    RescanWalletToTip(*this, *reloaded);
+
+    {
+        LOCK(reloaded->cs_wallet);
+        BOOST_REQUIRE_EQUAL(reloaded->mapWallet.count(funding_txid), 1U);
+    }
+
+    const CTxDestination next_receive = *Assert(reloaded->GetNewPQDestination("post reload"));
+    BOOST_CHECK_EQUAL(EncodeDestination(next_receive), EncodeDestination(DerivePQDestination(root_seed, /*internal=*/false, /*index=*/1)));
+}
+
+BOOST_AUTO_TEST_CASE(pq_wallet_remove_txs_clears_wallet_spend_tracking)
+{
+    std::array<unsigned char, 32> root_seed{};
+    root_seed.fill(0x36);
+
+    auto loaded = CreateActivePQWallet(*this, root_seed);
+    const CTxDestination first_receive = *Assert(loaded->GetNewPQDestination("first receive"));
+    const Txid funding_txid = FundWalletFromCoinbase(*this, *loaded, first_receive);
+
+    const auto funding_ref = WITH_LOCK(loaded->cs_wallet, return loaded->mapWallet.at(funding_txid).tx);
+    const CTxDestination sink = WitnessV0KeyHash(GenerateRandomKey().GetPubKey().GetID());
+    CWalletTx& spend_wtx = CommitAndConfirm(*this, *loaded, CRecipient{sink, 1 * COIN, /*subtract_fee=*/false});
+    const Txid spend_hash = spend_wtx.GetHash();
+
+    {
+        LOCK(loaded->cs_wallet);
+        BOOST_CHECK(loaded->HasWalletSpend(funding_ref));
+        BOOST_CHECK_EQUAL(loaded->mapWallet.count(spend_hash), 1U);
+
+        std::vector<Txid> hashes{spend_hash};
+        const auto removal = loaded->RemoveTxs(hashes);
+        BOOST_REQUIRE_MESSAGE(removal, util::ErrorString(removal).original);
+
+        BOOST_CHECK(!loaded->HasWalletSpend(funding_ref));
+        BOOST_CHECK_EQUAL(loaded->mapWallet.count(spend_hash), 0U);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -65,6 +65,7 @@ class MockableBatch : public DatabaseBatch
 private:
     MockableData& m_records;
     bool m_pass;
+    bool m_active_txn{false};
 
     bool ReadKey(DataStream&& key, DataStream& value) override;
     bool WriteKey(DataStream&& key, DataStream&& value, bool overwrite=true) override;
@@ -85,10 +86,25 @@ public:
     std::unique_ptr<DatabaseCursor> GetNewPrefixCursor(std::span<const std::byte> prefix) override {
         return std::make_unique<MockableCursor>(m_records, m_pass, prefix);
     }
-    bool TxnBegin() override { return m_pass; }
-    bool TxnCommit() override { return m_pass; }
-    bool TxnAbort() override { return m_pass; }
-    bool HasActiveTxn() override { return false; }
+    bool TxnBegin() override
+    {
+        if (!m_pass || m_active_txn) return false;
+        m_active_txn = true;
+        return true;
+    }
+    bool TxnCommit() override
+    {
+        if (!m_pass || !m_active_txn) return false;
+        m_active_txn = false;
+        return true;
+    }
+    bool TxnAbort() override
+    {
+        if (!m_pass || !m_active_txn) return false;
+        m_active_txn = false;
+        return true;
+    }
+    bool HasActiveTxn() override { return m_active_txn; }
 };
 
 /** A WalletDatabase whose contents and return values can be modified as needed for testing


### PR DESCRIPTION
## Summary
- promote the existing PQ wallet functional suites into the required PQ gate
- add PQ-native wallet and PSBT coverage to the default test_pqbtc profile
- align CI/status docs with the implemented-but-previously-under-gated wallet surface

## Testing
- /Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --catch_system_error=no
- /Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=pq_wallet_tests --catch_system_error=no --log_level=test_suite
- /Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=pq_psbt_tests --catch_system_error=no --log_level=test_suite
- /Users/scott/quantum-proof-bitcoin/build/test/functional/test_runner.py --jobs=1 wallet_pq_active_ranged.py wallet_pq_backup_recovery.py wallet_pq_psbt.py
- xargs /Users/scott/quantum-proof-bitcoin/build/test/functional/test_runner.py --jobs=1 < /Users/scott/quantum-proof-bitcoin/ci/test/pq_functional_tests.txt
- python3 /Users/scott/quantum-proof-bitcoin/ci/test/check_ci_inventory.py
- git -C /Users/scott/quantum-proof-bitcoin diff --check

Closes #12