### PR TITLE
[codex] test: freeze wallet_address_types boundary

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1455,7 +1455,7 @@
     "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
     "tracking_issue": "#23",
-    "notes": "Includes bech32m/Taproot-facing address branches; retained under the current non-gating dual-profile contract and classified as deferred in the #23 migration matrix."
+    "notes": "Contains low-risk inherited address-shape smoke coverage plus an explicit PQ-only inherited-address rejection boundary and a deferred inherited sendmany negative control; retained under the current non-gating dual-profile contract and classified as deferred in the #23 migration matrix."
   },
   {
     "name": "wallet_anchor.py",

--- a/docs/PQ_ADDRESS_RPC_POSTURE.md
+++ b/docs/PQ_ADDRESS_RPC_POSTURE.md
@@ -52,7 +52,7 @@ silently drifting back into classical address-family semantics.
 
 This posture note does **not** mean:
 
-- `wallet_address_types.py` is now an owned PQ suite
+- `wallet_address_types.py` is now an owned full PQ migration suite
 - inherited legacy, P2SH-SegWit, or bech32m address-family behavior is fully
   migrated to PQ semantics
 - broad mixed address-family send flows are now green
@@ -62,24 +62,39 @@ The broad inherited suite remains:
 - [wallet_address_types.py](../test/functional/wallet_address_types.py)
   - current inventory posture: `dual_profile`
   - current Taproot matrix bucket: `deferred`
+  - current owned boundary:
+    - low-risk inherited address-shape smoke coverage that still passes
+    - explicit PQ-only inherited `getnewaddress` / `getrawchangeaddress`
+      rejection coverage for valid explicit address types, including `bech32m`
+    - one deferred inherited classical `sendmany` negative control
 
-On 2026-04-06 it still failed in the inherited classical path at
-`sendmany("", sends)` with `Signing transaction failed`, before the new PQ-only
-address-RPC guards became the relevant question.
+As of 2026-04-12, that suite no longer fails accidentally in the inherited
+classical path. Instead, it freezes the current failure explicitly:
+
+- inherited classical `sendmany("", sends)` still fails with
+  `Signing transaction failed`
+- that behavior remains deferred Track A compatibility work, not a PQ-address
+  RPC regression
 
 ## Confidence Snapshot
 
-Targeted confidence on 2026-04-06:
+Targeted confidence on 2026-04-12:
 
+- `python3 test/functional/wallet_address_types.py`
+  - result: passed
+  - covers low-risk inherited address-shape smoke checks, explicit PQ-only
+    inherited address-RPC rejection for default plus `legacy` /
+    `p2sh-segwit` / `bech32` / `bech32m`, and one deferred inherited
+    `sendmany` negative control
 - `python3 test/functional/wallet_pq_active_ranged.py`
   - result: passed
-  - covers dedicated PQ setup, default inherited address-RPC rejection, and
-    explicit `bech32` / `legacy` / `p2sh-segwit` inherited address-RPC
-    rejection before and after restore
+  - covers dedicated PQ setup plus the broader before/after-restore inherited
+    address-RPC rejection boundary on active PQ wallets
 
 ## Interpretation
 
 - the owned PQ wallet address UX is now explicit
-- broad inherited address-type rehabilitation remains separate deferred work
-- `wallet_address_types.py` should be treated as reference inventory, not as
-  the current Track A wallet-address milestone
+- `wallet_address_types.py` now freezes a narrow inherited-address boundary,
+  not a broad compatibility rehab
+- broad inherited address-type send/sign rehabilitation remains separate
+  deferred work

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -14,9 +14,9 @@ active, use this file to choose the next safe step for `quantum-proof-bitcoin`.
 
 ## Current Objective
 
-Freeze the inherited `createwalletdescriptor` xpub-only boundary for `#23`,
-keep PQ-native setup on `createpqwalletmanagers`, then move the next owned
-follow-on to `wallet_address_types.py`.
+Freeze the inherited address-RPC boundary in `wallet_address_types.py`, keep
+broad inherited classical send/sign compatibility deferred, then move the next
+owned follow-on to `wallet_miniscript_decaying_multisig_descriptor_psbt.py`.
 
 ## Current Working Thesis
 
@@ -38,50 +38,53 @@ Chosen first owned tranche:
 
 Next likely follow-ons:
 
-2. `wallet_address_types.py`
-3. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-4. `wallet_miniscript.py`
-5. `feature_block.py`
+2. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+3. `wallet_miniscript.py`
+4. `feature_block.py`
+5. `rpc_createmultisig.py`
 
 ## Current Queue
 
-1. This slice freezes `wallet_createwalletdescriptor.py` as:
-   - inherited xpub-based `bech32` / `bech32m` descriptor creation
-   - one explicit PQ-only rejection boundary on active `pqpriv(...)` managers
+1. This slice freezes `wallet_address_types.py` as:
+   - low-risk inherited address-shape smoke coverage
+   - one explicit PQ-only inherited `getnewaddress` / `getrawchangeaddress`
+     rejection boundary
+   - one deferred inherited classical `sendmany` negative control
    Minimum validation only:
-   - `python3 test/functional/wallet_createwalletdescriptor.py`
+   - `python3 test/functional/wallet_address_types.py`
    - `python3 test/functional/wallet_pq_active_ranged.py`
    Stays deferred:
-   - PQ-native descriptor creation through `createwalletdescriptor`
-   - Taproot-replacement descriptor semantics beyond current inherited
-     `tr(...)` coverage
-   - broad inherited address-type rehabilitation
+   - broad inherited address-family send/receive rehabilitation
+   - broad mixed-mode change policy rehabilitation
+   - bech32m/Taproot-facing address migration semantics
 2. Recommended next PR after this slice:
-   - preferred: `wallet_address_types.py`
+   - preferred: `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
    - lower-risk alternate: `feature_block.py`
    Why next:
-   - moves past the inherited xpub-builder boundary
-   - keeps momentum on wallet-owned migration surfaces
-   - tightens the next broad inherited address surface under the same Track A
-     posture
-3. Use `CREATEWALLETDESCRIPTOR_POSTURE.md` as the current owned slice.
+   - moves past the inherited address-RPC boundary
+   - keeps pressure on descriptor/PSBT migration surfaces
+   - avoids reopening broad inherited classical send/sign rehab
+3. Use `PQ_ADDRESS_RPC_POSTURE.md` as the current owned slice.
 4. Use `PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md` as the fixed public descriptor
    contract.
-5. Treat `createwalletdescriptor` as an inherited xpub builder, not a PQ-native
+5. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
+   PQ-only active-manager wallets; the owned PQ address UX remains
+   `getnewpqaddress` / `getrawpqchangeaddress`.
+6. Treat `createwalletdescriptor` as an inherited xpub builder, not a PQ-native
    wallet-manager creation path under the all-PQ Track A stance.
-6. Use `GENESIS_AND_NETWORK_POSTURE.md` as the launch-level interpretation for
+7. Use `GENESIS_AND_NETWORK_POSTURE.md` as the launch-level interpretation for
    a fresh block-0 chain with its own network identity.
-7. Use `PSBT_REPLACEMENT_TRANCHE.md` to keep the owned PQ `rpc_psbt.py`
+8. Use `PSBT_REPLACEMENT_TRANCHE.md` to keep the owned PQ `rpc_psbt.py`
    subset separate from inherited classical PSBT rehabilitation.
-8. Use `PQ_WALLET_MANAGER_SETUP.md` as the current setup-path contract for
+9. Use `PQ_WALLET_MANAGER_SETUP.md` as the current setup-path contract for
    active PQ receive/change managers.
-9. Use `PQ_ADDRESS_RPC_POSTURE.md` as the current inherited-address boundary
-   for PQ-only active wallets.
-10. Use `TEST_COST_POSTURE.md` to choose the cheapest defensible validation tier
-   for each tranche before running tests.
-11. Re-run and inspect the current required PQ-first functional gate strategy at
+10. Use `CREATEWALLETDESCRIPTOR_POSTURE.md` to keep inherited descriptor
+    creation separate from the PQ-native creation path.
+11. Use `TEST_COST_POSTURE.md` to choose the cheapest defensible validation tier
+    for each tranche before running tests.
+12. Re-run and inspect the current required PQ-first functional gate strategy at
     a targeted level.
-12. Reproduce the current `OPS_SLO` evidence flow only when the work has
+13. Reproduce the current `OPS_SLO` evidence flow only when the work has
     actually reached milestone-evidence scope.
 
 ## Autonomous Scope
@@ -244,6 +247,13 @@ Aineko must ask before:
   creation stays green, PQ-only active-manager wallets reject both families
   without mutating descriptor or manager state, and the next clean wallet
   follow-on shifts to `wallet_address_types.py`.
+- 2026-04-12: `wallet_address_types.py` now freezes the inherited address-RPC
+  boundary directly: low-risk inherited address-shape smoke coverage stays
+  green, PQ-only active-manager wallets reject inherited `getnewaddress` /
+  `getrawchangeaddress` across valid inherited address types including
+  `bech32m`, and one explicit `sendmany` negative control keeps broad
+  inherited classical send/sign compatibility deferred. The next clean wallet
+  follow-on shifts to `wallet_miniscript_decaying_multisig_descriptor_psbt.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -2,68 +2,36 @@
 # Copyright (c) 2017-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test that the wallet can send and receive using all combinations of address types.
+"""Freeze a narrow address-type boundary under PQBTC Track A.
 
-There are 5 nodes-under-test:
-    - node0 uses legacy addresses
-    - node1 uses p2sh/segwit addresses
-    - node2 uses p2sh/segwit addresses and bech32 addresses for change
-    - node3 uses bech32 addresses
-    - node4 uses a p2sh/segwit addresses for change
+This file no longer tries to rehabilitate the full inherited address-family
+matrix. Instead it keeps:
 
-node5 exists to generate new blocks.
-
-## Multisig address test
-
-Test that adding a multisig address with:
-    - an uncompressed pubkey always gives a legacy address
-    - only compressed pubkeys gives the an `-addresstype` address
-
-## Sending to address types test
-
-A series of tests, iterating over node0-node4. In each iteration of the test, one node sends:
-    - 10/101th of its balance to itself (using getrawchangeaddress for single key addresses)
-    - 20/101th to the next node
-    - 30/101th to the node after that
-    - 40/101th to the remaining node
-    - 1/101th remains as fee+change
-
-Iterate over each node for single key addresses, and then over each node for
-multisig addresses.
-
-Repeat test, but with explicit address_type parameters passed to getnewaddress
-and getrawchangeaddress:
-    - node0 and node3 send to p2sh.
-    - node1 sends to bech32.
-    - node2 sends to legacy.
-
-As every node sends coins after receiving, this also
-verifies that spending coins sent to all these address types works.
-
-## Change type test
-
-Test that the nodes generate the correct change address type:
-    - node0 always uses a legacy change address.
-    - node1 uses a bech32 addresses for change if any destination address is bech32.
-    - node2 always uses a bech32 address for change
-    - node3 always uses a bech32 address for change
-    - node4 always uses p2sh/segwit output for change.
+- low-risk inherited address-shape smoke coverage that still passes
+- one explicit deferred inherited sendmany negative control
+- one PQ-only inherited-address rejection boundary for active pqpriv() wallets
 """
 
 from decimal import Decimal
-import itertools
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.descriptors import (
-    descsum_create,
-    descsum_check,
-)
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
 )
