### PR TITLE
ci: promote assumeutxo suites into pq required gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -36,10 +36,10 @@
   },
   {
     "name": "feature_assumeutxo.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes a narrow PQBTC assumeutxo boundary: regtest assumeutxo metadata is committed for heights 110/200/299, snapshot activation/restart/reindex coverage stays green under the live harness, the non-empty-mempool rejection uses a PQ-safe raw P2WSH path, and the inherited snapshot-only MiniWallet spend is an explicit `scriptpubkey (-26)` negative control."
+    "notes": "Now promoted into pq_required as the owned PQBTC assumeutxo activation gate: regtest assumeutxo metadata is committed for heights 110/200/299, snapshot activation/restart/reindex coverage stays green under the live harness, the non-empty-mempool rejection uses a PQ-safe raw P2WSH path, and the inherited snapshot-only MiniWallet spend is an explicit `scriptpubkey (-26)` negative control."
   },
   {
     "name": "feature_assumevalid.py",
@@ -1466,10 +1466,10 @@
   },
   {
     "name": "wallet_assumeutxo.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes a narrow PQBTC wallet-side assumeutxo boundary: the chain stays aligned with the current assumeutxo anchors while inherited MiniWallet mempool funding is replaced by direct-mined transactions, snapshot-height backup restore is allowed during background sync, older backup restore and rescans stay blocked until background validation completes, and final owned balances still settle to 34 and 340."
+    "notes": "Now promoted into pq_required as the owned PQBTC wallet-side assumeutxo gate: the chain stays aligned with the current assumeutxo anchors while inherited MiniWallet mempool funding is replaced by direct-mined transactions, snapshot-height backup restore is allowed during background sync, older backup restore and rescans stay blocked until background validation completes, and final owned balances still settle to 34 and 340."
   },
   {
     "name": "wallet_avoid_mixing_output_types.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -1,3 +1,4 @@
+feature_assumeutxo.py
 feature_pq_block_limits.py
 feature_pq_reorg.py
 feature_pqsig_basic.py
@@ -9,6 +10,7 @@ feature_taproot_replacement_active_semantic_guard.py
 feature_taproot_replacement_active_positive_seam.py
 mempool_pq_limits.py
 mempool_pq_stress.py
+wallet_assumeutxo.py
 wallet_pq_active_ranged.py
 wallet_pq_backup_recovery.py
 wallet_pq_create_tx.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `20` |
-| `pq_backlog` | `100` |
+| `pq_required` | `22` |
+| `pq_backlog` | `98` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
 
@@ -63,6 +63,8 @@ Current required PQ-first gates:
 18. `wallet_pq_sendall.py`
 19. `wallet_pq_sendmany.py`
 20. `wallet_pq_signrawtransaction.py`
+21. `feature_assumeutxo.py`
+22. `wallet_assumeutxo.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -71,10 +73,13 @@ direct raw-signing, and PSBT unit coverage to the default `test_pqbtc`
 profile. The
 replacement-path confidence gap is closed in this tranche by promoting the full
 deterministic Taproot replacement functional stack into the required PQ gate.
-The remaining key backlog families are:
+The assumeutxo confidence gap is closed in this tranche by promoting the live
+snapshot-activation surface and the adjacent wallet-side background-sync
+surface into the canonical required gate. The remaining key backlog families
+are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment
-2. chainstate and validation-facing feature tests that still need a later PQ migration decision
+2. additional chainstate and validation-facing feature tests that still need a later PQ migration decision
 3. broader dual-profile and legacy-only coverage that still needs durable ownership and migration boundaries
 
 Explicit legacy-only coverage in this tranche includes:

--- a/docs/FEATURE_ASSUMEUTXO_POSTURE.md
+++ b/docs/FEATURE_ASSUMEUTXO_POSTURE.md
@@ -38,7 +38,6 @@ This posture note does **not** mean:
 
 - wallet behavior during assumeutxo background sync is owned here
 - inherited MiniWallet mempool acceptance is rehabilitated here
-- this suite is promoted into `pq_required`
 
 Those remain separate follow-on surfaces.
 
@@ -57,7 +56,7 @@ Targeted confidence pass run on 2026-04-14:
 ## Interpretation
 
 - `feature_assumeutxo.py` is now a fixed PQBTC assumeutxo activation slice
-- it remains `pq_backlog`, not a required PQ-first gate
+- it is now `pq_required` in the canonical PQ-first functional gate
 - the adjacent wallet-side background-sync surface is now owned by
   [wallet_assumeutxo.py](../test/functional/wallet_assumeutxo.py)
 - the next clean actionable follow-on is

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-13
+## Updated: 2026-04-14
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -28,9 +28,10 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 `feature_utxo_set_hash.py`, `feature_coinstatsindex.py`, and
 `feature_reindex.py`, `feature_reindex_init.py`, and
 `feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, and
-move the next owned follow-on to `feature_coinstatsindex_compatibility.py`,
-with broader inherited miniscript funding/finalization rehab as the local
-wallet alternate.
+promote `feature_assumeutxo.py` and `wallet_assumeutxo.py` into the canonical
+`pq_required` gate, then return the next owned follow-on to
+`feature_coinstatsindex_compatibility.py`, with broader inherited miniscript
+funding/finalization rehab as the local wallet alternate.
 
 ## Current Working Thesis
 
@@ -66,7 +67,7 @@ Wallet alternate:
 
 Still deferred:
 
-4. `wallet_assumeutxo.py` gate promotion
+4. `feature_assumevalid.py` gate promotion
 5. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -470,7 +471,6 @@ Still deferred:
    Still deferred inside this suite:
    - wallet behavior during assumeutxo background sync
    - inherited MiniWallet mempool acceptance rehabilitation
-   - promotion into `pq_required`
 25. `wallet_assumeutxo.py` now owns:
    - a wallet-side assumeutxo background-sync contract on top of the current
      regtest assumeutxo anchors
@@ -487,7 +487,6 @@ Still deferred:
    - `python3 test/functional/wallet_assumeutxo.py`
    Still deferred inside this suite:
    - broad inherited MiniWallet mempool acceptance
-   - promotion into `pq_required`
 26. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
    - alternate: broader inherited miniscript funding/finalization rehab
@@ -890,6 +889,12 @@ Aineko must ask before:
   balances still settle to `34` and `340`. The next owned follow-on shifts to
   `feature_coinstatsindex_compatibility.py`, with broader inherited miniscript
   funding/finalization rehab remaining the local wallet alternate.
+- 2026-04-14: `feature_assumeutxo.py` and `wallet_assumeutxo.py` are now
+  promoted into the canonical `pq_required` gate. The current required PQ path
+  therefore covers both snapshot activation and the adjacent wallet-side
+  background-sync contract on the live regtest assumeutxo anchors. The next
+  owned follow-on remains `feature_coinstatsindex_compatibility.py`, while
+  `feature_assumevalid.py` remains the nearby validation-side gate candidate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full

--- a/docs/WALLET_ASSUMEUTXO_POSTURE.md
+++ b/docs/WALLET_ASSUMEUTXO_POSTURE.md
@@ -38,7 +38,6 @@ This posture note does **not** mean:
 
 - broad inherited MiniWallet mempool acceptance is owned here
 - generic wallet behavior across all assumeutxo permutations is owned here
-- this suite is promoted into `pq_required`
 
 Those remain separate follow-on surfaces.
 
@@ -57,7 +56,7 @@ Targeted confidence pass run on 2026-04-14:
 ## Interpretation
 
 - `wallet_assumeutxo.py` is now a fixed PQBTC wallet-side assumeutxo slice
-- it remains `pq_backlog`, not a required PQ-first gate
+- it is now `pq_required` in the canonical PQ-first functional gate
 - the next clean actionable follow-on is
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py),
   if the required previous-release assets are available locally

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -569,21 +569,21 @@ public:
                 .height = 110,
                 .hash_serialized = AssumeutxoHash{uint256{"23404ca0ff8546dcc26f857a526538f1201d9765baae5aeacf927b3a490b8712"}},
                 .m_chain_tx_count = 111,
