### PR TITLE
ci: promote feature_block into pq required gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -78,10 +78,10 @@
   },
   {
     "name": "feature_block.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Current owned tranche adapts PQ signing, same-work header delivery, explicit invalid multi-block branch handling, transport-oversize disconnect expectations, and mempool-baseline resurrection assertions inside the functional harness; broader CI/gating follow-up remains deferred."
+    "notes": "Now promoted into pq_required as the owned PQBTC full-block gate: the functional harness uses PQ signing helpers, same-work side branches stay header-only until explicitly force-sent, invalid multi-block branches preserve the active tip, transport-oversize paths are treated as disconnect cases, and resurrection checks stay grounded on the actual mempool baseline."
   },
   {
     "name": "feature_blocksdir.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -1,5 +1,6 @@
 feature_assumeutxo.py
 feature_assumevalid.py
+feature_block.py
 feature_pq_block_limits.py
 feature_pq_reorg.py
 feature_pqsig_basic.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `23` |
-| `pq_backlog` | `97` |
+| `pq_required` | `24` |
+| `pq_backlog` | `96` |
 | `dual_profile` | `147` |
 | `legacy_only` | `9` |
 
@@ -65,7 +65,8 @@ Current required PQ-first gates:
 20. `wallet_pq_signrawtransaction.py`
 21. `feature_assumeutxo.py`
 22. `feature_assumevalid.py`
-23. `wallet_assumeutxo.py`
+23. `feature_block.py`
+24. `wallet_assumeutxo.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -78,8 +79,10 @@ The assumeutxo confidence gap is closed in this tranche by promoting the live
 snapshot-activation surface and the adjacent wallet-side background-sync
 surface into the canonical required gate. The assumevalid confidence gap is
 closed in this tranche by promoting the fixed invalid-signature burial-depth
-validation slice into the same required PQ path. The remaining key backlog
-families are:
+validation slice into the same required PQ path. The full-block confidence gap
+is narrowed in this tranche by promoting the bounded invalid-branch, transport,
+and resurrection `feature_block.py` surface into the same required PQ path.
+The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment
 2. additional chainstate and validation-facing feature tests that still need a later PQ migration decision

--- a/docs/FEATURE_BLOCK_POSTURE.md
+++ b/docs/FEATURE_BLOCK_POSTURE.md
@@ -42,7 +42,6 @@ It freezes six things:
 
 This tranche still does not:
 
-- promote `feature_block.py` into `pq_required`
 - claim a general PQ migration decision for every chainstate-facing behavior in
   the suite
 - redesign consensus, policy, or mempool semantics outside the specific
@@ -50,3 +49,17 @@ This tranche still does not:
 
 Those remain later CI/backlog decisions, not a reason to widen this tranche
 into a broader chainstate rewrite.
+
+## Interpretation
+
+- `feature_block.py` is now the required PQ-first full-block validation gate
+  for this bounded harness surface
+- it remains a deliberately scoped contract, not a blanket ownership claim over
+  every chainstate behavior in the inherited suite
+- the next clean actionable local follow-on is
+  [feature_coinstatsindex.py](../test/functional/feature_coinstatsindex.py),
+  which already owns a bounded txoutset/index slice and is the next honest
+  local gate-promotion candidate
+- the environment-dependent compatibility follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py),
+  which stays blocked until real prior PQBTC release assets exist

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -29,10 +29,11 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 `feature_reindex.py`, `feature_reindex_init.py`, and
 `feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, and
 keep the new `feature_assumeutxo.py` and `wallet_assumeutxo.py` gates frozen,
-promote `feature_assumevalid.py` into the canonical `pq_required` gate, then
-return the next owned follow-on to
-`feature_coinstatsindex_compatibility.py`, with broader inherited miniscript
-funding/finalization rehab as the local wallet alternate.
+keep `feature_assumevalid.py` frozen in the canonical `pq_required` gate,
+promote `feature_block.py` into the same gate, then return the next local
+owned follow-on to `feature_coinstatsindex.py`, while
+`feature_coinstatsindex_compatibility.py` stays blocked until real prior PQBTC
+release assets exist.
 
 ## Current Working Thesis
 
@@ -48,17 +49,17 @@ funding/finalization rehab as the local wallet alternate.
 
 Preferred next owned tranche:
 
-1. `feature_coinstatsindex_compatibility.py`
-   - Why next: the core assumeutxo activation surface and the adjacent
-     wallet-side background-sync surface are now frozen, so the remaining
-     nearby chainstate/index follow-on is cross-version coinstats
-     compatibility.
+1. `feature_coinstatsindex.py` gate promotion
+   - Why next: after the assumevalid and full-block validation gates are in the
+     required path, the next honest local chainstate/index follow-on is the
+     bounded txoutset/index slice that already passes on the current PQBTC
+     harness.
 
 Alternate rebalance:
 
-2. broader inherited miniscript funding/finalization rehab
-   - Why alternate: if local wallet adjacency is still the priority, this
-     remains the next wallet-side surface to reopen.
+2. `feature_coinstatsindex_compatibility.py`
+   - Why alternate: if real prior PQBTC release assets become available, the
+     blocked cross-version compatibility surface becomes actionable again.
 
 Wallet alternate:
 
@@ -68,7 +69,7 @@ Wallet alternate:
 
 Still deferred:
 
-4. `feature_block.py` gate promotion
+4. `feature_coinstatsindex_compatibility.py` with real prior PQBTC release assets
 5. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -107,7 +108,6 @@ Still deferred:
    Minimum validation target:
    - `python3 test/functional/feature_block.py`
    Still deferred inside this suite:
-   - promotion into `pq_required`
    - broader CI ownership decisions for chainstate-facing backlog beyond this
      fixed functional contract
 3. `wallet_miniscript.py` now owns:
@@ -901,6 +901,13 @@ Aineko must ask before:
   activation and wallet background-sync surfaces. The next owned follow-on
   remains `feature_coinstatsindex_compatibility.py`, while `feature_block.py`
   becomes the nearby validation-side gate candidate.
+- 2026-04-14: `feature_block.py` is now promoted into the canonical
+  `pq_required` gate. The current required PQ path therefore also covers the
+  bounded full-block invalid-branch, transport-oversize, and resurrection
+  harness surface. The next local owned follow-on shifts to
+  `feature_coinstatsindex.py`, while
+  `feature_coinstatsindex_compatibility.py` remains blocked until real prior
+  PQBTC release assets exist.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote feature_block.py into the pq_required functional gate
- update CI inventory/completeness and the feature_block posture/status docs
- record feature_coinstatsindex.py as the next local gate candidate while coinstatsindex compatibility stays blocked without prior PQBTC assets

## Testing
- python3 test/functional/feature_block.py --configfile=/Users/scott/quantum-proof-bitcoin/test/config.ini --cachedir=/Users/scott/quantum-proof-bitcoin/test/cache
- python3 ci/test/check_ci_inventory.py
- python3 test/lint/lint-files.py
- git diff --check