+
+
+GETNEWADDRESS_PQ_ERROR = (
+    "Active pqpriv() managers do not use inherited getnewaddress; "
+    "use getnewpqaddress"
+)
+GETRAWCHANGEADDRESS_PQ_ERROR = (
+    "Active pqpriv() managers do not use inherited getrawchangeaddress; "
+    "use getrawpqchangeaddress"
+)
+
 
 class AddressTypeTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -86,281 +54,176 @@ class AddressTypeTest(BitcoinTestFramework):
         self.setup_nodes()
 
         # Fully mesh-connect nodes for faster mempool sync
-        for i, j in itertools.product(range(self.num_nodes), repeat=2):
-            if i > j:
+        for i in range(self.num_nodes):
+            for j in range(i):
                 self.connect_nodes(i, j)
         self.sync_all()
 
-    def get_balances(self, key='trusted'):
-        """Return a list of balances."""
-        return [self.nodes[i].getbalances()['mine'][key] for i in range(4)]
-
-    def test_address(self, node, address, multisig, typ):
+    def test_address(self, node, address, typ):
         """Run sanity checks on an address."""
         info = self.nodes[node].getaddressinfo(address)
-        assert self.nodes[node].validateaddress(address)['isvalid']
-        assert_equal(info.get('solvable'), True)
+        assert self.nodes[node].validateaddress(address)["isvalid"]
+        assert_equal(info["solvable"], True)
 
