### PR TITLE
[codex] Promote wallet reindex gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1812,10 +1812,10 @@
   },
   {
     "name": "wallet_reindex.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited wallet reindex interaction under the current legacy-compatible PQC profile: watch-only descriptor birthtime adjustment, explicit rescan detection for a previously missed transaction, -reindex restart completion, confirmed transaction survival after reindex, and descriptor wallet birthtime convergence to the transaction time."
   },
   {
     "name": "wallet_reorgsrestore.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -28,6 +28,7 @@ wallet_pq_send.py
 wallet_pq_sendall.py
 wallet_pq_sendmany.py
 wallet_pq_signrawtransaction.py
+wallet_reindex.py
 wallet_resendwallettransactions.py
 wallet_send.py
 wallet_sendall.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `34` |
-| `pq_backlog` | `91` |
+| `pq_required` | `35` |
+| `pq_backlog` | `90` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -73,10 +73,11 @@ Current required PQ-first gates:
 28. `wallet_miniscript.py`
 29. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
 30. `wallet_multisig_descriptor_psbt.py`
-31. `wallet_resendwallettransactions.py`
-32. `wallet_send.py`
-33. `wallet_sendall.py`
-34. `wallet_sendmany.py`
+31. `wallet_reindex.py`
+32. `wallet_resendwallettransactions.py`
+33. `wallet_send.py`
+34. `wallet_sendall.py`
+35. `wallet_sendmany.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -112,6 +113,12 @@ required gate: `wallet_resendwallettransactions.py` covers delayed wallet
 transaction rebroadcast, scheduler-triggered resubmission, peer inventory
 announcement, and parent-before-child rebroadcast for unconfirmed transaction
 chains evicted from the mempool under the current PQC profile.
+The inherited wallet reindex confidence gap is now also part of the required
+gate: `wallet_reindex.py` covers watch-only descriptor birthtime adjustment,
+explicit rescan detection for a previously missed transaction, `-reindex`
+restart completion, confirmed transaction survival after reindex, and
+descriptor wallet birthtime convergence to the transaction time under the
+current PQC profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -36,10 +36,12 @@ funding/signing/finalization surface and `wallet_address_types.py`
 address/RPC boundary plus `wallet_fundrawtransaction.py` raw funding boundary
 and `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` inherited
 send-path boundaries and `wallet_resendwallettransactions.py` rebroadcast
-boundary in the canonical `pq_required` gate, then return the next owned
-follow-on to `feature_coinstatsindex_compatibility.py` when real prior PQBTC
-release assets exist, with broader inherited wallet reindex/rescan/reorg rehab
-beyond the current rebroadcast gate as the local alternate.
+boundary and `wallet_reindex.py` wallet/reindex boundary in the canonical
+`pq_required` gate, then return the next owned follow-on to
+`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
+exist, with broader inherited wallet
+fast-rescan/unconfirmed-rescan/reorg-restore rehab beyond the current reindex
+gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -63,17 +65,17 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet reindex/rescan/reorg rehab beyond the current
-   `wallet_resendwallettransactions.py` rebroadcast gate
+2. broader inherited wallet fast-rescan/unconfirmed-rescan/reorg-restore rehab
+   beyond the current `wallet_reindex.py` gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
      re-litigating the now-owned descriptor, miniscript, address/RPC, raw
-     funding, inherited send-path, and rebroadcast tranches.
+     funding, inherited send-path, rebroadcast, and reindex tranches.
 
 Still deferred:
 
 3. broader inherited wallet lifecycle breadth beyond the next
-   reindex/rescan/reorg-focused tranche
+   fast-rescan/unconfirmed-rescan/reorg-restore-focused tranche
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -522,11 +524,29 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_resendwallettransactions.py`
    Still deferred inside this suite:
-   - wallet reindex, rescan, or reorg restore semantics
-29. Recommended next PR after this tranche:
+   - wallet fast-rescan, unconfirmed-rescan, or reorg-restore semantics
+29. `wallet_reindex.py` now owns:
+   - restored inherited wallet reindex interaction under the current
+     legacy-compatible PQC profile
+   - watch-only descriptor import with `timestamp=now` missing an older
+     transaction before explicit rescan
+   - descriptor wallet birthtime adjustment to the chain MTP rescan window
+   - explicit `rescanblockchain` detection of the previously missed
+     transaction
+   - `-reindex=1` restart completion while the wallet remains load-on-startup
+   - confirmed wallet transaction survival after reindex
+   - descriptor wallet birthtime convergence to the transaction time after
+     reindex
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_reindex.py`
+   Still deferred inside this suite:
+   - wallet fast-rescan, unconfirmed-rescan, or reorg-restore semantics
+   - wallet backup/restore compatibility beyond existing PQ-owned backup
+     coverage
+30. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet reindex/rescan/reorg rehab beyond the
-     current rebroadcast gate
+   - alternate: broader inherited wallet fast-rescan/unconfirmed-rescan/reorg-
+     restore rehab beyond the current reindex gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -1009,6 +1029,18 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist, with broader inherited wallet reindex/rescan/reorg rehab beyond
   this rebroadcast gate as the local alternate.
+- 2026-04-24: `wallet_reindex.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited wallet reindex
+  interaction under the current legacy-compatible PQC profile: watch-only
+  descriptor birthtime adjustment, explicit rescan detection for a previously
+  missed transaction, `-reindex` restart completion, confirmed transaction
+  survival after reindex, and descriptor wallet birthtime convergence to the
+  transaction time. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with broader inherited wallet
+  fast-rescan/unconfirmed-rescan/reorg-restore rehab beyond this reindex gate
+  as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1064,5 +1096,7 @@ Aineko must ask before:
 - There is no current blocker in the restored inherited wallet rebroadcast
   surface: `wallet_resendwallettransactions.py` passes targeted validation in
   the current tree.
+- There is no current blocker in the restored inherited wallet reindex surface:
+  `wallet_reindex.py` passes targeted validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_REINDEX_POSTURE.md
+++ b/docs/WALLET_REINDEX_POSTURE.md
@@ -1,0 +1,59 @@
+# PQBTC `wallet_reindex.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-REINDEX-POSTURE-v1
+## Updated: 2026-04-24
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_reindex.py](../test/functional/wallet_reindex.py) wallet/reindex
+interaction contract under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_reindex.py` is now a required PQ gate for restored inherited wallet
+reindex behavior. The owned boundary covers:
+
+- watch-only descriptor import with `timestamp=now` missing an older
+  transaction before explicit rescan
+- descriptor wallet birthtime adjustment to the chain MTP rescan window
+- explicit `rescanblockchain` detection of the previously missed transaction
+- trusted balance and confirmation preservation before restart
+- `-reindex=1` restart completion while the wallet remains load-on-startup
+- confirmed wallet transaction survival after reindex
+- descriptor wallet birthtime convergence to the transaction time after reindex
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet fast-rescan, unconfirmed-rescan, or reorg-restore semantics
+- wallet backup/restore compatibility beyond existing PQ-owned backup coverage
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-24:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_reindex.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=35`, `pq_backlog=90`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet reindex interaction
+contract that already passes under the current PQC-compatible legacy profile.
+The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to adjacent inherited wallet lifecycle surfaces:
+fast rescan, unconfirmed rescan, and reorg restore behavior.


### PR DESCRIPTION
## Summary
- promote wallet_reindex.py from pq_backlog to pq_required
- add the required gate entry in inventory order and update CI completeness counts to pq_required=35 / pq_backlog=90
- add wallet reindex posture docs and update Track A handoff toward fast-rescan/unconfirmed-rescan/reorg-restore follow-ons

## Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- build/test/functional/test_runner.py --jobs=1 wallet_reindex.py