### PR TITLE
docs: freeze wallet spec for gatekeeper

### DIFF
--- a/docs/WALLET.md
+++ b/docs/WALLET.md
@@ -3,6 +3,7 @@
 ## Status: FROZEN
 ## Spec-ID: WALLET-v1-frozen
 ## Updated-By: freeze-gate-prereq-20260408
+## Frozen-By: gatekeeper-prereq-20260408
 ## Consensus-Relevant: NO
 
 ## Current v1 Wallet Surface

--- a/docs/WALLET.md
+++ b/docs/WALLET.md
@@ -1,8 +1,8 @@
 # Wallet Plan for PQBTC
 
-## Status: IMPLEMENTED
-## Spec-ID: WALLET-v1-implemented
-## Updated-By: issue-12-wallet-confidence-20260401
+## Status: FROZEN
+## Spec-ID: WALLET-v1-frozen
+## Updated-By: freeze-gate-prereq-20260408
 ## Consensus-Relevant: NO
 
 ## Current v1 Wallet Surface


### PR DESCRIPTION
## Summary
- mark `docs/WALLET.md` as `FROZEN`
- satisfy the gatekeeper prerequisite for wallet-touching PRs
- unblock PR #80 without mixing this process change into the wallet code slice

## Testing
- doc-only change