-        if not multisig and typ == 'legacy':
+        if typ == "legacy":
             # P2PKH
-            assert not info['isscript']
-            assert not info['iswitness']
-            assert 'pubkey' in info
-        elif not multisig and typ == 'p2sh-segwit':
+            assert not info["isscript"]
+            assert not info["iswitness"]
+            assert "pubkey" in info
+        elif typ == "p2sh-segwit":
             # P2SH-P2WPKH
-            assert info['isscript']
-            assert not info['iswitness']
-            assert_equal(info['script'], 'witness_v0_keyhash')
-            assert 'pubkey' in info
-        elif not multisig and typ == 'bech32':
+            assert info["isscript"]
+            assert not info["iswitness"]
+            assert_equal(info["script"], "witness_v0_keyhash")
+            assert "pubkey" in info
+        elif typ == "bech32":
             # P2WPKH
-            assert not info['isscript']
-            assert info['iswitness']
-            assert_equal(info['witness_version'], 0)
-            assert_equal(len(info['witness_program']), 40)
-            assert 'pubkey' in info
-        elif not multisig and typ == "bech32m":
+            assert not info["isscript"]
+            assert info["iswitness"]
+            assert_equal(info["witness_version"], 0)
+            assert_equal(len(info["witness_program"]), 40)
+            assert "pubkey" in info
+        elif typ == "bech32m":
             # P2TR single sig
             assert info["isscript"]
             assert info["iswitness"]
             assert_equal(info["witness_version"], 1)
             assert_equal(len(info["witness_program"]), 64)
