### PR TITLE
rpc: convert createpqwalletmanagers CLI args

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -169,6 +169,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "walletcreatefundedpsbt", 3, "max_tx_weight"},
     { "walletcreatefundedpsbt", 4, "bip32derivs" },
     { "walletcreatefundedpsbt", 5, "version" },
+    { "createpqwalletmanagers", 1, "range_end" },
+    { "createpqwalletmanagers", 2, "next_index" },
     { "walletprocesspsbt", 1, "sign" },
     { "walletprocesspsbt", 3, "bip32derivs" },
     { "walletprocesspsbt", 4, "finalize" },


### PR DESCRIPTION
## Summary
- teach bitcoin-cli to convert createpqwalletmanagers numeric parameters
- fix the i686/usecli Promotion Matrix failure on wallet_pq_active_ranged
- keep the fix in the RPC client conversion table instead of adding test-only workarounds

## Testing
- python3 test/functional/wallet_pq_active_ranged.py --configfile=build-hotfix/test/config.ini --usecli
- python3 test/functional/wallet_pq_psbt.py --configfile=build-hotfix/test/config.ini --usecli