### PR TITLE
[codex] Promote wallet unconfirmed rescan gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1826,10 +1826,10 @@
   },
   {
     "name": "wallet_rescan_unconfirmed.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited descriptor-wallet unconfirmed-rescan behavior under the current legacy-compatible PQC profile: descriptor import rescans mempool transactions after a mocked reorg, recognizes the watched parent address as ismine, detects the re-entered parent, and detects the unconfirmed child sweep through input ordering."
   },
   {
     "name": "wallet_resendwallettransactions.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -30,6 +30,7 @@ wallet_pq_sendall.py
 wallet_pq_sendmany.py
 wallet_pq_signrawtransaction.py
 wallet_reindex.py
+wallet_rescan_unconfirmed.py
 wallet_resendwallettransactions.py
 wallet_send.py
 wallet_sendall.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `36` |
-| `pq_backlog` | `89` |
+| `pq_required` | `37` |
+| `pq_backlog` | `88` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -75,10 +75,11 @@ Current required PQ-first gates:
 30. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
 31. `wallet_multisig_descriptor_psbt.py`
 32. `wallet_reindex.py`
-33. `wallet_resendwallettransactions.py`
-34. `wallet_send.py`
-35. `wallet_sendall.py`
-36. `wallet_sendmany.py`
+33. `wallet_rescan_unconfirmed.py`
+34. `wallet_resendwallettransactions.py`
+35. `wallet_send.py`
+36. `wallet_sendall.py`
+37. `wallet_sendmany.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -125,6 +126,11 @@ required gate: `wallet_fast_rescan.py` covers block-filter fast rescan and
 slow full-block rescan parity for descriptor wallets across backup restore and
 non-active descriptor import paths, including ranged descriptor top-ups and a
 fixed non-ranged descriptor under the current PQC profile.
+The inherited wallet unconfirmed-rescan confidence gap is now also part of the
+required gate: `wallet_rescan_unconfirmed.py` covers descriptor import rescans
+of mempool transactions after a mocked reorg, watched parent-address ownership,
+re-entered parent detection, and unconfirmed child sweep detection through
+input ordering under the current PQC profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -38,10 +38,11 @@ and `wallet_send.py`, `wallet_sendall.py`, and `wallet_sendmany.py` inherited
 send-path boundaries and `wallet_resendwallettransactions.py` rebroadcast
 boundary and `wallet_reindex.py` wallet/reindex boundary in the canonical
 `pq_required` gate plus `wallet_fast_rescan.py` descriptor-wallet fast-rescan
-boundary, then return the next owned follow-on to
-`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist, with broader inherited wallet unconfirmed-rescan/reorg-restore rehab
-beyond the current fast-rescan gate as the local alternate.
+boundary and `wallet_rescan_unconfirmed.py` unconfirmed-rescan boundary, then
+return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist, with broader inherited wallet
+reorg-restore rehab beyond the current unconfirmed-rescan gate as the local
+alternate.
 
 ## Current Working Thesis
 
@@ -65,18 +66,18 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet unconfirmed-rescan/reorg-restore rehab beyond the
-   current `wallet_fast_rescan.py` gate
+2. broader inherited wallet reorg-restore rehab beyond the current
+   `wallet_rescan_unconfirmed.py` gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
      re-litigating the now-owned descriptor, miniscript, address/RPC, raw
-     funding, inherited send-path, rebroadcast, reindex, and fast-rescan
-     tranches.
+     funding, inherited send-path, rebroadcast, reindex, fast-rescan, and
+     unconfirmed-rescan tranches.
 
 Still deferred:
 
-3. broader inherited wallet lifecycle breadth beyond the next
-   unconfirmed-rescan/reorg-restore-focused tranche
+3. broader inherited wallet lifecycle breadth beyond the next reorg-restore
+   focused tranche
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -541,7 +542,7 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_reindex.py`
    Still deferred inside this suite:
-   - wallet unconfirmed-rescan or reorg-restore semantics
+   - broader wallet reorg-restore semantics
    - wallet backup/restore compatibility beyond existing PQ-owned backup
      coverage
 30. `wallet_fast_rescan.py` now owns:
@@ -557,12 +558,31 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_fast_rescan.py`
    Still deferred inside this suite:
-   - wallet unconfirmed-rescan or reorg-restore semantics
+   - broader wallet reorg-restore semantics
    - wallet backup/restore compatibility beyond the fast-rescan backup fixture
-31. Recommended next PR after this tranche:
+31. `wallet_rescan_unconfirmed.py` now owns:
+   - restored inherited descriptor-wallet unconfirmed-rescan behavior under the
+     current legacy-compatible PQC profile
+   - confirmed parent transaction creation in a block that is later
+     disconnected
+   - child `sendall` sweep creation without a wallet change output
+   - mocked reorg that returns the parent transaction to the mempool after its
+     child
+   - descriptor import into a watch-only wallet after both transactions are in
+     the mempool
+   - watched parent address recognition as solvable and `ismine`
+   - rescan detection of the re-entered unconfirmed parent and unconfirmed
+     child
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_rescan_unconfirmed.py`
+   Still deferred inside this suite:
+   - broader wallet reorg-restore semantics
+   - wallet backup/restore compatibility beyond existing PQ-owned backup
+     coverage
+32. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet unconfirmed-rescan/reorg-restore rehab
-     beyond the current fast-rescan gate
+   - alternate: broader inherited wallet reorg-restore rehab beyond the current
+     unconfirmed-rescan gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -1068,6 +1088,17 @@ Aineko must ask before:
   PQBTC release assets exist, with broader inherited wallet
   unconfirmed-rescan/reorg-restore rehab beyond this fast-rescan gate as the
   local alternate.
+- 2026-04-25: `wallet_rescan_unconfirmed.py` is now promoted into the
+  canonical `pq_required` gate and locally revalidated with the build-tree
+  functional runner. The owned boundary covers restored inherited
+  descriptor-wallet unconfirmed-rescan behavior under the current
+  legacy-compatible PQC profile: descriptor import rescans mempool transactions
+  after a mocked reorg, recognizes the watched parent address as `ismine`,
+  detects the re-entered parent, and detects the unconfirmed child sweep
+  through input ordering. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with broader inherited wallet reorg-restore rehab beyond this
+  unconfirmed-rescan gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1128,5 +1159,8 @@ Aineko must ask before:
 - There is no current blocker in the restored inherited wallet fast-rescan
   surface: `wallet_fast_rescan.py` passes targeted validation in the current
   tree.
+- There is no current blocker in the restored inherited wallet
+  unconfirmed-rescan surface: `wallet_rescan_unconfirmed.py` passes targeted
+  validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_RESCAN_UNCONFIRMED_POSTURE.md
+++ b/docs/WALLET_RESCAN_UNCONFIRMED_POSTURE.md
@@ -1,0 +1,63 @@
+# PQBTC `wallet_rescan_unconfirmed.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-RESCAN-UNCONFIRMED-POSTURE-v1
+## Updated: 2026-04-25
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_rescan_unconfirmed.py](../test/functional/wallet_rescan_unconfirmed.py)
+descriptor-wallet unconfirmed-rescan contract under the current
+legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_rescan_unconfirmed.py` is now a required PQ gate for restored inherited
+descriptor-wallet unconfirmed-rescan behavior. The owned boundary covers:
+
+- parent transaction creation and confirmation in a block that is later
+  disconnected
+- child `sendall` sweep creation from the parent output without a wallet change
+  output
+- mocked reorg that returns the parent transaction to the mempool after its
+  child
+- descriptor import into a watch-only wallet after the parent and child are
+  both in the mempool
+- watched parent address recognition as solvable and `ismine`
+- rescan detection of the re-entered unconfirmed parent
+- rescan detection of the unconfirmed child through input processing order
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- broader wallet reorg-restore semantics
+- wallet backup/restore compatibility beyond existing PQ-owned backup coverage
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-25:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_rescan_unconfirmed.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=37`, `pq_backlog=88`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited descriptor-wallet
+unconfirmed-rescan contract that already passes under the current
+PQC-compatible legacy profile. The preferred Track A follow-on remains
+`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
+exist locally. Until then, the repo-local wallet alternate moves to the
+adjacent inherited wallet reorg-restore surface.


### PR DESCRIPTION
## Summary
- promote wallet_rescan_unconfirmed.py from pq_backlog to pq_required
- add the required gate entry in inventory order and update CI completeness counts to pq_required=37 / pq_backlog=88
- add wallet unconfirmed-rescan posture docs and update Track A handoff toward reorg-restore follow-ons

## Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- build/test/functional/test_runner.py --jobs=1 wallet_rescan_unconfirmed.py