### PR TITLE
[codex] Promote wallet transaction-time rescan gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1918,10 +1918,10 @@
   },
   {
     "name": "wallet_transactiontime_rescan.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited wallet transaction-time rescan behavior under the current legacy-compatible PQC profile: watch-only descriptor imports preserve transaction blocktime/time across original detection and full restoration rescans, abortrescan returns false when idle, invalid rescanblockchain parameters are rejected, and locked encrypted wallets reject rescans without unlock."
   },
   {
     "name": "wallet_txn_clone.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -36,3 +36,4 @@ wallet_resendwallettransactions.py
 wallet_send.py
 wallet_sendall.py
 wallet_sendmany.py
+wallet_transactiontime_rescan.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `38` |
-| `pq_backlog` | `87` |
+| `pq_required` | `39` |
+| `pq_backlog` | `86` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -81,6 +81,7 @@ Current required PQ-first gates:
 36. `wallet_send.py`
 37. `wallet_sendall.py`
 38. `wallet_sendmany.py`
+39. `wallet_transactiontime_rescan.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -138,6 +139,12 @@ restoration across longer-chain reloads, conflicted transaction recovery,
 startup abandonment of orphaned coinbase transactions and descendants, and
 unclean-shutdown reorg recovery without duplicate-disconnect crashes under the
 current PQC profile.
+The inherited wallet transaction-time rescan confidence gap is now also part
+of the required gate: `wallet_transactiontime_rescan.py` covers watch-only
+descriptor transaction time preservation across original detection and full
+restoration rescans, idle `abortrescan`, invalid `rescanblockchain` parameter
+rejection, and locked encrypted wallet rescan rejection under the current PQC
+profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-25
+## Updated: 2026-04-26
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -40,10 +40,11 @@ boundary and `wallet_reindex.py` wallet/reindex boundary in the canonical
 `pq_required` gate plus `wallet_fast_rescan.py` descriptor-wallet fast-rescan
 boundary and `wallet_rescan_unconfirmed.py` unconfirmed-rescan boundary, then
 keep `wallet_reorgsrestore.py` wallet reorg-restore behavior in the same gate,
-then return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with broader inherited wallet
-backup/restore and transaction-time rescan rehab beyond the current
-reorg-restore gate as the local alternate.
+keep `wallet_transactiontime_rescan.py` transaction-time rescan behavior in the
+same gate, then return the next owned follow-on to
+`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
+exist, with broader inherited wallet backup/restore rehab beyond the current
+transaction-time rescan gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -67,18 +68,18 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet backup/restore and transaction-time rescan rehab
-   beyond the current `wallet_reorgsrestore.py` gate
+2. broader inherited wallet backup/restore rehab beyond the current
+   `wallet_transactiontime_rescan.py` gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
      re-litigating the now-owned descriptor, miniscript, address/RPC, raw
      funding, inherited send-path, rebroadcast, reindex, fast-rescan, and
-     unconfirmed-rescan/reorg-restore tranches.
+     unconfirmed-rescan/reorg-restore/transaction-time-rescan tranches.
 
 Still deferred:
 
 3. broader inherited wallet lifecycle breadth beyond the next backup/restore
-   and transaction-time rescan tranche
+   tranche
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -599,11 +600,29 @@ Still deferred:
    - `build/test/functional/test_runner.py --jobs=1 wallet_reorgsrestore.py`
    Still deferred inside this suite:
    - broader wallet backup/restore compatibility
-   - wallet transaction-time rescan behavior
-33. Recommended next PR after this tranche:
+33. `wallet_transactiontime_rescan.py` now owns:
+   - restored inherited wallet transaction-time rescan behavior under the
+     current legacy-compatible PQC profile
+   - watch-only descriptor imports for three received transactions separated
+     by mock-time intervals
+   - original transaction `blocktime` and wallet `time` matching the block
+     times at initial detection
+   - wallet restoration with `timestamp=now` descriptors starting with no
+     detected historical transactions
+   - idle `abortrescan` returning `false`
+   - partial-history rescan followed by full-history rescan
+   - restored balance, transaction count, and transaction times after full
+     rescan
+   - invalid `rescanblockchain` start/stop height rejection
+   - locked encrypted wallet rescan rejection until unlock
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_transactiontime_rescan.py`
+   Still deferred inside this suite:
+   - broader wallet backup/restore compatibility
+34. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet backup/restore and transaction-time
-     rescan rehab beyond the current reorg-restore gate
+   - alternate: broader inherited wallet backup/restore rehab beyond the
+     current transaction-time rescan gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -1132,6 +1151,17 @@ Aineko must ask before:
   assets exist, with broader inherited wallet backup/restore and
   transaction-time rescan rehab beyond this reorg-restore gate as the local
   alternate.
+- 2026-04-26: `wallet_transactiontime_rescan.py` is now promoted into the
+  canonical `pq_required` gate and locally revalidated with the build-tree
+  functional runner. The owned boundary covers restored inherited wallet
+  transaction-time rescan behavior under the current legacy-compatible PQC
+  profile: watch-only descriptor transaction times match original block times,
+  restoration rescans preserve those times, idle `abortrescan` returns false,
+  invalid `rescanblockchain` parameters are rejected, and locked encrypted
+  wallets reject rescans until unlock. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with broader inherited wallet backup/restore rehab beyond this
+  transaction-time rescan gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1198,5 +1228,8 @@ Aineko must ask before:
 - There is no current blocker in the restored inherited wallet reorg-restore
   surface: `wallet_reorgsrestore.py` passes targeted validation in the current
   tree.
+- There is no current blocker in the restored inherited wallet transaction-time
+  rescan surface: `wallet_transactiontime_rescan.py` passes targeted validation
+  in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_TRANSACTIONTIME_RESCAN_POSTURE.md
+++ b/docs/WALLET_TRANSACTIONTIME_RESCAN_POSTURE.md
@@ -1,0 +1,64 @@
+# PQBTC `wallet_transactiontime_rescan.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-TRANSACTIONTIME-RESCAN-POSTURE-v1
+## Updated: 2026-04-26
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_transactiontime_rescan.py](../test/functional/wallet_transactiontime_rescan.py)
+wallet transaction-time rescan contract under the current legacy-compatible
+PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_transactiontime_rescan.py` is now a required PQ gate for restored
+inherited wallet transaction-time rescan behavior. The owned boundary covers:
+
+- watch-only descriptor imports for three received transactions separated by
+  mock-time intervals
+- original transaction `blocktime` and wallet `time` matching the block times
+  at initial detection
+- wallet restoration with `timestamp=now` descriptors that intentionally starts
+  with no detected historical transactions
+- idle `abortrescan` returning `false`
+- partial-history rescan followed by full-history rescan
+- restored balance and transaction count after the full rescan
+- restored transaction `blocktime` and wallet `time` matching the original
+  detected times
+- invalid `rescanblockchain` start and stop height rejection
+- locked encrypted wallet rescan rejection until the wallet is unlocked
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- broader wallet backup/restore compatibility
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-26:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_transactiontime_rescan.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=39`, `pq_backlog=86`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet transaction-time
+rescan contract that already passes under the current PQC-compatible legacy
+profile. The preferred Track A follow-on remains
+`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
+exist locally. Until then, the repo-local wallet alternate moves to broader
+inherited wallet backup/restore coverage.


### PR DESCRIPTION
## Summary
- promote wallet_transactiontime_rescan.py from pq_backlog to pq_required
- add the required gate entry in inventory order and update CI completeness counts to pq_required=39 / pq_backlog=86
- add wallet transaction-time rescan posture docs and update Track A handoff toward broader backup/restore follow-ons

## Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- build/test/functional/test_runner.py --jobs=1 wallet_transactiontime_rescan.py