### PR TITLE
Add taproot replacement active-boundary reporting coverage

### DIFF
--- a/ci/test/check_ci_inventory.py
+++ b/ci/test/check_ci_inventory.py
@@ -18,6 +18,7 @@ VALID_POLICY_CLASSES = {"pq_required", "pq_backlog", "dual_profile", "legacy_onl
 VALID_TAPROOT_MATRIX_BUCKETS = {"legacy_only", "replacement_migration", "deferred"}
 REQUIRED_TAPROOT_MATRIX_BUCKETS = {
     "feature_taproot.py": "legacy_only",
+    "feature_taproot_replacement_active_boundary.py": "replacement_migration",
     "feature_taproot_replacement_compat.py": "replacement_migration",
     "feature_taproot_replacement_deployment.py": "replacement_migration",
     "rpc_createmultisig.py": "deferred",

--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -437,6 +437,14 @@
     "notes": "Cross-node pre-active compatibility coverage for defined vs started and defined vs locked_in reporting divergence on the same accepted chain; classified as replacement_migration while remaining out of the PQ gate."
   },
   {
+    "name": "feature_taproot_replacement_active_boundary.py",
+    "policy_class": "pq_backlog",
+    "taproot_matrix_bucket": "replacement_migration",
+    "owner": "@scottdhughes",
+    "tracking_issue": "#23",
+    "notes": "Cross-node defined vs active reporting-boundary coverage on the same accepted chain using plain blocks only; classified as replacement_migration while remaining out of the PQ gate."
+  },
+  {
     "name": "feature_uacomment.py",
     "policy_class": "dual_profile",
     "owner": "@scottdhughes",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -32,12 +32,12 @@ This tranche does not migrate legacy suites to PQ semantics and does not optimiz
 
 ## Current Inventory Summary
 
-The current functional corpus has `268` tracked test files, classified as:
+The current functional corpus has `269` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
 | `pq_required` | `9` |
-| `pq_backlog` | `103` |
+| `pq_backlog` | `104` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
 
@@ -70,12 +70,13 @@ Explicit legacy-only coverage in this tranche includes:
 
 Inherited Taproot-specific suites remain `legacy_only` in the current CI contract,
 while `feature_taproot_replacement_deployment.py` and
-`feature_taproot_replacement_compat.py` remain `pq_backlog` as replacement-path
-deployment and pre-active compatibility coverage. Their future status is governed
-by `TAPROOT_POSTURE.md` and `TAPROOT_MIGRATION_MATRIX.md`. `policy_class` remains
-the CI gating/ownership surface, while `taproot_matrix_bucket` is
-migration-matrix metadata only and does not change required CI behavior in this
-tranche.
+`feature_taproot_replacement_compat.py` and
+`feature_taproot_replacement_active_boundary.py` remain `pq_backlog` as
+replacement-path deployment, pre-active compatibility, and active-boundary
+reporting coverage. Their future status is governed by `TAPROOT_POSTURE.md` and
+`TAPROOT_MIGRATION_MATRIX.md`. `policy_class` remains the CI gating/ownership
+surface, while `taproot_matrix_bucket` is migration-matrix metadata only and
+does not change required CI behavior in this tranche.
 
 ## Ownership
 

--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -28,8 +28,10 @@ and define the concrete work required for a full-and-complete post-v1 program.
 - post-v1 update: replacement activation family, parameter schema, and rollback envelope are frozen in `TAPROOT_ACTIVATION.md`.
 - post-v1 update: concrete far-future dormant deployment values and the `taproot_replacement` reporting surface are wired into the repo.
 - post-v1 update: directional migration/compatibility matrix and Taproot suite classification are frozen in `TAPROOT_MIGRATION_MATRIX.md`.
+- post-v1 update: runtime evidence now covers the pre-active rows and the defined vs active reporting boundary using plain blocks only.
 - full-complete delta:
-  - implement the cross-version compatibility and migration functional suites for the replacement path
+  - implement the first true active-semantic compatibility tranche for the replacement path
+  - implement the deferred cross-version migration functional suites for the replacement path
 
 ### 3. PQ-first CI profile
 - v1 state: default CI gates PQ suites; legacy profile is explicit opt-in.

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -18,7 +18,7 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 
 2. Taproot posture beyond v1
 - Scope: frozen explicit-replacement posture, concrete dormant replacement deployment/reporting path, frozen migration matrix, and compatibility tests.
-- Current state: frozen posture, activation, deployment/reporting, and pre-active runtime compatibility evidence are now checked in; remaining work is active-replacement compatibility and the deferred Taproot-facing surfaces tracked under `#23`.
+- Current state: frozen posture, activation, deployment/reporting, pre-active runtime compatibility evidence, and the defined vs active reporting boundary are now checked in; remaining work is the first true active-semantic compatibility slice and the deferred Taproot-facing surfaces tracked under `#23`.
 - Exit criteria: frozen replacement posture, concrete dormant deployment/reporting path, and implemented cross-version validation against the frozen matrix.
 
 3. Multi-algorithm evolution (`ALG_ID` registry)

--- a/docs/TAPROOT_MIGRATION_MATRIX.md
+++ b/docs/TAPROOT_MIGRATION_MATRIX.md
@@ -59,8 +59,10 @@ The matrix is directional. Each row is evaluated as `local state -> observed/com
 | `SIGNALING` | `DORMANT_BASELINE` | `same-consensus / pre-active deployment divergence` | Same as above from the opposite observation direction. | Regtest-only deployment-status coverage. |
 | `DORMANT_BASELINE` | `LOCKED_IN_PRE_ACTIVE` | `same-consensus / pre-active deployment divergence` | Historical baseline and regtest lock-in may disagree on deployment status only. No approved replacement semantics exist. | Regtest-only deployment-status coverage. |
 | `LOCKED_IN_PRE_ACTIVE` | `DORMANT_BASELINE` | `same-consensus / pre-active deployment divergence` | Same as above from the opposite observation direction. | Regtest-only deployment-status coverage. |
-| `*` | `ACTIVE_REPLACEMENT` | `future-active compatibility reserved` | Any pairing involving future active replacement is reserved for later implementation work. This document does not define active replacement semantics. | Bucket and inventory now; implementation later. |
-| `ACTIVE_REPLACEMENT` | `*` | `future-active compatibility reserved` | Any pairing involving future active replacement is reserved for later implementation work. This document does not define active replacement semantics. | Bucket and inventory now; implementation later. |
+| `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `ACTIVE_REPLACEMENT` | `same-consensus / reporting-only divergence` | Versionbits/deployment reporting may diverge while the nodes remain on the same accepted chain, provided only plain blocks are exercised. This is not evidence of replacement witness-v1 semantics. | Plain-block same-chain reporting assertions only. |
+| `ACTIVE_REPLACEMENT` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `same-consensus / reporting-only divergence` | Same as above from the opposite observation direction. This is not evidence of replacement witness-v1 semantics. | Plain-block same-chain reporting assertions only. |
+| `*` | `ACTIVE_REPLACEMENT` | `future-active compatibility reserved` | Any remaining pairing involving future active replacement is reserved for later implementation work. This document does not define active replacement semantics. | Bucket and inventory now; implementation later. |
+| `ACTIVE_REPLACEMENT` | `*` | `future-active compatibility reserved` | Any remaining pairing involving future active replacement is reserved for later implementation work. This document does not define active replacement semantics. | Bucket and inventory now; implementation later. |
 
 ## Coverage Guardrails
 
@@ -71,21 +73,37 @@ The matrix is directional. Each row is evaluated as `local state -> observed/com
    approved merely because deployment reporting exists.
 4. This matrix freezes what is comparable today; it does not speculate about
    active replacement semantics beyond reserving them for later work.
+5. Runtime evidence for `ACTIVE_REPLACEMENT` in this slice is limited to plain
+   blocks and deployment reporting only.
 
 ## Implemented Pre-Active Runtime Evidence
 
 The opening slice of `#23` froze this matrix and its suite classification. The
-current runtime slice adds evidence for the currently exercisable pre-active rows
+current runtime slices add evidence for the currently exercisable reporting rows
 without changing the matrix meaning:
 
 1. `feature_taproot_replacement_deployment.py` remains the single-node proof of
    concrete dormant replacement deployment reporting and regtest BIP9 override
-   transitions.
+   transitions through the exact active boundary.
 2. `feature_taproot_replacement_compat.py` adds cross-node runtime evidence for
    `DEPLOYMENT_DEFINED_NOT_SIGNALING <-> SIGNALING` and
    `DEPLOYMENT_DEFINED_NOT_SIGNALING <-> LOCKED_IN_PRE_ACTIVE` on the same
    accepted chain, with `active = false` on both nodes.
-3. Any row involving `ACTIVE_REPLACEMENT` remains explicitly deferred.
+3. `feature_taproot_replacement_active_boundary.py` adds cross-node runtime
+   evidence for `DEPLOYMENT_DEFINED_NOT_SIGNALING <-> ACTIVE_REPLACEMENT` on the
+   same accepted chain using plain blocks only.
+4. Active replacement semantics remain explicitly deferred.
+
+## Explicit-Replacement Semantic Guard
+
+The current repo evidence for `ACTIVE_REPLACEMENT` is limited to versionbits and
+deployment reporting reaching `active`.
+
+This slice does **not** bless inherited Taproot witness-v1, bech32m, `tr(...)`,
+or P2TR transaction behavior as PQBTC replacement behavior. The inspected
+consensus and networking activation hooks for witness handling remain tied to
+`DEPLOYMENT_SEGWIT`, not `DEPLOYMENT_TAPROOT`, so this matrix freezes only the
+reporting boundary here.
 
 ## Frozen Suite Classification
 
@@ -95,6 +113,7 @@ without changing the matrix meaning:
 | `wallet_taproot.py` | `legacy_only` | `legacy_only` | Explicit inherited Taproot wallet coverage; not a PQBTC replacement target as-is. |
 | `feature_taproot_replacement_deployment.py` | `pq_backlog` | `replacement_migration` | Directly exercises the frozen dormant replacement deployment/reporting path and regtest pre-active BIP9 transitions. |
 | `feature_taproot_replacement_compat.py` | `pq_backlog` | `replacement_migration` | Adds cross-node evidence that defined, started, and locked_in pre-active states can diverge in reporting while remaining on the same accepted chain. |
+| `feature_taproot_replacement_active_boundary.py` | `pq_backlog` | `replacement_migration` | Adds cross-node evidence that defined and active reporting can diverge on the same accepted chain using plain blocks only, without defining active semantics. |
 | `rpc_createmultisig.py` | `dual_profile` | `deferred` | Contains Taproot-adjacent bech32m coverage, but replacement-specific semantics are not yet defined. |
 | `rpc_psbt.py` | `dual_profile` | `deferred` | Contains Taproot-facing PSBT surfaces, but replacement-specific semantics are not yet defined. |
 | `wallet_address_types.py` | `dual_profile` | `deferred` | Contains bech32m/Taproot-facing address branches, but replacement-specific semantics are not yet defined. |
@@ -114,7 +133,9 @@ This slice does **not** define:
 ## Downstream Boundary
 
 The opening slice of `#23` froze the directional matrix and suite classification.
-This runtime slice implements the currently exercisable pre-active evidence only.
+The current runtime slices implement the currently exercisable reporting rows
+only.
 
-Remaining `#23` work after this slice is the active-replacement compatibility and
-the deferred Taproot-facing migration suites implied by this matrix.
+Remaining `#23` work after this slice is the first true active-semantic
+compatibility tranche and the deferred Taproot-facing migration suites implied
+by this matrix.

--- a/test/functional/feature_taproot_replacement_active_boundary.py
+++ b/test/functional/feature_taproot_replacement_active_boundary.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test defined vs active Taproot replacement reporting boundary.
+
+Validate that the frozen replacement deployment can reach ACTIVE_REPLACEMENT on
+regtest while a default node remains DEPLOYMENT_DEFINED_NOT_SIGNALING, and that
+the nodes can still share the same accepted chain when only plain blocks are
+mined.
+"""
+
+from test_framework.blocktools import TIME_GENESIS_BLOCK
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+TAPROOT_REPLACEMENT_NAME = "taproot_replacement"
+NO_TIMEOUT = 0x7fffffffffffffff
+TIME_STEP = 600
+ACTIVE_HEIGHT = 432
+
+
+class TaprootReplacementActiveBoundaryTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.supports_cli = False
+
+    def set_network_mocktime(self, height):
+        mocktime = TIME_GENESIS_BLOCK + height * TIME_STEP
+        for node in self.nodes:
+            node.setmocktime(mocktime)
+
+    def restart_active_node(self):
+        self.restart_node(1, extra_args=[f"-vbparams={TAPROOT_REPLACEMENT_NAME}:0:{NO_TIMEOUT}"])
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
+
+    def mine_to_height(self, target):
+        while self.nodes[1].getblockcount() < target:
+            next_height = self.nodes[1].getblockcount() + 1
+            self.set_network_mocktime(next_height)
+            self.generate(self.nodes[1], 1, sync_fun=self.sync_blocks)
+
+    def assert_same_chain(self, expected_height):
+        best_hash_0 = self.nodes[0].getbestblockhash()
+        best_hash_1 = self.nodes[1].getbestblockhash()
+        assert_equal(best_hash_0, best_hash_1)
+        assert_equal(self.nodes[0].getblockcount(), expected_height)
+        assert_equal(self.nodes[1].getblockcount(), expected_height)
+        return best_hash_0
+
+    def assert_directional_state_pair(self, local_idx, compared_idx, expected_local_status, expected_local_active, expected_compared_status, expected_compared_active):
+        tip_hash = self.assert_same_chain(ACTIVE_HEIGHT)
+        local_info = self.nodes[local_idx].getdeploymentinfo(tip_hash)
+        compared_info = self.nodes[compared_idx].getdeploymentinfo(tip_hash)
+
+        assert_equal(local_info["hash"], tip_hash)
+        assert_equal(compared_info["hash"], tip_hash)
+        assert_equal(local_info["height"], ACTIVE_HEIGHT)
+        assert_equal(compared_info["height"], ACTIVE_HEIGHT)
+
+        local_dep = local_info["deployments"][TAPROOT_REPLACEMENT_NAME]
+        compared_dep = compared_info["deployments"][TAPROOT_REPLACEMENT_NAME]
+
+        assert_equal(local_dep["type"], "bip9")
+        assert_equal(compared_dep["type"], "bip9")
+        assert_equal(local_dep["active"], expected_local_active)
+        assert_equal(compared_dep["active"], expected_compared_active)
+        assert_equal(local_dep["bip9"]["status"], expected_local_status)
+        assert_equal(compared_dep["bip9"]["status"], expected_compared_status)
+
+        if expected_local_active:
+            assert_equal(local_dep["height"], ACTIVE_HEIGHT)
+        else:
+            assert "height" not in local_dep
+
+        if expected_compared_active:
+            assert_equal(compared_dep["height"], ACTIVE_HEIGHT)
+        else:
+            assert "height" not in compared_dep
+
+    def run_test(self):
+        self.log.info("Restart node1 with regtest vbparams override for taproot_replacement")
+        self.restart_active_node()
+
+        self.log.info("Mine plain blocks only to the active boundary")
+        self.mine_to_height(ACTIVE_HEIGHT)
+
+        self.log.info("Assert defined -> active reporting-only divergence on the same accepted chain")
+        self.assert_directional_state_pair(
+            0,
+            1,
+            "defined",
+            False,
+            "active",
+            True,
+        )
+
+        self.log.info("Assert active -> defined reporting-only divergence on the same accepted chain")
+        self.assert_directional_state_pair(
+            1,
+            0,
+            "active",
+            True,
+            "defined",
+            False,
+        )
+
+
+if __name__ == '__main__':
+    TaprootReplacementActiveBoundaryTest(__file__).main()

--- a/test/functional/feature_taproot_replacement_compat.py
+++ b/test/functional/feature_taproot_replacement_compat.py
@@ -15,7 +15,6 @@ pre-active deployment reporting state.
 from test_framework.blocktools import TIME_GENESIS_BLOCK
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
-from test_framework.wallet import MiniWallet
 
 
 TAPROOT_REPLACEMENT_NAME = "taproot_replacement"
@@ -40,13 +39,12 @@ class TaprootReplacementCompatTest(BitcoinTestFramework):
         while self.nodes[1].getblockcount() < target:
             next_height = self.nodes[1].getblockcount() + 1
             self.set_network_mocktime(next_height)
-            self.generate(self.miner, 1, sync_fun=self.sync_blocks)
+            self.generate(self.nodes[1], 1, sync_fun=self.sync_blocks)
 
     def restart_signalling_node(self):
         self.restart_node(1, extra_args=[f"-vbparams={TAPROOT_REPLACEMENT_NAME}:0:{NO_TIMEOUT}"])
         self.connect_nodes(0, 1)
         self.sync_blocks()
-        self.miner = MiniWallet(self.nodes[1])
 
     def assert_same_chain(self, expected_height):
         best_hash_0 = self.nodes[0].getbestblockhash()
@@ -93,8 +91,6 @@ class TaprootReplacementCompatTest(BitcoinTestFramework):
         self.assert_directional_state_pair(1, 0, signalling_status, "defined", expected_height)
 
     def run_test(self):
-        self.miner = MiniWallet(self.nodes[1])
-
         self.log.info("Restart node1 with regtest vbparams override for taproot_replacement")
         self.restart_signalling_node()
 

--- a/test/functional/feature_taproot_replacement_deployment.py
+++ b/test/functional/feature_taproot_replacement_deployment.py
@@ -12,7 +12,6 @@ existing BIP9 reporting surface for the replacement slot.
 from test_framework.blocktools import TIME_GENESIS_BLOCK
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
-from test_framework.wallet import MiniWallet
 
 
 TAPROOT_REPLACEMENT_NAME = "taproot_replacement"
@@ -22,6 +21,10 @@ NO_TIMEOUT = 0x7fffffffffffffff
 VB_PERIOD = 144
 VB_THRESHOLD = 108
 TIME_STEP = 600
+STARTED_CHECKPOINT_HEIGHT = 207
+LOCKED_IN_TRANSITION_HEIGHT = 287
+ACTIVE_TRANSITION_HEIGHT = 431
+ACTIVE_HEIGHT = 432
 
 
 class TaprootReplacementDeploymentTest(BitcoinTestFramework):
@@ -34,7 +37,7 @@ class TaprootReplacementDeploymentTest(BitcoinTestFramework):
         while self.nodes[0].getblockcount() < target:
             next_height = self.nodes[0].getblockcount() + 1
             self.nodes[0].setmocktime(TIME_GENESIS_BLOCK + next_height * TIME_STEP)
-            self.generate(self.wallet, 1)
+            self.generate(self.nodes[0], 1)
 
     def assert_default_defined(self):
         deployment_info = self.nodes[0].getdeploymentinfo()
@@ -84,19 +87,69 @@ class TaprootReplacementDeploymentTest(BitcoinTestFramework):
         assert_equal(stats["possible"], True)
         assert_equal(bip9["signalling"], "#" * (height - 143))
 
+    def assert_locked_in_transition(self, height):
+        deployment_info = self.nodes[0].getdeploymentinfo()
+        assert_equal(deployment_info["height"], height)
+
+        dep = deployment_info["deployments"][TAPROOT_REPLACEMENT_NAME]
+        assert_equal(dep["type"], "bip9")
+        assert_equal(dep["active"], True)
+        assert_equal(dep["height"], ACTIVE_HEIGHT)
+
+        bip9 = dep["bip9"]
+        assert_equal(bip9["bit"], 2)
+        assert_equal(bip9["start_time"], 0)
+        assert_equal(bip9["timeout"], NO_TIMEOUT)
+        assert_equal(bip9["min_activation_height"], 0)
+        assert_equal(bip9["status"], "locked_in")
+        assert_equal(bip9["status_next"], "active")
+        assert_equal(bip9["since"], 288)
+
+        stats = bip9["statistics"]
+        assert_equal(stats["period"], VB_PERIOD)
+        assert_equal(stats["elapsed"], height - 287)
+        assert_equal(stats["count"], height - 287)
+        assert "threshold" not in stats
+        assert "possible" not in stats
+        assert_equal(bip9["signalling"], "#" * (height - 287))
+
+    def assert_active_state(self, height):
+        deployment_info = self.nodes[0].getdeploymentinfo()
+        assert_equal(deployment_info["height"], height)
+
+        dep = deployment_info["deployments"][TAPROOT_REPLACEMENT_NAME]
+        assert_equal(dep["type"], "bip9")
+        assert_equal(dep["active"], True)
+        assert_equal(dep["height"], ACTIVE_HEIGHT)
+
+        bip9 = dep["bip9"]
+        assert_equal(bip9["start_time"], 0)
+        assert_equal(bip9["timeout"], NO_TIMEOUT)
+        assert_equal(bip9["min_activation_height"], 0)
+        assert_equal(bip9["status"], "active")
+        assert_equal(bip9["status_next"], "active")
+        assert_equal(bip9["since"], ACTIVE_HEIGHT)
+        assert "bit" not in bip9
+        assert "statistics" not in bip9
+        assert "signalling" not in bip9
+
     def run_test(self):
-        self.wallet = MiniWallet(self.nodes[0])
         self.assert_default_defined()
 
         self.stop_node(0)
         self.start_node(0, extra_args=[f"-vbparams={TAPROOT_REPLACEMENT_NAME}:0:{NO_TIMEOUT}"])
-        self.wallet = MiniWallet(self.nodes[0])
 
-        self.mine_to_height(207)
-        self.assert_signalling_state(207, "started")
+        self.mine_to_height(STARTED_CHECKPOINT_HEIGHT)
+        self.assert_signalling_state(STARTED_CHECKPOINT_HEIGHT, "started")
 
-        self.mine_to_height(287)
-        self.assert_signalling_state(287, "locked_in")
+        self.mine_to_height(LOCKED_IN_TRANSITION_HEIGHT)
+        self.assert_signalling_state(LOCKED_IN_TRANSITION_HEIGHT, "locked_in")
+
+        self.mine_to_height(ACTIVE_TRANSITION_HEIGHT)
+        self.assert_locked_in_transition(ACTIVE_TRANSITION_HEIGHT)
+
+        self.mine_to_height(ACTIVE_HEIGHT)
+        self.assert_active_state(ACTIVE_HEIGHT)
 
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -145,6 +145,7 @@ BASE_SCRIPTS = [
     'feature_config_args.py',
     'feature_taproot_replacement_deployment.py',
     'feature_taproot_replacement_compat.py',
+    'feature_taproot_replacement_active_boundary.py',
     'wallet_listtransactions.py',
     'wallet_miniscript.py',
     # vv Tests less than 30s vv


### PR DESCRIPTION
## Summary
- extend taproot replacement deployment coverage through the locked_in -> active boundary
- add a separate cross-node defined vs active reporting-boundary test using plain blocks only
- freeze the reporting-only active-boundary semantics in the migration docs and inventory

## Testing
- python3 /Users/scott/quantum-proof-bitcoin/test/functional/feature_taproot_replacement_deployment.py --configfile=/Users/scott/quantum-proof-bitcoin/build/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/build/test/cache
- python3 /Users/scott/quantum-proof-bitcoin/test/functional/feature_taproot_replacement_compat.py --configfile=/Users/scott/quantum-proof-bitcoin/build/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/build/test/cache
- python3 /Users/scott/quantum-proof-bitcoin/test/functional/feature_taproot_replacement_active_boundary.py --configfile=/Users/scott/quantum-proof-bitcoin/build/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/build/test/cache
- python3 /Users/scott/quantum-proof-bitcoin/ci/test/check_ci_inventory.py
- git -C /Users/scott/quantum-proof-bitcoin diff --check

Refs #23
Refs #13