### PR TITLE
[codex] Promote wallet reorg restore gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1819,10 +1819,10 @@
   },
   {
     "name": "wallet_reorgsrestore.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited wallet reorg-restore behavior under the current legacy-compatible PQC profile: confirmed wallet transactions are restored on a longer chain after wallet reload, conflicted transactions recover expected confirmation state, orphaned coinbase transactions and descendants are abandoned during startup, and unclean-shutdown reorg recovery rescans and un-abandons transactions without duplicate-disconnect crashes."
   },
   {
     "name": "wallet_rescan_unconfirmed.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -30,6 +30,7 @@ wallet_pq_sendall.py
 wallet_pq_sendmany.py
 wallet_pq_signrawtransaction.py
 wallet_reindex.py
+wallet_reorgsrestore.py
 wallet_rescan_unconfirmed.py
 wallet_resendwallettransactions.py
 wallet_send.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `37` |
-| `pq_backlog` | `88` |
+| `pq_required` | `38` |
+| `pq_backlog` | `87` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -75,11 +75,12 @@ Current required PQ-first gates:
 30. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
 31. `wallet_multisig_descriptor_psbt.py`
 32. `wallet_reindex.py`
-33. `wallet_rescan_unconfirmed.py`
-34. `wallet_resendwallettransactions.py`
-35. `wallet_send.py`
-36. `wallet_sendall.py`
-37. `wallet_sendmany.py`
+33. `wallet_reorgsrestore.py`
+34. `wallet_rescan_unconfirmed.py`
+35. `wallet_resendwallettransactions.py`
+36. `wallet_send.py`
+37. `wallet_sendall.py`
+38. `wallet_sendmany.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -131,6 +132,12 @@ required gate: `wallet_rescan_unconfirmed.py` covers descriptor import rescans
 of mempool transactions after a mocked reorg, watched parent-address ownership,
 re-entered parent detection, and unconfirmed child sweep detection through
 input ordering under the current PQC profile.
+The inherited wallet reorg-restore confidence gap is now also part of the
+required gate: `wallet_reorgsrestore.py` covers wallet transaction status
+restoration across longer-chain reloads, conflicted transaction recovery,
+startup abandonment of orphaned coinbase transactions and descendants, and
+unclean-shutdown reorg recovery without duplicate-disconnect crashes under the
+current PQC profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -39,10 +39,11 @@ send-path boundaries and `wallet_resendwallettransactions.py` rebroadcast
 boundary and `wallet_reindex.py` wallet/reindex boundary in the canonical
 `pq_required` gate plus `wallet_fast_rescan.py` descriptor-wallet fast-rescan
 boundary and `wallet_rescan_unconfirmed.py` unconfirmed-rescan boundary, then
-return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
+keep `wallet_reorgsrestore.py` wallet reorg-restore behavior in the same gate,
+then return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
 when real prior PQBTC release assets exist, with broader inherited wallet
-reorg-restore rehab beyond the current unconfirmed-rescan gate as the local
-alternate.
+backup/restore and transaction-time rescan rehab beyond the current
+reorg-restore gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -66,18 +67,18 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet reorg-restore rehab beyond the current
-   `wallet_rescan_unconfirmed.py` gate
+2. broader inherited wallet backup/restore and transaction-time rescan rehab
+   beyond the current `wallet_reorgsrestore.py` gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
      re-litigating the now-owned descriptor, miniscript, address/RPC, raw
      funding, inherited send-path, rebroadcast, reindex, fast-rescan, and
-     unconfirmed-rescan tranches.
+     unconfirmed-rescan/reorg-restore tranches.
 
 Still deferred:
 
-3. broader inherited wallet lifecycle breadth beyond the next reorg-restore
-   focused tranche
+3. broader inherited wallet lifecycle breadth beyond the next backup/restore
+   and transaction-time rescan tranche
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -558,7 +559,7 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_fast_rescan.py`
    Still deferred inside this suite:
-   - broader wallet reorg-restore semantics
+   - broader wallet backup/restore and transaction-time rescan semantics
    - wallet backup/restore compatibility beyond the fast-rescan backup fixture
 31. `wallet_rescan_unconfirmed.py` now owns:
    - restored inherited descriptor-wallet unconfirmed-rescan behavior under the
@@ -576,13 +577,33 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_rescan_unconfirmed.py`
    Still deferred inside this suite:
-   - broader wallet reorg-restore semantics
+   - broader wallet backup/restore and transaction-time rescan semantics
    - wallet backup/restore compatibility beyond existing PQ-owned backup
      coverage
-32. Recommended next PR after this tranche:
+32. `wallet_reorgsrestore.py` now owns:
+   - restored inherited wallet reorg-restore behavior under the current
+     legacy-compatible PQC profile
+   - confirmed wallet transaction status restoration after wallet reload on a
+     longer chain
+   - restored confirmations with a different block hash after reorg
+   - conflicted wallet transaction recovery when the formerly conflicted
+     transaction becomes confirmed on the longer chain
+   - startup abandonment of orphaned coinbase transactions and descendants
+   - trusted-balance reset after orphaned coinbase abandonment
+   - unclean-shutdown restart rescan after an invalidated block was not flushed
+     to disk
+   - duplicate block-disconnection tolerance across a follow-up reorg
+   - abandon/un-abandon consistency across `invalidateblock` and
+     `reconsiderblock`
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_reorgsrestore.py`
+   Still deferred inside this suite:
+   - broader wallet backup/restore compatibility
+   - wallet transaction-time rescan behavior
+33. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet reorg-restore rehab beyond the current
-     unconfirmed-rescan gate
+   - alternate: broader inherited wallet backup/restore and transaction-time
+     rescan rehab beyond the current reorg-restore gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -1099,6 +1120,18 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist, with broader inherited wallet reorg-restore rehab beyond this
   unconfirmed-rescan gate as the local alternate.
+- 2026-04-25: `wallet_reorgsrestore.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited wallet reorg-restore
+  behavior under the current legacy-compatible PQC profile: confirmed
+  transaction status restoration after wallet reload on a longer chain,
+  conflicted transaction recovery, startup abandonment of orphaned coinbase
+  transactions and descendants, and unclean-shutdown reorg recovery without
+  duplicate-disconnect crashes. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with broader inherited wallet backup/restore and
+  transaction-time rescan rehab beyond this reorg-restore gate as the local
+  alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1162,5 +1195,8 @@ Aineko must ask before:
 - There is no current blocker in the restored inherited wallet
   unconfirmed-rescan surface: `wallet_rescan_unconfirmed.py` passes targeted
   validation in the current tree.
+- There is no current blocker in the restored inherited wallet reorg-restore
+  surface: `wallet_reorgsrestore.py` passes targeted validation in the current
+  tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_REORGSRESTORE_POSTURE.md
+++ b/docs/WALLET_REORGSRESTORE_POSTURE.md
@@ -1,0 +1,66 @@
+# PQBTC `wallet_reorgsrestore.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-REORGSRESTORE-POSTURE-v1
+## Updated: 2026-04-25
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_reorgsrestore.py](../test/functional/wallet_reorgsrestore.py)
+wallet reorg-restore contract under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_reorgsrestore.py` is now a required PQ gate for restored inherited
+wallet reorg-restore behavior. The owned boundary covers:
+
+- confirmed wallet transaction status restoration after a wallet file is loaded
+  on a longer chain
+- restored confirmation state with a different block hash after reorg
+- conflicted wallet transaction recovery when the formerly conflicted
+  transaction becomes confirmed on the longer chain
+- startup abandonment of orphaned coinbase transactions when their block is no
+  longer on the best chain
+- startup abandonment of descendants of orphaned coinbase transactions
+- trusted-balance reset after orphaned coinbase abandonment
+- unclean-shutdown restart rescan after an invalidated block was not flushed to
+  disk
+- un-abandoning a coinbase transaction when the restarted node again sees it in
+  the active chain
+- duplicate block-disconnection tolerance across a follow-up reorg
+- abandon/un-abandon consistency across `invalidateblock` and `reconsiderblock`
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- broader wallet backup/restore compatibility
+- wallet transaction-time rescan behavior
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-25:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_reorgsrestore.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=38`, `pq_backlog=87`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet reorg-restore contract
+that already passes under the current PQC-compatible legacy profile. The
+preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to broader inherited wallet backup/restore and
+transaction-time rescan surfaces.


### PR DESCRIPTION
## Summary
- promote wallet_reorgsrestore.py from pq_backlog to pq_required
- add the required gate entry in inventory order and update CI completeness counts to pq_required=38 / pq_backlog=87
- add wallet reorg-restore posture docs and update Track A handoff toward backup/restore and transaction-time rescan follow-ons

## Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- build/test/functional/test_runner.py --jobs=1 wallet_reorgsrestore.py