-        elif typ == 'legacy':
-            # P2SH-multisig
-            assert info['isscript']
-            assert_equal(info['script'], 'multisig')
-            assert not info['iswitness']
-            assert 'pubkeys' in info
-        elif typ == 'p2sh-segwit':
-            # P2SH-P2WSH-multisig
-            assert info['isscript']
-            assert_equal(info['script'], 'witness_v0_scripthash')
-            assert not info['iswitness']
-            assert info['embedded']['isscript']
-            assert_equal(info['embedded']['script'], 'multisig')
-            assert info['embedded']['iswitness']
-            assert_equal(info['embedded']['witness_version'], 0)
-            assert_equal(len(info['embedded']['witness_program']), 64)
-            assert 'pubkeys' in info['embedded']
-        elif typ == 'bech32':
-            # P2WSH-multisig
-            assert info['isscript']
-            assert_equal(info['script'], 'multisig')
-            assert info['iswitness']
-            assert_equal(info['witness_version'], 0)
-            assert_equal(len(info['witness_program']), 64)
-            assert 'pubkeys' in info
         else:
             # Unknown type
-            assert False
+            raise AssertionError(f"Unknown type {typ}")
 
-    def test_desc(self, node, address, multisig, typ, utxo):
-        """Run sanity checks on a descriptor reported by getaddressinfo."""
-        info = self.nodes[node].getaddressinfo(address)
-        assert 'desc' in info
-        assert_equal(info['desc'], utxo['desc'])
-        assert self.nodes[node].validateaddress(address)['isvalid']
+    def create_pq_wallet(self, node_index, wallet_name, *, root_seed_hex):
+        node = self.nodes[node_index]
+        node.createwallet(wallet_name=wallet_name, blank=True)
+        wallet = node.get_wallet_rpc(wallet_name)
+        wallet.createpqwalletmanagers(root_seed_hex, 9)
+        return wallet
 
-        # Use a ridiculously roundabout way to find the key origin info through
-        # the PSBT logic. However, this does test consistency between the PSBT reported
-        # fingerprints/paths and the descriptor logic.
-        psbt = self.nodes[node].createpsbt([{'txid':utxo['txid'], 'vout':utxo['vout']}],[{address:0.00010000}])
-        psbt = self.nodes[node].walletprocesspsbt(psbt, False, "ALL", True)
-        decode = self.nodes[node].decodepsbt(psbt['psbt'])
-        key_descs = {}
-        for deriv in decode['inputs'][0]['bip32_derivs']:
-            assert_equal(len(deriv['master_fingerprint']), 8)
-            assert_equal(deriv['path'][0], 'm')
-            key_descs[deriv['pubkey']] = '[' + deriv['master_fingerprint'] + deriv['path'][1:].replace("'","h") + ']' + deriv['pubkey']
+    def assert_pq_inherited_address_rpc_rejected(self, wallet):
+        assert_raises_rpc_error(
+            -5,
+            GETNEWADDRESS_PQ_ERROR,
+            wallet.getnewaddress,
+        )
+        for address_type in ("legacy", "p2sh-segwit", "bech32", "bech32m"):
+            assert_raises_rpc_error(
+                -5,
+                GETNEWADDRESS_PQ_ERROR,
+                wallet.getnewaddress,
+                "",
+                address_type,
+            )
 
