### PR TITLE
test: add PQ raw-signing wallet slice

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1804,6 +1804,13 @@
     "notes": "Required PQ-only sendmany RPC anti-fee-sniping and multi-recipient subtractfeefrom coverage."
   },
   {
+    "name": "wallet_pq_signrawtransaction.py",
+    "policy_class": "pq_required",
+    "owner": "@scottdhughes",
+    "tracking_issue": "#12",
+    "notes": "Required PQ-only signrawtransactionwithwallet default/ALL parity, fixed-sighash rejection, and direct witness-shape coverage."
+  },
+  {
     "name": "wallet_reindex.py",
     "policy_class": "pq_backlog",
     "owner": "@scottdhughes",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -17,3 +17,4 @@ wallet_pq_psbt.py
 wallet_pq_send.py
 wallet_pq_sendall.py
 wallet_pq_sendmany.py
+wallet_pq_signrawtransaction.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -32,11 +32,11 @@ This tranche does not migrate legacy suites to PQ semantics and does not optimiz
 
 ## Current Inventory Summary
 
-The current functional corpus has `275` tracked test files, classified as:
+The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `19` |
+| `pq_required` | `20` |
 | `pq_backlog` | `100` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
@@ -62,11 +62,13 @@ Current required PQ-first gates:
 17. `wallet_pq_send.py`
 18. `wallet_pq_sendall.py`
 19. `wallet_pq_sendmany.py`
+20. `wallet_pq_signrawtransaction.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
 fixed watch-only descriptor, direct create-tx, `send`, `sendall`, `sendmany`,
-and PSBT unit coverage to the default `test_pqbtc` profile. The
+direct raw-signing, and PSBT unit coverage to the default `test_pqbtc`
+profile. The
 replacement-path confidence gap is closed in this tranche by promoting the full
 deterministic Taproot replacement functional stack into the required PQ gate.
 The remaining key backlog families are:

--- a/docs/PQ_WALLET_SIGNRAWTRANSACTION_POSTURE.md
+++ b/docs/PQ_WALLET_SIGNRAWTRANSACTION_POSTURE.md
@@ -1,0 +1,65 @@
+# PQBTC PQ Wallet Raw-Signing Posture
+
+## Status: ACTIVE
+## Spec-ID: PQ-WALLET-SIGNRAWTRANSACTION-POSTURE-v1
+## Updated: 2026-04-11
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the owned PQ-only
+[signrawtransactionwithwallet](../src/wallet/rpc/spend.cpp)
+contract without reopening the broad inherited
+[wallet_signrawtransactionwithwallet.py](../test/functional/wallet_signrawtransactionwithwallet.py)
+matrix.
+
+## Owned Surface
+
+The current owned PQ-native raw-signing path is:
+
+- [wallet_pq_signrawtransaction.py](../test/functional/wallet_pq_signrawtransaction.py)
+
+It covers a PQ-only active wallet created through
+[createpqwalletmanagers](../src/wallet/rpc/wallet.cpp).
+
+## Contract
+
+On PQ-only active wallets:
+
+- direct raw spends of wallet-owned PQ UTXOs through
+  `signrawtransactionwithwallet` are supported
+- the default omitted sighash path and explicit `"ALL"` must produce the same
+  fully signed transaction
+- explicit non-`ALL` sighash modes remain unsupported on this PQ path and must
+  leave the transaction incomplete rather than silently producing a different
+  signature contract
+- the signed witness stack is the current PQ witness shape:
+  `[pq_signature, witness_script]`
+- the PQ signature payload remains the current fixed `4480`-byte signature
+- caller-chosen transaction fields such as version, locktime, and explicit
+  sequence numbers remain intact
+
+## Why This Slice Exists
+
+Track A already owns the PQ-native setup path, change/funding path, PSBT path,
+and operator-facing send family. This slice closes the remaining direct
+wallet-owned raw-signing gap without reopening inherited classical signing
+compatibility or the full historical `wallet_signrawtransactionwithwallet.py`
+matrix.
+
+## Non-Goals In This Tranche
+
+This tranche does not own:
+
+- broad inherited `wallet_signrawtransactionwithwallet.py` behavior
+- mixed classical/PQ signing compatibility
+- `prevtxs` matrix coverage for legacy descriptor families
+- broad `wallet_fundrawtransaction.py` rehabilitation
+- inherited classical PSBT finalize/decode compatibility in `rpc_psbt.py`
+
+## Confidence
+
+Minimum validation for this slice:
+
+- `python3 test/functional/wallet_pq_signrawtransaction.py`
+- `python3 ci/test/check_ci_inventory.py`

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,8 +2,8 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-09
-## Current Phase: Phase 1 - Confidence and Slice Selection
+## Updated: 2026-04-11
+## Current Phase: Phase 1 - Wallet Surface Expansion
 
 ## Purpose
 
@@ -46,25 +46,21 @@ Next likely follow-ons:
 
 ## Current Queue
 
-1. Recommended next PR after the currently open send-path / CI and CLI hotfix
-   work: land the Track A strategy and launch-posture docs pack.
+1. Recommended next PR after the PQ raw-signing slice: extend active PQ
+   manager restore semantics.
    Exact files for that PR:
-   - `docs/TRACK_A_NATIVE_PQ_BITCOIN.md`
-   - `docs/TRACK_A_90_DAY_ROADMAP.md`
-   - `docs/GENESIS_AND_NETWORK_POSTURE.md`
-   - `docs/RESEARCH_INDEX.md`
-   - `docs/PSBT_REPLACEMENT_TRANCHE.md`
-   - `docs/TEST_COST_POSTURE.md`
+   - `test/functional/wallet_pq_backup_recovery.py`
+   - `test/functional/wallet_pq_active_ranged.py`
+   - `docs/PQ_WALLET_MANAGER_SETUP.md`
+   - `docs/WALLET.md`
    - `docs/TRACK_A_STATUS.md`
-   - `docs/README_PQBTC.md`
-   - `docs/Spec.md`
-   - `docs/DECISION_DEFERRAL_LEDGER.md`
    Minimum validation only:
-   - doc-only review
-   - keep links repo-relative
+   - `python3 test/functional/wallet_pq_backup_recovery.py`
+   - `python3 test/functional/wallet_pq_active_ranged.py`
    Stays deferred:
-   - product-identity and Qt/CLI naming cleanup in `src/` and `src/qt/`
-   - `OPS_SLO` evidence/artifact refresh and `docs/artifacts/ops-slo/*`
+   - broad inherited backup/recovery migration rehab
+   - broad inherited `wallet_signrawtransactionwithwallet.py` rehabilitation
+   - broad `wallet_fundrawtransaction.py` rehabilitation
    - inherited `createwalletdescriptor` expansion beyond the current xpub-based surface
    - broad `wallet_address_types.py` rehabilitation
    - inherited classical PSBT compatibility in `rpc_psbt.py`
@@ -221,6 +217,23 @@ Aineko must ask before:
   doc-only review and repo-relative links. Product identity/Qt naming work,
   `OPS_SLO` evidence/artifact updates, broad inherited address-type rehab, and
   inherited classical PSBT compatibility remain deferred.
+- 2026-04-10: After merging the docs, identity, and `OPS_SLO` slices and
+  resyncing the old dirty worktree to current `main`, no further real tranche
+  remained in that worktree. The next clean owned slice is now a PQ-specific
+  `signrawtransactionwithwallet` contract, implemented as a dedicated
+  `wallet_pq_signrawtransaction.py` surface plus a matching posture doc and PQ
+  gate/inventory updates. Broad inherited `wallet_signrawtransactionwithwallet`
+  and `wallet_fundrawtransaction` rehab remain deferred.
+- 2026-04-11: The next owned wallet surface remains a PQ-specific
+  `signrawtransactionwithwallet` slice: direct wallet-owned raw spends,
+  default/`ALL` parity, explicit non-`ALL` rejection, and fixed PQ witness
+  shape, without reopening the broad inherited raw-signing matrix.
+- 2026-04-11: The PQ-only raw-signing slice is now owned explicitly through
+  `wallet_pq_signrawtransaction.py` and
+  `PQ_WALLET_SIGNRAWTRANSACTION_POSTURE.md`, with required-gate promotion in
+  `pq_functional_tests.txt` and `functional_suite_inventory.json`. The next
+  wallet follow-on should extend active PQ manager restore semantics rather
+  than reopening the inherited raw-signing matrix.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -212,6 +212,7 @@ BASE_SCRIPTS = [
     'rpc_whitelist.py',
     'feature_proxy.py',
     'wallet_signrawtransactionwithwallet.py',
+    'wallet_pq_signrawtransaction.py',
     'rpc_signrawtransactionwithkey.py',
     'rpc_rawtransaction.py',
     'wallet_transactiontime_rescan.py',

--- a/test/functional/wallet_pq_signrawtransaction.py
+++ b/test/functional/wallet_pq_signrawtransaction.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test PQ-only wallet raw-signing posture."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from test_framework.descriptors import descsum_create
+from test_framework.messages import COIN
+from test_framework.pqsig import create_wallet_funded_tx
+from test_framework.pq_wallet_helper import build_active_pq_descriptor_entry
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+RAW_TRUE_DESCRIPTOR = descsum_create("raw(51)")
+PQ_SIGNATURE_HEX_LEN = 2 * 4480
+
+
+class WalletPQSignRawTransactionTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-acceptnonstdtxn=1"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def mine_block(self):
+        return self.nodes[0].generatetodescriptor(1, RAW_TRUE_DESCRIPTOR, called_by_framework=True)[0]
+
+    def fund_entry(self, entry, amount_sat: int) -> str:
+        tx = create_wallet_funded_tx(self.nodes[0], bytes(entry.script_pub_key), amount_sat)
+        return self.nodes[0].sendrawtransaction(tx.serialize().hex())
+
+    def find_unspent(self, wallet, address: str, txid: str):
+        matches = [u for u in wallet.listunspent() if u["address"] == address and u["txid"] == txid]
+        assert_equal(len(matches), 1)
+        return matches[0]
+
+    def run_test(self):
+        node = self.nodes[0]
+        root_seed = bytes.fromhex("3a" * 32)
+        receive_entry = build_active_pq_descriptor_entry(root_seed, internal=False, index=0)
+
+        node.createwallet(wallet_name="sink")
+        sink = node.get_wallet_rpc("sink")
+        sink_address = sink.getnewaddress()
+
+        node.createwallet(wallet_name="pqsignraw", blank=True)
+        wallet = node.get_wallet_rpc("pqsignraw")
+        wallet.createpqwalletmanagers(root_seed.hex(), 9)
+
+        self.log.info("Fund a PQ-only wallet and construct a direct raw spend without fundrawtransaction or PSBT")
+        assert_equal(wallet.getnewpqaddress("receive"), receive_entry.address)
+        funding_txid = self.fund_entry(receive_entry, 6 * COIN)
+        self.mine_block()
+        funded = self.find_unspent(wallet, receive_entry.address, funding_txid)
+        assert_equal(funded["has_private_keys"], True)
+
+        locktime = node.getblockcount()
+        raw_tx = node.createrawtransaction(
+            [{"txid": funded["txid"], "vout": funded["vout"], "sequence": 0xFFFFFFFE}],
+            {sink_address: Decimal("5.99900000")},
+            locktime,
+        )
+
+        self.log.info("The default raw-signing path should match explicit SIGHASH_ALL on PQ-only wallets")
+        signed_default = wallet.signrawtransactionwithwallet(raw_tx)
+        assert_equal(signed_default["complete"], True)
+
+        signed_all = wallet.signrawtransactionwithwallet(hexstring=raw_tx, sighashtype="ALL")
+        assert_equal(signed_all["complete"], True)
+        assert_equal(signed_default["hex"], signed_all["hex"])
+
+        self.log.info("Non-ALL sighash modes remain unsupported on the PQ raw-signing path")
+        signed_none = wallet.signrawtransactionwithwallet(hexstring=raw_tx, sighashtype="NONE")
+        assert_equal(signed_none["complete"], False)
+        assert_equal(signed_none["hex"], raw_tx)
+
+        signed_anyonecanpay = wallet.signrawtransactionwithwallet(
+            hexstring=raw_tx,
+            sighashtype="ALL|ANYONECANPAY",
+        )
+        assert_equal(signed_anyonecanpay["complete"], False)
+        assert_equal(signed_anyonecanpay["hex"], raw_tx)
+
+        self.log.info("The signed transaction should preserve caller-chosen tx fields and emit the expected PQ witness shape")
+        signed_again = wallet.signrawtransactionwithwallet(signed_default["hex"])
+        assert_equal(signed_again["complete"], True)
+        assert_equal(signed_again["hex"], signed_default["hex"])
+
+        decoded = node.decoderawtransaction(signed_default["hex"])
+        assert_equal(decoded["version"], 2)
+        assert_equal(decoded["locktime"], locktime)
+        assert_equal(decoded["vin"][0]["sequence"], 0xFFFFFFFE)
+        assert_equal(len(decoded["vin"][0]["txinwitness"]), 2)
+        assert_equal(len(decoded["vin"][0]["txinwitness"][0]), PQ_SIGNATURE_HEX_LEN)
+        assert_equal(decoded["vin"][0]["txinwitness"][1], bytes(receive_entry.witness_script).hex())
+
+        self.log.info("Broadcast the signed transaction to prove the owned raw-signing surface is usable end-to-end")
+        txid = node.sendrawtransaction(signed_default["hex"])
+        assert_equal(txid, decoded["txid"])
+        self.mine_block()
+
+
+if __name__ == "__main__":
+    WalletPQSignRawTransactionTest(__file__).main()


### PR DESCRIPTION
## Summary
- add a dedicated PQ-only raw-signing functional test for direct wallet-owned spends
- freeze the PQ signrawtransactionwithwallet contract in a posture doc
- promote the slice into the PQ gate, full functional inventory, and Track A handoff

## Validation
- python3 test/functional/wallet_pq_signrawtransaction.py
- python3 ci/test/check_ci_inventory.py
- python3 test/lint/lint-files.py
- git diff --check