### PR TITLE
[codex] Promote wallet rebroadcast gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1833,10 +1833,10 @@
   },
   {
     "name": "wallet_resendwallettransactions.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited wallet rebroadcast behavior under the current legacy-compatible PQC profile: delayed resend timing, peer inventory rebroadcast, scheduler-triggered resubmission, and parent-before-child rebroadcast for unconfirmed wallet transaction chains evicted from the mempool."
   },
   {
     "name": "wallet_send.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -28,6 +28,7 @@ wallet_pq_send.py
 wallet_pq_sendall.py
 wallet_pq_sendmany.py
 wallet_pq_signrawtransaction.py
+wallet_resendwallettransactions.py
 wallet_send.py
 wallet_sendall.py
 wallet_sendmany.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `33` |
-| `pq_backlog` | `92` |
+| `pq_required` | `34` |
+| `pq_backlog` | `91` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -73,9 +73,10 @@ Current required PQ-first gates:
 28. `wallet_miniscript.py`
 29. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
 30. `wallet_multisig_descriptor_psbt.py`
-31. `wallet_send.py`
-32. `wallet_sendall.py`
-33. `wallet_sendmany.py`
+31. `wallet_resendwallettransactions.py`
+32. `wallet_send.py`
+33. `wallet_sendall.py`
+34. `wallet_sendmany.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -106,6 +107,11 @@ restored legacy-compatible destination send, sweep, PSBT/no-broadcast,
 fee/change/input-selection, watch-only, confirmation-control, anti-fee-sniping,
 and subtract-fee-from-output validation surfaces that currently pass under the
 PQC profile.
+The inherited wallet rebroadcast confidence gap is now also part of the
+required gate: `wallet_resendwallettransactions.py` covers delayed wallet
+transaction rebroadcast, scheduler-triggered resubmission, peer inventory
+announcement, and parent-before-child rebroadcast for unconfirmed transaction
+chains evicted from the mempool under the current PQC profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -35,10 +35,11 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 funding/signing/finalization surface and `wallet_address_types.py`
 address/RPC boundary plus `wallet_fundrawtransaction.py` raw funding boundary
 and `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` inherited
-send-path boundaries in the canonical `pq_required` gate, then return the next
-owned follow-on to `feature_coinstatsindex_compatibility.py` when real prior
-PQBTC release assets exist, with broader inherited wallet lifecycle/rebroadcast
-rehab beyond the current send-path gate as the local alternate.
+send-path boundaries and `wallet_resendwallettransactions.py` rebroadcast
+boundary in the canonical `pq_required` gate, then return the next owned
+follow-on to `feature_coinstatsindex_compatibility.py` when real prior PQBTC
+release assets exist, with broader inherited wallet reindex/rescan/reorg rehab
+beyond the current rebroadcast gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -62,17 +63,17 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet lifecycle/rebroadcast rehab beyond the current
-   `wallet_send.py` / `wallet_sendall.py` / `wallet_sendmany.py` send-path gate
+2. broader inherited wallet reindex/rescan/reorg rehab beyond the current
+   `wallet_resendwallettransactions.py` rebroadcast gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
      re-litigating the now-owned descriptor, miniscript, address/RPC, raw
-     funding, and inherited send-path tranches.
+     funding, inherited send-path, and rebroadcast tranches.
 
 Still deferred:
 
-3. broader inherited wallet lifecycle/reindex/rescan/reorg breadth beyond the
-   next rebroadcast-focused tranche
+3. broader inherited wallet lifecycle breadth beyond the next
+   reindex/rescan/reorg-focused tranche
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -508,16 +509,30 @@ Still deferred:
    Still deferred inside these suites:
    - replacement-path Taproot or bech32m wallet semantics beyond existing tests
    - new PQ-only active-manager RPC behavior
-28. Recommended next PR after this tranche:
+28. `wallet_resendwallettransactions.py` now owns:
+   - restored inherited wallet transaction rebroadcast behavior under the
+     current legacy-compatible PQC profile
+   - initial wallet transaction announcement to peers
+   - delayed rebroadcast timing after a sufficiently later block
+   - scheduler-triggered `MaybeResendWalletTxs` resubmission
+   - no early rebroadcast inside the first twelve-hour window
+   - rebroadcast after the upper resend timer bound
+   - parent-before-child rebroadcast for unconfirmed wallet transaction chains
+   - resubmission after wallet transactions are evicted from the mempool
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_resendwallettransactions.py`
+   Still deferred inside this suite:
+   - wallet reindex, rescan, or reorg restore semantics
+29. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet lifecycle/rebroadcast rehab beyond the
-     current send-path gate
+   - alternate: broader inherited wallet reindex/rescan/reorg rehab beyond the
+     current rebroadcast gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - broader inherited wallet lifecycle work remains useful, but additional
-     wallet work stays behind the asset-dependent compatibility slice once prior
-     PQBTC release assets are available
+   - adjacent wallet lifecycle work remains useful, but additional wallet work
+     stays behind the asset-dependent compatibility slice once prior PQBTC
+     release assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -985,6 +1000,15 @@ Aineko must ask before:
   follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
   PQBTC release assets exist, with broader inherited wallet
   lifecycle/rebroadcast rehab beyond this send-path gate as the local alternate.
+- 2026-04-24: `wallet_resendwallettransactions.py` is now promoted into the
+  canonical `pq_required` gate and locally revalidated with the build-tree
+  functional runner. The owned boundary covers restored inherited wallet
+  rebroadcast timing, scheduler-triggered resubmission, peer inventory
+  announcement, and parent-before-child rebroadcast for unconfirmed wallet
+  transaction chains evicted from the mempool. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with broader inherited wallet reindex/rescan/reorg rehab beyond
+  this rebroadcast gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1037,5 +1061,8 @@ Aineko must ask before:
 - There is no current blocker in the restored inherited wallet send-path
   surface: `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` pass
   targeted validation in the current tree.
+- There is no current blocker in the restored inherited wallet rebroadcast
+  surface: `wallet_resendwallettransactions.py` passes targeted validation in
+  the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_RESENDWALLETTRANSACTIONS_POSTURE.md
+++ b/docs/WALLET_RESENDWALLETTRANSACTIONS_POSTURE.md
@@ -1,0 +1,57 @@
+# PQBTC `wallet_resendwallettransactions.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-RESENDWALLETTRANSACTIONS-POSTURE-v1
+## Updated: 2026-04-24
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_resendwallettransactions.py](../test/functional/wallet_resendwallettransactions.py)
+rebroadcast contract under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_resendwallettransactions.py` is now a required PQ gate for restored
+wallet rebroadcast behavior. The owned boundary covers:
+
+- initial wallet transaction announcement to peers
+- delayed rebroadcast timing after a sufficiently later block
+- scheduler-triggered `MaybeResendWalletTxs` resubmission
+- no early rebroadcast inside the first twelve-hour window
+- rebroadcast after the upper resend timer bound
+- parent-before-child rebroadcast for unconfirmed wallet transaction chains
+- resubmission after wallet transactions are evicted from the mempool
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet reindex, rescan, or reorg restore semantics
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-24:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_resendwallettransactions.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=34`, `pq_backlog=91`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet rebroadcast contract
+that already passes under the current PQC-compatible legacy profile. The
+preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to the adjacent inherited wallet lifecycle surfaces:
+reindex, rescan-unconfirmed, and reorg restore behavior.


### PR DESCRIPTION
## Summary
- Promote wallet_resendwallettransactions.py from pq_backlog to pq_required.
- Add it to ci/test/pq_functional_tests.txt and update CI completeness counts to pq_required=34 and pq_backlog=91.
- Add a rebroadcast posture doc and refresh Track A handoff docs; no source or test behavior changes.

## Validation
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 wallet_resendwallettransactions.py

## Notes
- feature_coinstatsindex_compatibility.py remains blocked until real prior PQBTC release assets exist.
- The local alternate moves to adjacent inherited wallet lifecycle surfaces: reindex, rescan-unconfirmed, and reorg restore behavior.