### PR TITLE
[codex] test: freeze createwalletdescriptor PQ boundary

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1568,7 +1568,7 @@
     "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
     "tracking_issue": "#23",
-    "notes": "Includes tr()/bech32m descriptor creation paths; kept in pq_backlog and classified as deferred in the #23 migration matrix."
+    "notes": "Inherited xpub descriptor builder with bech32/wpkh and bech32m/tr coverage plus an explicit PQ-only rejection boundary; kept in pq_backlog and classified as deferred in the #23 migration matrix."
   },
   {
     "name": "wallet_crosschain.py",

--- a/docs/CREATEWALLETDESCRIPTOR_POSTURE.md
+++ b/docs/CREATEWALLETDESCRIPTOR_POSTURE.md
@@ -28,6 +28,8 @@ In practice, the current functional coverage proves:
 
 - `type="bech32"` creates `wpkh(...)` descriptors
 - `type="bech32m"` creates `tr(...)` descriptors
+- PQ-only wallets with active `pqpriv(...)` managers are rejected explicitly
+  because this RPC remains xpub-only
 
 The current passing suite is:
 
@@ -106,19 +108,23 @@ Reasoning:
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-06:
+Targeted confidence pass run on 2026-04-12:
 
 - `python3 test/functional/wallet_createwalletdescriptor.py`
   - result: passed
+  - relevant guard: inherited xpub creation still works for `bech32` /
+    `bech32m`, while PQ-only active-manager wallets reject both families with
+    the current PQ-specific xpub-only RPC error and without mutating
+    descriptor, HD-key, or active-manager state
 - `python3 test/functional/wallet_pq_active_ranged.py`
   - result: passed
-  - relevant guard: dedicated PQ setup is now covered directly, and active
-    `pqpriv(...)` managers still reject inherited
-    `createwalletdescriptor("bech32")` and `createwalletdescriptor("bech32m")`
-    because they expose no HD xpub source, now with a PQ-specific RPC error
+  - relevant guard: dedicated PQ setup remains on
+    `createpqwalletmanagers`, and restore/reload rejection coverage for active
+    `pqpriv(...)` managers stays owned there
 
 Interpretation:
 
 - inherited descriptor creation remains healthy
-- PQ-native setup is now explicit and test-backed without overloading the
-  inherited RPC
+- PQ-only wallets are explicitly rejected by this inherited RPC
+- PQ-native setup remains explicit and test-backed on
+  `createpqwalletmanagers` without overloading the inherited RPC

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -14,9 +14,9 @@ active, use this file to choose the next safe step for `quantum-proof-bitcoin`.
 
 ## Current Objective
 
-Freeze the owned `rpc_psbt.py` PQ subset for `#23`, keep inherited classical
-PSBT finalize as an explicit deferred legacy boundary, then move the next owned
-follow-on to descriptor/address creation surfaces.
+Freeze the inherited `createwalletdescriptor` xpub-only boundary for `#23`,
+keep PQ-native setup on `createpqwalletmanagers`, then move the next owned
+follow-on to `wallet_address_types.py`.
 
 ## Current Working Thesis
 
@@ -38,41 +38,41 @@ Chosen first owned tranche:
 
 Next likely follow-ons:
 
-2. `wallet_createwalletdescriptor.py`
-3. `wallet_address_types.py`
-4. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-5. `wallet_miniscript.py`
+2. `wallet_address_types.py`
+3. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+4. `wallet_miniscript.py`
+5. `feature_block.py`
 
 ## Current Queue
 
-1. This slice freezes `rpc_psbt.py` as:
-   - one narrow PQ-owned wallet PSBT subset
-   - one explicit inherited classical negative control at `finalizepsbt`
+1. This slice freezes `wallet_createwalletdescriptor.py` as:
+   - inherited xpub-based `bech32` / `bech32m` descriptor creation
+   - one explicit PQ-only rejection boundary on active `pqpriv(...)` managers
    Minimum validation only:
-   - `python3 test/functional/rpc_psbt.py`
-   - `python3 test/functional/wallet_pq_psbt.py`
+   - `python3 test/functional/wallet_createwalletdescriptor.py`
+   - `python3 test/functional/wallet_pq_active_ranged.py`
    Stays deferred:
-   - broad inherited PSBT rehabilitation
-   - dual-mode classical/PQ signature finalize compatibility
-   - broad inherited backup/recovery migration rehab
-   - broad inherited `wallet_signrawtransactionwithwallet.py` rehabilitation
-   - broad `wallet_fundrawtransaction.py` rehabilitation
+   - PQ-native descriptor creation through `createwalletdescriptor`
+   - Taproot-replacement descriptor semantics beyond current inherited
+     `tr(...)` coverage
+   - broad inherited address-type rehabilitation
 2. Recommended next PR after this slice:
-   - preferred: `wallet_createwalletdescriptor.py`
-   - lower-risk alternate: `wallet_pq_descriptors.py`
+   - preferred: `wallet_address_types.py`
+   - lower-risk alternate: `feature_block.py`
    Why next:
-   - moves past the PSBT tranche
+   - moves past the inherited xpub-builder boundary
    - keeps momentum on wallet-owned migration surfaces
-   - avoids reopening inherited classical PSBT behavior
-3. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned slice.
+   - tightens the next broad inherited address surface under the same Track A
+     posture
+3. Use `CREATEWALLETDESCRIPTOR_POSTURE.md` as the current owned slice.
 4. Use `PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md` as the fixed public descriptor
    contract.
-5. Treat the `rpc_psbt.py` classical `finalizepsbt` failure as an intentionally deferred
-   inherited classical-PSBT compatibility gap under the all-PQ Track A stance.
+5. Treat `createwalletdescriptor` as an inherited xpub builder, not a PQ-native
+   wallet-manager creation path under the all-PQ Track A stance.
 6. Use `GENESIS_AND_NETWORK_POSTURE.md` as the launch-level interpretation for
    a fresh block-0 chain with its own network identity.
-7. Use `CREATEWALLETDESCRIPTOR_POSTURE.md` to keep inherited descriptor
-   creation separate from the PQ-native creation path.
+7. Use `PSBT_REPLACEMENT_TRANCHE.md` to keep the owned PQ `rpc_psbt.py`
+   subset separate from inherited classical PSBT rehabilitation.
 8. Use `PQ_WALLET_MANAGER_SETUP.md` as the current setup-path contract for
    active PQ receive/change managers.
 9. Use `PQ_ADDRESS_RPC_POSTURE.md` as the current inherited-address boundary
@@ -239,6 +239,11 @@ Aineko must ask before:
   restored internal manager. With the owned `rpc_psbt.py` PQ subset now
   frozen, the next clean Track A wallet follow-on shifts to the
   `wallet_createwalletdescriptor.py` boundary.
+- 2026-04-12: `wallet_createwalletdescriptor.py` now freezes the inherited
+  xpub-only boundary directly: inherited `bech32` / `bech32m` descriptor
+  creation stays green, PQ-only active-manager wallets reject both families
+  without mutating descriptor or manager state, and the next clean wallet
+  follow-on shifts to `wallet_address_types.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full

--- a/test/functional/wallet_createwalletdescriptor.py
+++ b/test/functional/wallet_createwalletdescriptor.py
@@ -13,6 +13,12 @@ from test_framework.util import (
 from test_framework.wallet_util import WalletUnlock
 
 
+PQ_CREATEWALLETDESCRIPTOR_ERROR = (
+    "Active pqpriv() managers do not expose HD keys; createwalletdescriptor "
+    "only supports xpub-based descriptor families"
+)
+
+
 class WalletCreateDescriptorTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -25,6 +31,28 @@ class WalletCreateDescriptorTest(BitcoinTestFramework):
         self.test_basic()
         self.test_imported_other_keys()
         self.test_encrypted()
+        self.test_pq_active_managers_reject_inherited_descriptor_creation()
+
+    def descriptor_snapshot(self, wallet):
+        snapshot = []
+        for descriptor in wallet.listdescriptors(private=True)["descriptors"]:
+            snapshot.append({
+                "desc": descriptor["desc"],
+                "active": descriptor["active"],
+                "internal": descriptor["internal"],
+                "range": descriptor.get("range"),
+                "next_index": descriptor.get("next_index"),
+            })
+        return sorted(snapshot, key=lambda item: item["desc"])
+
+    def pq_wallet_state_snapshot(self, wallet):
+        info = wallet.getwalletinfo()
+        return {
+            "descriptors": self.descriptor_snapshot(wallet),
+            "hdkeys": wallet.gethdkeys(),
+            "keypoolsize": info["keypoolsize"],
+            "keypoolsize_hd_internal": info["keypoolsize_hd_internal"],
+        }
 
     def test_basic(self):
         def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
@@ -113,6 +141,25 @@ class WalletCreateDescriptorTest(BitcoinTestFramework):
 
         with WalletUnlock(wallet, "pass"):
             wallet.createwalletdescriptor(type="bech32m")
+
+    def test_pq_active_managers_reject_inherited_descriptor_creation(self):
+        self.log.info("Test createwalletdescriptor rejects PQ-only active managers without mutating wallet state")
+        self.nodes[0].createwallet("pq_only", blank=True)
+        wallet = self.nodes[0].get_wallet_rpc("pq_only")
+        wallet.createpqwalletmanagers(("42" * 32), 9)
+
+        state_before = self.pq_wallet_state_snapshot(wallet)
+        assert_equal(state_before["hdkeys"], [])
+        assert_equal(len(state_before["descriptors"]), 2)
+
+        for output_type in ("bech32", "bech32m"):
+            assert_raises_rpc_error(
+                -5,
+                PQ_CREATEWALLETDESCRIPTOR_ERROR,
+                wallet.createwalletdescriptor,
+                output_type,
+            )
+            assert_equal(self.pq_wallet_state_snapshot(wallet), state_before)
 
 
 


### PR DESCRIPTION
## Summary
- freeze `wallet_createwalletdescriptor.py` as an inherited xpub-only descriptor-builder surface
- add a PQ-only negative control that rejects `bech32` and `bech32m` on active `pqpriv(...)` wallets without mutating manager state
- update the posture/status docs and inventory note to point the next Track A follow-on at `wallet_address_types.py`

## Testing
- python3 test/functional/wallet_createwalletdescriptor.py
- python3 test/functional/wallet_pq_active_ranged.py
- python3 ci/test/check_ci_inventory.py
- python3 test/lint/lint-files.py
- git diff --check