### PR TITLE
wallet: add PQ wallet manager foundation

### DIFF
--- a/docs/CREATEWALLETDESCRIPTOR_POSTURE.md
+++ b/docs/CREATEWALLETDESCRIPTOR_POSTURE.md
@@ -1,0 +1,124 @@
+# PQBTC `createwalletdescriptor` Posture
+
+## Status: ACTIVE
+## Spec-ID: CREATEWALLETDESCRIPTOR-POSTURE-v1
+## Frozen-By: track-a-phase1-20260406
+## Consensus-Relevant: NO
+
+## Purpose
+
+State clearly what `createwalletdescriptor` means in the repo today, and what it
+does not mean under the all-PQ Track A stance.
+
+This note exists because the inherited RPC name sounds like it should be part of
+ PQ wallet-manager creation, but today it is not.
+
+## Current Reality
+
+The current RPC at [wallet.cpp](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/wallet.cpp#L749)
+is still the inherited HD-xpub descriptor builder.
+
+It currently:
+
+- chooses an existing active HD xpub from wallet descriptors
+- derives a new descriptor family from `OutputType`
+- adds standard descriptor managers for inherited address families
+
+In practice, the current functional coverage proves:
+
+- `type="bech32"` creates `wpkh(...)` descriptors
+- `type="bech32m"` creates `tr(...)` descriptors
+
+The current passing suite is:
+
+- [wallet_createwalletdescriptor.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_createwalletdescriptor.py)
+
+## What It Does Not Do
+
+`createwalletdescriptor` does **not** currently:
+
+- create `pq(...)` descriptors
+- create active ranged `pqpriv(...)` managers
+- understand PQ root seeds
+- drive `getnewpqaddress` or PQ change-manager setup
+
+So under Track A, this RPC is **not** evidence that PQ-native descriptor
+creation is solved.
+
+## Current PQ Creation Path
+
+The current PQ-native wallet-manager creation path is different:
+
+- call the dedicated
+  [createpqwalletmanagers](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/wallet.cpp)
+  RPC on a descriptor wallet with no active managers
+- let the dedicated PQ manager own address generation and signing
+
+That path is already exercised in:
+
+- [wallet_pq_active_ranged.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_active_ranged.py)
+- [PQ_WALLET_MANAGER_SETUP.md](/Users/scott/quantum-proof-bitcoin/docs/PQ_WALLET_MANAGER_SETUP.md)
+
+And the lower-level descriptor import path is still exercised in:
+
+- [wallet_pq_psbt.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_psbt.py)
+
+And the fixed public watch-only side is exercised in:
+
+- [wallet_pq_descriptors.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_descriptors.py)
+
+## Track A Interpretation
+
+Under the all-PQ stance:
+
+- the current `createwalletdescriptor` behavior is inherited and deferred
+- it remains useful as reference coverage for descriptor-wallet plumbing
+- it is not an owned PQ-native milestone by itself
+
+Current UX improvement:
+
+- when a wallet's active state is driven only by `pqpriv(...)` managers,
+  `createwalletdescriptor` now says so directly instead of pretending the issue
+  is generic HD-key ambiguity
+- current RPC error:
+  `Active pqpriv() managers do not expose HD keys; createwalletdescriptor only supports xpub-based descriptor families`
+
+This means a green
+[wallet_createwalletdescriptor.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_createwalletdescriptor.py)
+run tells us inherited descriptor creation still works. It does **not** tell us
+that PQ-native descriptor creation semantics are defined.
+
+## Recommended Direction
+
+Current recommendation:
+
+- do **not** overload the inherited `createwalletdescriptor` RPC yet
+- keep PQ wallet-manager creation on the dedicated PQ-RPC path
+- keep raw `pqpriv(...)` import as a lower-level descriptor/test surface, not the
+  primary setup UX
+
+Reasoning:
+
+- the inherited RPC is organized around `OutputType` and HD xpubs
+- the PQ path is organized around a root seed and dedicated PQ manager state
+- forcing both shapes through one API too early is likely to blur the boundary
+  between inherited descriptor families and the owned PQ-native wallet model
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-04-06:
+
+- `python3 test/functional/wallet_createwalletdescriptor.py`
+  - result: passed
+- `python3 test/functional/wallet_pq_active_ranged.py`
+  - result: passed
+  - relevant guard: dedicated PQ setup is now covered directly, and active
+    `pqpriv(...)` managers still reject inherited
+    `createwalletdescriptor("bech32")` and `createwalletdescriptor("bech32m")`
+    because they expose no HD xpub source, now with a PQ-specific RPC error
+
+Interpretation:
+
+- inherited descriptor creation remains healthy
+- PQ-native setup is now explicit and test-backed without overloading the
+  inherited RPC

--- a/docs/CREATEWALLETDESCRIPTOR_POSTURE.md
+++ b/docs/CREATEWALLETDESCRIPTOR_POSTURE.md
@@ -15,7 +15,7 @@ This note exists because the inherited RPC name sounds like it should be part of
 
 ## Current Reality
 
-The current RPC at [wallet.cpp](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/wallet.cpp#L749)
+The current RPC at [wallet.cpp](../src/wallet/rpc/wallet.cpp)
 is still the inherited HD-xpub descriptor builder.
 
 It currently:
@@ -31,7 +31,7 @@ In practice, the current functional coverage proves:
 
 The current passing suite is:
 
-- [wallet_createwalletdescriptor.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_createwalletdescriptor.py)
+- [wallet_createwalletdescriptor.py](../test/functional/wallet_createwalletdescriptor.py)
 
 ## What It Does Not Do
 
@@ -50,22 +50,22 @@ creation is solved.
 The current PQ-native wallet-manager creation path is different:
 
 - call the dedicated
-  [createpqwalletmanagers](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/wallet.cpp)
+  [createpqwalletmanagers](../src/wallet/rpc/wallet.cpp)
   RPC on a descriptor wallet with no active managers
 - let the dedicated PQ manager own address generation and signing
 
 That path is already exercised in:
 
-- [wallet_pq_active_ranged.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_active_ranged.py)
-- [PQ_WALLET_MANAGER_SETUP.md](/Users/scott/quantum-proof-bitcoin/docs/PQ_WALLET_MANAGER_SETUP.md)
+- [wallet_pq_active_ranged.py](../test/functional/wallet_pq_active_ranged.py)
+- [PQ_WALLET_MANAGER_SETUP.md](./PQ_WALLET_MANAGER_SETUP.md)
 
 And the lower-level descriptor import path is still exercised in:
 
-- [wallet_pq_psbt.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_psbt.py)
+- [wallet_pq_psbt.py](../test/functional/wallet_pq_psbt.py)
 
 And the fixed public watch-only side is exercised in:
 
-- [wallet_pq_descriptors.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_descriptors.py)
+- [wallet_pq_descriptors.py](../test/functional/wallet_pq_descriptors.py)
 
 ## Track A Interpretation
 
@@ -84,7 +84,7 @@ Current UX improvement:
   `Active pqpriv() managers do not expose HD keys; createwalletdescriptor only supports xpub-based descriptor families`
 
 This means a green
-[wallet_createwalletdescriptor.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_createwalletdescriptor.py)
+[wallet_createwalletdescriptor.py](../test/functional/wallet_createwalletdescriptor.py)
 run tells us inherited descriptor creation still works. It does **not** tell us
 that PQ-native descriptor creation semantics are defined.
 

--- a/docs/PQ_ADDRESS_RPC_POSTURE.md
+++ b/docs/PQ_ADDRESS_RPC_POSTURE.md
@@ -1,0 +1,85 @@
+# PQBTC Address RPC Posture
+
+## Status: ACTIVE
+## Spec-ID: PQ-ADDRESS-RPC-POSTURE-v1
+## Frozen-By: track-a-phase1-20260406
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the supported address-generation RPC posture for PQ-only wallets under
+the all-PQ Track A stance.
+
+## Current Owned Address RPC Surface
+
+The supported PQ-native address RPCs are:
+
+- [getnewpqaddress](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
+- [getrawpqchangeaddress](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
+
+These are the owned receive/change entry points when a wallet's active state is
+driven by ranged `pqpriv(...)` managers.
+
+## Inherited RPC Boundary
+
+The inherited address RPCs are still present:
+
+- [getnewaddress](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
+- [getrawchangeaddress](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
+
+But for wallets whose active managers are entirely PQ-native, those inherited
+RPCs are no longer part of the supported UX. They now reject immediately with a
+PQ-specific instruction instead of falling through to generic keypool or
+address-family errors.
+
+Current RPC errors:
+
+- `Active pqpriv() managers do not use inherited getnewaddress; use getnewpqaddress`
+- `Active pqpriv() managers do not use inherited getrawchangeaddress; use getrawpqchangeaddress`
+
+This applies to the inherited RPC surface itself, not only to the default
+`bech32`-shaped call pattern. The goal is to keep PQ-only wallets from
+silently drifting back into classical address-family semantics.
+
+## Why This Exists
+
+- Track A is explicitly all-PQ, not mixed-mode by default.
+- Active PQ receive/change managers already have dedicated RPCs.
+- Generic inherited address RPCs otherwise produce confusing failures or
+  accidental classical-looking semantics when the wallet is actually PQ-only.
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- `wallet_address_types.py` is now an owned PQ suite
+- inherited legacy, P2SH-SegWit, or bech32m address-family behavior is fully
+  migrated to PQ semantics
+- broad mixed address-family send flows are now green
+
+The broad inherited suite remains:
+
+- [wallet_address_types.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_address_types.py)
+  - current inventory posture: `dual_profile`
+  - current Taproot matrix bucket: `deferred`
+
+On 2026-04-06 it still failed in the inherited classical path at
+`sendmany("", sends)` with `Signing transaction failed`, before the new PQ-only
+address-RPC guards became the relevant question.
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-06:
+
+- `python3 test/functional/wallet_pq_active_ranged.py`
+  - result: passed
+  - covers dedicated PQ setup, default inherited address-RPC rejection, and
+    explicit `bech32` / `legacy` / `p2sh-segwit` inherited address-RPC
+    rejection before and after restore
+
+## Interpretation
+
+- the owned PQ wallet address UX is now explicit
+- broad inherited address-type rehabilitation remains separate deferred work
+- `wallet_address_types.py` should be treated as reference inventory, not as
+  the current Track A wallet-address milestone

--- a/docs/PQ_ADDRESS_RPC_POSTURE.md
+++ b/docs/PQ_ADDRESS_RPC_POSTURE.md
@@ -14,8 +14,8 @@ the all-PQ Track A stance.
 
 The supported PQ-native address RPCs are:
 
-- [getnewpqaddress](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
-- [getrawpqchangeaddress](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
+- [getnewpqaddress](../src/wallet/rpc/addresses.cpp)
+- [getrawpqchangeaddress](../src/wallet/rpc/addresses.cpp)
 
 These are the owned receive/change entry points when a wallet's active state is
 driven by ranged `pqpriv(...)` managers.
@@ -24,8 +24,8 @@ driven by ranged `pqpriv(...)` managers.
 
 The inherited address RPCs are still present:
 
-- [getnewaddress](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
-- [getrawchangeaddress](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
+- [getnewaddress](../src/wallet/rpc/addresses.cpp)
+- [getrawchangeaddress](../src/wallet/rpc/addresses.cpp)
 
 But for wallets whose active managers are entirely PQ-native, those inherited
 RPCs are no longer part of the supported UX. They now reject immediately with a
@@ -59,7 +59,7 @@ This posture note does **not** mean:
 
 The broad inherited suite remains:
 
-- [wallet_address_types.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_address_types.py)
+- [wallet_address_types.py](../test/functional/wallet_address_types.py)
   - current inventory posture: `dual_profile`
   - current Taproot matrix bucket: `deferred`
 

--- a/docs/PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md
+++ b/docs/PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md
@@ -1,0 +1,202 @@
+# PQBTC Watch-Only `pq(...)` Descriptor Contract
+
+## Status: ACTIVE
+## Spec-ID: PQ-DESCRIPTOR-WATCHONLY-v1
+## Frozen-By: track-a-phase1-20260406
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the currently owned contract for fixed watch-only `pq(...)` descriptors.
+
+This note is intentionally narrower than the broader descriptor roadmap. It
+captures what the repo already supports today for importing, persisting,
+introspecting, and tracking funds with a fixed public PQ descriptor.
+
+## Scope
+
+This contract covers:
+
+- top-level `pq(PK_script)` parsing and inference
+- watch-only wallet import behavior for fixed `pq(...)` descriptors
+- descriptor round-trip and address derivation behavior
+- persistence and balance tracking for imported `pq(...)` outputs
+- the current watch-only spend-preparation boundary for fixed `pq(...)`
+  descriptors
+
+## Out Of Scope
+
+This contract does not define:
+
+- active ranged wallet managers
+- `getnewpqaddress` behavior
+- external signer standards
+- replacement `tr(...)` semantics
+- generic address-type migration policy
+
+Those belong to adjacent or later work, especially `pqpriv(...)` managers and
+descriptor-creation follow-ons.
+
+## Canonical Contract
+
+### 1. Descriptor form
+
+`pq(...)` is a top-level only descriptor over one fixed PQ `PK_script`.
+
+Owned constraints:
+
+- `PK_script` must be valid hex
+- `PK_script` must be exactly `pqsig::PK_SCRIPT_SIZE` bytes
+- `PK_script` must use the active `ALG_ID_RC2`
+- `pq(...)` cannot be nested inside wrappers such as `wsh(...)`
+
+### 2. Script form
+
+`pq(PK_script)` expands to the standard PQ witness program already used in the
+repo today:
+
+- witness script: `<PK_script> OP_CHECKSIG`
+- scriptPubKey: `P2WSH(witness_script)`
+- output type: `bech32`
+
+This is a single-type descriptor with one output script and a two-element
+maximum witness satisfaction:
+
+- PQ signature
+- witness script
+
+### 3. Wallet import posture
+
+A fixed `pq(...)` descriptor is watch-only and non-ranged.
+
+Current import contract:
+
+- `importdescriptors([{desc: pq(...), timestamp: ...}])` succeeds
+- keypool remains `0`
+- `active=true` is rejected
+- `range` is rejected
+- `next_index` is rejected
+
+In simple terms: `pq(...)` is for watching one exact PQ output shape, not for
+running an active wallet manager.
+
+### 4. Introspection contract
+
+Current RPC-visible expectations:
+
+- `getdescriptorinfo(pq(...))`
+  - `isrange = false`
+  - `issolvable = true`
+  - `hasprivatekeys = false`
+- `deriveaddresses(pq(...))` returns exactly one address
+- `getaddressinfo(address)["desc"]` round-trips to the descriptor
+- `getaddressinfo(address)["has_private_keys"] = false`
+- `listdescriptors()` returns the descriptor as watch-only, inactive state
+
+Private export is intentionally unavailable for this fixed public descriptor:
+
+- `listdescriptors(true)` fails with `Can't get descriptor string`
+
+### 5. Persistence and watch-only tracking
+
+Imported `pq(...)` descriptors must:
+
+- survive unload/load
+- preserve descriptor round-trip after reload
+- track funds sent to the standard PQ `P2WSH` output
+- report the watched UTXO and watch-only balance correctly
+
+### 6. Watch-only spend-preparation boundary
+
+Imported fixed `pq(...)` descriptors are watch-only but still solvable enough to
+prepare a PSBT-backed send when the wallet is given the exact tracked input and
+no change output is needed.
+
+Current owned expectations:
+
+- `listunspent()` reports the tracked coin as solvable
+- `listunspent()[*]["has_private_keys"] = false`
+- `send(..., psbt=true)` can return an incomplete PSBT when the caller
+  preselects the tracked input and uses `subtract_fee_from_outputs` to avoid
+  change
+- the watch-only wallet does not add PQ proprietary partial-signature fields
+- `walletprocesspsbt(finalize=false)` on that watch-only wallet remains
+  non-signing and incomplete
+
+This is a spend-preparation boundary only. It does not make the fixed watch-only
+descriptor an active signer.
+
+Deprecated RPC metadata is intentionally not the contract here:
+
+- `getaddressinfo()["iswatchonly"]` remains deprecated and always `false`
+- `listunspent()[*]["spendable"]` remains deprecated and always `true`
+
+For fixed public `pq(...)` descriptors, the owned source-of-truth fields are
+`private_keys_enabled = false` at wallet scope plus
+`has_private_keys = false` at address/coin scope.
+
+### 7. Relationship to `pqpriv(...)`
+
+`pq(...)` and `pqpriv(...)` are related, but not interchangeable:
+
+- `pq(...)` is fixed, public, watch-only, and non-ranged
+- `pqpriv(...)` is ranged, active-wallet-capable, and rooted in a private seed
+
+When the repo can infer a fixed public descriptor from a derived PQ wallet
+output, the inferred public form is `pq(...)`, not `pqpriv(...)`.
+
+## Rejected Shapes
+
+The following are intentionally rejected today:
+
+- malformed hex in `pq(...)`
+- wrong-length `PK_script`
+- wrong `ALG_ID`
+- nested `pq(...)` expressions
+- active/ranged import settings on a fixed watch-only `pq(...)` descriptor
+
+## Evidence
+
+Implementation references:
+
+- [descriptor.cpp](/Users/scott/quantum-proof-bitcoin/src/script/descriptor.cpp)
+- [pq_scriptpubkeyman.cpp](/Users/scott/quantum-proof-bitcoin/src/wallet/pq_scriptpubkeyman.cpp)
+- [backup.cpp](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/backup.cpp)
+
+Current test evidence:
+
+- [pq_descriptor_tests.cpp](/Users/scott/quantum-proof-bitcoin/src/test/pq_descriptor_tests.cpp)
+- [wallet_pq_descriptors.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_descriptors.py)
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-04-08:
+
+- `build/bin/test_pqbtc --run_test=pq_descriptor_tests`
+  - result: passed
+- `python3 test/functional/wallet_pq_descriptors.py`
+  - result: passed
+  - covers import rejection guards, descriptor round-trip, reload persistence,
+    watch-only tracking, and the fixed watch-only non-signing PSBT-preparation
+    boundary
+
+Interpretation:
+
+- the fixed public `pq(...)` descriptor contract is healthy
+- the current owned boundary between fixed watch-only `pq(...)` and active
+  ranged `pqpriv(...)` behavior is explicit and test-backed
+- the suite is now strong enough to sit in the required PQ-first functional
+  gate
+
+## Next Follow-On
+
+The next descriptor-facing question is not whether fixed `pq(...)` works. It
+does.
+
+The next owned follow-on is:
+
+- [wallet_createwalletdescriptor.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_createwalletdescriptor.py)
+
+That is where the repo needs to decide how much descriptor creation behavior it
+wants to own under an all-PQ Track A stance instead of inheriting old Taproot
+expectations.

--- a/docs/PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md
+++ b/docs/PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md
@@ -159,14 +159,14 @@ The following are intentionally rejected today:
 
 Implementation references:
 
-- [descriptor.cpp](/Users/scott/quantum-proof-bitcoin/src/script/descriptor.cpp)
-- [pq_scriptpubkeyman.cpp](/Users/scott/quantum-proof-bitcoin/src/wallet/pq_scriptpubkeyman.cpp)
-- [backup.cpp](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/backup.cpp)
+- [descriptor.cpp](../src/script/descriptor.cpp)
+- [pq_scriptpubkeyman.cpp](../src/wallet/pq_scriptpubkeyman.cpp)
+- [backup.cpp](../src/wallet/rpc/backup.cpp)
 
 Current test evidence:
 
-- [pq_descriptor_tests.cpp](/Users/scott/quantum-proof-bitcoin/src/test/pq_descriptor_tests.cpp)
-- [wallet_pq_descriptors.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_descriptors.py)
+- [pq_descriptor_tests.cpp](../src/test/pq_descriptor_tests.cpp)
+- [wallet_pq_descriptors.py](../test/functional/wallet_pq_descriptors.py)
 
 ## Confidence Snapshot
 
@@ -195,7 +195,7 @@ does.
 
 The next owned follow-on is:
 
-- [wallet_createwalletdescriptor.py](/Users/scott/quantum-proof-bitcoin/test/functional/wallet_createwalletdescriptor.py)
+- [wallet_createwalletdescriptor.py](../test/functional/wallet_createwalletdescriptor.py)
 
 That is where the repo needs to decide how much descriptor creation behavior it
 wants to own under an all-PQ Track A stance instead of inheriting old Taproot

--- a/docs/PQ_WALLET_MANAGER_SETUP.md
+++ b/docs/PQ_WALLET_MANAGER_SETUP.md
@@ -1,0 +1,111 @@
+# PQBTC PQ Wallet Manager Setup
+
+## Status: ACTIVE
+## Spec-ID: PQ-WALLET-MANAGER-SETUP-v1
+## Updated: 2026-04-08
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the supported user-facing setup path for active PQ receive/change wallet
+managers.
+
+## Current Supported Path
+
+The dedicated PQ-native setup RPC is:
+
+- [createpqwalletmanagers](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/wallet.cpp)
+
+It creates and activates the receive/change `pqpriv(...)` manager pair from one
+shared 32-byte root seed.
+
+## Contract
+
+Inputs:
+
+- `root_seed`: 32-byte hex seed
+- `range_end`: inclusive end index for both branches
+- `next_index`: optional initial next index for both branches, default `0`
+
+Guards:
+
+- wallet must be a descriptor wallet
+- private keys must be enabled
+- wallet must have no active address managers yet
+- encrypted wallets must be unlocked
+
+Outputs:
+
+- active receive `pqpriv(...)` descriptor metadata
+- active change `pqpriv(...)` descriptor metadata
+- explicit `range` and `next_index` state for both branches
+
+## Why This Exists
+
+This RPC keeps the PQ-native setup path separate from the inherited HD-xpub
+descriptor builder:
+
+- [createwalletdescriptor](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/wallet.cpp)
+
+That inherited RPC still creates `wpkh(...)` / `tr(...)` descriptor families.
+It does not understand PQ root seeds and should not be overloaded early.
+
+## Lower-Level Alternative
+
+The lower-level path still exists:
+
+- import active `pqpriv(...)` descriptors through `importdescriptors`
+
+That remains useful for restore-style or descriptor-level testing, but it is no
+longer the preferred initial setup UX for Track A PQ wallets.
+
+## Keypool Maintenance
+
+Once the active PQ managers exist, the inherited
+[keypoolrefill](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
+RPC remains a supported maintenance path.
+
+Under PQ-only active wallets it does not create inherited address families.
+Instead, it expands the active receive/change `pqpriv(...)` ranges so each
+branch keeps at least the requested number of unused destinations available.
+
+## Funding And Change Behavior
+
+Once the active PQ managers exist, the owned funding/change posture is:
+
+- raw-transaction funding through
+  [fundrawtransaction](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/spend.cpp)
+  remains a supported wallet path
+- PSBT funding through
+  [walletcreatefundedpsbt](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/spend.cpp)
+  remains a supported wallet path for both explicit-input and automatic-input
+  flows
+- automatic change selection on PQ-only wallets must continue to consume the
+  active internal `pqpriv(...)` manager, not an inherited address family
+- current option-edge coverage keeps that same rule in force for
+  `changePosition` and `subtractFeeFromOutputs`
+- PQ-only active wallet/address RPC surfaces now expose
+  `has_private_keys = true` for owned `pqpriv(...)` receive/change outputs,
+  instead of relying on deprecated `iswatchonly` / `spendable` fields
+
+This keeps the user-facing PQ setup path compatible with the wallet's existing
+funding machinery without reopening inherited `getrawchangeaddress` semantics.
+
+## Confidence
+
+Targeted confidence pass on 2026-04-08:
+
+- `python3 test/functional/wallet_pq_active_ranged.py`
+  - result: passed
+  - covers dedicated PQ setup, active receive/change generation, PQ-aware
+    `keypoolrefill`, spend/change, restart, backup, and restore
+- `python3 test/functional/wallet_pq_psbt.py`
+  - result: passed
+  - covers the main PQ-native PSBT/signing flow starting from the dedicated
+    setup RPC, including `fundrawtransaction` and automatic-input
+    `walletcreatefundedpsbt` with automatic PQ change, including
+    `changePosition` and `subtractFeeFromOutputs`, while keeping one lower-level
+    `importdescriptors` check alive
+- `python3 test/functional/wallet_createwalletdescriptor.py`
+  - result: passed
+  - confirms inherited descriptor creation still stays separate

--- a/docs/PQ_WALLET_MANAGER_SETUP.md
+++ b/docs/PQ_WALLET_MANAGER_SETUP.md
@@ -14,7 +14,7 @@ managers.
 
 The dedicated PQ-native setup RPC is:
 
-- [createpqwalletmanagers](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/wallet.cpp)
+- [createpqwalletmanagers](../src/wallet/rpc/wallet.cpp)
 
 It creates and activates the receive/change `pqpriv(...)` manager pair from one
 shared 32-byte root seed.
@@ -45,7 +45,7 @@ Outputs:
 This RPC keeps the PQ-native setup path separate from the inherited HD-xpub
 descriptor builder:
 
-- [createwalletdescriptor](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/wallet.cpp)
+- [createwalletdescriptor](../src/wallet/rpc/wallet.cpp)
 
 That inherited RPC still creates `wpkh(...)` / `tr(...)` descriptor families.
 It does not understand PQ root seeds and should not be overloaded early.
@@ -62,7 +62,7 @@ longer the preferred initial setup UX for Track A PQ wallets.
 ## Keypool Maintenance
 
 Once the active PQ managers exist, the inherited
-[keypoolrefill](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/addresses.cpp)
+[keypoolrefill](../src/wallet/rpc/addresses.cpp)
 RPC remains a supported maintenance path.
 
 Under PQ-only active wallets it does not create inherited address families.
@@ -74,10 +74,10 @@ branch keeps at least the requested number of unused destinations available.
 Once the active PQ managers exist, the owned funding/change posture is:
 
 - raw-transaction funding through
-  [fundrawtransaction](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/spend.cpp)
+  [fundrawtransaction](../src/wallet/rpc/spend.cpp)
   remains a supported wallet path
 - PSBT funding through
-  [walletcreatefundedpsbt](/Users/scott/quantum-proof-bitcoin/src/wallet/rpc/spend.cpp)
+  [walletcreatefundedpsbt](../src/wallet/rpc/spend.cpp)
   remains a supported wallet path for both explicit-input and automatic-input
   flows
 - automatic change selection on PQ-only wallets must continue to consume the

--- a/docs/WALLET.md
+++ b/docs/WALLET.md
@@ -16,6 +16,22 @@ The wallet surface is no longer deferred in the repo. Current `main` includes:
 - backup, restore, and ranged-descriptor recovery coverage
 - default PQ-native unit coverage for wallet bookkeeping and PSBT role/error handling
 
+Important boundary:
+
+- inherited `createwalletdescriptor` support is still separate from the PQ-native
+  wallet-manager path
+- inherited `getnewaddress` and `getrawchangeaddress` are still separate from
+  the PQ-native address path and are explicitly rejected on PQ-only active
+  wallets in favor of `getnewpqaddress` and `getrawpqchangeaddress`
+- PQ wallet-manager creation now has a dedicated setup RPC,
+  `createpqwalletmanagers`, rather than entering through the inherited
+  xpub-based descriptor builder
+- inherited `keypoolrefill` remains a supported maintenance RPC for active
+  PQ managers; on PQ-only wallets it expands the receive/change `pqpriv(...)`
+  ranges instead of creating inherited address families
+- raw `importdescriptors` with `pqpriv(...)` remains available as a lower-level
+  descriptor/test path
+
 ## Confidence Closure In This Tranche
 
 This tranche closes the remaining wallet confidence gap by:

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -22,7 +22,7 @@ RPCHelpMan getnewaddress()
 {
     return RPCHelpMan{
         "getnewaddress",
-        "Returns a new Bitcoin address for receiving payments.\n"
+        "Returns a new PQBTC address for receiving payments.\n"
                 "If 'label' is specified, it is added to the address book \n"
                 "so payments received with the address will be associated with 'label'.\n",
                 {
@@ -30,7 +30,7 @@ RPCHelpMan getnewaddress()
                     {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -addresstype"}, "The address type to use. Options are " + FormatAllOutputTypes() + "."},
                 },
                 RPCResult{
-                    RPCResult::Type::STR, "address", "The new bitcoin address"
+                    RPCResult::Type::STR, "address", "The new PQBTC address"
                 },
                 RPCExamples{
                     HelpExampleCli("getnewaddress", "")
@@ -59,6 +59,13 @@ RPCHelpMan getnewaddress()
         output_type = parsed.value();
     }
 
+    if (pwallet->HasOnlyActivePQManagers()) {
+        throw JSONRPCError(
+            RPC_INVALID_ADDRESS_OR_KEY,
+            "Active pqpriv() managers do not use inherited getnewaddress; use getnewpqaddress"
+        );
+    }
+
     auto op_dest = pwallet->GetNewDestination(output_type, label);
     if (!op_dest) {
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
@@ -73,7 +80,7 @@ RPCHelpMan getrawchangeaddress()
 {
     return RPCHelpMan{
         "getrawchangeaddress",
-        "Returns a new Bitcoin address, for receiving change.\n"
+        "Returns a new PQBTC address, for receiving change.\n"
                 "This is for use with raw transactions, NOT normal use.\n",
                 {
                     {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -changetype"}, "The address type to use. Options are " + FormatAllOutputTypes() + "."},
@@ -103,6 +110,13 @@ RPCHelpMan getrawchangeaddress()
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[0].get_str()));
         }
         output_type = parsed.value();
+    }
+
+    if (pwallet->HasOnlyActivePQManagers()) {
+        throw JSONRPCError(
+            RPC_INVALID_ADDRESS_OR_KEY,
+            "Active pqpriv() managers do not use inherited getrawchangeaddress; use getrawpqchangeaddress"
+        );
     }
 
     auto op_dest = pwallet->GetNewChangeDestination(output_type);
@@ -179,7 +193,7 @@ RPCHelpMan setlabel()
         "setlabel",
         "Sets the label associated with the given address.\n",
                 {
-                    {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitcoin address to be associated with a label."},
+                    {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The PQBTC address to be associated with a label."},
                     {"label", RPCArg::Type::STR, RPCArg::Optional::NO, "The label to assign to the address."},
                 },
                 RPCResult{RPCResult::Type::NONE, "", ""},
@@ -196,7 +210,7 @@ RPCHelpMan setlabel()
 
     CTxDestination dest = DecodeDestination(request.params[0].get_str());
     if (!IsValidDestination(dest)) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PQBTC address");
     }
 
     const std::string label{LabelFromValue(request.params[1])};
@@ -227,7 +241,7 @@ RPCHelpMan listaddressgroupings()
                         {
                             {RPCResult::Type::ARR_FIXED, "", "",
                             {
-                                {RPCResult::Type::STR, "address", "The bitcoin address"},
+                                {RPCResult::Type::STR, "address", "The PQBTC address"},
                                 {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT},
                                 {RPCResult::Type::STR, "label", /*optional=*/true, "The label"},
                             }},
@@ -276,11 +290,11 @@ RPCHelpMan listaddressgroupings()
 RPCHelpMan keypoolrefill()
 {
     return RPCHelpMan{"keypoolrefill",
-                "Refills each descriptor keypool in the wallet up to the specified number of new keys.\n"
-                "By default, descriptor wallets have 4 active ranged descriptors (" + FormatAllOutputTypes() + "), each with " + util::ToString(DEFAULT_KEYPOOL_SIZE) + " entries.\n" +
+                "Refills each active ranged keypool or manager in the wallet up to the specified number of unused destinations.\n"
+                "For inherited descriptor wallets, this tops up the active descriptor keypools. For PQ-only wallets, this expands the active pqpriv() receive/change ranges so each branch keeps at least the requested number of unused destinations available.\n" +
         HELP_REQUIRING_PASSPHRASE,
                 {
-                    {"newsize", RPCArg::Type::NUM, RPCArg::DefaultHint{strprintf("%u, or as set by -keypool", DEFAULT_KEYPOOL_SIZE)}, "The new keypool size"},
+                    {"newsize", RPCArg::Type::NUM, RPCArg::DefaultHint{strprintf("%u, or as set by -keypool", DEFAULT_KEYPOOL_SIZE)}, "The minimum available size to maintain for each active ranged keypool or manager"},
                 },
                 RPCResult{RPCResult::Type::NONE, "", ""},
                 RPCExamples{
@@ -439,6 +453,7 @@ RPCHelpMan getaddressinfo()
                         {RPCResult::Type::STR_HEX, "scriptPubKey", "The hex-encoded output script generated by the address."},
                         {RPCResult::Type::BOOL, "ismine", "If the address is yours."},
                         {RPCResult::Type::BOOL, "iswatchonly", "(DEPRECATED) Always false."},
+                        {RPCResult::Type::BOOL, "has_private_keys", "Whether the wallet has private key material for this address script."},
                         {RPCResult::Type::BOOL, "solvable", "If we know how to spend coins sent to this address, ignoring the possible lack of private keys."},
                         {RPCResult::Type::STR, "desc", /*optional=*/true, "A descriptor for spending coins sent to this address (only when solvable)."},
                         {RPCResult::Type::STR, "parent_desc", /*optional=*/true, "The descriptor used to derive this address if this is a descriptor wallet"},
@@ -460,7 +475,7 @@ RPCHelpMan getaddressinfo()
                         {RPCResult::Type::OBJ, "embedded", /*optional=*/true, "Information about the address embedded in P2SH or P2WSH, if relevant and known.",
                         {
                             {RPCResult::Type::ELISION, "", "Includes all getaddressinfo output fields for the embedded address, excluding metadata (timestamp, hdkeypath, hdseedid)\n"
-                            "and relation to the wallet (ismine)."},
+                            "and relation to the wallet (ismine, has_private_keys)."},
                         }},
                         {RPCResult::Type::BOOL, "iscompressed", /*optional=*/true, "If the pubkey is compressed."},
                         {RPCResult::Type::NUM_TIME, "timestamp", /*optional=*/true, "The creation time of the key, if available, expressed in " + UNIX_EPOCH_TIME + "."},
@@ -534,6 +549,7 @@ RPCHelpMan getaddressinfo()
     }
 
     ret.pushKV("iswatchonly", false);
+    ret.pushKV("has_private_keys", ScriptPubKeyHasPrivateKeys(*pwallet, scriptPubKey));
 
     UniValue detail = DescribeWalletAddress(*pwallet, dest);
     ret.pushKVs(std::move(detail));

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -29,7 +29,7 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
         // Get the address
         CTxDestination dest = DecodeDestination(params[0].get_str());
         if (!IsValidDestination(dest)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PQBTC address");
         }
         addresses.emplace_back(dest);
     }
@@ -83,7 +83,7 @@ RPCHelpMan getreceivedbyaddress()
         "getreceivedbyaddress",
         "Returns the total amount received by the given address in transactions with at least minconf confirmations.\n",
                 {
-                    {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitcoin address for transactions."},
+                    {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The PQBTC address for transactions."},
                     {"minconf", RPCArg::Type::NUM, RPCArg::Default{1}, "Only include transactions confirmed at least this many times."},
                     {"include_immature_coinbase", RPCArg::Type::BOOL, RPCArg::Default{false}, "Include immature coinbase transactions."},
                 },
@@ -499,6 +499,7 @@ RPCHelpMan listunspent()
                             {RPCResult::Type::STR_HEX, "redeemScript", /*optional=*/true, "The redeem script if the output script is P2SH"},
                             {RPCResult::Type::STR, "witnessScript", /*optional=*/true, "witness script if the output script is P2WSH or P2SH-P2WSH"},
                             {RPCResult::Type::BOOL, "spendable", "(DEPRECATED) Always true"},
+                            {RPCResult::Type::BOOL, "has_private_keys", "Whether the wallet has private key material for this output script."},
                             {RPCResult::Type::BOOL, "solvable", "Whether we know how to spend this output, ignoring the lack of keys"},
                             {RPCResult::Type::BOOL, "reused", /*optional=*/true, "(only present if avoid_reuse is set) Whether this output is reused/dirty (sent to an address that was previously spent from)"},
                             {RPCResult::Type::STR, "desc", /*optional=*/true, "(only when solvable) A descriptor for spending this output"},
@@ -674,6 +675,7 @@ RPCHelpMan listunspent()
             }
         }
         entry.pushKV("spendable", true); // Any coins we list are always spendable
+        entry.pushKV("has_private_keys", ScriptPubKeyHasPrivateKeys(*pwallet, scriptPubKey));
         entry.pushKV("solvable", out.solvable);
         if (out.solvable) {
             std::unique_ptr<SigningProvider> provider = pwallet->GetSolvingProvider(scriptPubKey);

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -111,6 +111,18 @@ std::string LabelFromValue(const UniValue& value)
     return label;
 }
 
+bool ScriptPubKeyHasPrivateKeys(const CWallet& wallet, const CScript& script_pubkey)
+{
+    AssertLockHeld(wallet.cs_wallet);
+
+    for (const auto* spk_man : wallet.GetScriptPubKeyMans(script_pubkey)) {
+        if (spk_man->HavePrivateKeys()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void PushParentDescriptors(const CWallet& wallet, const CScript& script_pubkey, UniValue& entry)
 {
     UniValue parent_descs(UniValue::VARR);

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -49,6 +49,8 @@ WalletContext& EnsureWalletContext(const std::any& context);
 
 bool GetAvoidReuseFlag(const CWallet& wallet, const UniValue& param);
 std::string LabelFromValue(const UniValue& value);
+//! Return whether any wallet ScriptPubKey manager for this script currently has private key material.
+bool ScriptPubKeyHasPrivateKeys(const CWallet& wallet, const CScript& script_pubkey) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 //! Fetch parent descriptors of this scriptPubKey.
 void PushParentDescriptors(const CWallet& wallet, const CScript& script_pubkey, UniValue& entry);
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -9,15 +9,21 @@
 #include <key_io.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
+#include <script/descriptor.h>
 #include <univalue.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <wallet/context.h>
+#include <wallet/pq_scriptpubkeyman.h>
 #include <wallet/receive.h>
 #include <wallet/rpc/util.h>
 #include <wallet/rpc/wallet.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
+#include <algorithm>
+#include <array>
+#include <limits>
 #include <optional>
 
 
@@ -216,7 +222,7 @@ static RPCHelpMan loadwallet()
     return RPCHelpMan{
         "loadwallet",
         "Loads a wallet from a wallet file or directory."
-                "\nNote that all wallet command-line options used when starting bitcoind will be"
+                "\nNote that all wallet command-line options used when starting pqbtcd will be"
                 "\napplied to the new wallet.\n",
                 {
                     {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "The path to the directory of the wallet to be loaded, either absolute or relative to the \"wallets\" directory. The \"wallets\" directory is set by the -walletdir option and defaults to the \"wallets\" folder within the data directory."},
@@ -800,6 +806,12 @@ static RPCHelpMan createwalletdescriptor()
             if (hdkey.isNull()) {
                 std::set<CExtPubKey> active_xpubs = pwallet->GetActiveHDPubKeys();
                 if (active_xpubs.size() != 1) {
+                    if (active_xpubs.empty() && pwallet->HasActivePQManagers()) {
+                        throw JSONRPCError(
+                            RPC_INVALID_ADDRESS_OR_KEY,
+                            "Active pqpriv() managers do not expose HD keys; createwalletdescriptor only supports xpub-based descriptor families"
+                        );
+                    }
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to determine which HD key to use from active descriptors. Please specify with 'hdkey'");
                 }
                 xpub = *active_xpubs.begin();
@@ -839,6 +851,138 @@ static RPCHelpMan createwalletdescriptor()
             }
             UniValue out{UniValue::VOBJ};
             out.pushKV("descs", std::move(descs));
+            return out;
+        }
+    };
+}
+
+static RPCHelpMan createpqwalletmanagers()
+{
+    return RPCHelpMan{"createpqwalletmanagers",
+        "Creates and activates the wallet's PQ-native receive and change managers from a shared root seed. "
+        "This is the dedicated setup path for all-PQ descriptor wallets and requires the wallet to have no active address managers."
+        + HELP_REQUIRING_PASSPHRASE,
+        {
+            {"root_seed", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The 32-byte root seed used to derive both pqpriv() branches."},
+            {"range_end", RPCArg::Type::NUM, RPCArg::Optional::NO, "Inclusive end index for both the receive and change pqpriv() ranges."},
+            {"next_index", RPCArg::Type::NUM, RPCArg::Default{0}, "Initial next_index for both the receive and change pqpriv() managers."},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::OBJ, "receive", "The activated receive pqpriv() manager",
+                    {
+                        {RPCResult::Type::STR, "desc", "The receive pqpriv() descriptor"},
+                        {RPCResult::Type::BOOL, "active", "Whether the manager is active"},
+                        {RPCResult::Type::BOOL, "internal", "Whether the manager is internal"},
+                        {RPCResult::Type::ARR_FIXED, "range", "The inclusive descriptor range",
+                            {
+                                {RPCResult::Type::NUM, "begin", "Range start"},
+                                {RPCResult::Type::NUM, "end", "Range end"},
+                            }},
+                        {RPCResult::Type::NUM, "next_index", "The initial next index"},
+                    }},
+                {RPCResult::Type::OBJ, "change", "The activated change pqpriv() manager",
+                    {
+                        {RPCResult::Type::STR, "desc", "The change pqpriv() descriptor"},
+                        {RPCResult::Type::BOOL, "active", "Whether the manager is active"},
+                        {RPCResult::Type::BOOL, "internal", "Whether the manager is internal"},
+                        {RPCResult::Type::ARR_FIXED, "range", "The inclusive descriptor range",
+                            {
+                                {RPCResult::Type::NUM, "begin", "Range start"},
+                                {RPCResult::Type::NUM, "end", "Range end"},
+                            }},
+                        {RPCResult::Type::NUM, "next_index", "The initial next index"},
+                    }},
+            },
+        },
+        RPCExamples{
+            HelpExampleCli("createpqwalletmanagers", "\"" + std::string(64, '2') + "\" 9")
+            + HelpExampleRpc("createpqwalletmanagers", "\"" + std::string(64, '2') + "\", 9")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        {
+            std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+
+            const std::vector<unsigned char> root_seed_bytes = ParseHexV(request.params[0], "root_seed");
+            if (root_seed_bytes.size() != 32) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "root_seed must be exactly 32 bytes");
+            }
+
+            const int64_t range_end_inclusive = request.params[1].getInt<int64_t>();
+            if (range_end_inclusive < 0 || range_end_inclusive >= std::numeric_limits<int32_t>::max()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "range_end must be between 0 and 2147483646");
+            }
+
+            const int64_t next_index = request.params[2].isNull() ? 0 : request.params[2].getInt<int64_t>();
+            if (next_index < 0 || next_index > range_end_inclusive) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "next_index is out of range");
+            }
+
+            std::array<unsigned char, 32> root_seed{};
+            std::copy(root_seed_bytes.begin(), root_seed_bytes.end(), root_seed.begin());
+
+            LOCK(pwallet->cs_wallet);
+
+            if (!pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "createpqwalletmanagers requires a descriptor wallet");
+            }
+            if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "createpqwalletmanagers requires private keys to be enabled");
+            }
+            if (!pwallet->GetActiveScriptPubKeyMans().empty()) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "createpqwalletmanagers requires a wallet without active address managers");
+            }
+
+            EnsureWalletIsUnlocked(*pwallet);
+
+            const int32_t range_start = 0;
+            const int32_t range_end = static_cast<int32_t>(range_end_inclusive + 1);
+            const int32_t initial_next_index = static_cast<int32_t>(next_index);
+            const uint64_t creation_time = GetTime();
+
+            auto receive_res = pwallet->AddWalletPQDescriptor(
+                PQPrivateDescriptorInfo{root_seed, /*internal=*/false},
+                creation_time,
+                range_start,
+                range_end,
+                initial_next_index
+            );
+            if (!receive_res) {
+                throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Could not create receive pqpriv() manager: %s", util::ErrorString(receive_res).original));
+            }
+
+            auto change_res = pwallet->AddWalletPQDescriptor(
+                PQPrivateDescriptorInfo{root_seed, /*internal=*/true},
+                creation_time,
+                range_start,
+                range_end,
+                initial_next_index
+            );
+            if (!change_res) {
+                throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Could not create change pqpriv() manager: %s", util::ErrorString(change_res).original));
+            }
+
+            pwallet->AddActivePQScriptPubKeyMan(receive_res.value().get().GetID(), /*internal=*/false);
+            pwallet->AddActivePQScriptPubKeyMan(change_res.value().get().GetID(), /*internal=*/true);
+
+            const auto make_branch_result = [&](bool internal) {
+                UniValue branch(UniValue::VOBJ);
+                branch.pushKV("desc", GetPQPrivateDescriptorString(root_seed, internal));
+                branch.pushKV("active", true);
+                branch.pushKV("internal", internal);
+                UniValue range(UniValue::VARR);
+                range.push_back(range_start);
+                range.push_back(static_cast<int32_t>(range_end_inclusive));
+                branch.pushKV("range", std::move(range));
+                branch.pushKV("next_index", initial_next_index);
+                return branch;
+            };
+
+            UniValue out(UniValue::VOBJ);
+            out.pushKV("receive", make_branch_result(/*internal=*/false));
+            out.pushKV("change", make_branch_result(/*internal=*/true));
             return out;
         }
     };
@@ -918,6 +1062,7 @@ std::span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &bumpfee},
         {"wallet", &psbtbumpfee},
         {"wallet", &createwallet},
+        {"wallet", &createpqwalletmanagers},
         {"wallet", &createwalletdescriptor},
         {"wallet", &restorewallet},
         {"wallet", &encryptwallet},

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1719,6 +1719,9 @@ bool CWallet::CanGetAddresses(bool internal) const
 {
     LOCK(cs_wallet);
     if (m_spk_managers.empty()) return false;
+    if (!internal && m_external_pq_spk_manager && m_external_pq_spk_manager->CanGetAddresses(/*internal=*/false)) {
+        return true;
+    }
     if (internal && m_internal_pq_spk_manager && m_internal_pq_spk_manager->CanGetAddresses(/*internal=*/true)) {
         return true;
     }
@@ -4659,6 +4662,35 @@ std::set<CExtPubKey> CWallet::GetActiveHDPubKeys() const
         active_xpubs.merge(std::move(desc_xpubs));
     }
     return active_xpubs;
+}
+
+bool CWallet::HasActivePQManagers() const
+{
+    AssertLockHeld(cs_wallet);
+    if (!IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) return false;
+
+    for (const auto& spkm : GetActiveScriptPubKeyMans()) {
+        if (dynamic_cast<PQDescriptorScriptPubKeyMan*>(spkm)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CWallet::HasOnlyActivePQManagers() const
+{
+    AssertLockHeld(cs_wallet);
+    if (!IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) return false;
+
+    const auto active_spkms = GetActiveScriptPubKeyMans();
+    if (active_spkms.empty()) return false;
+
+    for (const auto& spkm : active_spkms) {
+        if (!dynamic_cast<PQDescriptorScriptPubKeyMan*>(spkm)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 std::optional<CKey> CWallet::GetKey(const CKeyID& keyid) const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1072,6 +1072,10 @@ public:
 
     //! Retrieve the xpubs in use by the active descriptors
     std::set<CExtPubKey> GetActiveHDPubKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    //! Returns true when any active ScriptPubKey manager is PQ-native
+    bool HasActivePQManagers() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    //! Returns true when all active ScriptPubKey managers are PQ-native
+    bool HasOnlyActivePQManagers() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Find the private key for the given key id from the wallet's descriptors, if available
     //! Returns nullopt when no descriptor has the key or if the wallet is locked.

--- a/test/functional/wallet_pq_active_ranged.py
+++ b/test/functional/wallet_pq_active_ranged.py
@@ -14,7 +14,6 @@ from test_framework.pqsig import create_wallet_funded_tx
 from test_framework.pq_wallet_helper import (
     build_active_pq_descriptor_entry,
     make_pqpriv_descriptor,
-    make_pqpriv_import_request,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
@@ -52,28 +51,47 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
             }
         return descriptors
 
-    def assert_descriptor_state(self, wallet, root_seed: bytes, *, external_next: int, internal_next: int):
+    def assert_descriptor_state(
+        self,
+        wallet,
+        root_seed: bytes,
+        *,
+        external_next: int,
+        internal_next: int,
+        external_range: list[int] | None = None,
+        internal_range: list[int] | None = None,
+    ):
+        if external_range is None:
+            external_range = [0, 9]
+        if internal_range is None:
+            internal_range = [0, 9]
         descs = self.descriptor_state(wallet)
         expected = {
             make_pqpriv_descriptor(root_seed, False): {
                 "active": True,
                 "internal": False,
-                "range": [0, 9],
+                "range": external_range,
                 "next_index": external_next,
             },
             make_pqpriv_descriptor(root_seed, True): {
                 "active": True,
                 "internal": True,
-                "range": [0, 9],
+                "range": internal_range,
                 "next_index": internal_next,
             },
         }
         assert_equal(descs, expected)
 
+    def assert_keypool_info(self, wallet, *, external: int, internal: int):
+        info = wallet.getwalletinfo()
+        assert_equal(info["keypoolsize"], external)
+        assert_equal(info["keypoolsize_hd_internal"], internal)
+
     def assert_address_info(self, wallet, entry, *, is_change: bool, label: str | None = None):
         info = wallet.getaddressinfo(entry.address)
         assert_equal(info["desc"], entry.descriptor)
         assert_equal(info["ismine"], True)
+        assert_equal(info["has_private_keys"], True)
         assert_equal(info["solvable"], True)
         assert_equal(info["ischange"], is_change)
         assert "parent_desc" not in info
@@ -92,6 +110,7 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         assert_equal(unspent[0]["address"], entry.address)
         assert_equal(unspent[0]["amount"], amount)
         assert_equal(unspent[0]["spendable"], True)
+        assert_equal(unspent[0]["has_private_keys"], True)
         assert_equal(wallet.getbalances()["mine"]["trusted"], amount)
 
     def find_output_amount(self, txid: str, address: str, *, blockhash: str) -> Decimal:
@@ -117,25 +136,112 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         ext_entries = [build_active_pq_descriptor_entry(root_seed, internal=False, index=i) for i in range(6)]
         int_entries = [build_active_pq_descriptor_entry(root_seed, internal=True, index=i) for i in range(4)]
         node.createwallet(wallet_name="sink")
-        sink_addr = node.get_wallet_rpc("sink").getnewaddress()
+        sink_wallet = node.get_wallet_rpc("sink")
+        sink_addr = sink_wallet.getnewaddress()
 
-        self.log.info("Create a blank descriptor wallet and import active pqpriv() receive/change descriptors")
+        self.log.info("Reject PQ manager setup on wallets that already have active address managers")
+        assert_raises_rpc_error(
+            -4,
+            "createpqwalletmanagers requires a wallet without active address managers",
+            sink_wallet.createpqwalletmanagers,
+            root_seed.hex(),
+            9,
+        )
+        assert_raises_rpc_error(
+            -8,
+            "next_index is out of range",
+            sink_wallet.createpqwalletmanagers,
+            root_seed.hex(),
+            9,
+            10,
+        )
+
+        self.log.info("Create a blank descriptor wallet and activate the dedicated PQ receive/change managers")
         node.createwallet(wallet_name="pqactive", blank=True)
         wallet = node.get_wallet_rpc("pqactive")
-        result = wallet.importdescriptors([
-            make_pqpriv_import_request(root_seed, internal=False, active=True, timestamp="now", range_end=9),
-            make_pqpriv_import_request(root_seed, internal=True, active=True, timestamp="now", range_end=9),
-        ])
-        assert all(item["success"] for item in result)
+        result = wallet.createpqwalletmanagers(root_seed.hex(), 9)
+        assert_equal(result["receive"]["desc"], make_pqpriv_descriptor(root_seed, False))
+        assert_equal(result["receive"]["active"], True)
+        assert_equal(result["receive"]["internal"], False)
+        assert_equal(result["receive"]["range"], [0, 9])
+        assert_equal(result["receive"]["next_index"], 0)
+        assert_equal(result["change"]["desc"], make_pqpriv_descriptor(root_seed, True))
+        assert_equal(result["change"]["active"], True)
+        assert_equal(result["change"]["internal"], True)
+        assert_equal(result["change"]["range"], [0, 9])
+        assert_equal(result["change"]["next_index"], 0)
+        assert_raises_rpc_error(
+            -4,
+            "createpqwalletmanagers requires a wallet without active address managers",
+            wallet.createpqwalletmanagers,
+            root_seed.hex(),
+            9,
+        )
 
         self.assert_descriptor_state(wallet, root_seed, external_next=0, internal_next=0)
+        self.assert_keypool_info(wallet, external=10, internal=10)
         assert_raises_rpc_error(-4, "Public export for ranged pqpriv() descriptors is not available.", wallet.listdescriptors, False)
         assert_equal(wallet.gethdkeys(), [])
         assert_raises_rpc_error(
             -5,
-            "Unable to determine which HD key to use from active descriptors. Please specify with 'hdkey'",
+            "Active pqpriv() managers do not use inherited getnewaddress; use getnewpqaddress",
+            wallet.getnewaddress,
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getnewaddress; use getnewpqaddress",
+            wallet.getnewaddress,
+            "",
+            "bech32",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getnewaddress; use getnewpqaddress",
+            wallet.getnewaddress,
+            "",
+            "legacy",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getnewaddress; use getnewpqaddress",
+            wallet.getnewaddress,
+            "",
+            "p2sh-segwit",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getrawchangeaddress; use getrawpqchangeaddress",
+            wallet.getrawchangeaddress,
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getrawchangeaddress; use getrawpqchangeaddress",
+            wallet.getrawchangeaddress,
+            "bech32",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getrawchangeaddress; use getrawpqchangeaddress",
+            wallet.getrawchangeaddress,
+            "legacy",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getrawchangeaddress; use getrawpqchangeaddress",
+            wallet.getrawchangeaddress,
+            "p2sh-segwit",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not expose HD keys; createwalletdescriptor only supports xpub-based descriptor families",
             wallet.createwalletdescriptor,
             "bech32",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not expose HD keys; createwalletdescriptor only supports xpub-based descriptor families",
+            wallet.createwalletdescriptor,
+            "bech32m",
         )
 
         self.log.info("Generate receive/change PQ addresses from the active managers")
@@ -149,6 +255,19 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         self.assert_address_info(wallet, ext_entries[2], is_change=False)
         self.assert_address_info(wallet, int_entries[0], is_change=True)
         self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=1)
+        self.assert_keypool_info(wallet, external=7, internal=9)
+
+        self.log.info("Use keypoolrefill to expand the active PQ receive/change ranges")
+        wallet.keypoolrefill(12)
+        self.assert_descriptor_state(
+            wallet,
+            root_seed,
+            external_next=3,
+            internal_next=1,
+            external_range=[0, 14],
+            internal_range=[0, 12],
+        )
+        self.assert_keypool_info(wallet, external=12, internal=12)
 
         self.log.info("Fund a later generated PQ address and confirm it is tracked and spendable")
         txid = self.fund_entry(ext_entries[2], 4 * COIN)
@@ -160,14 +279,28 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         spend_blockhash = self.mine_block()
         change_amount = self.find_output_amount(spend_txid, int_entries[1].address, blockhash=spend_blockhash)
         self.assert_owned_unspent(wallet, spend_txid, int_entries[1], change_amount, category=None)
-        self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=2)
+        self.assert_descriptor_state(
+            wallet,
+            root_seed,
+            external_next=3,
+            internal_next=2,
+            external_range=[0, 14],
+            internal_range=[0, 12],
+        )
         self.assert_address_info(wallet, int_entries[1], is_change=True)
 
         self.log.info("Restart and confirm active manager state and tracked outputs persist")
         self.restart_node(0, self.extra_args[0])
         node = self.nodes[0]
         wallet = self.ensure_wallet_loaded("pqactive")
-        self.assert_descriptor_state(wallet, root_seed, external_next=3, internal_next=2)
+        self.assert_descriptor_state(
+            wallet,
+            root_seed,
+            external_next=3,
+            internal_next=2,
+            external_range=[0, 14],
+            internal_range=[0, 12],
+        )
         self.assert_owned_unspent(wallet, spend_txid, int_entries[1], change_amount, category=None)
 
         self.log.info("Back up and restore the wallet with active PQ managers intact")
@@ -176,31 +309,88 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
         node.restorewallet("pqactive_restored", str(backup_path))
         restored = node.get_wallet_rpc("pqactive_restored")
 
-        self.assert_descriptor_state(restored, root_seed, external_next=3, internal_next=2)
+        self.assert_descriptor_state(
+            restored,
+            root_seed,
+            external_next=3,
+            internal_next=2,
+            external_range=[0, 14],
+            internal_range=[0, 12],
+        )
         self.assert_owned_unspent(restored, spend_txid, int_entries[1], change_amount, category=None)
         self.assert_address_info(restored, int_entries[1], is_change=True)
         assert_equal(restored.gethdkeys(), [])
         assert_raises_rpc_error(-4, "Public export for ranged pqpriv() descriptors is not available.", restored.listdescriptors, False)
         assert_raises_rpc_error(
             -5,
-            "Unable to determine which HD key to use from active descriptors. Please specify with 'hdkey'",
+            "Active pqpriv() managers do not use inherited getnewaddress; use getnewpqaddress",
+            restored.getnewaddress,
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getnewaddress; use getnewpqaddress",
+            restored.getnewaddress,
+            "",
+            "legacy",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getrawchangeaddress; use getrawpqchangeaddress",
+            restored.getrawchangeaddress,
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not use inherited getrawchangeaddress; use getrawpqchangeaddress",
+            restored.getrawchangeaddress,
+            "legacy",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not expose HD keys; createwalletdescriptor only supports xpub-based descriptor families",
             restored.createwalletdescriptor,
             "bech32",
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Active pqpriv() managers do not expose HD keys; createwalletdescriptor only supports xpub-based descriptor families",
+            restored.createwalletdescriptor,
+            "bech32m",
         )
 
         self.log.info("Generated addresses continue from the correct next index after restore")
         assert_equal(restored.getnewpqaddress("restored receive"), ext_entries[3].address)
         assert_equal(restored.getrawpqchangeaddress(), int_entries[2].address)
-        self.assert_descriptor_state(restored, root_seed, external_next=4, internal_next=3)
+        self.assert_descriptor_state(
+            restored,
+            root_seed,
+            external_next=4,
+            internal_next=3,
+            external_range=[0, 14],
+            internal_range=[0, 12],
+        )
 
         self.log.info("Reload the restored wallet and confirm watch set and next_index remain stable")
         restored.unloadwallet()
         node.loadwallet("pqactive_restored")
         restored = node.get_wallet_rpc("pqactive_restored")
-        self.assert_descriptor_state(restored, root_seed, external_next=4, internal_next=3)
+        self.assert_descriptor_state(
+            restored,
+            root_seed,
+            external_next=4,
+            internal_next=3,
+            external_range=[0, 14],
+            internal_range=[0, 12],
+        )
         self.assert_owned_unspent(restored, spend_txid, int_entries[1], change_amount, category=None)
         assert_equal(restored.getnewpqaddress(), ext_entries[4].address)
-        self.assert_descriptor_state(restored, root_seed, external_next=5, internal_next=3)
+        self.assert_descriptor_state(
+            restored,
+            root_seed,
+            external_next=5,
+            internal_next=3,
+            external_range=[0, 14],
+            internal_range=[0, 12],
+        )
 
 
 if __name__ == "__main__":

--- a/test/functional/wallet_pq_descriptors.py
+++ b/test/functional/wallet_pq_descriptors.py
@@ -31,8 +31,18 @@ class WalletPQDescriptorsTest(BitcoinTestFramework):
     def mine_block(self):
         self.nodes[0].generatetodescriptor(1, RAW_TRUE_DESCRIPTOR, called_by_framework=True)
 
+    def find_pq_props(self, decoded_input):
+        return [
+            prop for prop in decoded_input.get("proprietary", [])
+            if prop["identifier"] == "7071627463" and prop["subtype"] == 1
+        ]
+
     def run_test(self):
         node = self.nodes[0]
+        node.createwallet(wallet_name="sink")
+        sink = node.get_wallet_rpc("sink")
+        sink_address = sink.getnewaddress()
+
         node.createwallet(wallet_name="watch", disable_private_keys=True, blank=True)
         watch = node.get_wallet_rpc("watch")
 
@@ -94,7 +104,9 @@ class WalletPQDescriptorsTest(BitcoinTestFramework):
         info = watch.getaddressinfo(address)
         assert_equal(info["desc"], descriptor)
         assert_equal(info["ismine"], True)
+        assert_equal(info["has_private_keys"], False)
         assert_equal(info["solvable"], True)
+        assert_equal(watch.getwalletinfo()["private_keys_enabled"], False)
 
         self.log.info("Descriptor survives unload/load")
         watch.unloadwallet()
@@ -114,9 +126,38 @@ class WalletPQDescriptorsTest(BitcoinTestFramework):
         assert_equal(unspent[0]["txid"], txid)
         assert_equal(unspent[0]["address"], address)
         assert_equal(unspent[0]["amount"], Decimal("5.00000000"))
+        assert_equal(unspent[0]["has_private_keys"], False)
+        assert_equal(unspent[0]["solvable"], True)
         balances = watch.getbalances()
         tracked_bucket = balances["watchonly"] if "watchonly" in balances else balances["mine"]
         assert_equal(tracked_bucket["trusted"], Decimal("5.00000000"))
+
+        self.log.info("Fixed watch-only pq(...) can prepare but not sign a PSBT-backed send")
+        created = watch.send(
+            outputs={sink_address: Decimal("5.00000000")},
+            options={
+                "inputs": [{"txid": unspent[0]["txid"], "vout": unspent[0]["vout"]}],
+                "add_inputs": False,
+                "subtract_fee_from_outputs": [0],
+                "psbt": True,
+            },
+        )
+        assert_equal(created["complete"], False)
+        assert "txid" not in created
+        decoded = node.decodepsbt(created["psbt"])
+        assert_equal(len(decoded["inputs"]), 1)
+        assert_equal(len(decoded["tx"]["vin"]), 1)
+        assert_equal(len(decoded["tx"]["vout"]), 1)
+        assert "witness_utxo" in decoded["inputs"][0]
+        assert_equal(self.find_pq_props(decoded["inputs"][0]), [])
+        assert "final_scriptwitness" not in decoded["inputs"][0]
+        assert Decimal(str(decoded["tx"]["vout"][0]["value"])) < Decimal("5.00000000")
+
+        processed = watch.walletprocesspsbt(psbt=created["psbt"], finalize=False)
+        assert_equal(processed["complete"], False)
+        processed_decoded = node.decodepsbt(processed["psbt"])
+        assert_equal(self.find_pq_props(processed_decoded["inputs"][0]), [])
+        assert "final_scriptwitness" not in processed_decoded["inputs"][0]
 
 
 if __name__ == "__main__":

--- a/test/functional/wallet_pq_psbt.py
+++ b/test/functional/wallet_pq_psbt.py
@@ -63,6 +63,17 @@ class WalletPQPSBTTest(BitcoinTestFramework):
                 return Decimal(str(vout["value"]))
         raise AssertionError(f"Unable to find output for {address} in {txid}")
 
+    def find_decoded_output_address(self, decoded_tx, vout_index: int) -> str:
+        script_pub_key = decoded_tx["vout"][vout_index]["scriptPubKey"]
+        output_address = script_pub_key.get("address")
+        if output_address is None:
+            addresses = script_pub_key.get("addresses", [])
+            if addresses:
+                output_address = addresses[0]
+        if output_address is None:
+            raise AssertionError(f"Unable to resolve output address at vout={vout_index}")
+        return output_address
+
     def find_pq_props(self, decoded_input):
         return [
             prop for prop in decoded_input.get("proprietary", [])
@@ -72,22 +83,26 @@ class WalletPQPSBTTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]
         root_seed = bytes.fromhex("36" * 32)
-        ext_entries = [build_active_pq_descriptor_entry(root_seed, internal=False, index=i) for i in range(4)]
-        int_entries = [build_active_pq_descriptor_entry(root_seed, internal=True, index=i) for i in range(4)]
+        import_root_seed = bytes.fromhex("37" * 32)
+        ext_entries = [build_active_pq_descriptor_entry(root_seed, internal=False, index=i) for i in range(5)]
+        int_entries = [build_active_pq_descriptor_entry(root_seed, internal=True, index=i) for i in range(7)]
+        import_ext_entries = [build_active_pq_descriptor_entry(import_root_seed, internal=False, index=i) for i in range(2)]
 
         node.createwallet(wallet_name="sink")
         sink = node.get_wallet_rpc("sink")
         sink_a = sink.getnewaddress()
         sink_b = sink.getnewaddress()
 
-        self.log.info("Create a blank descriptor wallet with active pqpriv() receive/change managers")
+        self.log.info("Create a blank descriptor wallet with active PQ receive/change managers via the dedicated setup RPC")
         node.createwallet(wallet_name="pqspend", blank=True)
         wallet = node.get_wallet_rpc("pqspend")
-        result = wallet.importdescriptors([
-            make_pqpriv_import_request(root_seed, internal=False, active=True, timestamp="now", range_end=9),
-            make_pqpriv_import_request(root_seed, internal=True, active=True, timestamp="now", range_end=9),
-        ])
-        assert all(item["success"] for item in result)
+        result = wallet.createpqwalletmanagers(root_seed.hex(), 9)
+        assert_equal(result["receive"]["desc"], make_pqpriv_import_request(root_seed, internal=False, active=True, timestamp="now", range_end=9)["desc"])
+        assert_equal(result["receive"]["range"], [0, 9])
+        assert_equal(result["receive"]["next_index"], 0)
+        assert_equal(result["change"]["desc"], make_pqpriv_import_request(root_seed, internal=True, active=True, timestamp="now", range_end=9)["desc"])
+        assert_equal(result["change"]["range"], [0, 9])
+        assert_equal(result["change"]["next_index"], 0)
 
         self.log.info("Fund the first generated PQ address and spend it through sendmany")
         assert_equal(wallet.getnewpqaddress("first receive"), ext_entries[0].address)
@@ -134,6 +149,7 @@ class WalletPQPSBTTest(BitcoinTestFramework):
         wallet = self.ensure_wallet_loaded("pqspend")
         sink = self.ensure_wallet_loaded("sink")
         sink_a = sink.getnewaddress()
+        sink_b = sink.getnewaddress()
 
         assert_equal(wallet.getnewpqaddress("post-restart receive"), ext_entries[2].address)
         restart_funding_txid = self.fund_entry(ext_entries[2], 3 * COIN)
@@ -145,6 +161,110 @@ class WalletPQPSBTTest(BitcoinTestFramework):
         direct_send_blockhash = self.mine_block()
         direct_change = self.find_output_amount(direct_send_txid, int_entries[2].address, blockhash=direct_send_blockhash)
         assert self.find_unspent(wallet, int_entries[2].address, direct_send_txid)["amount"] == direct_change
+
+        self.log.info("Fund a raw transaction and confirm automatic PQ change stays on the active internal manager")
+        raw_tx = node.createrawtransaction([], {sink_b: Decimal("0.75000000")})
+        funded = wallet.fundrawtransaction(raw_tx, {"fee_rate": 1})
+        assert funded["changepos"] >= 0
+        decoded_funded = node.decoderawtransaction(funded["hex"])
+        assert_equal(self.find_decoded_output_address(decoded_funded, funded["changepos"]), int_entries[3].address)
+
+        signed = wallet.signrawtransactionwithwallet(funded["hex"])
+        assert_equal(signed["complete"], True)
+        funded_txid = node.sendrawtransaction(signed["hex"])
+        funded_blockhash = self.mine_block()
+        funded_change = self.find_output_amount(funded_txid, int_entries[3].address, blockhash=funded_blockhash)
+        assert self.find_unspent(wallet, int_entries[3].address, funded_txid)["amount"] == funded_change
+
+        self.log.info("Create a PQ-native PSBT with automatic input selection and confirm automatic PQ change")
+        auto_created = wallet.walletcreatefundedpsbt(
+            [],
+            {sink_b: Decimal("0.60000000")},
+            0,
+            {"add_inputs": True, "fee_rate": 1},
+        )
+        assert auto_created["changepos"] >= 0
+        decoded_auto_created = node.decodepsbt(auto_created["psbt"])
+        assert_equal(self.find_decoded_output_address(decoded_auto_created["tx"], auto_created["changepos"]), int_entries[4].address)
+
+        auto_processed = wallet.walletprocesspsbt(psbt=auto_created["psbt"], finalize=False)
+        assert "hex" not in auto_processed
+        decoded_auto_processed = node.decodepsbt(auto_processed["psbt"])
+        assert len(decoded_auto_processed["inputs"]) >= 1
+        for decoded_input in decoded_auto_processed["inputs"]:
+            pq_props = self.find_pq_props(decoded_input)
+            assert_equal(len(pq_props), 1)
+            assert_equal(len(pq_props[0]["value"]), 2 * 4480)
+
+        auto_finalized = node.finalizepsbt(auto_processed["psbt"])
+        assert_equal(auto_finalized["complete"], True)
+        auto_txid = node.sendrawtransaction(auto_finalized["hex"])
+        auto_blockhash = self.mine_block()
+        auto_change = self.find_output_amount(auto_txid, int_entries[4].address, blockhash=auto_blockhash)
+        assert self.find_unspent(wallet, int_entries[4].address, auto_txid)["amount"] == auto_change
+
+        self.log.info("Respect walletcreatefundedpsbt changePosition while keeping PQ change on the active internal manager")
+        positioned = wallet.walletcreatefundedpsbt(
+            [],
+            {sink_a: Decimal("0.45000000")},
+            0,
+            {"add_inputs": True, "fee_rate": 1, "changePosition": 1},
+        )
+        assert_equal(positioned["changepos"], 1)
+        decoded_positioned = node.decodepsbt(positioned["psbt"])
+        assert_equal(self.find_decoded_output_address(decoded_positioned["tx"], positioned["changepos"]), int_entries[5].address)
+
+        positioned_processed = wallet.walletprocesspsbt(psbt=positioned["psbt"], finalize=False)
+        decoded_positioned_processed = node.decodepsbt(positioned_processed["psbt"])
+        for decoded_input in decoded_positioned_processed["inputs"]:
+            pq_props = self.find_pq_props(decoded_input)
+            assert_equal(len(pq_props), 1)
+            assert_equal(len(pq_props[0]["value"]), 2 * 4480)
+
+        positioned_finalized = node.finalizepsbt(positioned_processed["psbt"])
+        assert_equal(positioned_finalized["complete"], True)
+        positioned_txid = node.sendrawtransaction(positioned_finalized["hex"])
+        positioned_blockhash = self.mine_block()
+        positioned_change = self.find_output_amount(positioned_txid, int_entries[5].address, blockhash=positioned_blockhash)
+        assert self.find_unspent(wallet, int_entries[5].address, positioned_txid)["amount"] == positioned_change
+
+        self.log.info("Respect walletcreatefundedpsbt subtractFeeFromOutputs while keeping PQ change on the active internal manager")
+        subtracting = wallet.walletcreatefundedpsbt(
+            [],
+            {sink_b: Decimal("0.40000000")},
+            0,
+            {"add_inputs": True, "fee_rate": 1, "subtractFeeFromOutputs": [0]},
+        )
+        assert subtracting["changepos"] >= 0
+        decoded_subtracting = node.decodepsbt(subtracting["psbt"])
+        assert_equal(self.find_decoded_output_address(decoded_subtracting["tx"], subtracting["changepos"]), int_entries[6].address)
+
+        subtracting_processed = wallet.walletprocesspsbt(psbt=subtracting["psbt"], finalize=False)
+        decoded_subtracting_processed = node.decodepsbt(subtracting_processed["psbt"])
+        for decoded_input in decoded_subtracting_processed["inputs"]:
+            pq_props = self.find_pq_props(decoded_input)
+            assert_equal(len(pq_props), 1)
+            assert_equal(len(pq_props[0]["value"]), 2 * 4480)
+
+        subtracting_finalized = node.finalizepsbt(subtracting_processed["psbt"])
+        assert_equal(subtracting_finalized["complete"], True)
+        subtracting_txid = node.sendrawtransaction(subtracting_finalized["hex"])
+        subtracting_blockhash = self.mine_block()
+        subtracting_change = self.find_output_amount(subtracting_txid, int_entries[6].address, blockhash=subtracting_blockhash)
+        assert self.find_unspent(wallet, int_entries[6].address, subtracting_txid)["amount"] == subtracting_change
+        recipient_amount = self.find_output_amount(subtracting_txid, sink_b, blockhash=subtracting_blockhash)
+        assert recipient_amount < Decimal("0.40000000")
+
+        self.log.info("Keep lower-level pqpriv() import coverage alive for descriptor-level setup")
+        node.createwallet(wallet_name="pqspend_import", blank=True)
+        imported_wallet = node.get_wallet_rpc("pqspend_import")
+        import_result = imported_wallet.importdescriptors([
+            make_pqpriv_import_request(import_root_seed, internal=False, active=True, timestamp="now", range_end=3),
+            make_pqpriv_import_request(import_root_seed, internal=True, active=True, timestamp="now", range_end=3),
+        ])
+        assert all(item["success"] for item in import_result)
+        assert_equal(imported_wallet.getnewpqaddress("imported receive"), import_ext_entries[0].address)
+        assert_equal(imported_wallet.getnewpqaddress(), import_ext_entries[1].address)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the dedicated PQ wallet-manager setup foundation for descriptor wallets
- freeze the PQ-only address and fixed `pq(...)` descriptor boundaries in code and docs
- add explicit `has_private_keys` RPC metadata instead of overloading deprecated watch-only fields

## Testing
- cmake --build /Users/scott/quantum-proof-bitcoin/build --target pqbtcd pqbtc-wallet -j4
- python3 /Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_active_ranged.py
- python3 /Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_descriptors.py
- python3 /Users/scott/quantum-proof-bitcoin/test/functional/wallet_pq_psbt.py
