### PR TITLE
test: extend PQ wallet restore semantics

### DIFF
--- a/docs/PQ_WALLET_MANAGER_SETUP.md
+++ b/docs/PQ_WALLET_MANAGER_SETUP.md
@@ -98,7 +98,9 @@ Targeted confidence pass on 2026-04-08:
 - `python3 test/functional/wallet_pq_active_ranged.py`
   - result: passed
   - covers dedicated PQ setup, active receive/change generation, PQ-aware
-    `keypoolrefill`, spend/change, restart, backup, and restore
+    `keypoolrefill`, spend/change, restart, backup, restore, restored
+    keypool continuity, and post-restore automatic PQ change on the restored
+    internal manager
 - `python3 test/functional/wallet_pq_psbt.py`
   - result: passed
   - covers the main PQ-native PSBT/signing flow starting from the dedicated

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -234,6 +234,11 @@ Aineko must ask before:
   `pq_functional_tests.txt` and `functional_suite_inventory.json`. The next
   wallet follow-on should extend active PQ manager restore semantics rather
   than reopening the inherited raw-signing matrix.
+- 2026-04-12: Active PQ manager restore semantics now explicitly include
+  restored keypool continuity and post-restore automatic PQ change on the
+  restored internal manager. With the owned `rpc_psbt.py` PQ subset now
+  frozen, the next clean Track A wallet follow-on shifts to the
+  `wallet_createwalletdescriptor.py` boundary.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full

--- a/docs/WALLET.md
+++ b/docs/WALLET.md
@@ -14,6 +14,8 @@ The wallet surface is no longer deferred in the repo. Current `main` includes:
 - deterministic PQ destination derivation with persisted `next_index`
 - PQ signing and PQ PSBT proprietary partial-signature handling under the current fixed `SIGHASH_ALL` rule
 - backup, restore, and ranged-descriptor recovery coverage
+- active PQ manager restore continuity for persisted `next_index`, keypool
+  state, and post-restore automatic PQ change
 - default PQ-native unit coverage for wallet bookkeeping and PSBT role/error handling
 
 Important boundary:

--- a/test/functional/wallet_pq_active_ranged.py
+++ b/test/functional/wallet_pq_active_ranged.py
@@ -287,6 +287,7 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
             external_range=[0, 14],
             internal_range=[0, 12],
         )
+        self.assert_keypool_info(wallet, external=12, internal=11)
         self.assert_address_info(wallet, int_entries[1], is_change=True)
 
         self.log.info("Restart and confirm active manager state and tracked outputs persist")
@@ -317,6 +318,7 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
             external_range=[0, 14],
             internal_range=[0, 12],
         )
+        self.assert_keypool_info(restored, external=12, internal=11)
         self.assert_owned_unspent(restored, spend_txid, int_entries[1], change_amount, category=None)
         self.assert_address_info(restored, int_entries[1], is_change=True)
         assert_equal(restored.gethdkeys(), [])
@@ -368,6 +370,7 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
             external_range=[0, 14],
             internal_range=[0, 12],
         )
+        self.assert_keypool_info(restored, external=11, internal=10)
 
         self.log.info("Reload the restored wallet and confirm watch set and next_index remain stable")
         restored.unloadwallet()
@@ -381,6 +384,7 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
             external_range=[0, 14],
             internal_range=[0, 12],
         )
+        self.assert_keypool_info(restored, external=11, internal=10)
         self.assert_owned_unspent(restored, spend_txid, int_entries[1], change_amount, category=None)
         assert_equal(restored.getnewpqaddress(), ext_entries[4].address)
         self.assert_descriptor_state(
@@ -391,6 +395,27 @@ class WalletPQActiveRangedTest(BitcoinTestFramework):
             external_range=[0, 14],
             internal_range=[0, 12],
         )
+        self.assert_keypool_info(restored, external=10, internal=10)
+
+        self.log.info("Automatic PQ change still uses the restored internal manager after reload")
+        restored_spend_txid = restored.sendtoaddress(sink_addr, 1)
+        restored_spend_blockhash = self.mine_block()
+        restored_change_amount = self.find_output_amount(
+            restored_spend_txid,
+            int_entries[3].address,
+            blockhash=restored_spend_blockhash,
+        )
+        self.assert_owned_unspent(restored, restored_spend_txid, int_entries[3], restored_change_amount, category=None)
+        self.assert_descriptor_state(
+            restored,
+            root_seed,
+            external_next=5,
+            internal_next=4,
+            external_range=[0, 14],
+            internal_range=[0, 12],
+        )
+        self.assert_keypool_info(restored, external=10, internal=9)
+        self.assert_address_info(restored, int_entries[3], is_change=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend active PQ manager restore coverage to freeze keypool continuity and post-restore automatic PQ change
- update the wallet setup and Track A docs to reflect the owned restore semantics

## Validation
- python3 test/functional/wallet_pq_active_ranged.py
- python3 test/functional/wallet_pq_backup_recovery.py
- python3 test/lint/lint-files.py
- git diff --check