-        # Verify the descriptor checksum against the Python implementation
-        assert descsum_check(info['desc'])
-        # Verify that stripping the checksum and recreating it using Python roundtrips
-        assert info['desc'] == descsum_create(info['desc'][:-9])
-        # Verify that stripping the checksum and feeding it to getdescriptorinfo roundtrips
-        assert info['desc'] == self.nodes[0].getdescriptorinfo(info['desc'][:-9])['descriptor']
-        assert_equal(info['desc'][-8:], self.nodes[0].getdescriptorinfo(info['desc'][:-9])['checksum'])
-        # Verify that keeping the checksum and feeding it to getdescriptorinfo roundtrips
-        assert info['desc'] == self.nodes[0].getdescriptorinfo(info['desc'])['descriptor']
-        assert_equal(info['desc'][-8:], self.nodes[0].getdescriptorinfo(info['desc'])['checksum'])
+        assert_raises_rpc_error(
+            -5,
+            GETRAWCHANGEADDRESS_PQ_ERROR,
+            wallet.getrawchangeaddress,
+        )
+        for address_type in ("legacy", "p2sh-segwit", "bech32", "bech32m"):
+            assert_raises_rpc_error(
+                -5,
+                GETRAWCHANGEADDRESS_PQ_ERROR,
+                wallet.getrawchangeaddress,
+                address_type,
+            )
 
-        if not multisig and typ == 'legacy':
-            # P2PKH
-            assert_equal(info['desc'], descsum_create("pkh(%s)" % key_descs[info['pubkey']]))
-        elif not multisig and typ == 'p2sh-segwit':
-            # P2SH-P2WPKH
-            assert_equal(info['desc'], descsum_create("sh(wpkh(%s))" % key_descs[info['pubkey']]))
-        elif not multisig and typ == 'bech32':
-            # P2WPKH
-            assert_equal(info['desc'], descsum_create("wpkh(%s)" % key_descs[info['pubkey']]))
-        elif typ == 'legacy':
-            # P2SH-multisig
-            assert_equal(info['desc'], descsum_create("sh(multi(2,%s,%s))" % (key_descs[info['pubkeys'][0]], key_descs[info['pubkeys'][1]])))
-        elif typ == 'p2sh-segwit':
-            # P2SH-P2WSH-multisig
-            assert_equal(info['desc'], descsum_create("sh(wsh(multi(2,%s,%s)))" % (key_descs[info['embedded']['pubkeys'][0]], key_descs[info['embedded']['pubkeys'][1]])))
-        elif typ == 'bech32':
-            # P2WSH-multisig
-            assert_equal(info['desc'], descsum_create("wsh(multi(2,%s,%s))" % (key_descs[info['pubkeys'][0]], key_descs[info['pubkeys'][1]])))
-        else:
-            # Unknown type
-            assert False
+    def test_basic_inherited_address_shapes(self):
+        self.log.info("Smoke test inherited address-shape coverage that still passes")
+        self.test_address(0, self.nodes[0].getnewaddress(), "legacy")
+        self.test_address(0, self.nodes[0].getrawchangeaddress(), "legacy")
+        self.test_address(1, self.nodes[1].getnewaddress(), "p2sh-segwit")
+        self.test_address(1, self.nodes[1].getrawchangeaddress(), "p2sh-segwit")
+        self.test_address(2, self.nodes[2].getnewaddress(), "p2sh-segwit")
+        self.test_address(2, self.nodes[2].getrawchangeaddress(), "bech32")
+        self.test_address(3, self.nodes[3].getnewaddress(), "bech32")
+        self.test_address(3, self.nodes[3].getrawchangeaddress(), "bech32")
+        self.test_address(4, self.nodes[4].getrawchangeaddress(), "p2sh-segwit")
 
-    def test_change_output_type(self, node_sender, destinations, expected_type):
-        txid = self.nodes[node_sender].sendmany(dummy="", amounts=dict.fromkeys(destinations, 0.001))
-        tx = self.nodes[node_sender].gettransaction(txid=txid, verbose=True)['decoded']
+    def test_invalid_address_type_arguments(self):
+        self.log.info("Invalid address type arguments still fail before any PQ-specific guard")
+        compressed_1 = "0296b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52"
+        compressed_2 = "037211a824f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073"
+        wallet = self.nodes[3]
 
