### PR TITLE
[codex] Promote wallet fast rescan gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1607,10 +1607,10 @@
   },
   {
     "name": "wallet_fast_rescan.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited descriptor-wallet fast-rescan behavior under the current legacy-compatible PQC profile: block-filter fast rescan and slow full-block rescan find the same top-up transactions across active backup restore and non-active descriptor import paths, including ranged descriptors and one fixed non-ranged descriptor."
   },
   {
     "name": "wallet_fundrawtransaction.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -15,6 +15,7 @@ mempool_pq_stress.py
 rpc_psbt.py
 wallet_address_types.py
 wallet_assumeutxo.py
+wallet_fast_rescan.py
 wallet_fundrawtransaction.py
 wallet_miniscript.py
 wallet_miniscript_decaying_multisig_descriptor_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `35` |
-| `pq_backlog` | `90` |
+| `pq_required` | `36` |
+| `pq_backlog` | `89` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -69,15 +69,16 @@ Current required PQ-first gates:
 24. `rpc_psbt.py`
 25. `wallet_address_types.py`
 26. `wallet_assumeutxo.py`
-27. `wallet_fundrawtransaction.py`
-28. `wallet_miniscript.py`
-29. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-30. `wallet_multisig_descriptor_psbt.py`
-31. `wallet_reindex.py`
-32. `wallet_resendwallettransactions.py`
-33. `wallet_send.py`
-34. `wallet_sendall.py`
-35. `wallet_sendmany.py`
+27. `wallet_fast_rescan.py`
+28. `wallet_fundrawtransaction.py`
+29. `wallet_miniscript.py`
+30. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+31. `wallet_multisig_descriptor_psbt.py`
+32. `wallet_reindex.py`
+33. `wallet_resendwallettransactions.py`
+34. `wallet_send.py`
+35. `wallet_sendall.py`
+36. `wallet_sendmany.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -119,6 +120,11 @@ explicit rescan detection for a previously missed transaction, `-reindex`
 restart completion, confirmed transaction survival after reindex, and
 descriptor wallet birthtime convergence to the transaction time under the
 current PQC profile.
+The inherited wallet fast-rescan confidence gap is now also part of the
+required gate: `wallet_fast_rescan.py` covers block-filter fast rescan and
+slow full-block rescan parity for descriptor wallets across backup restore and
+non-active descriptor import paths, including ranged descriptor top-ups and a
+fixed non-ranged descriptor under the current PQC profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-24
+## Updated: 2026-04-25
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -37,11 +37,11 @@ address/RPC boundary plus `wallet_fundrawtransaction.py` raw funding boundary
 and `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` inherited
 send-path boundaries and `wallet_resendwallettransactions.py` rebroadcast
 boundary and `wallet_reindex.py` wallet/reindex boundary in the canonical
-`pq_required` gate, then return the next owned follow-on to
+`pq_required` gate plus `wallet_fast_rescan.py` descriptor-wallet fast-rescan
+boundary, then return the next owned follow-on to
 `feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist, with broader inherited wallet
-fast-rescan/unconfirmed-rescan/reorg-restore rehab beyond the current reindex
-gate as the local alternate.
+exist, with broader inherited wallet unconfirmed-rescan/reorg-restore rehab
+beyond the current fast-rescan gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -65,17 +65,18 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet fast-rescan/unconfirmed-rescan/reorg-restore rehab
-   beyond the current `wallet_reindex.py` gate
+2. broader inherited wallet unconfirmed-rescan/reorg-restore rehab beyond the
+   current `wallet_fast_rescan.py` gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
      re-litigating the now-owned descriptor, miniscript, address/RPC, raw
-     funding, inherited send-path, rebroadcast, and reindex tranches.
+     funding, inherited send-path, rebroadcast, reindex, and fast-rescan
+     tranches.
 
 Still deferred:
 
 3. broader inherited wallet lifecycle breadth beyond the next
-   fast-rescan/unconfirmed-rescan/reorg-restore-focused tranche
+   unconfirmed-rescan/reorg-restore-focused tranche
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -540,13 +541,28 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_reindex.py`
    Still deferred inside this suite:
-   - wallet fast-rescan, unconfirmed-rescan, or reorg-restore semantics
+   - wallet unconfirmed-rescan or reorg-restore semantics
    - wallet backup/restore compatibility beyond existing PQ-owned backup
      coverage
-30. Recommended next PR after this tranche:
+30. `wallet_fast_rescan.py` now owns:
+   - restored inherited descriptor-wallet fast-rescan behavior under the
+     current legacy-compatible PQC profile
+   - ranged descriptor end-range address derivation and top-up detection
+   - fixed non-ranged descriptor funding detection
+   - block-filter fast rescan during wallet backup restore and non-active
+     descriptor import
+   - slow full-block rescan during wallet backup restore and non-active
+     descriptor import when block filters are disabled
+   - parity between fast and slow rescan transaction discovery
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_fast_rescan.py`
+   Still deferred inside this suite:
+   - wallet unconfirmed-rescan or reorg-restore semantics
+   - wallet backup/restore compatibility beyond the fast-rescan backup fixture
+31. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet fast-rescan/unconfirmed-rescan/reorg-
-     restore rehab beyond the current reindex gate
+   - alternate: broader inherited wallet unconfirmed-rescan/reorg-restore rehab
+     beyond the current fast-rescan gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -1041,6 +1057,17 @@ Aineko must ask before:
   assets exist, with broader inherited wallet
   fast-rescan/unconfirmed-rescan/reorg-restore rehab beyond this reindex gate
   as the local alternate.
+- 2026-04-25: `wallet_fast_rescan.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited descriptor-wallet
+  fast-rescan behavior under the current legacy-compatible PQC profile:
+  block-filter fast rescan and slow full-block rescan parity across wallet
+  backup restore and non-active descriptor import paths, including ranged
+  descriptor top-ups and one fixed non-ranged descriptor. The next owned
+  follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+  PQBTC release assets exist, with broader inherited wallet
+  unconfirmed-rescan/reorg-restore rehab beyond this fast-rescan gate as the
+  local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1098,5 +1125,8 @@ Aineko must ask before:
   the current tree.
 - There is no current blocker in the restored inherited wallet reindex surface:
   `wallet_reindex.py` passes targeted validation in the current tree.
+- There is no current blocker in the restored inherited wallet fast-rescan
+  surface: `wallet_fast_rescan.py` passes targeted validation in the current
+  tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_FAST_RESCAN_POSTURE.md
+++ b/docs/WALLET_FAST_RESCAN_POSTURE.md
@@ -1,0 +1,62 @@
+# PQBTC `wallet_fast_rescan.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-FAST-RESCAN-POSTURE-v1
+## Updated: 2026-04-25
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_fast_rescan.py](../test/functional/wallet_fast_rescan.py)
+descriptor-wallet fast-rescan contract under the current legacy-compatible PQC
+profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_fast_rescan.py` is now a required PQ gate for restored inherited
+descriptor-wallet fast-rescan behavior. The owned boundary covers:
+
+- descriptor wallet backup before funded top-up activity
+- ranged descriptor end-range address derivation and top-up detection
+- fixed non-ranged descriptor funding detection
+- block-filter fast rescan during wallet backup restore
+- block-filter fast rescan during non-active descriptor import
+- slow full-block rescan during wallet backup restore when block filters are
+  disabled
+- slow full-block rescan during non-active descriptor import when block filters
+  are disabled
+- parity between fast and slow rescan transaction discovery
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- unconfirmed-rescan or reorg-restore semantics
+- wallet backup/restore compatibility beyond the fast-rescan backup fixture
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-25:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_fast_rescan.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=36`, `pq_backlog=89`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited descriptor-wallet fast-rescan
+contract that already passes under the current PQC-compatible legacy profile.
+The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to adjacent inherited wallet lifecycle surfaces:
+unconfirmed rescan and reorg restore behavior.


### PR DESCRIPTION
## Summary
- promote wallet_fast_rescan.py from pq_backlog to pq_required
- add the required gate entry in inventory order and update CI completeness counts to pq_required=36 / pq_backlog=89
- add wallet fast-rescan posture docs and update Track A handoff toward unconfirmed-rescan/reorg-restore follow-ons

## Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- build/test/functional/test_runner.py --jobs=1 wallet_fast_rescan.py