### PR TITLE
docs: add Track A strategy and launch pack

### DIFF
--- a/docs/DECISION_DEFERRAL_LEDGER.md
+++ b/docs/DECISION_DEFERRAL_LEDGER.md
@@ -16,11 +16,14 @@ and define the concrete work required for a full-and-complete post-v1 program.
 - post-v1 update: fixed watch-only `pq(<PK_script>)` descriptor import/list/inference is implemented for standard single-sig PQ P2WSH outputs.
 - post-v1 update: `#19` validates backup/recovery of statically imported bounded PQ descriptor batches only.
 - post-v1 update: active ranged private `pqpriv(...)` receive/change managers are implemented with dedicated PQ address generation and private export.
+- post-v1 update: PQ-only active wallets explicitly reject inherited `getnewaddress` / `getrawchangeaddress`; the owned address UX is `getnewpqaddress` / `getrawpqchangeaddress`.
+- post-v1 update: inherited `createwalletdescriptor` coverage remains green, but it is still the HD-xpub builder for `wpkh(...)` / `tr(...)`, not the PQ-native manager creation path.
 - deferred: wallet/keypool UX and end-user signing flows.
 - full-complete delta:
   - PSBT construction/finalization for PQ scripts
   - wallet RPC parity and wallet functional coverage
   - spendability/signing parity for generated PQ outputs
+  - settle the API shape for PQ-native descriptor creation (`createwalletdescriptor` extension vs dedicated PQ path)
 
 ### 2. Taproot disabled for v1
 - v1 state: taproot activation remains `NEVER_ACTIVE` on PQBTC deployment tracks.

--- a/docs/GENESIS_AND_NETWORK_POSTURE.md
+++ b/docs/GENESIS_AND_NETWORK_POSTURE.md
@@ -1,0 +1,160 @@
+# PQBTC Genesis And Network Posture
+
+## Status: ACTIVE
+## Spec-ID: GENESIS-NETWORK-POSTURE-v1
+## Frozen-By: track-a-launch-posture-20260406
+## Consensus-Relevant: YES
+
+## Purpose
+
+State the practical launch consequences of the Track A thesis:
+
+- PQBTC is a new chain starting at block 0
+- PQBTC owns its own network identity
+- PQBTC is not a continuation of inherited Bitcoin chain history
+
+This note exists so future engineering work does not quietly drift into
+retrofit assumptions that do not match the project thesis.
+
+## Core Launch Posture
+
+PQBTC launches as a fresh chain with its own genesis block, its own chain
+history, and its own network namespace.
+
+That means:
+
+- no inherited Bitcoin mainnet/testnet/regtest history
+- no imported Bitcoin UTXO set as a launch prerequisite
+- no assumption that Bitcoin transactions, addresses, descriptors, or wallet
+  flows are preserved unless PQBTC defines them explicitly
+- no obligation to maintain broad classical wallet compatibility merely because
+  inherited Bitcoin Core code paths still exist in-tree
+
+The repo may continue to use Bitcoin-derived architecture, but the product
+posture is a new chain, not a live-upgrade fork.
+
+## Frozen Network Identity
+
+The chain identity is already frozen in:
+
+- [GENESIS.md](GENESIS.md)
+- [chainparams.cpp](../src/kernel/chainparams.cpp)
+- [NAMING.md](NAMING.md)
+
+Current public-network constants:
+
+- mainnet:
+  - message start: `0x85 0x92 0xa7 0xad`
+  - p2p port: `22833`
+  - rpc port: `22832`
+  - bech32 HRP: `pq`
+  - genesis hash: `2af71da20e6e03bfdfc2347edffbbb4087796678c8d57cacbccbd10eee7b31e4`
+- testnet:
+  - message start: `0xa7 0xe2 0x9c 0xf7`
+  - p2p port: `23833`
+  - rpc port: `23832`
+  - bech32 HRP: `tq`
+  - genesis hash: `2b6939c6a048aa840a962d19ee680879c0bcbbeeff6e258fd049b5a6a947a979`
+- regtest:
+  - message start: `0x96 0xbd 0x87 0x9e`
+  - p2p port: `24833`
+  - rpc port: `24832`
+  - bech32 HRP: `rq`
+  - genesis hash: `36cc1172b59a75d055126cfb7a1d3b5d37eebc57bec9791fccfa48af6bbd15e2`
+
+These are not cosmetic renames. They are part of the chain-separation contract.
+
+## Practical Consequences
+
+### 1. Chain History
+
+PQBTC should be reasoned about as genesis-native from the first block onward.
+
+Do not assume:
+
+- importing Bitcoin chainstate
+- preserving Bitcoin block history
+- validating against inherited Bitcoin checkpoints
+- treating Bitcoin transaction history as PQBTC history
+
+### 2. Wallet Expectations
+
+The wallet default should follow the chain thesis:
+
+- PQ-native signing from genesis
+- PQ-native receive/change flows as the owned UX
+- inherited classical wallet/address surfaces treated as reference inventory
+  unless PQBTC explicitly adopts them
+
+This is why work such as:
+
+- [PQ_WALLET_MANAGER_SETUP.md](PQ_WALLET_MANAGER_SETUP.md)
+- [PQ_ADDRESS_RPC_POSTURE.md](PQ_ADDRESS_RPC_POSTURE.md)
+- [CREATEWALLETDESCRIPTOR_POSTURE.md](CREATEWALLETDESCRIPTOR_POSTURE.md)
+
+matters more than broad rehabilitation of inherited Bitcoin address families.
+
+### 3. Address And Namespace Separation
+
+New genesis implies new operator-facing namespace.
+
+PQBTC should keep:
+
+- its own binaries and datadirs
+- its own network magic and ports
+- its own HRPs and prefixes
+- its own user-agent and branding
+
+The goal is to prevent both technical and operator confusion with Bitcoin Core.
+
+### 4. Replay And Compatibility Framing
+
+Because PQBTC does not share Bitcoin chain history, launch planning should not
+be framed as a chain-split replay problem.
+
+That does **not** mean every Bitcoin-derived transaction shape is automatically
+safe or meaningful on PQBTC. It means replay protection against inherited
+Bitcoin history is not the central launch abstraction here. The central
+abstraction is chain separation by identity, history, and consensus rules.
+
+## Explicit Non-Goals At Launch
+
+Unless Scott changes direction, launch does **not** require:
+
+- importing Bitcoin mainnet UTXOs
+- preserving Bitcoin address-family parity as a product goal
+- preserving classical ECDSA/Schnorr signing flows
+- broad legacy wallet test rehabilitation for its own sake
+- presenting PQBTC as a live migration of existing Bitcoin chain history
+
+## What Still Matters From Bitcoin
+
+Starting at block 0 does **not** mean discarding Bitcoin-derived value where it
+still helps:
+
+- UTXO model
+- Script execution model
+- PoW schedule and monetary schedule defaults
+- node, wallet, and operational architecture
+- selected inherited test coverage where it still meaningfully exercises PQBTC
+
+The rule is: inherit architecture intentionally, not identity accidentally.
+
+## Current Engineering Interpretation
+
+Under this posture:
+
+- `wallet_address_types.py` staying red in classical send flow is not a launch
+  blocker by itself
+- inherited descriptor/address RPCs should earn their place explicitly rather
+  than by historical inertia
+- the highest-value work remains PQ-native wallet maturity, replacement-path
+  clarity, CI confidence, and operator hardening
+
+## References
+
+- [Spec.md](Spec.md)
+- [GENESIS.md](GENESIS.md)
+- [NAMING.md](NAMING.md)
+- [TRACK_A_NATIVE_PQ_BITCOIN.md](TRACK_A_NATIVE_PQ_BITCOIN.md)
+- [TRACK_A_STATUS.md](TRACK_A_STATUS.md)

