### PR TITLE
kernel: fix regtest utxo_snapshot checkpoint

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -574,9 +574,9 @@ public:
             {
                 // For use by fuzz target src/test/fuzz/utxo_snapshot.cpp
                 .height = 200,
-                .hash_serialized = AssumeutxoHash{uint256{"b11bef93d794f17407e61030bccced32895a8f43ce43e49b2879a551c35b7fdd"}},
-                .m_chain_tx_count = 202,
-                .blockhash = consteval_ctor(uint256{"1f27274693c29444457e66352aca915bcdb94e1089fd97d70eadcb62a5c5ddc9"}),
+                .hash_serialized = AssumeutxoHash{uint256{"17dcc016d188d16068907cdeb38b75691a118d43053b8cd6a25969419381d13a"}},
+                .m_chain_tx_count = 201,
+                .blockhash = consteval_ctor(uint256{"5457db193e5417616ab1f55ee211258f26283982fb894beb7930c85324bd34b6"}),
             },
             {
                 // For use by test/functional/feature_assumeutxo.py and test/functional/tool_bitcoin_chainstate.py


### PR DESCRIPTION
## Summary\n- update the regtest height-200 assumeutxo checkpoint used by the utxo_snapshot fuzz target\n- align the checkpoint with the current deterministic CreateBlockChain(200) chain under PQBTC genesis\n- keep the change scoped to the fuzz-only regtest checkpoint record\n\n## Testing\n- FUZZ=utxo_snapshot build-fuzz/bin/fuzz /tmp/pqbtc-empty-corpus/utxo_snapshot\n- python3 test/functional/feature_assumeutxo.py --configfile=test/config.ini --cachedir=test/cache\n- python3 test/functional/wallet_assumeutxo.py --configfile=test/config.ini --cachedir=test/cache\n- python3 test/lint/lint-files.py\n- git diff --check