-        # Make sure the transaction has change:
-        assert_equal(len(tx["vout"]), len(destinations) + 1)
+        assert_raises_rpc_error(
+            -5,
+            "Unknown address type ''",
+            wallet.createmultisig,
+            2,
+            [compressed_1, compressed_2],
+            address_type="",
+        )
+        assert_raises_rpc_error(-5, "Unknown address type ''", wallet.getnewaddress, None, "")
+        assert_raises_rpc_error(-5, "Unknown address type ''", wallet.getrawchangeaddress, "")
+        assert_raises_rpc_error(-5, "Unknown address type 'bech23'", wallet.getrawchangeaddress, "bech23")
+        assert_raises_rpc_error(-5, "Unknown address type 'bech23'", wallet.createwalletdescriptor, "bech23")
 
-        # Make sure the destinations are included, and remove them:
-        output_addresses = [vout['scriptPubKey']['address'] for vout in tx["vout"]]
-        change_addresses = [d for d in output_addresses if d not in destinations]
-        assert_equal(len(change_addresses), 1)
+    def test_descriptor_wallet_bech32m_smoke(self):
+        self.log.info("Descriptor wallets still expose inherited bech32m smoke coverage")
+        self.test_address(4, self.nodes[4].getnewaddress("", "bech32m"), "bech32m")
+        self.test_address(4, self.nodes[4].getrawchangeaddress("bech32m"), "bech32m")
 
-        self.log.debug("Check if change address " + change_addresses[0] + " is " + expected_type)
-        self.test_address(node_sender, change_addresses[0], multisig=False, typ=expected_type)
+    def test_deferred_legacy_sendmany_negative_control(self):
+        self.log.info("Freeze the current inherited classical sendmany failure as a deferred negative control")
+        assert_greater_than(self.nodes[0].getbalance(), Decimal("1"))
+
+        self_change = self.nodes[0].getrawchangeaddress()
+        p2sh_1 = self.nodes[1].getnewaddress()
+        p2sh_2 = self.nodes[2].getnewaddress()
+        bech32 = self.nodes[3].getnewaddress()
+
+        self.test_address(0, self_change, "legacy")
+        self.test_address(1, p2sh_1, "p2sh-segwit")
+        self.test_address(2, p2sh_2, "p2sh-segwit")
+        self.test_address(3, bech32, "bech32")
+
+        sends = {
+            self_change: Decimal("0.10"),
+            p2sh_1: Decimal("0.20"),
+            p2sh_2: Decimal("0.30"),
+            bech32: Decimal("0.40"),
+        }
+        assert_raises_rpc_error(-6, "Signing transaction failed", self.nodes[0].sendmany, "", sends)
+
+    def test_pq_only_inherited_address_rpc_boundary(self):
+        self.log.info("PQ-only active wallets reject inherited address RPCs for all valid inherited address types")
+        wallet = self.create_pq_wallet(4, "pq_only_boundary", root_seed_hex=("41" * 32))
+        receive_address = wallet.getnewpqaddress("pq receive")
+        change_address = wallet.getrawpqchangeaddress()
+
+        receive_info = wallet.getaddressinfo(receive_address)
+        assert_equal(receive_info["ismine"], True)
+        assert_equal(receive_info["has_private_keys"], True)
+        assert_equal(receive_info["solvable"], True)
+        assert_equal(receive_info["ischange"], False)
+
+        change_info = wallet.getaddressinfo(change_address)
+        assert_equal(change_info["ismine"], True)
+        assert_equal(change_info["has_private_keys"], True)
+        assert_equal(change_info["solvable"], True)
+        assert_equal(change_info["ischange"], True)
+
+        self.assert_pq_inherited_address_rpc_rejected(wallet)
+
+    def test_pq_unknown_type_precedence(self):
+        self.log.info("Unknown address types still fail before PQ-only inherited-address guards")
+        wallet = self.create_pq_wallet(4, "pq_invalid_types", root_seed_hex=("42" * 32))
+        assert_raises_rpc_error(-5, "Unknown address type ''", wallet.getnewaddress, "", "")
+        assert_raises_rpc_error(-5, "Unknown address type ''", wallet.getrawchangeaddress, "")
+        assert_raises_rpc_error(-5, "Unknown address type 'bech23'", wallet.getnewaddress, "", "bech23")
+        assert_raises_rpc_error(-5, "Unknown address type 'bech23'", wallet.getrawchangeaddress, "bech23")
 
     def run_test(self):
         # Mine 101 blocks on node5 to bring nodes out of IBD and make sure that
-        # no coinbases are maturing for the nodes-under-test during the test
+        # no coinbases are maturing for the nodes-under-test during the test.
         self.generate(self.nodes[5], COINBASE_MATURITY + 1)
