### PR TITLE
Add pre-active taproot replacement compatibility test

### DIFF
--- a/ci/test/check_ci_inventory.py
+++ b/ci/test/check_ci_inventory.py
@@ -18,6 +18,7 @@ VALID_POLICY_CLASSES = {"pq_required", "pq_backlog", "dual_profile", "legacy_onl
 VALID_TAPROOT_MATRIX_BUCKETS = {"legacy_only", "replacement_migration", "deferred"}
 REQUIRED_TAPROOT_MATRIX_BUCKETS = {
     "feature_taproot.py": "legacy_only",
+    "feature_taproot_replacement_compat.py": "replacement_migration",
     "feature_taproot_replacement_deployment.py": "replacement_migration",
     "rpc_createmultisig.py": "deferred",
     "rpc_psbt.py": "deferred",

--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -429,6 +429,14 @@
     "notes": "Concrete dormant replacement deployment reporting and regtest BIP9 override coverage; classified as replacement_migration while remaining out of the PQ gate."
   },
   {
+    "name": "feature_taproot_replacement_compat.py",
+    "policy_class": "pq_backlog",
+    "taproot_matrix_bucket": "replacement_migration",
+    "owner": "@scottdhughes",
+    "tracking_issue": "#23",
+    "notes": "Cross-node pre-active compatibility coverage for defined vs started and defined vs locked_in reporting divergence on the same accepted chain; classified as replacement_migration while remaining out of the PQ gate."
+  },
+  {
     "name": "feature_uacomment.py",
     "policy_class": "dual_profile",
     "owner": "@scottdhughes",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -32,12 +32,12 @@ This tranche does not migrate legacy suites to PQ semantics and does not optimiz
 
 ## Current Inventory Summary
 
-The current functional corpus has `267` tracked test files, classified as:
+The current functional corpus has `268` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
 | `pq_required` | `9` |
-| `pq_backlog` | `102` |
+| `pq_backlog` | `103` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
 
@@ -69,11 +69,13 @@ Explicit legacy-only coverage in this tranche includes:
 3. legacy message-signing flows
 
 Inherited Taproot-specific suites remain `legacy_only` in the current CI contract,
-while `feature_taproot_replacement_deployment.py` remains `pq_backlog` as replacement-path
-deployment coverage. Their future status is governed by `TAPROOT_POSTURE.md` and
-`TAPROOT_MIGRATION_MATRIX.md`. `policy_class` remains the CI gating/ownership surface,
-while `taproot_matrix_bucket` is migration-matrix metadata only and does not change
-required CI behavior in this tranche.
+while `feature_taproot_replacement_deployment.py` and
+`feature_taproot_replacement_compat.py` remain `pq_backlog` as replacement-path
+deployment and pre-active compatibility coverage. Their future status is governed
+by `TAPROOT_POSTURE.md` and `TAPROOT_MIGRATION_MATRIX.md`. `policy_class` remains
+the CI gating/ownership surface, while `taproot_matrix_bucket` is
+migration-matrix metadata only and does not change required CI behavior in this
+tranche.
 
 ## Ownership
 

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -18,6 +18,7 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 
 2. Taproot posture beyond v1
 - Scope: frozen explicit-replacement posture, concrete dormant replacement deployment/reporting path, frozen migration matrix, and compatibility tests.
+- Current state: frozen posture, activation, deployment/reporting, and pre-active runtime compatibility evidence are now checked in; remaining work is active-replacement compatibility and the deferred Taproot-facing surfaces tracked under `#23`.
 - Exit criteria: frozen replacement posture, concrete dormant deployment/reporting path, and implemented cross-version validation against the frozen matrix.
 
 3. Multi-algorithm evolution (`ALG_ID` registry)

--- a/docs/TAPROOT_MIGRATION_MATRIX.md
+++ b/docs/TAPROOT_MIGRATION_MATRIX.md
@@ -72,6 +72,21 @@ The matrix is directional. Each row is evaluated as `local state -> observed/com
 4. This matrix freezes what is comparable today; it does not speculate about
    active replacement semantics beyond reserving them for later work.
 
+## Implemented Pre-Active Runtime Evidence
+
+The opening slice of `#23` froze this matrix and its suite classification. The
+current runtime slice adds evidence for the currently exercisable pre-active rows
+without changing the matrix meaning:
+
+1. `feature_taproot_replacement_deployment.py` remains the single-node proof of
+   concrete dormant replacement deployment reporting and regtest BIP9 override
+   transitions.
+2. `feature_taproot_replacement_compat.py` adds cross-node runtime evidence for
+   `DEPLOYMENT_DEFINED_NOT_SIGNALING <-> SIGNALING` and
+   `DEPLOYMENT_DEFINED_NOT_SIGNALING <-> LOCKED_IN_PRE_ACTIVE` on the same
+   accepted chain, with `active = false` on both nodes.
+3. Any row involving `ACTIVE_REPLACEMENT` remains explicitly deferred.
+
 ## Frozen Suite Classification
 
 | Suite | Current `policy_class` | `taproot_matrix_bucket` | Rationale |
@@ -79,6 +94,7 @@ The matrix is directional. Each row is evaluated as `local state -> observed/com
 | `feature_taproot.py` | `legacy_only` | `legacy_only` | Explicit inherited BIP341/BIP342 functional coverage; not a PQBTC replacement target as-is. |
 | `wallet_taproot.py` | `legacy_only` | `legacy_only` | Explicit inherited Taproot wallet coverage; not a PQBTC replacement target as-is. |
 | `feature_taproot_replacement_deployment.py` | `pq_backlog` | `replacement_migration` | Directly exercises the frozen dormant replacement deployment/reporting path and regtest pre-active BIP9 transitions. |
+| `feature_taproot_replacement_compat.py` | `pq_backlog` | `replacement_migration` | Adds cross-node evidence that defined, started, and locked_in pre-active states can diverge in reporting while remaining on the same accepted chain. |
 | `rpc_createmultisig.py` | `dual_profile` | `deferred` | Contains Taproot-adjacent bech32m coverage, but replacement-specific semantics are not yet defined. |
 | `rpc_psbt.py` | `dual_profile` | `deferred` | Contains Taproot-facing PSBT surfaces, but replacement-specific semantics are not yet defined. |
 | `wallet_address_types.py` | `dual_profile` | `deferred` | Contains bech32m/Taproot-facing address branches, but replacement-specific semantics are not yet defined. |
@@ -97,7 +113,8 @@ This slice does **not** define:
 
 ## Downstream Boundary
 
-This document is the opening slice of `#23`.
+The opening slice of `#23` froze the directional matrix and suite classification.
+This runtime slice implements the currently exercisable pre-active evidence only.
 
-Remaining `#23` work after this slice is the actual implementation of the focused
-migration and compatibility suites implied by this matrix.
+Remaining `#23` work after this slice is the active-replacement compatibility and
+the deferred Taproot-facing migration suites implied by this matrix.

--- a/test/functional/feature_taproot_replacement_compat.py
+++ b/test/functional/feature_taproot_replacement_compat.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test pre-active cross-node Taproot replacement compatibility.
+
+Validate the frozen migration-matrix rows the repo can exercise today:
+- DEPLOYMENT_DEFINED_NOT_SIGNALING <-> SIGNALING
+- DEPLOYMENT_DEFINED_NOT_SIGNALING <-> LOCKED_IN_PRE_ACTIVE
+
+The nodes must remain on the same accepted chain while differing only in their
+pre-active deployment reporting state.
+"""
+
+from test_framework.blocktools import TIME_GENESIS_BLOCK
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+
+TAPROOT_REPLACEMENT_NAME = "taproot_replacement"
+NO_TIMEOUT = 0x7fffffffffffffff
+TIME_STEP = 600
+STARTED_CHECKPOINT_HEIGHT = 207
+LOCKED_IN_CHECKPOINT_HEIGHT = 288
+
+
+class TaprootReplacementCompatTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.supports_cli = False
+
+    def set_network_mocktime(self, height):
+        mocktime = TIME_GENESIS_BLOCK + height * TIME_STEP
+        for node in self.nodes:
+            node.setmocktime(mocktime)
+
+    def mine_to_height(self, target):
+        while self.nodes[1].getblockcount() < target:
+            next_height = self.nodes[1].getblockcount() + 1
+            self.set_network_mocktime(next_height)
+            self.generate(self.miner, 1, sync_fun=self.sync_blocks)
+
+    def restart_signalling_node(self):
+        self.restart_node(1, extra_args=[f"-vbparams={TAPROOT_REPLACEMENT_NAME}:0:{NO_TIMEOUT}"])
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
+        self.miner = MiniWallet(self.nodes[1])
+
+    def assert_same_chain(self, expected_height):
+        best_hash_0 = self.nodes[0].getbestblockhash()
+        best_hash_1 = self.nodes[1].getbestblockhash()
+        assert_equal(best_hash_0, best_hash_1)
+        assert_equal(self.nodes[0].getblockcount(), expected_height)
+        assert_equal(self.nodes[1].getblockcount(), expected_height)
+        assert_equal(self.nodes[0].getblockheader(best_hash_0)["height"], expected_height)
+        assert_equal(self.nodes[1].getblockheader(best_hash_1)["height"], expected_height)
+        return best_hash_0
+
+    def assert_directional_state_pair(self, local_idx, compared_idx, expected_local_status, expected_compared_status, expected_height):
+        tip_hash = self.assert_same_chain(expected_height)
+        local_info = self.nodes[local_idx].getdeploymentinfo(tip_hash)
+        compared_info = self.nodes[compared_idx].getdeploymentinfo(tip_hash)
+
+        assert_equal(local_info["hash"], tip_hash)
+        assert_equal(compared_info["hash"], tip_hash)
+        assert_equal(local_info["height"], expected_height)
+        assert_equal(compared_info["height"], expected_height)
+
+        local_dep = local_info["deployments"][TAPROOT_REPLACEMENT_NAME]
+        compared_dep = compared_info["deployments"][TAPROOT_REPLACEMENT_NAME]
+
+        assert_equal(local_dep["type"], "bip9")
+        assert_equal(compared_dep["type"], "bip9")
+        assert_equal(local_dep["active"], False)
+        assert_equal(compared_dep["active"], False)
+        assert "height" not in local_dep
+        assert "height" not in compared_dep
+        assert_equal(local_dep["bip9"]["status"], expected_local_status)
+        assert_equal(compared_dep["bip9"]["status"], expected_compared_status)
+        self.log.debug(
+            f"Directional check at height {expected_height}: "
+            f"local node{local_idx}={expected_local_status}, "
+            f"compared node{compared_idx}={expected_compared_status}, "
+            f"tip={tip_hash}"
+        )
+
+    def assert_pre_active_divergence(self, expected_height, signalling_status):
+        # defined -> pre-active signalling/locked_in
+        self.assert_directional_state_pair(0, 1, "defined", signalling_status, expected_height)
+        # pre-active signalling/locked_in -> defined
+        self.assert_directional_state_pair(1, 0, signalling_status, "defined", expected_height)
+
+    def run_test(self):
+        self.miner = MiniWallet(self.nodes[1])
+
+        self.log.info("Restart node1 with regtest vbparams override for taproot_replacement")
+        self.restart_signalling_node()
+
+        self.log.info("Mine to a same-chain defined vs started checkpoint")
+        self.mine_to_height(STARTED_CHECKPOINT_HEIGHT)
+        self.assert_pre_active_divergence(STARTED_CHECKPOINT_HEIGHT, "started")
+
+        self.log.info("Mine to a same-chain defined vs locked_in checkpoint")
+        self.mine_to_height(LOCKED_IN_CHECKPOINT_HEIGHT)
+        self.assert_pre_active_divergence(LOCKED_IN_CHECKPOINT_HEIGHT, "locked_in")
+
+
+if __name__ == '__main__':
+    TaprootReplacementCompatTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -144,6 +144,7 @@ BASE_SCRIPTS = [
     'p2p_sendheaders.py',
     'feature_config_args.py',
     'feature_taproot_replacement_deployment.py',
+    'feature_taproot_replacement_compat.py',
     'wallet_listtransactions.py',
     'wallet_miniscript.py',
     # vv Tests less than 30s vv


### PR DESCRIPTION
## Summary
- add a separate cross-node functional test for pre-active taproot_replacement compatibility
- inventory the new test as pq_backlog + replacement_migration without changing PQ-required gating
- align the migration and CI docs to the new pre-active runtime evidence

## Testing
- python3 /Users/scott/quantum-proof-bitcoin/test/functional/feature_taproot_replacement_compat.py --configfile=/Users/scott/quantum-proof-bitcoin/build/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/build/test/cache
- python3 /Users/scott/quantum-proof-bitcoin/test/functional/feature_taproot_replacement_deployment.py --configfile=/Users/scott/quantum-proof-bitcoin/build/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/build/test/cache
- python3 /Users/scott/quantum-proof-bitcoin/ci/test/check_ci_inventory.py
- git -C /Users/scott/quantum-proof-bitcoin diff --check

## Notes
- local runs of rpc_blockchain.py and interface_rest.py still hit the existing scriptpubkey (-26) failure before deployment-info assertions, so they are not attributed to this change
- refs #23
- refs #13