### PR TITLE
ci: promote assumevalid into pq required gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -43,10 +43,10 @@
   },
   {
     "name": "feature_assumevalid.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes a narrow PQBTC assumevalid boundary: a handcrafted invalid-signature block is rejected without assumevalid, accepted when buried deeply enough under `-assumevalid`, and still rejected when not buried deeply enough; assumeutxo snapshot behavior remains a separate follow-on surface."
+    "notes": "Now promoted into pq_required as the owned PQBTC assumevalid gate: a handcrafted invalid-signature block is rejected without assumevalid, accepted when buried deeply enough under `-assumevalid`, and still rejected when it is not buried deeply enough; assumeutxo snapshot behavior remains a separate follow-on surface."
   },
   {
     "name": "feature_bind_extra.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -1,4 +1,5 @@
 feature_assumeutxo.py
+feature_assumevalid.py
 feature_pq_block_limits.py
 feature_pq_reorg.py
 feature_pqsig_basic.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `22` |
-| `pq_backlog` | `98` |
+| `pq_required` | `23` |
+| `pq_backlog` | `97` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
 
@@ -64,7 +64,8 @@ Current required PQ-first gates:
 19. `wallet_pq_sendmany.py`
 20. `wallet_pq_signrawtransaction.py`
 21. `feature_assumeutxo.py`
-22. `wallet_assumeutxo.py`
+22. `feature_assumevalid.py`
+23. `wallet_assumeutxo.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -75,8 +76,10 @@ replacement-path confidence gap is closed in this tranche by promoting the full
 deterministic Taproot replacement functional stack into the required PQ gate.
 The assumeutxo confidence gap is closed in this tranche by promoting the live
 snapshot-activation surface and the adjacent wallet-side background-sync
-surface into the canonical required gate. The remaining key backlog families
-are:
+surface into the canonical required gate. The assumevalid confidence gap is
+closed in this tranche by promoting the fixed invalid-signature burial-depth
+validation slice into the same required PQ path. The remaining key backlog
+families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment
 2. additional chainstate and validation-facing feature tests that still need a later PQ migration decision

--- a/docs/FEATURE_ASSUMEVALID_POSTURE.md
+++ b/docs/FEATURE_ASSUMEVALID_POSTURE.md
@@ -32,9 +32,8 @@ a narrow validation slice:
 This posture note does **not** mean:
 
 - assumeutxo snapshot loading or snapshot-chainstate behavior is owned here
-- this suite is promoted into `pq_required`
 
-Those remain separate follow-on surfaces.
+That remains a separate follow-on surface.
 
 ## Confidence Snapshot
 
@@ -51,7 +50,7 @@ Targeted confidence pass run on 2026-04-14:
 ## Interpretation
 
 - `feature_assumevalid.py` is now a fixed PQBTC assumevalid slice
-- it remains `pq_backlog`, not a required PQ-first gate
+- it is now `pq_required` as the required PQ-first assumevalid validation gate
 - the adjacent snapshot-loading and wallet background-sync surfaces are now
   owned by
   [feature_assumeutxo.py](../test/functional/feature_assumeutxo.py) and

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -28,8 +28,9 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 `feature_utxo_set_hash.py`, `feature_coinstatsindex.py`, and
 `feature_reindex.py`, `feature_reindex_init.py`, and
 `feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, and
-promote `feature_assumeutxo.py` and `wallet_assumeutxo.py` into the canonical
-`pq_required` gate, then return the next owned follow-on to
+keep the new `feature_assumeutxo.py` and `wallet_assumeutxo.py` gates frozen,
+promote `feature_assumevalid.py` into the canonical `pq_required` gate, then
+return the next owned follow-on to
 `feature_coinstatsindex_compatibility.py`, with broader inherited miniscript
 funding/finalization rehab as the local wallet alternate.
 
@@ -67,7 +68,7 @@ Wallet alternate:
 
 Still deferred:
 
-4. `feature_assumevalid.py` gate promotion
+4. `feature_block.py` gate promotion
 5. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -448,12 +449,11 @@ Still deferred:
      assumevalid-enabled node
    - expected debug markers for disabling and re-enabling signature validation
    - rejection of the same bad block on the shallow assumevalid-enabled node
-     when it is not buried deeply enough
+   when it is not buried deeply enough
    Minimum validation target:
    - `python3 test/functional/feature_assumevalid.py`
    Still deferred inside this suite:
    - assumeutxo snapshot loading and activation behavior
-   - promotion into `pq_required`
 24. `feature_assumeutxo.py` now owns:
    - regtest assumeutxo metadata anchors at heights `110`, `200`, and `299`
      for the live PQBTC harness
@@ -895,6 +895,12 @@ Aineko must ask before:
   background-sync contract on the live regtest assumeutxo anchors. The next
   owned follow-on remains `feature_coinstatsindex_compatibility.py`, while
   `feature_assumevalid.py` remains the nearby validation-side gate candidate.
+- 2026-04-14: `feature_assumevalid.py` is now promoted into the canonical
+  `pq_required` gate. The current required PQ path therefore also covers the
+  fixed assumevalid burial-depth validation slice alongside the live assumeutxo
+  activation and wallet background-sync surfaces. The next owned follow-on
+  remains `feature_coinstatsindex_compatibility.py`, while `feature_block.py`
+  becomes the nearby validation-side gate candidate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote feature_assumevalid.py into the pq_required functional gate
- update CI inventory/completeness and the assumevalid posture/status docs
- keep the owned assumeutxo surfaces frozen while moving the next follow-on back to feature_coinstatsindex_compatibility.py

## Testing
- python3 test/functional/feature_assumevalid.py --configfile=/Users/scott/quantum-proof-bitcoin/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/test/cache
- python3 ci/test/check_ci_inventory.py
- python3 test/lint/lint-files.py
- git diff --check