--- a/docs/PSBT_REPLACEMENT_TRANCHE.md
+++ b/docs/PSBT_REPLACEMENT_TRANCHE.md
@@ -1,0 +1,312 @@
+# PQBTC PSBT Replacement Tranche
+
+## Status: ACTIVE
+## Spec-ID: PSBT-REPLACEMENT-TRANCHE-v1
+## Frozen-By: track-a-phase1-20260406
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the first owned product-facing Track A tranche for post-v1 Taproot
+replacement work.
+
+This tranche is intentionally narrow. It does not attempt to solve all future
+wallet, descriptor, RPC, or witness-v1 semantics at once. Its job is to make
+the PQ-native PSBT path explicit, testable, and correctly bounded.
+
+## Why This Tranche Comes First
+
+- It is user-facing and wallet-adjacent rather than purely theoretical.
+- It already has real PQ-native coverage in the repo.
+- It forces explicit decisions about how PQ signatures move through the
+  signing/finalization path without silently inheriting Taproot semantics.
+- It is narrow enough to finish cleanly before broader descriptor or address
+  work.
+
+## Scope
+
+This tranche covers:
+
+- PQ-native PSBT creation, processing, decode, and finalization behavior for
+  the currently implemented PQ wallet path
+- the proprietary PQ partial-signature representation already exercised in-tree
+- RPC-visible expectations for the existing PQ wallet flow
+- explicit boundaries between current PQ-native PSBT behavior and deferred
+  Taproot-replacement PSBT behavior
+
+## Out Of Scope
+
+This tranche does not define:
+
+- generic witness-v1 or inherited Taproot PSBT semantics
+- `tr(...)` descriptor semantics for the replacement path
+- replacement address encoding rules
+- a new production external-signer standard
+- multi-algorithm PSBT negotiation beyond the current active PQ profile
+- any consensus change
+
+## Current Implemented Facts
+
+The current repo already demonstrates the following behavior:
+
+1. A blank descriptor wallet can activate PQ-native receive and change managers
+   through the dedicated `createpqwalletmanagers` RPC and spend through a
+   PQ-native PSBT flow.
+2. `walletcreatefundedpsbt` followed by `walletprocesspsbt(finalize=false)`
+   produces a PSBT that carries one PQ proprietary partial-signature field on
+   each relevant PQ input.
+3. On PQ-only active wallets, explicit-input and automatic-input
+   `walletcreatefundedpsbt` flows keep automatic change on the active internal
+   `pqpriv(...)` manager rather than re-entering inherited change-address
+   behavior, including the current `changePosition` and
+   `subtractFeeFromOutputs` option edges.
+4. That proprietary field uses:
+   - identifier: `pqbtc`
+   - subtype: `1`
+   - key suffix: the active `pk_script`
+   - value: the current fixed-size PQ signature payload (`4480` bytes in binary)
+5. Finalization consumes that PQ proprietary partial signature and emits the
+   expected final witness stack:
+   - stack item 0: fixed-size PQ signature
+   - stack item 1: witness script
+6. Non-active PQ `pk_script` values in that proprietary partial-signature field
+   are rejected during PSBT round-trip parsing.
+7. The lower-level `importdescriptors` path for active `pqpriv(...)` managers
+   still works and remains lightly exercised as descriptor-level setup coverage.
+
+These facts are already exercised in:
+
+- [wallet_pq_psbt.py](../test/functional/wallet_pq_psbt.py)
+- [pqsig_script_tests.cpp](../src/test/pqsig_script_tests.cpp)
+- [PQ_WALLET_MANAGER_SETUP.md](PQ_WALLET_MANAGER_SETUP.md)
+
+## Canonical Semantics For This Tranche
+
+### 1. Current PQ-native signing path
+
+For the active PQ wallet path, PSBT signing is represented through the existing
+proprietary input field rather than through inherited Taproot PSBT fields.
+
+### 2. Proprietary field contract
+
+The current tranche treats the following as the owned PQBTC contract:
+
+- identifier `pqbtc`
+- subtype `1`
+- binary value carrying the fixed-size PQ signature for the active profile
+- key material bound to the active `pk_script`
+
+This is the current PQ-native bridge between wallet signing and PSBT
+finalization.
+
+### 3. Finalization contract
+
+For this tranche, finalization of the PQ-native PSBT path must produce the
+existing witness form that the repo already validates:
+
+- PQ signature
+- revealed witness script
+
+This tranche does not redefine sighash behavior. The current fixed
+`SIGHASH_ALL` posture remains in force.
+
+### 4. Decode visibility
+
+`decodepsbt` should expose the PQ proprietary field clearly enough for testing
+and debugging, but this tranche does not require a brand-new human-facing PSBT
+schema beyond the currently decoded proprietary representation.
+
+### 5. Active-profile restriction
+
+The proprietary PQ partial-signature field is owned only for the currently
+active PQ profile. Invalid or non-active `pk_script` values must continue to
+reject.
+
+## Deferred Boundaries
+
+The following remain explicitly deferred after this tranche:
+
+- inherited Taproot PSBT fields as replacement semantics
+- `tr(...)` descriptor meaning for replacement outputs
+- address-type promotion for replacement semantics
+- generic wallet address-type behavior involving witness-v1 replacement outputs
+- production external signer interface standardization
+
+Relevant neighboring surfaces that remain follow-on work:
+
+- [wallet_createwalletdescriptor.py](../test/functional/wallet_createwalletdescriptor.py)
+- [wallet_address_types.py](../test/functional/wallet_address_types.py)
+- [wallet_pq_descriptors.py](../test/functional/wallet_pq_descriptors.py)
+
+## Primary Test Surfaces
+
+- [wallet_pq_psbt.py](../test/functional/wallet_pq_psbt.py)
+  End-to-end wallet PSBT parity for active `pqpriv(...)` managers.
+- [rpc_psbt.py](../test/functional/rpc_psbt.py)
+  Broad inherited PSBT RPC surface that this tranche must not accidentally
+  destabilize.
+- [pqsig_script_tests.cpp](../src/test/pqsig_script_tests.cpp)
+  PQ proprietary partial-signature round-trip and rejection guards.
+
+## Expected Deliverables
+
+Phase-1 completion for this tranche means:
+
+1. this semantics doc is checked in
+2. the tranche boundaries are explicit
+3. the highest-value PSBT follow-on gaps are ranked
+4. targeted tests can be run without ambiguity about what behavior is owned now
+
+Phase-2 completion for this tranche means:
+
+1. any needed RPC/PSBT clarifications are implemented
+2. tests and docs agree on the proprietary PQ partial-signature path
+3. no inherited Taproot PSBT semantics are accidentally implied
+
+## Current Confidence Snapshot
+
+Targeted confidence pass run on 2026-04-08:
+
+- `build/bin/test_pqbtc --run_test=pqsig_script_tests`
+  - result: passed
+- `python3 test/functional/test_runner.py --jobs=1 wallet_pq_psbt.py`
+  - result: passed
+  - current posture: dedicated `createpqwalletmanagers` setup for the main
+    spend/PSBT path, explicit `fundrawtransaction` PQ-change coverage, explicit
+    automatic-input `walletcreatefundedpsbt` PQ-change coverage, including
+    `changePosition` and `subtractFeeFromOutputs`, with one retained low-level
+    `importdescriptors` check
+- `python3 test/functional/test_runner.py --jobs=1 rpc_psbt.py`
+  - result: failed
+  - failing point: `finalizepsbt`
+  - observed error: `TX decode failed Signature is not a valid encoding`
+
+Interpretation:
+
+- the owned PQ-native PSBT path is healthy
+- the broader inherited PSBT RPC surface still contains at least one path that
+  does not cleanly fit PQBTC's current signature semantics
+
+Narrowed root cause:
+
+- the failing repro spends classical `pkh(...)` inputs from the default wallet,
+  not the active `pqpriv(...)` path
+- `walletprocesspsbt(finalize=false)` emits ordinary-looking classical
+  `partial_sigs` for those inputs
+- `decodepsbt` / `finalizepsbt` then reject that signed PSBT because
+  [interpreter.cpp](../src/script/interpreter.cpp#L75)
+  currently makes `CheckSignatureEncoding()` PQ-only for all pre-taproot paths:
+  any non-empty signature whose size is not `pqsig::SIG_SIZE` is rejected as
+  `SCRIPT_ERR_SIG_DER`
+
+This means the current blocker is not a mystery in the owned PQ-native tranche.
+It is an explicit compatibility break in the inherited classical PSBT decode /
+finalize path.
+
+Decision boundary:
+
+- if PQBTC intends to keep classical pre-taproot PSBT flows alive during the
+  migration window, it needs dual-mode signature encoding validation here
+- if PQBTC intends to drop those flows, `rpc_psbt.py` should stay out of the
+  owned tranche and be marked as explicitly deferred legacy compatibility work
+
+Current decision:
+
+- Track A is all-PQ
+- inherited classical pre-taproot PSBT decode / finalize compatibility is not
+  part of the owned tranche
+- `rpc_psbt.py` remains a useful reference surface, but its classical signing
+  expectations should be treated as deferred legacy compatibility work rather
+  than a blocker on PQ-native progress
+
+## Follow-On Questions
+
+The next questions after this tranche should be:
+
+1. Should PQBTC expose a richer decode view for the PQ proprietary field?
+2. Which descriptor surface should be promoted next after PSBT:
+   `wallet_createwalletdescriptor.py` or `wallet_pq_descriptors.py`?
+3. What is the smallest safe replacement-path bridge from PQ-native PSBT
+   behavior toward future replacement witness-v1 semantics without importing
+   inherited Taproot behavior wholesale?
+
+## Ranked Follow-On Queue
+
+This is the current best next-work ranking after the initial PSBT tranche
+semantics are frozen.
+
+### 1. `wallet_pq_descriptors.py`
+
+- Current inventory posture: `pq_backlog`
+- Why first:
+  - already PQ-specific instead of inherited Taproot-first
+  - close to the owned PSBT tranche because it exercises `pq(...)`
+    descriptor behavior directly
+  - lower semantic risk than broad address-type or miniscript work
+- Goal:
+  tighten the canonical descriptor contract for fixed watch-only `pq(...)`
+  behavior before expanding replacement descriptor creation surfaces
+
+### 2. `wallet_createwalletdescriptor.py`
+
+- Current inventory posture: `pq_backlog`, `deferred` in the Taproot migration
+  matrix
+- Why second:
+  - high leverage descriptor-creation surface
+  - directly relevant to future replacement descriptor semantics
+  - more dangerous than `wallet_pq_descriptors.py` because it touches inherited
+    `tr(...)` / `bech32m` creation paths
+- Goal:
+  decide what, if anything, should become an explicitly PQBTC-owned replacement
+  descriptor creation surface instead of inherited Taproot behavior
+
+### 3. `wallet_address_types.py`
+
+- Current inventory posture: `dual_profile`, `deferred`
+- Why third:
+  - likely needed eventually for address/output-type policy coherence
+  - broad and mixed surface with significant inherited behavior
+  - should follow descriptor clarifications, not lead them
+- Goal:
+  revisit address-type behavior only after descriptor and PSBT boundaries are
+  more explicit
+
+### 4. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+
+- Current inventory posture: `dual_profile`, `deferred`
+- Why fourth:
+  - intersects both descriptor and PSBT behavior
+  - useful stress case later
+  - too indirect for the first replacement tranche
+
+### 5. `wallet_miniscript.py`
+
+- Current inventory posture: `dual_profile`, `deferred`
+- Why fifth:
+  - large inherited surface
+  - high semantic blast radius
+  - best handled only after narrower descriptor and PSBT contracts are stable
+
+## Explicit "Not Next" Surfaces
+
+These are useful references, but they should not drive the next Track A slice:
+
+- `feature_taproot.py`
+  Current posture: `legacy_only`
+- `wallet_taproot.py`
+  Current posture: `legacy_only`
+
+They are good negative-control context, not the next owned replacement work.
+
+## Immediate Debug Queue
+
+Before widening this tranche, the next debug questions should be:
+
+1. Which exact `rpc_psbt.py` scenario at the failing line is still assuming an
+   inherited non-PQ signature encoding path?
+2. Should PQBTC carve out a PQ-specific `rpc_psbt` subset rather than trying to
+   preserve the full inherited surface?
+3. Is the correct fix:
+   - adapting test expectations
+   - routing signing/finalization differently for non-PQ paths
+   - or explicitly declaring the inherited path out of scope for Track A?

--- a/docs/README_PQBTC.md
+++ b/docs/README_PQBTC.md
@@ -22,6 +22,14 @@ This project implements a Bitcoin-like UTXO chain using hash-based post-quantum 
 
 - [Protocol Specification](Spec.md) - Normative spec with MUST/SHOULD language
 - [Core Diff Plan](CORE_DIFF_PLAN.md) - Bitcoin Core fork implementation phases
+- [Track A: Native PQ Bitcoin](TRACK_A_NATIVE_PQ_BITCOIN.md) - Strategic anchor, scope, non-goals, and how adjacent approaches fit
+- [Track A 90-Day Roadmap](TRACK_A_90_DAY_ROADMAP.md) - Concrete execution plan for April 6, 2026 through July 5, 2026
+- [Genesis And Network Posture](GENESIS_AND_NETWORK_POSTURE.md) - Launch interpretation for a fresh block-0 chain, network identity, and non-goals around inherited Bitcoin history
+- [Research Index](RESEARCH_INDEX.md) - Curated map of the repo's internal research corpus and key external references
+- [Watch-Only `pq(...)` Contract](PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md) - Fixed public PQ descriptor boundaries, import behavior, and test-backed expectations
+- [PQ Wallet Manager Setup](PQ_WALLET_MANAGER_SETUP.md) - Dedicated PQ-native receive/change manager setup path and its guardrails
+- [PQ Address RPC Posture](PQ_ADDRESS_RPC_POSTURE.md) - Dedicated PQ address RPC boundary and why inherited address RPCs stay separate on PQ-only wallets
+- [`createwalletdescriptor` Posture](CREATEWALLETDESCRIPTOR_POSTURE.md) - Current inherited descriptor-creation behavior and why it is not yet the PQ-native creation path
 
 ## Status
 

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -1,0 +1,190 @@
+# PQBTC Research Index
+
+## Status: ACTIVE
+## Spec-ID: RESEARCH-INDEX-v1
+## Updated: 2026-04-06
+## Consensus-Relevant: NO
+
+## Purpose
+
+Give Aineko and other future readers a single starting point for the research
+and design corpus behind `quantum-proof-bitcoin`.
+
+This index is intentionally opinionated. It points to the documents that best
+answer specific classes of questions instead of listing every file in `docs/`.
+
+## Current State
+
+- The repo has a strong internal design corpus in Markdown.
+- No PDF papers are currently checked into this repo.
+- Delving Bitcoin now provides concrete adjacent research references that are
+  directly relevant to Track A, especially around SHRINCS / SHRIMPS and
+  algorithm-agility framing.
+- `Spec.md` still does not name its external paper directly, but the strongest
+  current lineage is now identified below: the SHRINCS thread points directly
+  to `Hash-based Signature Schemes for Bitcoin`, while the SHRIMPS thread is a
+  valuable follow-on direction for later compact-signature and multi-device
+  thinking.
+
+## How To Use This Index
+
+- Start with the "Track A orientation" section for strategic work.
+- Use the "Core protocol and consensus" section for architecture questions.
+- Use the "Taproot replacement path" section for post-v1 migration work.
+- Use the "Wallet / PSBT / operator" section for user-facing and operational
+  work.
+- Treat the "External references" section as adjacent context, not automatic
+  design override.
+
+## Track A Orientation
+
+- [README_PQBTC.md](README_PQBTC.md)
+  What the repo currently claims at a high level.
+- [TRACK_A_NATIVE_PQ_BITCOIN.md](TRACK_A_NATIVE_PQ_BITCOIN.md)
+  Strategic anchor. Use this first when the question is "what is this project
+  actually trying to be?"
+- [TRACK_A_90_DAY_ROADMAP.md](TRACK_A_90_DAY_ROADMAP.md)
+  Current quarter execution plan.
+- [TRACK_A_STATUS.md](TRACK_A_STATUS.md)
+  Live working handoff for Aineko.
+
+## Core Protocol And Consensus
+
+- [Spec.md](Spec.md)
+  Developer-facing protocol spec for the genesis chain and PQSig framing.
+- [CONSENSUS_SURFACE.md](CONSENSUS_SURFACE.md)
+  Fastest way to see what is consensus-critical versus deliberately out of scope.
+- [CONSENSUS_DIFFS.md](CONSENSUS_DIFFS.md)
+  High-level change surface versus inherited Bitcoin Core behavior.
+- [SCRIPT_SEMANTICS.md](SCRIPT_SEMANTICS.md)
+  Script-level meaning of PQ verification choices.
+- [SIGHASH.md](SIGHASH.md)
+  Current signature-hash posture and why the repo stayed narrow.
+- [GENESIS.md](GENESIS.md)
+  Chain identity and genesis-specific decisions.
+
+## PQSig Construction And Encoding
+
+- [PQSIG_INTERNALS.md](PQSIG_INTERNALS.md)
+  Best internal explainer for how the signature system is assembled.
+- [PQSIG_WIRE_FORMAT.md](PQSIG_WIRE_FORMAT.md)
+  Signature layout reference.
+- [PQSIG_0X02_INTERNALS.md](PQSIG_0X02_INTERNALS.md)
+  Forward-compatible fixture path context.
+- [PQSIG_0X02_WIRE_FORMAT.md](PQSIG_0X02_WIRE_FORMAT.md)
+  Encoding details for the neutral future fixture.
+- [ALG_ID_REGISTRY.md](ALG_ID_REGISTRY.md)
+  Algorithm ID lifecycle and allocation rules.
+- [ALG_ID_PARSER_COMPAT.md](ALG_ID_PARSER_COMPAT.md)
+  Parser and compatibility contract for algorithm evolution.
+
+## Wallet, PSBT, And Signing Surface
+
+- [WALLET.md](WALLET.md)
+  Current implemented wallet state and what has already closed.
+- [PSBT_STRATEGY.md](PSBT_STRATEGY.md)
+  Frozen planning document for external signer and PSBT adaptations.
+- [doc/psbt.md](../doc/psbt.md)
+  Inherited upstream PSBT behavior reference.
+- [doc/external-signer.md](../doc/external-signer.md)
+  Useful when evaluating future external signer posture.
+- [doc/descriptors.md](../doc/descriptors.md)
+  Descriptor background for inherited surfaces that Track A may adapt.
+
+## Taproot Replacement Path
+
+- [TAPROOT_POSTURE.md](TAPROOT_POSTURE.md)
+  Canonical answer to "are we inheriting Taproot as-is?" The answer is no.
+- [TAPROOT_ACTIVATION.md](TAPROOT_ACTIVATION.md)
+  Frozen activation and deployment family.
+- [TAPROOT_MIGRATION_MATRIX.md](TAPROOT_MIGRATION_MATRIX.md)
+  Canonical migration and compatibility matrix for the replacement path.
+- [DECISION_DEFERRAL_LEDGER.md](DECISION_DEFERRAL_LEDGER.md)
+  What remains explicitly deferred and why.
+
+## Delivery, CI, And Operational Evidence
+
+- [CORE_DIFF_PLAN.md](CORE_DIFF_PLAN.md)
+  Big-picture implementation phases.
+- [POST_RC_EPICS.md](POST_RC_EPICS.md)
+  Remaining major epics after the first RC tranche.
+- [CI_COMPLETENESS.md](CI_COMPLETENESS.md)
+  Required gate and backlog classification.
+- [OPS_SLO.md](OPS_SLO.md)
+  Post-v1 operator confidence contract.
+- [GA_ACCEPTANCE_CHECKLIST.md](GA_ACCEPTANCE_CHECKLIST.md)
+  Useful history for understanding evidence discipline.
+- [GA_BURNIN_LOG.md](GA_BURNIN_LOG.md)
+  Release-era evidence trail and issue references.
+
+## External References
+
+- Blockstream Research, March 3, 2026:
+  [Quantum-resistant transaction signing on Liquid using Simplicity smart contracts](https://blog.blockstream.com/blockstream-research-demonstrates-quantum-resistant-transaction-signing-on-liquid-using-simplicity-smart-contracts/)
+  Use as an adjacent benchmark for opt-in deployment on a Bitcoin-like system,
+  not as a replacement for Track A.
+- Delving Bitcoin, December 11, 2025:
+  [SHRINCS: 324-byte stateful post-quantum signatures with static backups](https://delvingbitcoin.org/t/shrincs-324-byte-stateful-post-quantum-signatures-with-static-backups/2158)
+  Best current Delving Bitcoin lineage reference for the repo's likely
+  signature ancestry. The thread explicitly says SHRINCS is covered in the
+  appendix of `Hash-based Signature Schemes for Bitcoin` and discusses WOTS+C,
+  static backups, and stateful-versus-stateless fallback behavior.
+- Delving Bitcoin, March 27, 2026:
+  [SHRIMPS: 2.5 KB post-quantum signatures across multiple stateful devices](https://delvingbitcoin.org/t/shrimps-2-5-kb-post-quantum-signatures-across-multiple-stateful-devices/2355)
+  High-value follow-on research thread for Track A. Strong source for later
+  compact-signature and multiple-stateful-device thinking, even if it is less
+  likely than the SHRINCS thread to be the immediate source behind `Spec.md`.
+- Delving Bitcoin, February 9, 2026:
+  [Algorithm agility to defeat quantum and classical attacks on Bitcoin's signature algorithms](https://delvingbitcoin.org/t/algorithm-agility-to-defeat-quantum-and-classical-attacks-on-bitcoins-signature-algorithms/2241)
+  Important for migration thinking and long-horizon wallet safety framing.
+  Useful adjacent context even though PQBTC is a native chain rather than an
+  opt-in hedge for Bitcoin mainnet.
+- BlockstreamResearch GitHub organization:
+  [https://github.com/BlockstreamResearch](https://github.com/BlockstreamResearch)
+  Useful as an implementation-reference shelf when Track A needs concrete code
+  examples, especially around SHRINCS-family work, verifier structure, and
+  wallet backup ideas. Treat these repositories as adjacent code references,
+  not as an architecture source of truth for PQBTC.
+- BlockstreamResearch:
+  [shrincs-cpp](https://github.com/BlockstreamResearch/shrincs-cpp)
+  Best direct code-reference candidate for Track A if PQBTC needs concrete
+  C++ SHRINCS implementation patterns, tests, or KAT layout inspiration. Keep
+  in mind the repository describes itself as work in progress, not
+  production-ready.
+- BlockstreamResearch:
+  [shrincs-simplicity-verifier](https://github.com/BlockstreamResearch/shrincs-simplicity-verifier)
+  Useful for understanding how Blockstream packages SHRINCS verification logic
+  in a Bitcoin-adjacent environment. Good comparison material for verifier
+  structure, but not a direct dependency target for a block-0 native chain.
+- BlockstreamResearch:
+  [codex32](https://github.com/BlockstreamResearch/codex32)
+  Useful later if PQBTC needs stronger human-readable backup or recovery
+  posture. Relevant to wallet-operability thinking, not immediate consensus
+  work.
+- BlockstreamResearch:
+  [pq-p2pkh](https://github.com/BlockstreamResearch/pq-p2pkh)
+  Lower-priority reference. Keep in view for proof-system or ownership-proof
+  ideas, not for current launch-critical work.
+- BlockstreamResearch:
+  [simplicity](https://github.com/BlockstreamResearch/simplicity)
+  Adjacent research track only. Useful for understanding Blockstream's broader
+  execution model, but it should not pull PQBTC away from its native-chain
+  architecture by default.
+- Likely underlying paper for `Spec.md`:
+  [Hash-based Signature Schemes for Bitcoin](https://eprint.iacr.org/2025/2203)
+  by Mikhail Kudinov and Jonas Nick.
+  This is now the strongest identified external paper match for `Spec.md`.
+  It matches the repo's emphasis on SPHINCS-family variants, WOTS+C, PORS+FP,
+  reduced `q_s`, and wallet/key-derivation practicality, and the SHRINCS
+  Delving Bitcoin thread explicitly points to it.
+
+## Recommended Read Order For Aineko
+
+1. [TRACK_A_STATUS.md](TRACK_A_STATUS.md)
+2. [TRACK_A_NATIVE_PQ_BITCOIN.md](TRACK_A_NATIVE_PQ_BITCOIN.md)
+3. [TRACK_A_90_DAY_ROADMAP.md](TRACK_A_90_DAY_ROADMAP.md)
+4. [README_PQBTC.md](README_PQBTC.md)
+5. [TAPROOT_MIGRATION_MATRIX.md](TAPROOT_MIGRATION_MATRIX.md)
+6. [CI_COMPLETENESS.md](CI_COMPLETENESS.md)
+7. [OPS_SLO.md](OPS_SLO.md)
+8. Then the topic-specific document for the exact task.

--- a/docs/Spec.md
+++ b/docs/Spec.md
@@ -1,7 +1,7 @@
 # Quantum-Proof Bitcoin Fork (Genesis Chain) — Protocol Spec v0 (DRAFT)
 
 Status: Draft
-Last-Updated: YYYY-MM-DD
+Last-Updated: 2026-04-06
 
 This document is a developer-facing protocol specification for a Bitcoin Core-derived chain
 starting from a new genesis block (height 0), with post-quantum (PQ) signatures required
@@ -9,6 +9,17 @@ for transaction authorization from genesis.
 
 Normative language: "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY" are
 to be interpreted as in RFC 2119.
+
+Primary external reference for the PQ signature construction and parameter
+selection used here:
+
+- Mikhail Kudinov and Jonas Nick, "Hash-based Signature Schemes for Bitcoin"
+  (IACR ePrint 2025/2203)
+
+Related discussion:
+
+- Jonas Nick, "SHRINCS: 324-byte stateful post-quantum signatures with static
+  backups" (Delving Bitcoin, December 11, 2025)
 
 ---
 
@@ -65,8 +76,9 @@ PQSig v0 is a stateless, hash-based signature scheme in the SPHINCS framework, u
 - PORS+FP for the few-time layer,
 with hypertree parameters chosen for q_s = 2^40 max signatures per public key.
 
-(See the referenced paper's sections on WOTS+C, PORS+FP, SPHINCS framework substitution,
-and the parameter tables.)
+(See "Hash-based Signature Schemes for Bitcoin" for the WOTS+C, PORS+FP,
+SPHINCS-family substitution, and parameter-table background behind this
+construction.)
 
 ### 4.2 Security Parameterization (v0 constants)
 - Target security: NIST Level 1 / ~128-bit classical security.
@@ -220,4 +232,6 @@ Policy SHOULD enforce:
 PQSig v0 corresponds to the parameter set in Table 1:
 "W+C P+FP 2^40: h=44 d=4 a=16 k=8 w=16 l=32 S_{w,n}=240 SigSize=4480 SigVerify(compr.)=1292"
 
-(That spec is based directly on the paper's construction notes, parameter choices, and constraints around Hmsg sizing, HD wallets, and multisig practicality.)
+(This spec is based directly on "Hash-based Signature Schemes for Bitcoin" and
+its construction notes, parameter choices, and constraints around Hmsg sizing,
+HD wallets, and multisig practicality.)

--- a/docs/TEST_COST_POSTURE.md
+++ b/docs/TEST_COST_POSTURE.md
@@ -1,0 +1,235 @@
+# PQBTC Test Cost Posture
+
+## Status: ACTIVE
+## Spec-ID: TEST-COST-POSTURE-v1
+## Updated: 2026-04-06
+## Consensus-Relevant: NO
+
+## Purpose
+
+Protect development throughput on `quantum-proof-bitcoin` when inherited
+Bitcoin-style build and CI surfaces are expensive.
+
+This note exists to prevent a bad default:
+
+- tiny code changes
+- tiny commits
+- large validation tax
+- hours of waiting
+- little actual product movement
+
+For this repo, that pattern is a workflow failure, not a quality win.
+
+## Core Rule
+
+The unit of progress is the **tranche**, not the commit.
+
+That means:
+
+- many local edits may belong to one validation decision
+- many local commits may belong to one push or promotion event
+- expensive test campaigns should validate a coherent tranche, not a single
+  sentence change or a tiny UI fix
+
+## Validation Ladder
+
+### Tier 0: Cheap Local Proof
+
+Use for:
+
+- docs
+- naming
+- comments
+- resource strings
+- non-consensus UI wording
+- obvious local refactors with no behavior change
+
+Allowed proof:
+
+- no tests
+- or a compile check for the touched binary or library
+- or a single direct smoke command if the touched surface is trivial to verify
+
+Do **not** pay for broad functional suites here.
+
+### Tier 1: Narrow Slice Validation
+
+Use for:
+
+- one owned wallet/RPC/descriptor/PSBT slice
+- localized signing-path behavior
+- small operator-path or tooling behavior changes
+
+Allowed proof:
+
+- touched-target compile
+- one small unit test family
+- one to three directly relevant functional tests
+
+Examples:
+
+- `wallet_pq_active_ranged.py`
+- `wallet_pq_create_tx.py`
+- `wallet_pq_descriptors.py`
+- `wallet_pq_psbt.py`
+- `wallet_pq_send.py`
+- `wallet_pq_sendall.py`
+- `wallet_pq_sendmany.py`
+- `wallet_createwalletdescriptor.py`
+- `./build/bin/test_pqbtc --run_test=pqsig_script_tests`
+
+This is the default working tier for Track A.
+
+### Tier 2: Subsystem Promotion
+
+Use for:
+
+- promoting a tranche from "local confidence" to "shared candidate"
+- broader wallet/descriptor/PSBT or policy changes
+- any change where the touched surface crosses multiple owned seams
+
+Allowed proof:
+
+- targeted bundle for the subsystem
+- medium-cost compile plus multiple functional suites
+- optional manual push for broader CI visibility
+
+This tier is a deliberate promotion step, not the default after every edit.
+
+### Tier 3: Milestone Evidence
+
+Use for:
+
+- release candidates
+- milestone merges
+- sign-off
+- operator evidence refresh
+- full confidence resets after high-risk consensus work
+
+Allowed proof:
+
+- full PQ gate review
+- full `OPS_SLO` evidence refresh
+- long soak or multi-hour CI-style campaigns
+
+Examples:
+
+- `contrib/soak/capture_ops_slo_evidence.sh`
+- `contrib/soak/validate_ops_slo_evidence.py --signoff ...`
+
+This tier should be paid at milestone boundaries, not continuously.
+
+## Push And Promotion Policy
+
+For this repo:
+
+- local commits are cheap
+- pushes are expensive
+- heavy CI should be treated as a promotion event
+
+Default working policy:
+
+1. edit locally
+2. run Tier 0 or Tier 1 proof
+3. accumulate a coherent tranche
+4. push only when the tranche is worth paying a broader validation cost
+
+Do **not** push every small cleanup if the remote CI path is going to charge
+hours of waiting for it.
+
+## Current Track A Default Bundle
+
+When the touched work is in the active Track A wallet/descriptor/PSBT lane,
+prefer this order:
+
+1. build the touched target
+2. run the narrowest directly relevant unit or functional test
+3. stop unless the tranche is being promoted
+
+Current high-value narrow tests:
+
+- `python3 test/functional/wallet_pq_active_ranged.py`
+- `python3 test/functional/wallet_pq_create_tx.py`
+- `python3 test/functional/wallet_pq_descriptors.py`
+- `python3 test/functional/wallet_pq_psbt.py`
+- `python3 test/functional/wallet_pq_send.py`
+- `python3 test/functional/wallet_pq_sendall.py`
+- `python3 test/functional/wallet_pq_sendmany.py`
+- `python3 test/functional/wallet_createwalletdescriptor.py`
+- `./build/bin/test_pqbtc --run_test=pqsig_script_tests`
+
+Current expensive milestone path:
+
+- `STAMP=$(date -u +%Y-%m-%d) contrib/soak/capture_ops_slo_evidence.sh`
+- `python3 contrib/soak/validate_ops_slo_evidence.py --signoff docs/artifacts/ops-slo/$STAMP`
+
+## Risk Classes
+
+### Green
+
+- docs
+- naming
+- UI text
+- metadata
+- resource files
+
+Default validation: Tier 0 only.
+
+### Yellow
+
+- wallet
+- PSBT
+- descriptors
+- RPC behavior
+- operator flows
+
+Default validation: Tier 1, then Tier 2 only when promoting the tranche.
+
+### Red
+
+- consensus
+- script validation
+- signature encoding
+- chain identity
+- network identity
+- chainstate safety
+
+Default validation: Tier 1 first, then explicit approval before broad or
+expensive promotion work.
+
+## Aineko Operating Rules
+
+Aineko may do without asking:
+
+- Tier 0 validation
+- Tier 1 validation
+- small compile checks
+- one to three narrow tests tied directly to the changed slice
+
+Aineko must ask before:
+
+- Tier 2 subsystem-promotion runs that are likely to take substantial time
+- Tier 3 milestone evidence runs
+- any multi-hour CI or soak campaign
+- paying large remote CI cost for a small local change
+
+## Practical Throughput Goal
+
+The repo should spend most of its time in:
+
+- designing tranches
+- landing tranche code
+- running narrow proofs
+
+It should spend much less time in:
+
+- watching broad CI for tiny changes
+- rerunning long suites mid-thought
+- paying milestone-grade validation for non-milestone work
+
+## Related References
+
+- [TRACK_A_STATUS.md](TRACK_A_STATUS.md)
+- [CI_COMPLETENESS.md](CI_COMPLETENESS.md)
+- [OPS_SLO.md](OPS_SLO.md)
+- [TRACK_A_90_DAY_ROADMAP.md](TRACK_A_90_DAY_ROADMAP.md)

--- a/docs/TRACK_A_90_DAY_ROADMAP.md
+++ b/docs/TRACK_A_90_DAY_ROADMAP.md
@@ -1,0 +1,203 @@
+# PQBTC Track A 90-Day Roadmap
+
+## Status: ACTIVE
+## Spec-ID: TRACK-A-90D-v1
+## Frozen-By: roadmap-pass-20260406
+## Consensus-Relevant: NO
+## Timebox: 2026-04-06 through 2026-07-05
+
+## Purpose
+
+Turn `TRACK_A_NATIVE_PQ_BITCOIN.md` into an execution plan for the next ninety
+days.
+
+This roadmap is intentionally biased toward **native-chain credibility** rather
+than novelty theater. The repo does not need a new thesis in this window. It
+needs confidence, coverage, and sharper ownership of the remaining migration
+surface.
+
+## Day-90 Outcomes
+
+By July 5, 2026, the repo should have:
+
+1. at least one owned Taproot-replacement wallet/RPC/descriptor/PSBT tranche
+   moved from deferred posture into explicit semantics plus tests
+2. a tighter CI completeness contract with the highest-value backlog suites
+   either promoted, rewritten, or explicitly frozen with durable rationale
+3. a refreshed and validated post-v1 operational evidence bundle
+4. a clearer measured-runtime instrumentation plan, with either landed counters
+   or an explicit checked-in decision on what remains deferred
+5. a crisp external positioning story explaining how PQBTC differs from
+   Blockstream's Liquid/Simplicity path without treating that path as the enemy
+
+## Roadmap Rules
+
+- Do not restart the chain design in this window.
+- Do not swap out PQSig rc2 merely because an adjacent architecture looks more
+  deployable.
+- Prefer evidence-producing work over speculative architecture work.
+- Prefer one fully-owned migration tranche over five vague partial surfaces.
+- If tradeoffs are required, choose correctness and explicit scope over breadth.
+
+## Phase 1: Confidence And Slice Selection
+## Window: 2026-04-06 through 2026-05-03
+
+### Objectives
+
+- lock the first owned post-matrix migration slice for `#23`
+- remove ambiguity around which CI backlog work matters first
+- refresh local confidence in the required gate and operator evidence paths
+
+### Primary Work
+
+1. Pick the first owned Taproot-replacement product-facing slice.
+   Candidate surfaces:
+   - `rpc_psbt.py`
+   - `wallet_createwalletdescriptor.py`
+   - `wallet_address_types.py`
+   - descriptor- or PSBT-facing docs already tracked under `docs/`
+2. Write the exact semantics for that slice before broad implementation.
+3. Audit current `pq_backlog` and `deferred` suites and rank them by:
+   - direct relevance to the replacement path
+   - operator risk if left ambiguous
+   - value as required-gate candidates
+4. Re-run and inspect the current required PQ-first functional gate locally.
+5. Reproduce and validate the current `OPS_SLO` evidence path so the repo has a
+   fresh operational baseline before new churn.
+
+### Exit Criteria
+
+- one first migration slice is explicitly named and scoped
+- its acceptance semantics are written down in repo docs
+- the highest-value backlog suites are ranked, not just listed
+- current required-gate health is understood
+- the current ops evidence path is reproducible on demand
+
+## Phase 2: First Owned Migration Tranche
+## Window: 2026-05-04 through 2026-05-31
+
+### Objectives
+
+- land the first non-trivial Taproot-replacement tranche beyond pure matrix
+  freezing
+- convert at least one deferred product-facing surface into explicit semantics
+  and tests
+
+### Primary Work
+
+1. Implement the chosen `#23` tranche end to end.
+2. Add or update functional coverage so the tranche is exercised in the current
+   repo posture, not just documented.
+3. Update all affected docs so wallet/RPC/descriptor/PSBT behavior matches the
+   actual runtime contract.
+4. Decide whether the covered suites become:
+   - `pq_required`
+   - `pq_backlog` with sharper ownership
+   - `dual_profile` with durable rationale
+
+### Preferred Shape
+
+The best tranche for this window is one that is:
+
+- visible to users and operators
+- narrow enough to finish cleanly
+- strong enough to prove the repo can move beyond block-validation-only seams
+
+### Exit Criteria
+
+- at least one product-facing replacement surface is implemented and testable
+- the affected suites have an explicit CI disposition
+- the docs no longer imply broader semantics than the code actually owns
+
+## Phase 3: CI Contract Tightening And Ops Hardening
+## Window: 2026-06-01 through 2026-06-21
+
+### Objectives
+
+- reduce ambiguity in the CI contract
+- strengthen post-v1 operator confidence under PQ load
+
+### Primary Work
+
+1. Promote the best next backlog suites or explicitly freeze them with durable
+   rationale.
+2. Refresh the checked-in `OPS_SLO` evidence bundle under a new dated stamp.
+3. Extend adversarial throughput and scenario coverage under the current PQ
+   load assumptions where that improves sign-off confidence.
+4. Check for gate flakiness or evidence drift introduced by the migration
+   tranche.
+
+### Concrete Targets
+
+- the CI completeness doc reflects actual owned priorities rather than a large
+  undifferentiated backlog
+- `contrib/soak/capture_ops_slo_evidence.sh` and
+  `contrib/soak/validate_ops_slo_evidence.py --signoff ...` produce a fresh,
+  valid bundle
+- operator-facing restart, reorg, large-witness, and RBF churn confidence is
+  refreshed after the tranche lands
+
+### Exit Criteria
+
+- the CI contract is tighter than it was on April 6, 2026
+- the repo has a fresh validated ops evidence bundle
+- no new unresolved ambiguity has been introduced into the required PQ gate
+
+## Phase 4: Instrumentation And Positioning Checkpoint
+## Window: 2026-06-22 through 2026-07-05
+
+### Objectives
+
+- finish the quarter with a clear technical and narrative checkpoint
+- avoid ending the ninety-day push with code only and no decision framing
+
+### Primary Work
+
+1. Land measured bench/runtime counters if they are ready, or write the exact
+   deferred decision and why.
+2. Write a short checked-in comparison note:
+   - PQBTC native chain
+   - Liquid/Simplicity opt-in verifier path
+   - where they overlap
+   - where they fundamentally diverge
+3. Produce the next-step checkpoint:
+   - what shipped in the ninety-day window
+   - what remains on `#23`
+   - what deserves the next ninety-day slot
+
+### Exit Criteria
+
+- instrumentation direction is explicit rather than hand-wavy
+- the repo has a durable external positioning note
+- the next roadmap can start from facts, not memory
+
+## Prioritization Order
+
+If bandwidth is constrained, work in this order:
+
+1. first owned `#23` migration tranche
+2. CI disposition and gate confidence
+3. operational hardening and fresh evidence
+4. bench instrumentation hardening
+5. external comparison and narrative polish
+
+## Explicit Deferrals For This Window
+
+Do not make these the main effort before July 5, 2026:
+
+- full signature-stack replacement
+- consensus redesign for a new cryptographic family
+- sidechain pivot or Liquid-first product reset
+- speculative mainnet go-to-market planning without stronger implementation
+  evidence
+- broad multi-feature expansion that outruns tests and operator confidence
+
+## Success Test
+
+This roadmap succeeds if, by July 5, 2026, a technically serious reader can see
+that PQBTC is:
+
+- still clearly a native post-quantum Bitcoin project
+- materially less ambiguous about its replacement-path migration surface
+- more credible operationally
+- better positioned against adjacent post-quantum Bitcoin-like approaches

--- a/docs/TRACK_A_NATIVE_PQ_BITCOIN.md
+++ b/docs/TRACK_A_NATIVE_PQ_BITCOIN.md
@@ -1,0 +1,124 @@
+# PQBTC Track A: Native Post-Quantum Bitcoin
+
+## Status: ACTIVE
+## Spec-ID: TRACK-A-v1
+## Frozen-By: strategy-pass-20260406
+## Consensus-Relevant: NO
+
+## Purpose
+
+Clarify the strategic anchor for `quantum-proof-bitcoin` so engineering decisions
+do not drift toward a different product category.
+
+## Core Claim
+
+`quantum-proof-bitcoin` is a **consensus-native post-quantum Bitcoin-like
+chain from genesis**, not merely a migration aid or an opt-in add-on for an
+existing network.
+
+Operationally, that means the intended launch posture is a **new chain starting
+at block 0**, not an attempt to graft PQBTC consensus onto inherited Bitcoin
+chain history.
+
+The project should preserve that identity unless Scott explicitly changes the
+product thesis.
+
+## Scope
+
+Track A covers:
+
+- a PQ-native chain with post-quantum authorization built into consensus
+- a new genesis and new chain history owned by PQBTC itself
+- wallet, PSBT, descriptor, RPC, and operational flows that assume PQ-native
+  signing as the default path
+- migration and compatibility work needed for the repo's chosen explicit
+  Taproot-replacement posture
+- test, CI, and operator hardening needed to make the implementation credible
+
+## Non-Goals
+
+Track A is not:
+
+- a Liquid wallet integration project
+- a Simplicity contract demo
+- an opt-in protection layer that leaves the base chain classical by default
+- a near-term attempt to replace Bitcoin mainnet by social consensus alone
+- a generic "post-quantum blockchain" rebrand that discards the current repo's
+  Bitcoin-derived architecture
+
+## Why Track A Stays The Anchor
+
+- The repo already contains substantial native-chain work: frozen PQ-only
+  consensus, descriptor-native wallet flows, PQ PSBT support, and migration
+  posture documentation.
+- Resetting onto an opt-in sidechain path would discard the project's main
+  differentiator.
+- The hard problem worth owning here is not just "can a Bitcoin-like system
+  verify PQ signatures," but "what does a coherent PQ-native Bitcoin-derived
+  chain look like end to end?"
+
+## How Blockstream Fits
+
+On March 3, 2026, Blockstream Research published a production Liquid mainnet
+demonstration of post-quantum transaction signing using Simplicity and a
+SHRINCS verifier.
+
+This matters because it shows:
+
+- post-quantum verification can run on a production Bitcoin-like system today
+- an opt-in path can be deployed without consensus changes
+- stateful versus stateless recovery tradeoffs are product-level design
+  questions, not just cryptography details
+
+But it does **not** replace Track A because:
+
+- Liquid + Simplicity is an opt-in sidechain path, not a consensus-native base
+  chain redesign
+- Blockstream's write-up explicitly says the result is not a complete
+  system-wide quantum fix
+- the demonstrated verifier stack is materially different from this repo's
+  current PQSig rc2 design
+
+Therefore the correct use of the Blockstream work is:
+
+- benchmark
+- inspiration
+- migration and interoperability input
+
+and **not**:
+
+- reason to restart the repo from zero
+- reason to abandon the native-chain thesis
+
+## Decision Rule
+
+If the question is "what is the fastest path to opt-in post-quantum protection
+for Bitcoin-like assets," then the Blockstream/Liquid/Simplicity line is a
+strong reference path.
+
+If the question is "what should `quantum-proof-bitcoin` be," Track A remains
+the answer: a native post-quantum chain.
+
+Do not collapse those two questions into one.
+
+## Near-Term Engineering Bias
+
+Near-term work should favor:
+
+1. CI completeness and gating confidence
+2. Taproot replacement migration coverage
+3. wallet and signing flow maturity
+4. operator hardening and runtime evidence
+5. clear external positioning against adjacent approaches such as
+   Liquid/Simplicity
+
+## Adjacent Track
+
+It is reasonable to keep a separate research track for:
+
+- Liquid/Simplicity comparison notes
+- migration design ideas
+- interoperability thought experiments
+- stateful versus stateless recovery analysis
+
+That adjacent track should inform Track A. It should not silently replace it.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -1,0 +1,273 @@
+# PQBTC Track A Status
+
+## Status: ACTIVE
+## Spec-ID: TRACK-A-STATUS-v1
+## Updated: 2026-04-09
+## Current Phase: Phase 1 - Confidence and Slice Selection
+
+## Purpose
+
+Operational status for the ninety-day Track A plan.
+
+This file is the working handoff for Aineko. When no more specific repo task is
+active, use this file to choose the next safe step for `quantum-proof-bitcoin`.
+
+## Current Objective
+
+Execute the first owned Taproot-replacement tranche for `#23`, starting with
+explicit PQ-native PSBT semantics, then lock the fixed watch-only `pq(...)`
+descriptor contract, the dedicated PQ wallet/address setup path, and refresh
+confidence in the current gate/evidence paths.
+
+## Current Working Thesis
+
+- `quantum-proof-bitcoin` stays on Track A: native post-quantum Bitcoin.
+- Track A assumes PQBTC launches as a new chain at block 0, not as an in-place
+  continuation of inherited Bitcoin chain history.
+- Blockstream's Liquid/Simplicity work is a benchmark and adjacent migration
+  reference, not a reason to reset the repo.
+- The best progress in this window is one owned product-facing migration slice,
+  not broad speculative redesign.
+
+## Current Candidates For First Owned Slice
+
+Chosen first owned tranche:
+
+1. `rpc_psbt.py` / PQ-native PSBT semantics
+   - Why first: user-facing, testable, narrow enough to finish, and directly
+     connected to wallet/signing maturity.
+
+Next likely follow-ons:
+
+2. `wallet_createwalletdescriptor.py`
+3. `wallet_address_types.py`
+4. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+5. `wallet_miniscript.py`
+
+## Current Queue
+
+1. Recommended next PR after the currently open send-path / CI and CLI hotfix
+   work: land the Track A strategy and launch-posture docs pack.
+   Exact files for that PR:
+   - `docs/TRACK_A_NATIVE_PQ_BITCOIN.md`
+   - `docs/TRACK_A_90_DAY_ROADMAP.md`
+   - `docs/GENESIS_AND_NETWORK_POSTURE.md`
+   - `docs/RESEARCH_INDEX.md`
+   - `docs/PSBT_REPLACEMENT_TRANCHE.md`
+   - `docs/TEST_COST_POSTURE.md`
+   - `docs/TRACK_A_STATUS.md`
+   - `docs/README_PQBTC.md`
+   - `docs/Spec.md`
+   - `docs/DECISION_DEFERRAL_LEDGER.md`
+   Minimum validation only:
+   - doc-only review
+   - keep links repo-relative
+   Stays deferred:
+   - product-identity and Qt/CLI naming cleanup in `src/` and `src/qt/`
+   - `OPS_SLO` evidence/artifact refresh and `docs/artifacts/ops-slo/*`
+   - inherited `createwalletdescriptor` expansion beyond the current xpub-based surface
+   - broad `wallet_address_types.py` rehabilitation
+   - inherited classical PSBT compatibility in `rpc_psbt.py`
+2. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned slice.
+3. Use `PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md` as the fixed public descriptor
+   contract.
+4. Treat the `rpc_psbt.py` `finalizepsbt` failure as an intentionally deferred
+   inherited classical-PSBT compatibility gap under the all-PQ Track A stance.
+5. Use `GENESIS_AND_NETWORK_POSTURE.md` as the launch-level interpretation for
+   a fresh block-0 chain with its own network identity.
+6. Use `CREATEWALLETDESCRIPTOR_POSTURE.md` to keep inherited descriptor
+   creation separate from the PQ-native creation path.
+7. Use `PQ_WALLET_MANAGER_SETUP.md` as the current setup-path contract for
+   active PQ receive/change managers.
+8. Use `PQ_ADDRESS_RPC_POSTURE.md` as the current inherited-address boundary
+   for PQ-only active wallets.
+9. Use `TEST_COST_POSTURE.md` to choose the cheapest defensible validation tier
+   for each tranche before running tests.
+10. Re-run and inspect the current required PQ-first functional gate strategy at
+    a targeted level.
+11. Reproduce the current `OPS_SLO` evidence flow only when the work has
+    actually reached milestone-evidence scope.
+
+## Autonomous Scope
+
+Aineko may do these without asking:
+
+- read code, tests, and docs in this repo
+- tighten or add strategy/status docs
+- rank backlog items and propose tranche scope
+- run low-cost targeted tests and validation commands
+- update this file with decisions, results, and blockers
+
+Aineko must ask before:
+
+- consensus-rule changes
+- broad signature-stack changes or cryptographic-family pivots
+- destructive actions
+- long expensive build/test campaigns
+- public claims, releases, or external messaging
+- changing the Track A thesis itself
+
+## Phase 1 Deliverables
+
+- first tranche named
+- tranche semantics written down
+- backlog ranking tightened
+- current gate health summarized
+- ops evidence path sanity-checked
+
+## Reference Pack
+
+- `TRACK_A_NATIVE_PQ_BITCOIN.md`
+- `TRACK_A_90_DAY_ROADMAP.md`
+- `GENESIS_AND_NETWORK_POSTURE.md`
+- `RESEARCH_INDEX.md`
+- `PSBT_REPLACEMENT_TRANCHE.md`
+- `PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md`
+- `PQ_WALLET_MANAGER_SETUP.md`
+- `PQ_ADDRESS_RPC_POSTURE.md`
+- `CREATEWALLETDESCRIPTOR_POSTURE.md`
+- `TEST_COST_POSTURE.md`
+- `POST_RC_EPICS.md`
+- `CI_COMPLETENESS.md`
+- `TAPROOT_MIGRATION_MATRIX.md`
+- `OPS_SLO.md`
+
+## Decision Log
+
+- 2026-04-06: Track A confirmed as the repo anchor. No Liquid/Simplicity reset.
+- 2026-04-06: Launch posture clarified: PQBTC is intended as a fresh chain
+  starting at block 0, not as a retrofit onto inherited Bitcoin history.
+- 2026-04-06: `GENESIS_AND_NETWORK_POSTURE.md` added to freeze the practical
+  launch interpretation of that thesis: new history, new network identity, no
+  assumed Bitcoin UTXO inheritance, and no obligation to preserve broad
+  classical wallet compatibility by default.
+- 2026-04-06: Initial ninety-day roadmap added.
+- 2026-04-06: First owned tranche chosen: `rpc_psbt.py` / PQ-native PSBT semantics.
+- 2026-04-06: `PSBT_REPLACEMENT_TRANCHE.md` added as the tranche semantics note.
+- 2026-04-06: Follow-on queue tightened: `wallet_pq_descriptors.py` ahead of `wallet_createwalletdescriptor.py`, with address/miniscript surfaces later.
+- 2026-04-06: Targeted confidence pass: `pqsig_script_tests` passed, `wallet_pq_psbt.py` passed, `rpc_psbt.py` failed at `finalizepsbt` with `Signature is not a valid encoding`.
+- 2026-04-06: Root cause narrowed: `src/script/interpreter.cpp` currently makes
+  `CheckSignatureEncoding()` PQ-only for all pre-taproot paths, so classical
+  PSBT `partial_sigs` created for `pkh(...)` inputs decode-fail even when the
+  wallet signs them correctly.
+- 2026-04-06: Track A stance confirmed as all-PQ. Restoring inherited
+  classical PSBT decode/finalize compatibility is not current owned work.
+- 2026-04-06: Fixed watch-only `pq(...)` descriptor contract confirmed with
+  both unit and functional coverage; `wallet_createwalletdescriptor.py` is now
+  the next descriptor-facing follow-on.
+- 2026-04-06: `wallet_createwalletdescriptor.py` verified green, but confirmed
+  as inherited xpub-to-`wpkh/tr` descriptor creation rather than a PQ-native
+  creation path.
+- 2026-04-06: Recommended direction: keep PQ wallet-manager creation on the
+  dedicated `pqpriv(...)` path for now instead of overloading the inherited
+  `createwalletdescriptor` RPC early.
+- 2026-04-06: Active `pqpriv(...)` manager coverage now explicitly rejects both
+  inherited `bech32` and `bech32m` `createwalletdescriptor` paths as HD-xpub
+  creation flows, including after backup/restore.
+- 2026-04-06: `createwalletdescriptor` now returns a PQ-specific error on
+  PQ-only wallets instead of the generic HD-key ambiguity message.
+- 2026-04-06: Dedicated `createpqwalletmanagers` RPC landed for PQ-native
+  receive/change setup on descriptor wallets with no active managers.
+- 2026-04-06: `wallet_pq_active_ranged.py` now covers the dedicated setup RPC
+  directly.
+- 2026-04-06: `wallet_pq_psbt.py` now runs the main PQ-native PSBT path through
+  `createpqwalletmanagers`, while retaining one lower-level `importdescriptors`
+  check so raw `pqpriv(...)` setup stays exercised.
+- 2026-04-08: `wallet_pq_psbt.py` now also covers `fundrawtransaction` on a
+  PQ-only wallet, freezing the current expectation that automatic change stays
+  on the active internal `pqpriv(...)` manager rather than re-entering
+  inherited change-address semantics.
+- 2026-04-08: `wallet_pq_psbt.py` now also covers automatic-input
+  `walletcreatefundedpsbt` on a PQ-only wallet, freezing the current
+  expectation that the PSBT funding path keeps automatic change on the active
+  internal `pqpriv(...)` manager and emits one PQ proprietary partial-signature
+  field per funded PQ input.
+- 2026-04-08: The same PQ-owned `walletcreatefundedpsbt` tranche now covers the
+  `changePosition` and `subtractFeeFromOutputs` option edges, with automatic PQ
+  change still staying on the active internal `pqpriv(...)` manager.
+- 2026-04-08: `wallet_pq_create_tx.py` now owns the narrow PQ-only direct
+  wallet create-tx posture: inherited anti-fee-sniping stays in force on
+  `sendtoaddress`, old tips keep `locktime = 0`, recent tips keep
+  `0 < locktime <= height`, and the current wallet tx version stays `2`.
+- 2026-04-08: `wallet_pq_send.py` now owns the narrow PQ-only `send` RPC
+  posture: default recent-tip anti-fee-sniping stays in force, an explicit
+  `locktime = 0` override disables it, and the current wallet tx version stays
+  `2`.
+- 2026-04-08: `wallet_pq_sendall.py` now owns the narrow PQ-only `sendall`
+  RPC posture: default recent-tip anti-fee-sniping stays in force, an explicit
+  `locktime = 0` override disables it, and the current wallet tx version stays
+  `2`.
+- 2026-04-08: `wallet_pq_sendmany.py` now owns the narrow PQ-only `sendmany`
+  RPC posture: default anti-fee-sniping stays in force, the current wallet tx
+  version stays `2`, and one multi-recipient `subtractfeefrom` edge is now
+  owned in the required PQ gate.
+- 2026-04-08: `wallet_pq_descriptors.py` now owns the fixed watch-only
+  `pq(...)` descriptor boundary strongly enough for the required PQ gate:
+  import/introspection, reload persistence, watch-only tracking, and a
+  non-signing PSBT-preparation path with no PQ proprietary partial signatures.
+- 2026-04-08: Wallet RPC metadata now exposes an explicit
+  `has_private_keys` field on `getaddressinfo` and `listunspent`, so fixed
+  public `pq(...)` descriptors and active `pqpriv(...)` managers no longer
+  need to overload deprecated `iswatchonly` / `spendable` fields to express
+  signing capability.
+- 2026-04-09: Remaining-slice map refreshed after the send-path / CI and CLI
+  hotfix work. Recommended next PR is a docs-only Track A strategy and
+  launch-posture pack in `docs/TRACK_A_NATIVE_PQ_BITCOIN.md`,
+  `docs/TRACK_A_90_DAY_ROADMAP.md`,
+  `docs/GENESIS_AND_NETWORK_POSTURE.md`, `docs/RESEARCH_INDEX.md`,
+  `docs/PSBT_REPLACEMENT_TRANCHE.md`, `docs/TEST_COST_POSTURE.md`,
+  `docs/TRACK_A_STATUS.md`, `docs/README_PQBTC.md`, `docs/Spec.md`, and
+  `docs/DECISION_DEFERRAL_LEDGER.md`, with minimum validation limited to
+  doc-only review and repo-relative links. Product identity/Qt naming work,
+  `OPS_SLO` evidence/artifact updates, broad inherited address-type rehab, and
+  inherited classical PSBT compatibility remain deferred.
+- 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
+  `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
+- 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
+  soak capture. The frozen `2026-03-30` bundle still validates at sign-off, the
+  validator self-test passes, and a live `mempool_pq_limits.py` run still emits
+  the expected summary contract with `pass=true`, `crash_assert_hang=false`, and
+  stable restart counts.
+- 2026-04-06: Current targeted Track A gate snapshot is green for
+  `wallet_pq_active_ranged.py`, `wallet_pq_psbt.py`,
+  `wallet_pq_create_tx.py`, `wallet_pq_send.py`,
+  `wallet_pq_sendall.py`, `wallet_pq_sendmany.py`,
+  `wallet_pq_descriptors.py`,
+  `wallet_createwalletdescriptor.py`, and `pqsig_script_tests`.
+- 2026-04-06: PQ-only active wallets now reject inherited `getnewaddress` and
+  `getrawchangeaddress` outright, including explicit legacy-style address-type
+  requests, and direct operators to `getnewpqaddress` /
+  `getrawpqchangeaddress` instead.
+- 2026-04-06: `keypoolrefill` is now explicitly treated as a supported PQ
+  maintenance path: on PQ-only active wallets it expands the receive/change
+  `pqpriv(...)` ranges rather than acting as an inherited address-family UX.
+- 2026-04-06: `wallet_address_types.py` remains an inherited `dual_profile`
+  suite. Its current failure is still in classical `sendmany` signing flow, so
+  broad address-type rehabilitation is not the owned Track A wallet milestone.
+- 2026-04-06: Launch-facing operator identity is tighter on the main CLI/RPC
+  path: `pqbtcd`, `pqbtc-wallet`, and `pqbtc-util` help/version output now use
+  PQBTC naming, and wallet/RPC error/help strings now prefer `PQBTC address`,
+  `pqbtc-wallet`, and `pqbtcd` over inherited Bitcoin tool names on the active
+  operator surfaces.
+- 2026-04-06: The same identity cleanup now extends across the active Qt
+  source surfaces: `pqbtc-qt` entrypoint naming, PQBTC address/network wording,
+  payment/request UI text, and GUI metadata no longer default to inherited
+  Bitcoin branding on the main operator path. The current build tree does not
+  have the Qt target enabled, so this pass is source-level verified rather than
+  GUI-built in this environment.
+- 2026-04-06: `TEST_COST_POSTURE.md` added to freeze the development rule that
+  PQBTC should validate by tranche, not by tiny commit, and that expensive CI
+  or soak work should be paid only at explicit promotion or sign-off boundaries.
+
+## Blockers
+
+- `rpc_psbt.py` currently fails in the inherited broad PSBT RPC surface at `finalizepsbt` with `Signature is not a valid encoding`.
+- This is no longer just a hypothesis. The narrowed failing case spends
+  classical `pkh(...)` coinbase-style inputs, and the resulting ECDSA-looking
+  `partial_sigs` are rejected because global pre-taproot signature encoding
+  validation now requires fixed-size PQ signatures.
+- The owned PQ-native `pqpriv(...)` PSBT path is still healthy. The blocker is
+  only for inherited classical compatibility surfaces. Under the current Track A
+  stance, that legacy path stays explicitly deferred rather than restored.
+- There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
+  bundle satisfies the frozen signoff thresholds.


### PR DESCRIPTION
## Summary\n- add the Track A strategy, roadmap, launch-posture, and research index docs\n- freeze the PSBT tranche and test-cost posture in repo docs\n- update the Track A status handoff, spec citation, and deferral ledger to match current direction\n\n## Validation\n- python3 test/lint/lint-files.py\n- git diff --check\n- verified the docs pack uses repo-relative links (`mlc` not installed locally)