-                .blockhash = uint256{"2da67eeeb548a86288558ef4a8926898d7344a05e0118d0b7c5e4cfaeaa0a58f"},
+                .blockhash = consteval_ctor(uint256{"2da67eeeb548a86288558ef4a8926898d7344a05e0118d0b7c5e4cfaeaa0a58f"}),
             },
             {
                 // For use by fuzz target src/test/fuzz/utxo_snapshot.cpp
                 .height = 200,
                 .hash_serialized = AssumeutxoHash{uint256{"b11bef93d794f17407e61030bccced32895a8f43ce43e49b2879a551c35b7fdd"}},
                 .m_chain_tx_count = 202,
-                .blockhash = uint256{"1f27274693c29444457e66352aca915bcdb94e1089fd97d70eadcb62a5c5ddc9"},
+                .blockhash = consteval_ctor(uint256{"1f27274693c29444457e66352aca915bcdb94e1089fd97d70eadcb62a5c5ddc9"}),
             },
             {
                 // For use by test/functional/feature_assumeutxo.py and test/functional/tool_bitcoin_chainstate.py
                 .height = 299,
                 .hash_serialized = AssumeutxoHash{uint256{"b6380c577e5df2d31230c0f6cc9c851b102aae4c322ef4e12cbfe6b6a018fba5"}},
                 .m_chain_tx_count = 334,
-                .blockhash = uint256{"55f5b68156be54960d12a8e9ed01e4c232cbc7197b231735eb9596f49e306387"},
+                .blockhash = consteval_ctor(uint256{"55f5b68156be54960d12a8e9ed01e4c232cbc7197b231735eb9596f49e306387"}),
             },
         };
 


### PR DESCRIPTION
## Summary
- promote  and  into the canonical PQ-first required gate
- update the functional inventory and CI completeness counts to reflect 
- align Track A and assumeutxo posture docs with the new gate ownership

## Validation
- python3 test/functional/feature_assumeutxo.py --cachedir=/Users/scott/quantum-proof-bitcoin/test/cache
- python3 test/functional/wallet_assumeutxo.py --cachedir=/Users/scott/quantum-proof-bitcoin/test/cache
- python3 ci/test/check_ci_inventory.py
- python3 test/lint/lint-files.py
- git diff --check