-
-        compressed_1 = "0296b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52"
-        compressed_2 = "037211a824f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073"
-
-        do_multisigs = [False]
-
-        for explicit_type, multisig, from_node in itertools.product([False, True], do_multisigs, range(4)):
-            address_type = None
-            if explicit_type and not multisig:
-                if from_node == 1:
-                    address_type = 'bech32'
-                elif from_node == 0 or from_node == 3:
-                    address_type = 'p2sh-segwit'
-                else:
-                    address_type = 'legacy'
-            self.log.info("Sending from node {} ({}) with{} multisig using {}".format(from_node, self.extra_args[from_node], "" if multisig else "out", "default" if address_type is None else address_type))
-            old_balances = self.get_balances()
-            self.log.debug("Old balances are {}".format(old_balances))
-            to_send = (old_balances[from_node] / (COINBASE_MATURITY + 1)).quantize(Decimal("0.00000001"))
-            sends = {}
-            addresses = {}
-
-            self.log.debug("Prepare sends")
-            for n, to_node in enumerate(range(from_node, from_node + 4)):
-                to_node %= 4
-                change = False
-                if not multisig:
-                    if from_node == to_node:
-                        # When sending non-multisig to self, use getrawchangeaddress
-                        address = self.nodes[to_node].getrawchangeaddress(address_type=address_type)
-                        change = True
-                    else:
-                        address = self.nodes[to_node].getnewaddress(address_type=address_type)
-                else:
-                    pubkey1 = self.nodes[to_node].getaddressinfo(self.nodes[to_node].getnewaddress())["pubkey"]
-                    pubkey2 = self.nodes[to_node].getaddressinfo(self.nodes[to_node].getnewaddress())["pubkey"]
-                    ms = self.nodes[to_node].createmultisig(2, [pubkey1, pubkey2])
-                    import_res = self.nodes[to_node].importdescriptors([{"desc": ms["descriptor"], "timestamp": 0}])
-                    assert_equal(import_res[0]["success"], True)
-
-                # Do some sanity checking on the created address
-                if address_type is not None:
-                    typ = address_type
-                elif to_node == 0:
-                    typ = 'legacy'
-                elif to_node == 1 or (to_node == 2 and not change):
-                    typ = 'p2sh-segwit'
-                else:
-                    typ = 'bech32'
-                self.test_address(to_node, address, multisig, typ)
-
-                # Output entry
-                sends[address] = to_send * 10 * (1 + n)
-                addresses[to_node] = (address, typ)
-
-            self.log.debug("Sending: {}".format(sends))
-            self.nodes[from_node].sendmany("", sends)
-            self.sync_mempools()
-
-            unconf_balances = self.get_balances('untrusted_pending')
-            self.log.debug("Check unconfirmed balances: {}".format(unconf_balances))
-            assert_equal(unconf_balances[from_node], 0)
-            for n, to_node in enumerate(range(from_node + 1, from_node + 4)):
-                to_node %= 4
-                assert_equal(unconf_balances[to_node], to_send * 10 * (2 + n))
-
-            # node5 collects fee and block subsidy to keep accounting simple
-            self.generate(self.nodes[5], 1)
-
-            # Verify that the receiving wallet contains a UTXO with the expected address, and expected descriptor
-            for n, to_node in enumerate(range(from_node, from_node + 4)):
-                to_node %= 4
-                found = False
-                for utxo in self.nodes[to_node].listunspent():
-                    if utxo['address'] == addresses[to_node][0]:
-                        found = True
-                        self.test_desc(to_node, addresses[to_node][0], multisig, addresses[to_node][1], utxo)
-                        break
-                assert found
-
-            new_balances = self.get_balances()
-            self.log.debug("Check new balances: {}".format(new_balances))
-            # We don't know what fee was set, so we can only check bounds on the balance of the sending node
-            assert_greater_than(new_balances[from_node], to_send * 10)
-            assert_greater_than(to_send * 11, new_balances[from_node])
-            for n, to_node in enumerate(range(from_node + 1, from_node + 4)):
-                to_node %= 4
-                assert_equal(new_balances[to_node], old_balances[to_node] + to_send * 10 * (2 + n))
-
-        # Get one p2sh/segwit address from node2 and two bech32 addresses from node3:
-        to_address_p2sh = self.nodes[2].getnewaddress()
-        to_address_bech32_1 = self.nodes[3].getnewaddress()
-        to_address_bech32_2 = self.nodes[3].getnewaddress()
-
-        # Fund node 4:
-        self.nodes[5].sendtoaddress(self.nodes[4].getnewaddress(), Decimal("1"))
-        self.generate(self.nodes[5], 1)
-        assert_equal(self.nodes[4].getbalance(), 1)
-
-        self.log.info("Nodes with addresstype=legacy never use a P2WPKH change output (unless changetype is set otherwise):")
-        self.test_change_output_type(0, [to_address_bech32_1], 'legacy')
-
-        self.log.info("Nodes with addresstype=p2sh-segwit match the change output")
-        self.test_change_output_type(1, [to_address_p2sh], 'p2sh-segwit')
-        self.test_change_output_type(1, [to_address_bech32_1], 'bech32')
-        self.test_change_output_type(1, [to_address_p2sh, to_address_bech32_1], 'bech32')
-        self.test_change_output_type(1, [to_address_bech32_1, to_address_bech32_2], 'bech32')
-
-        self.log.info("Nodes with change_type=bech32 always use a P2WPKH change output:")
-        self.test_change_output_type(2, [to_address_bech32_1], 'bech32')
-        self.test_change_output_type(2, [to_address_p2sh], 'bech32')
-
-        self.log.info("Nodes with addresstype=bech32 match the change output (unless changetype is set otherwise):")
-        self.test_change_output_type(3, [to_address_bech32_1], 'bech32')
-        self.test_change_output_type(3, [to_address_p2sh], 'p2sh-segwit')
-
-        self.log.info('getrawchangeaddress defaults to addresstype if -changetype is not set and argument is absent')
-        self.test_address(3, self.nodes[3].getrawchangeaddress(), multisig=False, typ='bech32')
-
-        self.log.info('test invalid address type arguments')
-        assert_raises_rpc_error(-5, "Unknown address type ''", self.nodes[3].createmultisig, 2, [compressed_1, compressed_2], address_type="")
-        assert_raises_rpc_error(-5, "Unknown address type ''", self.nodes[3].getnewaddress, None, '')
-        assert_raises_rpc_error(-5, "Unknown address type ''", self.nodes[3].getrawchangeaddress, '')
-        assert_raises_rpc_error(-5, "Unknown address type 'bech23'", self.nodes[3].getrawchangeaddress, 'bech23')
-        assert_raises_rpc_error(-5, "Unknown address type 'bech23'", self.nodes[3].createwalletdescriptor, "bech23")
-
-        self.log.info("Nodes with changetype=p2sh-segwit never use a P2WPKH change output")
-        self.test_change_output_type(4, [to_address_bech32_1], 'p2sh-segwit')
-        self.test_address(4, self.nodes[4].getrawchangeaddress(), multisig=False, typ='p2sh-segwit')
-        self.log.info("Except for getrawchangeaddress if specified:")
-        self.test_address(4, self.nodes[4].getrawchangeaddress(), multisig=False, typ='p2sh-segwit')
-        self.test_address(4, self.nodes[4].getrawchangeaddress('bech32'), multisig=False, typ='bech32')
-
-        self.log.info("Descriptor wallets have bech32m addresses")
-        self.test_address(4, self.nodes[4].getnewaddress("", "bech32m"), multisig=False, typ="bech32m")
-        self.test_address(4, self.nodes[4].getrawchangeaddress("bech32m"), multisig=False, typ="bech32m")
+        self.test_basic_inherited_address_shapes()
+        self.test_invalid_address_type_arguments()
+        self.test_descriptor_wallet_bech32m_smoke()
+        self.test_deferred_legacy_sendmany_negative_control()
+        self.test_pq_only_inherited_address_rpc_boundary()
+        self.test_pq_unknown_type_precedence()
 
 if __name__ == '__main__':
     AddressTypeTest(__file__).main()


### PR DESCRIPTION
## Summary
- freeze `wallet_address_types.py` as a narrow Track A boundary instead of a broad inherited rehab
- keep low-risk inherited address-shape smoke coverage, add a PQ-only inherited-address rejection subsection, and turn the current classical `sendmany` break into an explicit deferred negative control
- update the address posture, Track A handoff, and suite inventory note to point the next follow-on at `wallet_miniscript_decaying_multisig_descriptor_psbt.py`

## Testing
- python3 test/functional/wallet_address_types.py
- python3 test/functional/wallet_pq_active_ranged.py
- python3 ci/test/check_ci_inventory.py
- python3 test/lint/lint-files.py
- git diff --check