### PR TITLE
[codex] Promote wallet send path gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1840,24 +1840,24 @@
   },
   {
     "name": "wallet_send.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited send RPC behavior under the current legacy-compatible PQC profile: destination sends, no-broadcast and PSBT creation, fee/feerate and confirmation-target options, watch-only PSBT signing, OP_RETURN outputs, manual inputs and change controls, locktime, RBF, subtract-fee-from-output, unsafe and minconf handling, external-input solving data, and transaction weight limits."
   },
   {
     "name": "wallet_sendall.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited sendall RPC behavior under the current legacy-compatible PQC profile: full-balance sweeps, split recipients, specified outputs, invalid recipient and amount handling, send_max, specific inputs, watch-only PSBT creation, minconf/maxconf, anti-fee-sniping, unconfirmed input/change behavior, ancestor-aware funding, and too-large transaction errors."
   },
   {
     "name": "wallet_sendmany.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited sendmany subtract-fee-from-output validation under the current legacy-compatible PQC profile, including duplicate, missing, negative, out-of-bounds, invalid-type, and mixed destination/index cases."
   },
   {
     "name": "wallet_signer.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -28,3 +28,6 @@ wallet_pq_send.py
 wallet_pq_sendall.py
 wallet_pq_sendmany.py
 wallet_pq_signrawtransaction.py
+wallet_send.py
+wallet_sendall.py
+wallet_sendmany.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `30` |
-| `pq_backlog` | `95` |
+| `pq_required` | `33` |
+| `pq_backlog` | `92` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -73,6 +73,9 @@ Current required PQ-first gates:
 28. `wallet_miniscript.py`
 29. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
 30. `wallet_multisig_descriptor_psbt.py`
+31. `wallet_send.py`
+32. `wallet_sendall.py`
+33. `wallet_sendmany.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -97,6 +100,12 @@ legacy-compatible PQC profile. The validation-side confidence gap is now also
 closed by promoting `feature_assumevalid.py` into the required gate, so the
 canonical PQ path covers the live assumevalid signature-skipping boundary in
 addition to the owned assumeutxo activation and wallet background-sync slices.
+The inherited wallet send-path confidence gap is now also part of the required
+gate: `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` cover the
+restored legacy-compatible destination send, sweep, PSBT/no-broadcast,
+fee/change/input-selection, watch-only, confirmation-control, anti-fee-sniping,
+and subtract-fee-from-output validation surfaces that currently pass under the
+PQC profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/PQ_WALLET_SENDALL_POSTURE.md
+++ b/docs/PQ_WALLET_SENDALL_POSTURE.md
@@ -2,14 +2,15 @@
 
 ## Status: ACTIVE
 ## Spec-ID: PQ-WALLET-SENDALL-v1
-## Updated: 2026-04-08
+## Updated: 2026-04-24
 ## Consensus-Relevant: NO
 
 ## Purpose
 
 Freeze the owned PQ-only
 [sendall](../test/functional/wallet_sendall.py)
-RPC posture without reopening the broad inherited `wallet_sendall.py` matrix.
+RPC posture and the restored inherited `wallet_sendall.py` matrix under the
+current legacy-compatible PQC profile.
 
 ## Owned Surface
 
@@ -19,6 +20,13 @@ The current owned PQ-native `sendall` RPC path is:
 
 It covers a PQ-only active wallet created through
 [createpqwalletmanagers](../src/wallet/rpc/wallet.cpp).
+
+The inherited compatibility path is:
+
+- [wallet_sendall.py](../test/functional/wallet_sendall.py)
+
+It is now part of the required PQ gate because it passes unchanged under the
+restored legacy-compatible PQC profile.
 
 ## Contract
 
@@ -39,14 +47,12 @@ The owned `sendmany` RPC contract is frozen separately in
 
 ## Non-Goals In This Tranche
 
-This tranche does not own the full inherited
-[wallet_sendall.py](../test/functional/wallet_sendall.py)
-matrix. It explicitly does not take on:
+This tranche does not define behavior outside the existing inherited and
+PQ-only test surfaces. It explicitly does not take on:
 
-- `send_max` and dust-handling behavior
-- specific-input and watch-only `sendall` semantics
-- minconf/maxconf and ancestor-aware funding coverage
-- too-large-transaction behavior
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 Those remain separate backlog or compatibility decisions.
 
@@ -58,3 +64,13 @@ Targeted confidence pass on 2026-04-08:
   - result: passed
   - covers the PQ-only `sendall` RPC posture for default anti-fee-sniping,
     explicit `locktime = 0`, and current tx version `2`
+
+Inherited send-path promotion on 2026-04-24:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_sendall.py`
+  - result: passed
+  - covers the inherited full-balance sweep, split-recipient, specified-output,
+    invalid recipient/amount, send_max, specific-input, watch-only PSBT,
+    minconf/maxconf, anti-fee-sniping, unconfirmed input/change,
+    ancestor-aware funding, and too-large transaction surfaces under the
+    current legacy-compatible PQC profile

--- a/docs/PQ_WALLET_SENDMANY_POSTURE.md
+++ b/docs/PQ_WALLET_SENDMANY_POSTURE.md
@@ -2,15 +2,15 @@
 
 ## Status: ACTIVE
 ## Spec-ID: PQ-WALLET-SENDMANY-v1
-## Updated: 2026-04-08
+## Updated: 2026-04-24
 ## Consensus-Relevant: NO
 
 ## Purpose
 
 Freeze the owned PQ-only
 [sendmany](../test/functional/wallet_sendmany.py)
-RPC posture without reopening the broad inherited `sendmany` and generic wallet
-behavior matrix.
+RPC posture and the restored inherited `wallet_sendmany.py` subtract-fee
+validation surface under the current legacy-compatible PQC profile.
 
 ## Owned Surface
 
@@ -20,6 +20,13 @@ The current owned PQ-native `sendmany` RPC path is:
 
 It covers a PQ-only active wallet created through
 [createpqwalletmanagers](../src/wallet/rpc/wallet.cpp).
+
+The inherited compatibility path is:
+
+- [wallet_sendmany.py](../test/functional/wallet_sendmany.py)
+
+It is now part of the required PQ gate because it passes unchanged under the
+restored legacy-compatible PQC profile.
 
 ## Contract
 
@@ -39,14 +46,12 @@ and
 
 ## Non-Goals In This Tranche
 
-This tranche does not own the full inherited
-[wallet_sendmany.py](../test/functional/wallet_sendmany.py)
-surface. It explicitly does not take on:
+This tranche does not define behavior outside the existing inherited and
+PQ-only test surfaces. It explicitly does not take on:
 
-- exhaustive `subtractfeefrom` validation edge cases
-- fee-rate matrix coverage
-- comment and verbose-return behavior
-- dual-profile or legacy address-family semantics
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 Those remain separate backlog or compatibility decisions.
 
@@ -58,3 +63,11 @@ Targeted confidence pass on 2026-04-08:
   - result: passed
   - covers the PQ-only `sendmany` RPC posture for default anti-fee-sniping,
     current tx version `2`, and one multi-recipient `subtractfeefrom` edge
+
+Inherited send-path promotion on 2026-04-24:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_sendmany.py`
+  - result: passed
+  - covers inherited `subtractfeefrom` validation for duplicate, missing,
+    negative, out-of-bounds, invalid-type, and mixed destination/index cases
+    under the current legacy-compatible PQC profile

--- a/docs/PQ_WALLET_SEND_POSTURE.md
+++ b/docs/PQ_WALLET_SEND_POSTURE.md
@@ -2,14 +2,15 @@
 
 ## Status: ACTIVE
 ## Spec-ID: PQ-WALLET-SEND-v1
-## Updated: 2026-04-08
+## Updated: 2026-04-24
 ## Consensus-Relevant: NO
 
 ## Purpose
 
 Freeze the owned PQ-only
 [send](../test/functional/wallet_send.py)
-RPC posture without reopening the broad inherited `wallet_send.py` matrix.
+RPC posture and the restored inherited `wallet_send.py` matrix under the
+current legacy-compatible PQC profile.
 
 ## Owned Surface
 
@@ -19,6 +20,13 @@ The current owned PQ-native `send` RPC path is:
 
 It covers a PQ-only active wallet created through
 [createpqwalletmanagers](../src/wallet/rpc/wallet.cpp).
+
+The inherited compatibility path is:
+
+- [wallet_send.py](../test/functional/wallet_send.py)
+
+It is now part of the required PQ gate because it passes unchanged under the
+restored legacy-compatible PQC profile.
 
 ## Contract
 
@@ -39,14 +47,12 @@ The owned `sendall` RPC contract is frozen separately in
 
 ## Non-Goals In This Tranche
 
-This tranche does not own the full inherited
-[wallet_send.py](../test/functional/wallet_send.py)
-matrix. It explicitly does not take on:
+This tranche does not define behavior outside the existing inherited and
+PQ-only test surfaces. It explicitly does not take on:
 
-- watch-only `send` behavior
-- fee-rate argument matrix coverage
-- change-address and change-type rehab
-- external input solving or dual-profile wallet semantics
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 Those remain separate backlog or compatibility decisions.
 
@@ -58,3 +64,14 @@ Targeted confidence pass on 2026-04-08:
   - result: passed
   - covers the PQ-only `send` RPC posture for default anti-fee-sniping,
     explicit `locktime = 0`, and current tx version `2`
+
+Inherited send-path promotion on 2026-04-24:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_send.py`
+  - result: passed
+  - covers the inherited destination send, no-broadcast and PSBT creation,
+    fee/feerate and confirmation-target options, watch-only PSBT signing,
+    OP_RETURN outputs, manual inputs and change controls, locktime, RBF,
+    subtract-fee-from-output, unsafe and minconf handling, external-input
+    solving data, and transaction weight limits under the current
+    legacy-compatible PQC profile

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-23
+## Updated: 2026-04-24
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -34,10 +34,11 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 `wallet_multisig_descriptor_psbt.py` wallet-side
 funding/signing/finalization surface and `wallet_address_types.py`
 address/RPC boundary plus `wallet_fundrawtransaction.py` raw funding boundary
-in the canonical `pq_required` gate, then return the next owned follow-on to
-`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist, with broader inherited send-path rehab beyond the current funding gate as
-the local alternate.
+and `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` inherited
+send-path boundaries in the canonical `pq_required` gate, then return the next
+owned follow-on to `feature_coinstatsindex_compatibility.py` when real prior
+PQBTC release assets exist, with broader inherited wallet lifecycle/rebroadcast
+rehab beyond the current send-path gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -61,17 +62,17 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited send-path rehab beyond the current
-   `wallet_fundrawtransaction.py` funding gate
+2. broader inherited wallet lifecycle/rebroadcast rehab beyond the current
+   `wallet_send.py` / `wallet_sendall.py` / `wallet_sendmany.py` send-path gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
-     re-litigating the now-owned descriptor, miniscript, address/RPC, and raw
-     funding tranches.
+     re-litigating the now-owned descriptor, miniscript, address/RPC, raw
+     funding, and inherited send-path tranches.
 
 Still deferred:
 
-3. broader inherited send-path rehab beyond the current
-   `wallet_fundrawtransaction.py` funding gate
+3. broader inherited wallet lifecycle/reindex/rescan/reorg breadth beyond the
+   next rebroadcast-focused tranche
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -487,18 +488,36 @@ Still deferred:
    - `build/test/functional/test_runner.py --jobs=1 wallet_fundrawtransaction.py`
    Still deferred inside this suite:
    - replacement-path Taproot or bech32m wallet semantics beyond existing tests
-   - broader send-path ownership for `wallet_send.py`, `wallet_sendall.py`, or
-     `wallet_sendmany.py`
-27. Recommended next PR after this tranche:
+27. `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` now own:
+   - restored inherited send RPC behavior under the current legacy-compatible
+     PQC profile
+   - destination sends, no-broadcast and PSBT creation, OP_RETURN outputs,
+     fee/feerate and confirmation-target options, manual inputs and change
+     controls, locktime, RBF, subtract-fee-from-output, unsafe/minconf handling,
+     external-input solving data, and transaction weight limits
+   - full-balance `sendall` sweeps, split recipients, specified outputs,
+     invalid recipient/amount handling, send_max, specific inputs, watch-only
+     PSBT creation, minconf/maxconf, anti-fee-sniping, unconfirmed
+     input/change behavior, ancestor-aware funding, and too-large transaction
+     errors
+   - inherited `sendmany` subtract-fee-from-output validation for duplicate,
+     missing, negative, out-of-bounds, invalid-type, and mixed
+     destination/index cases
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_send.py wallet_sendall.py wallet_sendmany.py`
+   Still deferred inside these suites:
+   - replacement-path Taproot or bech32m wallet semantics beyond existing tests
+   - new PQ-only active-manager RPC behavior
+28. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited send-path rehab beyond the current
-     `wallet_fundrawtransaction.py` funding gate
+   - alternate: broader inherited wallet lifecycle/rebroadcast rehab beyond the
+     current send-path gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - broader inherited wallet rehab remains useful, but additional wallet work
-     stays behind the asset-dependent compatibility slice once prior PQBTC
-     release assets are available
+   - broader inherited wallet lifecycle work remains useful, but additional
+     wallet work stays behind the asset-dependent compatibility slice once prior
+     PQBTC release assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -956,6 +975,16 @@ Aineko must ask before:
   follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
   PQBTC release assets exist, with broader inherited send-path rehab beyond
   this funding gate as the local alternate.
+- 2026-04-24: `wallet_send.py`, `wallet_sendall.py`, and
+  `wallet_sendmany.py` are now promoted into the canonical `pq_required` gate
+  and locally revalidated with the build-tree functional runner. The owned
+  boundary covers restored inherited destination send, sweep, PSBT/no-broadcast,
+  fee/change/input-selection, watch-only, confirmation-control,
+  anti-fee-sniping, transaction-size, and subtract-fee-from-output validation
+  surfaces under the current legacy-compatible PQC profile. The next owned
+  follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+  PQBTC release assets exist, with broader inherited wallet
+  lifecycle/rebroadcast rehab beyond this send-path gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1005,5 +1034,8 @@ Aineko must ask before:
   `wallet_miniscript_decaying_multisig_descriptor_psbt.py`, and
   `wallet_multisig_descriptor_psbt.py` pass targeted validation in the current
   tree.
+- There is no current blocker in the restored inherited wallet send-path
+  surface: `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` pass
+  targeted validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_FUNDRAWTRANSACTION_POSTURE.md
+++ b/docs/WALLET_FUNDRAWTRANSACTION_POSTURE.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: WALLET-FUNDRAWTRANSACTION-POSTURE-v1
-## Updated: 2026-04-23
+## Updated: 2026-04-24
 ## Consensus-Relevant: NO
 
 ## Purpose
@@ -37,8 +37,6 @@ This promotion does not define:
 
 - replacement-path Taproot or bech32m wallet semantics beyond existing tests
 - new PQ-only active-manager RPC behavior
-- broader send-path ownership for `wallet_send.py`, `wallet_sendall.py`, or
-  `wallet_sendmany.py`
 - prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 ## Confidence Snapshot
@@ -56,7 +54,9 @@ Targeted confidence on 2026-04-23:
 
 The canonical PQ gate now includes the inherited raw transaction funding
 contract that already passes under the current PQC-compatible legacy profile.
+The adjacent inherited send-path surface has since been promoted through
+`wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py`.
 The preferred Track A follow-on remains
 `feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist locally. Until then, the repo-local wallet alternate is the broader
-inherited send path beyond this funding gate.
+exist locally. Until then, the repo-local wallet alternate moves past this
+funding gate and the adjacent send-path gate.


### PR DESCRIPTION
## Summary
- Promote wallet_send.py, wallet_sendall.py, and wallet_sendmany.py from pq_backlog to pq_required.
- Add them to ci/test/pq_functional_tests.txt and update CI completeness counts to pq_required=33 and pq_backlog=92.
- Refresh send-path posture and Track A handoff docs; no source or test behavior changes.

## Validation
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 wallet_send.py wallet_sendall.py wallet_sendmany.py

## Notes
- feature_coinstatsindex_compatibility.py remains blocked until real prior PQBTC release assets exist.
- The local alternate moves to broader inherited wallet lifecycle/rebroadcast rehab beyond this send-path gate.