### PR TITLE
[codex] taproot: add first active PQ-native replacement seam

### DIFF
--- a/ci/test/check_ci_inventory.py
+++ b/ci/test/check_ci_inventory.py
@@ -19,6 +19,7 @@ VALID_TAPROOT_MATRIX_BUCKETS = {"legacy_only", "replacement_migration", "deferre
 REQUIRED_TAPROOT_MATRIX_BUCKETS = {
     "feature_taproot.py": "legacy_only",
     "feature_taproot_replacement_active_boundary.py": "replacement_migration",
+    "feature_taproot_replacement_active_positive_seam.py": "replacement_migration",
     "feature_taproot_replacement_active_semantic_guard.py": "replacement_migration",
     "feature_taproot_replacement_compat.py": "replacement_migration",
     "feature_taproot_replacement_deployment.py": "replacement_migration",

--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -453,6 +453,14 @@
     "notes": "Negative-control active-semantic coverage for inherited Taproot rejection under ACTIVE_REPLACEMENT; classified as replacement_migration while remaining out of the PQ gate."
   },
   {
+    "name": "feature_taproot_replacement_active_positive_seam.py",
+    "policy_class": "pq_backlog",
+    "taproot_matrix_bucket": "replacement_migration",
+    "owner": "@scottdhughes",
+    "tracking_issue": "#23",
+    "notes": "Positive active-semantic coverage for the first PQ-native witness-v1 replacement-script-hash block-validation seam under ACTIVE_REPLACEMENT; classified as replacement_migration while remaining out of the PQ gate."
+  },
+  {
     "name": "feature_uacomment.py",
     "policy_class": "dual_profile",
     "owner": "@scottdhughes",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -32,12 +32,12 @@ This tranche does not migrate legacy suites to PQ semantics and does not optimiz
 
 ## Current Inventory Summary
 
-The current functional corpus has `270` tracked test files, classified as:
+The current functional corpus has `271` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
 | `pq_required` | `9` |
-| `pq_backlog` | `105` |
+| `pq_backlog` | `106` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
 
@@ -72,10 +72,12 @@ Inherited Taproot-specific suites remain `legacy_only` in the current CI contrac
 while `feature_taproot_replacement_deployment.py` and
 `feature_taproot_replacement_compat.py` and
 `feature_taproot_replacement_active_boundary.py` and
+`feature_taproot_replacement_active_positive_seam.py` and
 `feature_taproot_replacement_active_semantic_guard.py` remain `pq_backlog` as
 replacement-path deployment, pre-active compatibility, active-boundary
-reporting, and negative-control active-semantic coverage. Their future status is
-governed by `TAPROOT_POSTURE.md` and `TAPROOT_MIGRATION_MATRIX.md`.
+reporting, first-positive active-semantic, and negative-control
+active-semantic coverage. Their future status is governed by
+`TAPROOT_POSTURE.md` and `TAPROOT_MIGRATION_MATRIX.md`.
 `policy_class` remains the CI gating/ownership surface, while
 `taproot_matrix_bucket` is migration-matrix metadata only and does not change
 required CI behavior in this tranche.

--- a/docs/CONSENSUS_DIFFS.md
+++ b/docs/CONSENSUS_DIFFS.md
@@ -21,4 +21,7 @@ Future witness-v1 replacement posture is frozen in `TAPROOT_POSTURE.md`, and the
 replacement activation/rollback model plus concrete dormant deployment values are
 frozen in `TAPROOT_ACTIVATION.md`. This v1 ledger records only the shipped v1
 consensus diffs and does not approve inherited Taproot activation semantics for a
-later tranche.
+later tranche. The first later-tranche positive seam is now frozen as a
+block-validation-only witness-v1 / 32-byte / non-P2SH replacement-script-hash
+path with `SHA256(revealed_script) == program` and fixed `SIGHASH_ALL`; it does
+not define generic witness-v1, mempool, relay, or policy semantics.

--- a/docs/CONSENSUS_SURFACE.md
+++ b/docs/CONSENSUS_SURFACE.md
@@ -23,6 +23,10 @@
 - Future witness-v1 posture is frozen in `TAPROOT_POSTURE.md`.
 - Activation/deployment/rollback model and concrete dormant replacement deployment values are frozen in `TAPROOT_ACTIVATION.md`.
 - Inherited Taproot semantics are not the future activation target as-is.
+- The first positive post-v1 seam is now frozen as a block-validation-only
+  witness-v1 / 32-byte / non-P2SH replacement-script-hash path with
+  `SHA256(revealed_script) == program`, fixed `SIGHASH_ALL`, and no generic
+  witness-v1, mempool, relay, or policy meaning.
 
 ## Out of Scope for v1
 - Wallet UX for keypool batching and recovery flows.

--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -30,9 +30,10 @@ and define the concrete work required for a full-and-complete post-v1 program.
 - post-v1 update: directional migration/compatibility matrix and Taproot suite classification are frozen in `TAPROOT_MIGRATION_MATRIX.md`.
 - post-v1 update: runtime evidence now covers the pre-active rows and the defined vs active reporting boundary using plain blocks only.
 - post-v1 update: the first active-semantic runtime seam is now checked in as a negative-control guard that rejects inherited Taproot witness-v1 block spends under `ACTIVE_REPLACEMENT`.
+- post-v1 update: the first positive PQ-native active-semantic seam is now checked in as a block-validation-only witness-v1 / 32-byte / non-P2SH replacement-script-hash path with `SHA256(revealed_script) == program`, a revealed script of exactly `<33-byte pk_script> OP_CHECKSIG`, and fixed `SIGHASH_ALL`.
 - full-complete delta:
-  - implement the first positive PQ-native active-semantic compatibility tranche for the replacement path
   - implement the deferred cross-version migration functional suites for the replacement path
+  - define any broader active witness-v1, mempool, relay, policy, wallet, RPC, descriptor, address, or PSBT semantics beyond the first positive seam
 
 ### 3. PQ-first CI profile
 - v1 state: default CI gates PQ suites; legacy profile is explicit opt-in.

--- a/docs/POST_RC_EPICS.md
+++ b/docs/POST_RC_EPICS.md
@@ -18,7 +18,7 @@ Execution tracker for work required after `v1.0.0-rc1` to reach full-and-complet
 
 2. Taproot posture beyond v1
 - Scope: frozen explicit-replacement posture, concrete dormant replacement deployment/reporting path, frozen migration matrix, and compatibility tests.
-- Current state: frozen posture, activation, deployment/reporting, pre-active runtime compatibility evidence, the defined vs active reporting boundary, and the first active-semantic negative-control guard are now checked in; remaining work is the first positive PQ-native active-semantic slice and the deferred Taproot-facing surfaces tracked under `#23`.
+- Current state: frozen posture, activation, deployment/reporting, pre-active runtime compatibility evidence, the defined vs active reporting boundary, the first active-semantic negative-control guard, and the first positive PQ-native block-validation seam are now checked in; remaining work is the deferred Taproot-facing wallet/RPC/descriptor/PSBT migration surface tracked under `#23`.
 - Exit criteria: frozen replacement posture, concrete dormant deployment/reporting path, and implemented cross-version validation against the frozen matrix.
 
 3. Multi-algorithm evolution (`ALG_ID` registry)

--- a/docs/TAPROOT_ACTIVATION.md
+++ b/docs/TAPROOT_ACTIVATION.md
@@ -36,9 +36,12 @@ unconfigured:
 
 The future active path, if ever deployed, is a PQ-native replacement path. It is
 not inherited BIP341/BIP342 Taproot semantics switched on as-is.
-The first owned active-semantic runtime seam now checked in is negative-control
-only: `ACTIVE_REPLACEMENT` explicitly rejects inherited witness-v1 Taproot block
-spends, and does not yet approve any positive PQ-native witness-v1 behavior.
+The current repo now owns two narrow active-semantic runtime seams:
+`ACTIVE_REPLACEMENT` explicitly rejects inherited witness-v1 Taproot block
+spends, and also accepts one positive PQ-native witness-v1 replacement seam.
+That positive seam is block-validation-only and does not define generic
+witness-v1, mempool, relay, policy, wallet, address, descriptor, RPC, or PSBT
+behavior.
 
 ## Mechanism Family Decision
 
@@ -125,11 +128,17 @@ operator phase is a distinct code state.
 - The PQ-native replacement path becomes active.
 - Only at this phase may downstream implementation tranches activate replacement-specific
   witness-v1/address/wallet/descriptor/PSBT/RPC behavior.
-- The current repo owns one negative-control semantic guard at this phase:
-  inherited witness-v1 Taproot block spends are explicitly rejected once
-  `ACTIVE_REPLACEMENT` is live.
-- This tranche still does not define any positive PQ-native active semantics; it
-  only defines when such semantics become eligible for later implementation.
+- The current repo owns two narrow witness-v1 semantic seams at this phase:
+  - inherited witness-v1 Taproot block spends are explicitly rejected as a
+    negative control
+  - one PQ-native replacement block-validation seam is accepted when the spend
+    is witness-v1 / 32-byte / non-P2SH, `SHA256(revealed_script) == program`,
+    the revealed script is exactly `<33-byte pk_script> OP_CHECKSIG`, and the
+    existing PQ witness-script engine is reused with fixed `SIGHASH_ALL`
+- This tranche still does not define generic witness-v1 semantics, keypath,
+  tree/tapscript, annex, mempool, relay, policy, wallet, descriptor, PSBT,
+  address, or RPC behavior. It only defines the first owned positive seam and
+  when broader semantics become eligible for later implementation.
 
 ### `ABORTED_PRE_ACTIVATION`
 - This is an operator/governance outcome, not a standalone BIP9 state.
@@ -216,13 +225,13 @@ started deployment instance. It is not a post-activation rollback concept.
 | Surface | `DORMANT_BASELINE` / `SPEC_FROZEN_NOT_DEPLOYING` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` / `SIGNALING` / `LOCKED_IN_PRE_ACTIVE` | `ACTIVE_REPLACEMENT` | Downstream owner |
 |---|---|---|---|---|
 | Deployment state / `getdeploymentinfo` posture | Current repo exposes a concrete far-future dormant `taproot_replacement` deployment; no replacement semantics are active | Deployment reporting may reflect BIP9 lifecycle, but no replacement semantics are active | Eligible for later implementation under the replacement rules | `#22` |
-| Witness-v1 output acceptance | Dormant inventory only | Unchanged; no approved activation during pre-active phases | Inherited Taproot witness-v1 block spends are explicitly rejected as negative-control evidence; positive PQ-native witness-v1 rules remain deferred | `#22` then `#23` |
+| Witness-v1 output acceptance | Dormant inventory only | Unchanged; no approved activation during pre-active phases | Inherited Taproot witness-v1 block spends are explicitly rejected as negative-control evidence, and one positive PQ-native witness-v1 / 32-byte / non-P2SH replacement-script-hash seam is accepted in block validation when `SHA256(revealed_script) == program`, the revealed script is exactly `<33-byte pk_script> OP_CHECKSIG`, and execution reuses the PQ witness-script engine with fixed `SIGHASH_ALL`; generic witness-v1, keypath, tree/tapscript, annex, mempool, relay, policy, wallet, address, descriptor, RPC, and PSBT semantics remain deferred | `#22` then `#23` |
 | Address encoding and reporting | Dormant inventory only | Unchanged; existing code is not approval for use | Eligible only after replacement-specific address/output rules are implemented | `#22` |
 | Wallet capability surfaces such as `taprootEnabled()` | Dormant inventory only | Unchanged; no approved wallet activation during pre-active phases | Eligible only after replacement-specific wallet behavior is defined | `#22` then `#23` |
 | Descriptor `tr(...)` | Legacy-only inventory surface | Unchanged; not approved for use during pre-active phases | Migration classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; replacement semantics remain deferred | `#23` |
 | PSBT Taproot fields | Legacy-only inventory surface | Unchanged; not approved for replacement use during pre-active phases | Migration classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; replacement semantics remain deferred | `#23` |
 | RPC create/decode/reporting surfaces | Dormant or legacy-only inventory surfaces | Unchanged; reporting does not imply approved replacement semantics | Migration classification is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; replacement-specific behavior remains deferred | `#22` then `#23` |
-| Functional Taproot suites | Legacy-only coverage | Unchanged | Migration relevance is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; runtime evidence now includes the negative-control active-semantic guard while broader active semantics remain deferred | `#23` |
+| Functional Taproot suites | Legacy-only coverage | Unchanged | Migration relevance is now frozen in `TAPROOT_MIGRATION_MATRIX.md`; runtime evidence now includes the negative-control guard and the first positive block-validation-only active seam while broader active semantics remain deferred | `#23` |
 | CI classification posture | Inherited Taproot suites remain `legacy_only`; replacement deployment reporting remains `pq_backlog` | Unchanged | `policy_class` remains frozen while `taproot_matrix_bucket` carries migration metadata only | `#23` |
 
 ## Release-Gating Baseline

--- a/docs/TAPROOT_MIGRATION_MATRIX.md
+++ b/docs/TAPROOT_MIGRATION_MATRIX.md
@@ -12,8 +12,9 @@ Taproot path.
 
 This document is the canonical future-facing authority for how PQBTC classifies
 Taproot-facing migration coverage across the already-frozen dormant, pre-active,
-and narrowly-owned negative-control active states. It does not define any
-positive PQ-native active replacement seam.
+and narrowly-owned active states. It now defines exactly one positive
+PQ-native active replacement seam, and keeps all remaining active semantics
+reserved.
 
 ## Current Inputs
 
@@ -24,6 +25,7 @@ This matrix builds on already-frozen inputs:
 3. The current repo state is `DEPLOYMENT_DEFINED_NOT_SIGNALING` with concrete but
    far-future dormant `taproot_replacement` deployment values.
 4. No dormant Taproot-facing surface is approved merely because code or reporting exists.
+5. Any positive active seam must be written down here before code or tests rely on it.
 
 ## Normative Bucket Definitions
 
@@ -42,6 +44,7 @@ This matrix freezes four compatibility outcome classes:
 - `same-consensus / reporting-only divergence`
 - `same-consensus / pre-active deployment divergence`
 - `active-semantic divergence / inherited-taproot rejected`
+- `active-semantic divergence / pq-native replacement accepted`
 - `future-active compatibility reserved`
 
 The matrix is directional. Each row is evaluated as `local state -> observed/compared state`.
@@ -64,8 +67,10 @@ The matrix is directional. Each row is evaluated as `local state -> observed/com
 | `ACTIVE_REPLACEMENT` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `same-consensus / reporting-only divergence` | Same as above from the opposite observation direction. This is not evidence of replacement witness-v1 semantics. | Plain-block same-chain reporting assertions only. |
 | `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `ACTIVE_REPLACEMENT` | `active-semantic divergence / inherited-taproot rejected` | For the inherited witness-v1 Taproot negative-control fixture, the defined node may accept a block that the active node rejects. This is negative-control active evidence only: it proves inherited Taproot semantics are not the replacement path and does not define any positive PQ-native active seam. | Cross-node block-validation negative-control fixture only. |
 | `ACTIVE_REPLACEMENT` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `active-semantic divergence / inherited-taproot rejected` | Same as above from the opposite observation direction. The active node rejects inherited Taproot witness-v1 semantics while the defined node still accepts the negative-control fixture. | Cross-node block-validation negative-control fixture only. |
-| `*` | `ACTIVE_REPLACEMENT` | `future-active compatibility reserved` | Any remaining pairing involving future active replacement beyond the explicit plain-block reporting rows and inherited-Taproot negative-control rows is reserved for later implementation work. This document does not define positive active replacement semantics. | Bucket and inventory now; implementation later. |
-| `ACTIVE_REPLACEMENT` | `*` | `future-active compatibility reserved` | Any remaining pairing involving future active replacement beyond the explicit plain-block reporting rows and inherited-Taproot negative-control rows is reserved for later implementation work. This document does not define positive active replacement semantics. | Bucket and inventory now; implementation later. |
+| `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `ACTIVE_REPLACEMENT` | `active-semantic divergence / pq-native replacement accepted` | For the first positive PQ-native seam, the defined node rejects a raw witness-v1 / 32-byte / non-P2SH replacement block that the active node accepts. This seam is block-validation-only: `SHA256(revealed_script) == program`, the revealed script is the exact PQ single-sig script `<33-byte pk_script> OP_CHECKSIG`, and execution reuses the existing PQ witness-script engine with fixed `SIGHASH_ALL`. It does not define generic witness-v1, keypath, tree, tapscript, annex, mempool, relay, policy, wallet, descriptor, RPC, address, or PSBT semantics. | Cross-node raw block positive fixture only. |
+| `ACTIVE_REPLACEMENT` | `DEPLOYMENT_DEFINED_NOT_SIGNALING` | `active-semantic divergence / pq-native replacement accepted` | Same as above from the opposite observation direction. The active node accepts the first positive PQ-native replacement fixture while the defined node rejects it under inherited witness-v1 handling. | Cross-node raw block positive fixture only. |
+| `*` | `ACTIVE_REPLACEMENT` | `future-active compatibility reserved` | Any remaining pairing involving future active replacement beyond the explicit plain-block reporting rows, inherited-Taproot negative-control rows, and the single positive replacement-script-hash row is reserved for later implementation work. | Bucket and inventory now; implementation later. |
+| `ACTIVE_REPLACEMENT` | `*` | `future-active compatibility reserved` | Any remaining pairing involving future active replacement beyond the explicit plain-block reporting rows, inherited-Taproot negative-control rows, and the single positive replacement-script-hash row is reserved for later implementation work. | Bucket and inventory now; implementation later. |
 
 ## Coverage Guardrails
 
@@ -75,11 +80,14 @@ The matrix is directional. Each row is evaluated as `local state -> observed/com
 3. No wallet, RPC, descriptor, PSBT, address, or witness-v1 behavior becomes
    approved merely because deployment reporting exists.
 4. This matrix freezes what is comparable today; it does not speculate about
-   active replacement semantics beyond reserving them for later work.
+   active replacement semantics beyond the explicit negative-control row and
+   the single positive replacement-script-hash row.
 5. Runtime evidence for `ACTIVE_REPLACEMENT` in the current repo is limited to:
    - plain-block same-chain reporting compatibility
    - inherited Taproot negative-control rejection
-6. No positive PQ-native active replacement seam is defined by this matrix.
+   - one block-validation-only PQ-native witness-v1 replacement script-hash seam
+6. No mempool, relay, or policy behavior is defined by this matrix.
+7. No wallet, RPC, descriptor, address, or PSBT meaning is defined by this matrix.
 
 ## Implemented Runtime Evidence
 
@@ -102,7 +110,14 @@ without changing the matrix meaning:
    `DEPLOYMENT_DEFINED_NOT_SIGNALING` node accepts a valid inherited witness-v1
    Taproot keypath spend at block-validation level, while an
    `ACTIVE_REPLACEMENT` node rejects the same block once the explicit guard is active.
-5. Positive PQ-native active replacement semantics remain explicitly deferred.
+5. `feature_taproot_replacement_active_positive_seam.py` adds the first positive
+   PQ-native active seam as a raw block fixture only: an
+   `ACTIVE_REPLACEMENT` node accepts a witness-v1 / 32-byte / non-P2SH
+   replacement-script-hash spend when `SHA256(revealed_script) == program` and
+   the revealed script is the exact PQ single-sig script
+   `<33-byte pk_script> OP_CHECKSIG`, while a
+   `DEPLOYMENT_DEFINED_NOT_SIGNALING` node rejects the same block.
+6. No mempool, relay, or policy acceptance is implied by the current runtime evidence.
 
 ## Explicit-Replacement Semantic Guard
 
@@ -115,6 +130,26 @@ witness-v1 semantics are **not** the PQBTC replacement path. It does **not**
 define any positive PQ-native active witness-v1, address, wallet, descriptor,
 RPC, or PSBT seam.
 
+## First Positive Active Seam
+
+The current repo now owns one explicit positive active-semantic boundary:
+`ACTIVE_REPLACEMENT` accepts exactly one PQ-native witness-v1 replacement seam.
+
+This is a **single block-validation seam only**:
+
+- witness version `1`
+- 32-byte witness program
+- non-P2SH
+- witness stack `[pq_signature, revealed_script]`
+- `SHA256(revealed_script) == program`
+- `revealed_script` is exactly `<33-byte pk_script> OP_CHECKSIG`
+- execution reuses the existing PQ witness-script engine through
+  `SigVersion::WITNESS_V0`
+- fixed `SIGHASH_ALL` only
+
+It does **not** define generic witness-v1 semantics, keypath, tree/tapscript,
+annex, mempool, relay, policy, wallet, descriptor, address, RPC, or PSBT behavior.
+
 ## Frozen Suite Classification
 
 | Suite | Current `policy_class` | `taproot_matrix_bucket` | Rationale |
@@ -125,6 +160,7 @@ RPC, or PSBT seam.
 | `feature_taproot_replacement_compat.py` | `pq_backlog` | `replacement_migration` | Adds cross-node evidence that defined, started, and locked_in pre-active states can diverge in reporting while remaining on the same accepted chain. |
 | `feature_taproot_replacement_active_boundary.py` | `pq_backlog` | `replacement_migration` | Adds cross-node evidence that defined and active reporting can diverge on the same accepted chain using plain blocks only, without defining active semantics. |
 | `feature_taproot_replacement_active_semantic_guard.py` | `pq_backlog` | `replacement_migration` | Adds the first active-semantic negative-control seam: inherited Taproot witness-v1 keypath spends remain acceptable on the defined side and are explicitly rejected on the active side. |
+| `feature_taproot_replacement_active_positive_seam.py` | `pq_backlog` | `replacement_migration` | Adds the first positive active-semantic seam: a raw witness-v1 replacement-script-hash block is accepted on the active side and rejected on the defined side. |
 | `rpc_createmultisig.py` | `dual_profile` | `deferred` | Contains Taproot-adjacent bech32m coverage, but replacement-specific semantics are not yet defined. |
 | `rpc_psbt.py` | `dual_profile` | `deferred` | Contains Taproot-facing PSBT surfaces, but replacement-specific semantics are not yet defined. |
 | `wallet_address_types.py` | `dual_profile` | `deferred` | Contains bech32m/Taproot-facing address branches, but replacement-specific semantics are not yet defined. |
@@ -136,10 +172,10 @@ RPC, or PSBT seam.
 
 This slice does **not** define:
 
-- positive PQ-native active replacement witness-v1 semantics
 - broad migration behavior between active replacement and dormant nodes beyond the explicit negative-control fixture
+- broad migration behavior between active replacement and dormant nodes beyond the explicit negative-control fixture and single positive replacement-script-hash fixture
 - CI reclassification of Taproot suites into PQ-required gates
-- wallet, RPC, descriptor, PSBT, address, or consensus implementation changes
+- generic witness-v1, keypath, tree/tapscript, annex, mempool, relay, policy, wallet, RPC, descriptor, PSBT, or address semantics
 
 ## Downstream Boundary
 

--- a/docs/TAPROOT_POSTURE.md
+++ b/docs/TAPROOT_POSTURE.md
@@ -69,16 +69,21 @@ model that the current implementation and docs do not define.
 3. Existing Taproot-related code and tests in the repo are implementation surfaces to
    classify, not proof of planned activation semantics.
 4. No current dormant Taproot surface becomes active merely because it exists in the codebase.
-5. The first owned `ACTIVE_REPLACEMENT` semantic seam is negative-control only:
-   inherited Taproot witness-v1 spending is explicitly rejected and is therefore
-   not the PQBTC replacement path.
+5. The current repo owns two narrow `ACTIVE_REPLACEMENT` witness-v1 seams:
+   - inherited Taproot witness-v1 spending is explicitly rejected and is
+     therefore not the PQBTC replacement path
+   - one positive PQ-native replacement-script-hash seam is accepted in
+     block validation only
+6. These seams do not define generic witness-v1 semantics, keypath,
+   tree/tapscript, annex, mempool, relay, policy, wallet, descriptor, RPC,
+   address, or PSBT behavior.
 
 ## Surface Boundary Matrix
 
 | Surface | Current v1 state | Explicit-replacement posture | Expected treatment | Downstream owner |
 |---|---|---|---|---|
 | Deployment state in `src/kernel/chainparams.cpp` | Shipped v1 used `DEPLOYMENT_TAPROOT = NEVER_ACTIVE`; current repo wires far-future dormant BIP9 values and reports them as `taproot_replacement` | Current deployment settings are concrete but still dormant; replacement activation model is frozen in `TAPROOT_ACTIVATION.md` | Retained dormant until a later tranche intentionally opens signaling and defines replacement semantics | `#22` |
-| Script semantics | Pre-taproot `CHECKSIG` / `CHECKMULTISIG` are PQ-only | Future witness-v1+ semantics must be defined as a new PQ-native replacement, not inherited Taproot semantics | Current active-negative-control guard explicitly rejects inherited Taproot witness-v1 block spends; positive replacement script rules remain deferred | `#22` then `#23` |
+| Script semantics | Pre-taproot `CHECKSIG` / `CHECKMULTISIG` are PQ-only | Future witness-v1+ semantics must be defined as a new PQ-native replacement, not inherited Taproot semantics | Current active seams explicitly reject inherited Taproot witness-v1 block spends and accept one positive witness-v1 / 32-byte / non-P2SH replacement-script-hash seam in block validation only; broader replacement script rules remain deferred | `#22` then `#23` |
 | Sighash posture | Pre-taproot paths are fixed to `SIGHASH_ALL` | This doc does not define any witness-v1+ replacement sighash rules | Downstream-defined only | `#22` |
 | Witness-v1 / Taproot address encoding in `src/key_io.cpp` | Bech32m/Taproot encoding and decoding code exists | Existing witness-v1 address code is not a commitment to activate inherited Taproot semantics | Retained dormant until a replacement address/output spec exists | `#22` |
 | Wallet Taproot capability surfaces such as `taprootEnabled()` | Interfaces and output-type plumbing exist | Existing wallet surfaces are inherited implementation artifacts, not approved future posture | Retained dormant and out of current sign-off scope | `#22` and `#23` |
@@ -95,6 +100,7 @@ This document does **not** define directly:
 - concrete activation parameter values or code wiring; see `TAPROOT_ACTIVATION.md`
 - runtime rollback machinery for a future replacement path
 - migration or compatibility implementation across pre/post-activation states; the frozen matrix now lives in `TAPROOT_MIGRATION_MATRIX.md`
+- generic witness-v1, keypath, tree/tapscript, annex, mempool, relay, policy, wallet, descriptor, RPC, address, or PSBT semantics beyond the explicitly frozen active seams
 - CI reclassification or conversion of Taproot-specific suites
 - runtime code changes, removals, or enablement
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1727,6 +1727,43 @@ static bool ExecuteWitnessScript(const std::span<const valtype>& stack_span, con
     return true;
 }
 
+static bool IsExactPQReplacementWitnessScript(const valtype& script_bytes)
+{
+    const CScript script{script_bytes.begin(), script_bytes.end()};
+    CScript::const_iterator pc = script.begin();
+    opcodetype opcode{};
+    std::vector<unsigned char> pushed_data;
+
+    if (!script.GetOp(pc, opcode, pushed_data)) return false;
+    if (opcode != static_cast<opcodetype>(pqsig::PK_SCRIPT_SIZE)) return false;
+    if (pushed_data.size() != pqsig::PK_SCRIPT_SIZE) return false;
+    if (pqsig::ClassifyPkScript(pushed_data) != pqsig::PkScriptParseStatus::VALID_ACTIVE) return false;
+
+    pushed_data.clear();
+    if (!script.GetOp(pc, opcode, pushed_data)) return false;
+    if (!pushed_data.empty() || opcode != OP_CHECKSIG) return false;
+
+    return pc == script.end();
+}
+
+static std::optional<bool> TryExecutePQReplacementWitnessProgram(const std::span<const valtype>& stack, std::span<const unsigned char> program, unsigned int flags, const BaseSignatureChecker& checker, ScriptExecutionData& execdata, ScriptError* serror)
+{
+    if (!(flags & SCRIPT_VERIFY_PQ_REPLACEMENT_V1_SCRIPTHASH)) return std::nullopt;
+    if (stack.size() != 2) return std::nullopt;
+
+    const valtype& revealed_script_bytes = stack.back();
+    if (!IsExactPQReplacementWitnessScript(revealed_script_bytes)) return std::nullopt;
+
+    const CScript exec_script{revealed_script_bytes.begin(), revealed_script_bytes.end()};
+    uint256 hash_exec_script;
+    CSHA256().Write(exec_script.data(), exec_script.size()).Finalize(hash_exec_script.begin());
+    if (memcmp(hash_exec_script.begin(), program.data(), WITNESS_V1_TAPROOT_SIZE) != 0) {
+        return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
+    }
+
+    return ExecuteWitnessScript(stack.first(stack.size() - 1), exec_script, flags, SigVersion::WITNESS_V0, checker, execdata, serror);
+}
+
 uint256 ComputeTapleafHash(uint8_t leaf_version, std::span<const unsigned char> script)
 {
     return (HashWriter{HASHER_TAPLEAF} << leaf_version << CompactSizeWriter(script.size()) << script).GetSHA256();
@@ -1803,7 +1840,12 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
             return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_WRONG_LENGTH);
         }
     } else if (witversion == 1 && program.size() == WITNESS_V1_TAPROOT_SIZE && !is_p2sh) {
-        // BIP341 Taproot: 32-byte non-P2SH witness v1 program (which encodes a P2C-tweaked pubkey)
+        // Witness v1 / 32-byte / non-P2SH programs first try the explicit
+        // replacement seam under the active replacement flag, then fall back to
+        // inherited Taproot handling or its active rejection guard.
+        if (const auto replacement_result = TryExecutePQReplacementWitnessProgram(stack, program, flags, checker, execdata, serror)) {
+            return *replacement_result;
+        }
         if (flags & SCRIPT_VERIFY_DISALLOW_INHERITED_TAPROOT) {
             return set_error(serror, SCRIPT_ERR_INHERITED_TAPROOT_DISALLOWED);
         }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -146,6 +146,10 @@ enum : uint32_t {
     // Internal replacement-path guard for inherited Taproot witness-v1 spends.
     SCRIPT_VERIFY_DISALLOW_INHERITED_TAPROOT = (1U << 21),
 
+    // Internal replacement-path enablement for the first positive PQ-native
+    // witness-v1 replacement-script-hash seam.
+    SCRIPT_VERIFY_PQ_REPLACEMENT_V1_SCRIPTHASH = (1U << 22),
+
     // Constants to point to the highest flag in use. Add new flags above this line.
     //
     SCRIPT_VERIFY_END_MARKER

--- a/src/test/pqsig_script_tests.cpp
+++ b/src/test/pqsig_script_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <addresstype.h>
 #include <consensus/amount.h>
+#include <crypto/sha256.h>
 #include <crypto/pqsig/params.h>
 #include <crypto/pqsig/pqsig.h>
 #include <psbt.h>
@@ -50,6 +51,16 @@ std::vector<uint8_t> SignForScript(const CMutableTransaction& tx, const CScript&
     return sig;
 }
 
+std::vector<uint8_t> SignForWitnessScript(const CMutableTransaction& tx, const CScript& witness_script, const CAmount amount, std::span<const uint8_t> pk_script)
+{
+    const uint256 sighash = SignatureHash(witness_script, tx, /*nIn=*/0, SIGHASH_ALL, amount, SigVersion::WITNESS_V0);
+    std::vector<uint8_t> sig(pqsig::SIG_SIZE);
+    if (!pqsig::PQSigSign(sig, std::span<const uint8_t>{sighash.begin(), sighash.size()}, TEST_SK_SEED, pk_script)) {
+        throw std::runtime_error("failed to produce deterministic witness signature");
+    }
+    return sig;
+}
+
 void MutateLayerCounter(std::vector<uint8_t>& sig, const size_t layer)
 {
     const size_t layer_offset = pqsig::params::HT_OFFSET + layer * pqsig::params::HT_LAYER_SIZE;
@@ -75,6 +86,13 @@ CScript MakeWitnessScript(const std::array<uint8_t, pqsig::PK_SCRIPT_SIZE>& pk_s
     return CScript{} << std::vector<unsigned char>{pk_script.begin(), pk_script.end()} << OP_CHECKSIG;
 }
 
+CScript MakeReplacementScriptPubKey(const CScript& witness_script)
+{
+    uint256 witness_script_hash;
+    CSHA256().Write(witness_script.data(), witness_script.size()).Finalize(witness_script_hash.begin());
+    return CScript{} << OP_1 << std::vector<unsigned char>{witness_script_hash.begin(), witness_script_hash.end()};
+}
+
 FlatSigningProvider MakePQSigningProvider(const std::array<uint8_t, pqsig::PK_SCRIPT_SIZE>& pk_script)
 {
     FlatSigningProvider provider;
@@ -83,6 +101,15 @@ FlatSigningProvider MakePQSigningProvider(const std::array<uint8_t, pqsig::PK_SC
     provider.pq_keys.emplace(pk_script, TEST_SK_SEED);
     return provider;
 }
+
+class AcceptingTaprootChecker final : public BaseSignatureChecker
+{
+public:
+    bool CheckSchnorrSignature(std::span<const unsigned char> sig, std::span<const unsigned char> pubkey, SigVersion sigversion, ScriptExecutionData&, ScriptError*) const override
+    {
+        return sigversion == SigVersion::TAPROOT && sig.size() == 64 && pubkey.size() == 32;
+    }
+};
 
 } // namespace
 
@@ -296,6 +323,54 @@ BOOST_AUTO_TEST_CASE(dummy_and_non_all_pq_signing_paths)
     SignatureData rejected_sigdata;
     CMutableTransaction tx = BuildSpendingTx();
     BOOST_CHECK(!ProduceSignature(provider, MutableTransactionSignatureCreator(tx, 0, amount, SIGHASH_NONE), script_pubkey, rejected_sigdata));
+}
+
+BOOST_AUTO_TEST_CASE(replacement_v1_script_hash_seam_is_active_only)
+{
+    constexpr unsigned int witness_flags{SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT};
+    constexpr unsigned int guarded_flags{witness_flags | SCRIPT_VERIFY_DISALLOW_INHERITED_TAPROOT};
+    constexpr unsigned int replacement_flags{guarded_flags | SCRIPT_VERIFY_PQ_REPLACEMENT_V1_SCRIPTHASH};
+
+    const auto pk_script = MakePkScript();
+    const CScript witness_script = MakeWitnessScript(pk_script);
+    const CScript replacement_script_pubkey = MakeReplacementScriptPubKey(witness_script);
+    const CAmount amount = 50 * COIN;
+
+    CMutableTransaction replacement_tx = BuildSpendingTx();
+    const std::vector<uint8_t> replacement_sig = SignForWitnessScript(replacement_tx, witness_script, amount, pk_script);
+    replacement_tx.vin[0].scriptWitness.stack = {
+        std::vector<unsigned char>{replacement_sig.begin(), replacement_sig.end()},
+        std::vector<unsigned char>{witness_script.begin(), witness_script.end()},
+    };
+
+    const CTransaction replacement_tx_const{replacement_tx};
+    const TransactionSignatureChecker replacement_checker(&replacement_tx_const, /*nInIn=*/0, amount, MissingDataBehavior::FAIL);
+    ScriptError err = SCRIPT_ERR_UNKNOWN_ERROR;
+
+    BOOST_CHECK(VerifyScript(CScript{}, replacement_script_pubkey, &replacement_tx.vin[0].scriptWitness, replacement_flags, replacement_checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+
+    err = SCRIPT_ERR_UNKNOWN_ERROR;
+    BOOST_CHECK(!VerifyScript(CScript{}, replacement_script_pubkey, &replacement_tx.vin[0].scriptWitness, guarded_flags, replacement_checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_INHERITED_TAPROOT_DISALLOWED);
+
+    const CScript mismatch_script_pubkey = MakeReplacementScriptPubKey(CScript{} << OP_TRUE);
+    err = SCRIPT_ERR_UNKNOWN_ERROR;
+    BOOST_CHECK(!VerifyScript(CScript{}, mismatch_script_pubkey, &replacement_tx.vin[0].scriptWitness, replacement_flags, replacement_checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
+
+    const CScript witness_v0_script_pubkey = GetScriptForDestination(WitnessV0ScriptHash(witness_script));
+    err = SCRIPT_ERR_UNKNOWN_ERROR;
+    BOOST_CHECK(VerifyScript(CScript{}, witness_v0_script_pubkey, &replacement_tx.vin[0].scriptWitness, replacement_flags, replacement_checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+
+    const CScript inherited_taproot_script_pubkey = CScript{} << OP_1 << std::vector<unsigned char>(32, 0x03);
+    CScriptWitness inherited_taproot_witness;
+    inherited_taproot_witness.stack = {std::vector<unsigned char>(64, 0x04)};
+    const AcceptingTaprootChecker taproot_checker;
+    err = SCRIPT_ERR_UNKNOWN_ERROR;
+    BOOST_CHECK(!VerifyScript(CScript{}, inherited_taproot_script_pubkey, &inherited_taproot_witness, replacement_flags, taproot_checker, &err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_INHERITED_TAPROOT_DISALLOWED);
 }
 
 BOOST_AUTO_TEST_CASE(psbt_roundtrips_pq_proprietary_partial_sig_and_finalizes)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2370,6 +2370,7 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
 
     if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_TAPROOT)) {
         flags |= SCRIPT_VERIFY_DISALLOW_INHERITED_TAPROOT;
+        flags |= SCRIPT_VERIFY_PQ_REPLACEMENT_V1_SCRIPTHASH;
     }
 
     return flags;

--- a/test/functional/feature_taproot_replacement_active_positive_seam.py
+++ b/test/functional/feature_taproot_replacement_active_positive_seam.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the first positive PQ-native ACTIVE_REPLACEMENT seam.
+
+This slice is block-validation-only. It does not exercise mempool, relay,
+policy, wallet, descriptor, address, RPC, or PSBT replacement behavior.
+"""
+
+import hashlib
+
+from test_framework.blocktools import (
+    add_witness_commitment,
+    create_block,
+    create_coinbase,
+)
+from test_framework.key import (
+    compute_xonly_pubkey,
+    generate_privkey,
+    sign_schnorr,
+    tweak_add_privkey,
+)
+from test_framework.messages import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    SEQUENCE_FINAL,
+    tx_from_hex,
+)
+from test_framework.pqsig import (
+    build_pq_keypair,
+    create_wallet_funded_tx,
+    sign_segwitv0_input_pq,
+)
+from test_framework.script import (
+    CScript,
+    OP_1,
+    OP_CHECKSIG,
+    OP_TRUE,
+    SIGHASH_DEFAULT,
+    TaprootSignatureHash,
+    taproot_construct,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+TAPROOT_REPLACEMENT_NAME = "taproot_replacement"
+NO_TIMEOUT = 0x7fffffffffffffff
+TIME_STEP = 600
+ACTIVE_HEIGHT = 432
+POST_ACTIVE_HEIGHT = ACTIVE_HEIGHT + 1
+ACTIVE_GUARD_REJECT_REASON = "Inherited Taproot witness-v1 semantics disallowed under active replacement"
+POSITIVE_OUTPUT_AMOUNT = COIN
+OUTPUT_FEE = 1000
+PQ_SK_SEED = bytes.fromhex(
+    "0711131719232931071113171923293107111317192329310711131719232931"
+)
+
+
+class TaprootReplacementActivePositiveSeamTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.supports_cli = False
+
+    def set_network_mocktime(self, mocktime):
+        for node in self.nodes:
+            node.setmocktime(mocktime)
+
+    def advance_network_mocktime(self):
+        mocktime = max(
+            node.getblockheader(node.getbestblockhash())["time"]
+            for node in self.nodes
+        ) + TIME_STEP
+        self.set_network_mocktime(mocktime)
+        return mocktime
+
+    def restart_active_node(self):
+        self.restart_node(1, extra_args=[f"-vbparams={TAPROOT_REPLACEMENT_NAME}:0:{NO_TIMEOUT}"])
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
+
+    def mine_plain_blocks(self, node, target_height, *, sync_fun=None):
+        while node.getblockcount() < target_height:
+            self.advance_network_mocktime()
+            if sync_fun is None:
+                self.generate(node, 1, sync_fun=lambda: None)
+            else:
+                self.generate(node, 1, sync_fun=sync_fun)
+
+    def mine_block_with_txs(self, node, txs, *, sync_fun=None):
+        next_height = node.getblockcount() + 1
+        block_time = self.advance_network_mocktime()
+        block = create_block(
+            int(node.getbestblockhash(), 16),
+            create_coinbase(next_height),
+            block_time,
+            txlist=txs,
+        )
+        if any(not tx.wit.is_null() for tx in txs):
+            add_witness_commitment(block)
+        block.solve()
+        response = node.submitblock(block.serialize().hex())
+        assert_equal(response, None)
+        assert_equal(node.getbestblockhash(), block.hash_hex)
+        if sync_fun is not None:
+            sync_fun()
+        return block
+
+    def submit_block(self, node, block, *, expect_accept, reject_reason=None):
+        prior_tip = node.getbestblockhash()
+        response = node.submitblock(block.serialize().hex())
+        if expect_accept:
+            assert_equal(response, None)
+            assert_equal(node.getbestblockhash(), block.hash_hex)
+        else:
+            assert_equal(node.getbestblockhash(), prior_tip)
+            assert response is not None
+            if reject_reason is not None:
+                assert reject_reason in response, response
+        return response
+
+    def assert_same_chain_active_boundary(self):
+        best_hash_0 = self.nodes[0].getbestblockhash()
+        best_hash_1 = self.nodes[1].getbestblockhash()
+        assert_equal(best_hash_0, best_hash_1)
+        assert_equal(self.nodes[0].getblockcount(), ACTIVE_HEIGHT)
+        assert_equal(self.nodes[1].getblockcount(), ACTIVE_HEIGHT)
+
+        info_0 = self.nodes[0].getdeploymentinfo(best_hash_0)
+        info_1 = self.nodes[1].getdeploymentinfo(best_hash_1)
+        dep_0 = info_0["deployments"][TAPROOT_REPLACEMENT_NAME]
+        dep_1 = info_1["deployments"][TAPROOT_REPLACEMENT_NAME]
+
+        assert_equal(dep_0["bip9"]["status"], "defined")
+        assert_equal(dep_0["active"], False)
+        assert "height" not in dep_0
+
+        assert_equal(dep_1["bip9"]["status"], "active")
+        assert_equal(dep_1["active"], True)
+        assert_equal(dep_1["height"], ACTIVE_HEIGHT)
+
+    def build_positive_fixture(self):
+        funding_node = self.nodes[1]
+        _, pk_script = build_pq_keypair(PQ_SK_SEED)
+        revealed_script = CScript([pk_script, OP_CHECKSIG])
+        replacement_program = hashlib.sha256(bytes(revealed_script)).digest()
+        replacement_script_pub_key = CScript([OP_1, replacement_program])
+        funding_tx = create_wallet_funded_tx(funding_node, bytes(replacement_script_pub_key), POSITIVE_OUTPUT_AMOUNT)
+        return {
+            "sk_seed": PQ_SK_SEED,
+            "pk_script": pk_script,
+            "revealed_script": revealed_script,
+            "script_pub_key": replacement_script_pub_key,
+            "funding_tx": funding_tx,
+            "prevout": funding_tx.vout[0],
+            "outpoint": COutPoint(int(funding_tx.txid_hex, 16), 0),
+        }
+
+    def build_negative_control_fixture(self):
+        funding_node = self.nodes[1]
+        internal_key = generate_privkey()
+        internal_pubkey, _ = compute_xonly_pubkey(internal_key)
+        tap = taproot_construct(internal_pubkey)
+        funding_tx = create_wallet_funded_tx(funding_node, bytes(tap.scriptPubKey), POSITIVE_OUTPUT_AMOUNT)
+        return {
+            "internal_key": internal_key,
+            "tap": tap,
+            "funding_tx": funding_tx,
+            "prevout": funding_tx.vout[0],
+            "outpoint": COutPoint(int(funding_tx.txid_hex, 16), 0),
+        }
+
+    def build_positive_block(self, node, fixture):
+        spend_tx = CTransaction()
+        spend_tx.vin = [CTxIn(fixture["outpoint"], nSequence=SEQUENCE_FINAL)]
+        spend_tx.vout = [CTxOut(fixture["prevout"].nValue - OUTPUT_FEE, CScript([OP_TRUE]))]
+        spend_tx.wit.vtxinwit = [CTxInWitness()]
+
+        signature = sign_segwitv0_input_pq(
+            spend_tx,
+            fixture["revealed_script"],
+            fixture["prevout"].nValue,
+            fixture["sk_seed"],
+            fixture["pk_script"],
+        )
+        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [signature, bytes(fixture["revealed_script"])]
+        spend_tx = tx_from_hex(spend_tx.serialize().hex())
+
+        next_height = node.getblockcount() + 1
+        block_time = self.advance_network_mocktime()
+        block = create_block(
+            int(node.getbestblockhash(), 16),
+            create_coinbase(next_height),
+            block_time,
+            txlist=[spend_tx],
+        )
+        add_witness_commitment(block)
+        block.solve()
+        return block
+
+    def build_negative_control_block(self, node, fixture):
+        spend_tx = CTransaction()
+        spend_tx.vin = [CTxIn(fixture["outpoint"], nSequence=SEQUENCE_FINAL)]
+        spend_tx.vout = [CTxOut(fixture["prevout"].nValue - OUTPUT_FEE, CScript([OP_TRUE]))]
+        spend_tx.wit.vtxinwit = [CTxInWitness()]
+
+        sighash = TaprootSignatureHash(spend_tx, [fixture["prevout"]], SIGHASH_DEFAULT, 0, scriptpath=False)
+        tweaked_key = tweak_add_privkey(fixture["internal_key"], fixture["tap"].tweak)
+        assert tweaked_key is not None
+        signature = sign_schnorr(tweaked_key, sighash, aux=bytes([0] * 32))
+        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [signature]
+        spend_tx = tx_from_hex(spend_tx.serialize().hex())
+
+        next_height = node.getblockcount() + 1
+        block_time = self.advance_network_mocktime()
+        block = create_block(
+            int(node.getbestblockhash(), 16),
+            create_coinbase(next_height),
+            block_time,
+            txlist=[spend_tx],
+        )
+        add_witness_commitment(block)
+        block.solve()
+        return block
+
+    def run_test(self):
+        self.log.info("Restart node1 with active vbparams before building any fixture blocks")
+        self.restart_active_node()
+
+        self.log.info("Disconnect node0 while building raw funding fixtures on the signaling node")
+        self.disconnect_nodes(0, 1)
+
+        self.log.info("Build one raw PQ-native replacement output and one inherited Taproot negative-control output")
+        positive_fixture = self.build_positive_fixture()
+        negative_fixture = self.build_negative_control_fixture()
+
+        self.log.info("Mine a shared raw funding block with both fixtures")
+        self.mine_block_with_txs(
+            self.nodes[1],
+            [positive_fixture["funding_tx"], negative_fixture["funding_tx"]],
+        )
+
+        self.log.info("Reconnect node0 and mine plain blocks on the signaling node to the active boundary")
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
+        self.mine_plain_blocks(self.nodes[1], ACTIVE_HEIGHT, sync_fun=self.sync_blocks)
+        self.assert_same_chain_active_boundary()
+
+        self.log.info("Mine one additional plain block inside ACTIVE_REPLACEMENT before exercising semantics")
+        self.mine_plain_blocks(self.nodes[1], POST_ACTIVE_HEIGHT, sync_fun=self.sync_blocks)
+        shared_tip = self.nodes[1].getbestblockhash()
+        assert_equal(shared_tip, self.nodes[0].getbestblockhash())
+
+        self.log.info("Disconnect peers before submitting the raw semantic fixtures")
+        self.disconnect_nodes(0, 1)
+
+        self.log.info("Assert the active node still rejects the inherited Taproot negative-control block")
+        negative_block = self.build_negative_control_block(self.nodes[1], negative_fixture)
+        self.submit_block(
+            self.nodes[1],
+            negative_block,
+            expect_accept=False,
+            reject_reason=ACTIVE_GUARD_REJECT_REASON,
+        )
+        assert_equal(self.nodes[1].getbestblockhash(), shared_tip)
+
+        self.log.info("Assert the active node accepts the first positive PQ-native replacement block")
+        positive_block = self.build_positive_block(self.nodes[1], positive_fixture)
+        self.submit_block(self.nodes[1], positive_block, expect_accept=True)
+
+        self.log.info("Assert the defined node rejects the same positive replacement block")
+        self.submit_block(self.nodes[0], positive_block, expect_accept=False)
+        assert self.nodes[0].getbestblockhash() != self.nodes[1].getbestblockhash()
+
+
+if __name__ == '__main__':
+    TaprootReplacementActivePositiveSeamTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -147,6 +147,7 @@ BASE_SCRIPTS = [
     'feature_taproot_replacement_compat.py',
     'feature_taproot_replacement_active_boundary.py',
     'feature_taproot_replacement_active_semantic_guard.py',
+    'feature_taproot_replacement_active_positive_seam.py',
     'wallet_listtransactions.py',
     'wallet_miniscript.py',
     # vv Tests less than 30s vv


### PR DESCRIPTION
## Summary
- freeze the first positive PQ-native `ACTIVE_REPLACEMENT` seam in the Taproot and consensus docs before code relies on it
- add an active-only witness-v1 / 32-byte / non-P2SH replacement-script-hash block-validation path
- keep the inherited-Taproot negative-control reject path intact as the fallback for non-matching witness-v1 shapes
- add low-level and functional coverage for the new positive seam without defining wallet, descriptor, address, RPC, PSBT, mempool, relay, or policy semantics

## What changed
- docs-first seam freeze in:
  - `docs/TAPROOT_MIGRATION_MATRIX.md`
  - `docs/TAPROOT_ACTIVATION.md`
  - `docs/TAPROOT_POSTURE.md`
  - `docs/CONSENSUS_SURFACE.md`
  - `docs/CONSENSUS_DIFFS.md`
  - `docs/POST_RC_EPICS.md`
  - `docs/DECISION_DEFERRAL_LEDGER.md`
- added `SCRIPT_VERIFY_PQ_REPLACEMENT_V1_SCRIPTHASH` and wired it into block validation when `DEPLOYMENT_TAPROOT` is active
- added the positive witness-v1 branch in `src/script/interpreter.cpp` with strict ordering:
  - active-only flag
  - exact seam shape check
  - positive seam execution
  - otherwise fall through to the existing inherited-Taproot reject path
- added low-level regression coverage in `src/test/pqsig_script_tests.cpp`
- added the new functional test `test/functional/feature_taproot_replacement_active_positive_seam.py`
- updated functional inventory and runner wiring

## Seam definition
This PR defines exactly one positive active seam:
- block-validation only
- witness-v1 / 32-byte / non-P2SH
- `SHA256(revealed_script) == program`
- revealed script must be exactly `<33-byte pk_script> OP_CHECKSIG`
- fixed `SIGHASH_ALL`
- no keypath, tree/tapscript, annex, mempool, relay, policy, wallet, descriptor, address, RPC, or PSBT semantics

## Validation
- `cmake -S /Users/scott/quantum-proof-bitcoin -B /Users/scott/quantum-proof-bitcoin/build`
- `cmake --build /Users/scott/quantum-proof-bitcoin/build --target pqbtcd test_pqbtc -j4`
- `/Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=pqsig_script_tests/replacement_v1_script_hash_seam_is_active_only --catch_system_error=no --log_level=test_suite`
- `/Users/scott/quantum-proof-bitcoin/build/bin/test_pqbtc --run_test=script_tests/inherited_taproot_rejection_guard_is_explicit --catch_system_error=no --log_level=test_suite`
- `python3 /Users/scott/quantum-proof-bitcoin/test/functional/feature_taproot_replacement_active_positive_seam.py --configfile=/Users/scott/quantum-proof-bitcoin/build/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/build/test/cache`
- `/Users/scott/quantum-proof-bitcoin/build/test/functional/test_runner.py --jobs=1 feature_taproot_replacement_deployment.py feature_taproot_replacement_compat.py feature_taproot_replacement_active_boundary.py feature_taproot_replacement_active_semantic_guard.py feature_taproot_replacement_active_positive_seam.py`
- `python3 /Users/scott/quantum-proof-bitcoin/ci/test/check_ci_inventory.py`
- `git -C /Users/scott/quantum-proof-bitcoin diff --check`

## Tracking
- continues `#23`
