### PR TITLE
[codex] Promote wallet backup gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1487,10 +1487,10 @@
   },
   {
     "name": "wallet_backup.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited wallet backup/restore behavior under the current legacy-compatible PQC profile: backupwallet/restorewallet preserve multi-wallet balances after transaction churn, invalid and missing backup files are rejected without creating wallets, existing destination paths are handled safely, backup-to-source paths fail, unnamed restore succeeds, and pruned-node restore behavior respects backup/prune-height boundaries."
   },
   {
     "name": "wallet_backwards_compatibility.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -15,6 +15,7 @@ mempool_pq_stress.py
 rpc_psbt.py
 wallet_address_types.py
 wallet_assumeutxo.py
+wallet_backup.py
 wallet_fast_rescan.py
 wallet_fundrawtransaction.py
 wallet_miniscript.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `39` |
-| `pq_backlog` | `86` |
+| `pq_required` | `40` |
+| `pq_backlog` | `85` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -69,19 +69,20 @@ Current required PQ-first gates:
 24. `rpc_psbt.py`
 25. `wallet_address_types.py`
 26. `wallet_assumeutxo.py`
-27. `wallet_fast_rescan.py`
-28. `wallet_fundrawtransaction.py`
-29. `wallet_miniscript.py`
-30. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-31. `wallet_multisig_descriptor_psbt.py`
-32. `wallet_reindex.py`
-33. `wallet_reorgsrestore.py`
-34. `wallet_rescan_unconfirmed.py`
-35. `wallet_resendwallettransactions.py`
-36. `wallet_send.py`
-37. `wallet_sendall.py`
-38. `wallet_sendmany.py`
-39. `wallet_transactiontime_rescan.py`
+27. `wallet_backup.py`
+28. `wallet_fast_rescan.py`
+29. `wallet_fundrawtransaction.py`
+30. `wallet_miniscript.py`
+31. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+32. `wallet_multisig_descriptor_psbt.py`
+33. `wallet_reindex.py`
+34. `wallet_reorgsrestore.py`
+35. `wallet_rescan_unconfirmed.py`
+36. `wallet_resendwallettransactions.py`
+37. `wallet_send.py`
+38. `wallet_sendall.py`
+39. `wallet_sendmany.py`
+40. `wallet_transactiontime_rescan.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -145,6 +146,11 @@ descriptor transaction time preservation across original detection and full
 restoration rescans, idle `abortrescan`, invalid `rescanblockchain` parameter
 rejection, and locked encrypted wallet rescan rejection under the current PQC
 profile.
+The inherited wallet backup/restore confidence gap is now also part of the
+required gate: `wallet_backup.py` covers `backupwallet`/`restorewallet`
+balance preservation after transaction churn, invalid and missing backup-file
+rejection, destination-path safety, backup-to-source failure, unnamed restore,
+and pruned-node restore behavior under the current PQC profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -41,10 +41,11 @@ boundary and `wallet_reindex.py` wallet/reindex boundary in the canonical
 boundary and `wallet_rescan_unconfirmed.py` unconfirmed-rescan boundary, then
 keep `wallet_reorgsrestore.py` wallet reorg-restore behavior in the same gate,
 keep `wallet_transactiontime_rescan.py` transaction-time rescan behavior in the
-same gate, then return the next owned follow-on to
-`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist, with broader inherited wallet backup/restore rehab beyond the current
-transaction-time rescan gate as the local alternate.
+same gate, keep `wallet_backup.py` backup/restore behavior in the same gate,
+then return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist, with broader inherited wallet
+lifecycle coverage beyond the current backup/restore gate as the local
+alternate.
 
 ## Current Working Thesis
 
@@ -68,18 +69,18 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet backup/restore rehab beyond the current
-   `wallet_transactiontime_rescan.py` gate
+2. broader inherited wallet lifecycle coverage beyond the current
+   `wallet_backup.py` gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
      re-litigating the now-owned descriptor, miniscript, address/RPC, raw
      funding, inherited send-path, rebroadcast, reindex, fast-rescan, and
-     unconfirmed-rescan/reorg-restore/transaction-time-rescan tranches.
+     unconfirmed-rescan/reorg-restore/transaction-time-rescan/backup tranches.
 
 Still deferred:
 
-3. broader inherited wallet lifecycle breadth beyond the next backup/restore
-   tranche
+3. broader inherited wallet lifecycle breadth beyond the next promoted wallet
+   lifecycle tranche
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -619,10 +620,28 @@ Still deferred:
    - `build/test/functional/test_runner.py --jobs=1 wallet_transactiontime_rescan.py`
    Still deferred inside this suite:
    - broader wallet backup/restore compatibility
-34. Recommended next PR after this tranche:
+34. `wallet_backup.py` now owns:
+   - restored inherited wallet backup/restore behavior under the current
+     legacy-compatible PQC profile
+   - multi-wallet transaction churn before and after `backupwallet`
+   - restored wallet balances matching pre-restore balances after later
+     transactions and fee-maturity mining
+   - invalid and missing backup-file rejection without creating target wallets
+   - existing wallet-name restore rejection without overwriting the destination
+   - restore into existing empty directories, directories containing non-wallet
+     files, and unnamed default wallets
+   - backup-to-source-path failure for file, directory, and equivalent path
+     forms
+   - pruned-node restore success near the prune height and failure when backup
+     synchronization goes beyond pruned data
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_backup.py`
+   Still deferred inside this suite:
+   - broader wallet backwards-compatibility and migration semantics
+35. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet backup/restore rehab beyond the
-     current transaction-time rescan gate
+   - alternate: broader inherited wallet lifecycle coverage beyond the current
+     backup/restore gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -1162,6 +1181,17 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist, with broader inherited wallet backup/restore rehab beyond this
   transaction-time rescan gate as the local alternate.
+- 2026-04-26: `wallet_backup.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited wallet backup/restore
+  behavior under the current legacy-compatible PQC profile: backup and restore
+  preserve multi-wallet balances after transaction churn, invalid and missing
+  backup files are rejected without target-wallet creation, destination paths
+  are handled safely, backup-to-source paths fail, unnamed restore succeeds,
+  and pruned-node restore behavior respects backup/prune-height boundaries.
+  The next owned follow-on remains `feature_coinstatsindex_compatibility.py`
+  when real prior PQBTC release assets exist, with broader inherited wallet
+  lifecycle coverage beyond this backup/restore gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1231,5 +1261,7 @@ Aineko must ask before:
 - There is no current blocker in the restored inherited wallet transaction-time
   rescan surface: `wallet_transactiontime_rescan.py` passes targeted validation
   in the current tree.
+- There is no current blocker in the restored inherited wallet backup/restore
+  surface: `wallet_backup.py` passes targeted validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_BACKUP_POSTURE.md
+++ b/docs/WALLET_BACKUP_POSTURE.md
@@ -1,0 +1,64 @@
+# PQBTC `wallet_backup.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-BACKUP-POSTURE-v1
+## Updated: 2026-04-26
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_backup.py](../test/functional/wallet_backup.py) wallet backup/restore
+contract under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_backup.py` is now a required PQ gate for restored inherited wallet
+backup/restore behavior. The owned boundary covers:
+
+- multi-wallet transaction churn before and after `backupwallet`
+- restored wallet balances matching the pre-restore balances after more
+  transactions and fee-maturity mining
+- invalid wallet backup rejection without creating the target wallet
+- missing backup-file rejection without creating the target wallet
+- existing wallet-name restore rejection without overwriting the destination
+- restore into an existing empty directory
+- restore into a directory containing non-wallet files without deleting them
+- restore rejection when the destination wallet database already exists
+- restore into an unnamed default wallet
+- backup-to-source-path failure for file, directory, and equivalent path forms
+- pruned-node restore success when the backup is near the prune height
+- pruned-node restore failure when backup synchronization goes beyond pruned
+  data
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- broader wallet backwards-compatibility or migration semantics
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-26:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_backup.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=40`, `pq_backlog=85`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet backup/restore
+contract that already passes under the current PQC-compatible legacy profile.
+The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to broader inherited wallet lifecycle coverage beyond
+the current backup/restore gate.


### PR DESCRIPTION
## Summary
- promote wallet_backup.py from pq_backlog to pq_required
- add the required gate entry in inventory order and update CI completeness counts to pq_required=40 / pq_backlog=85
- add wallet backup posture docs and update Track A handoff toward broader wallet lifecycle follow-ons

## Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- build/test/functional/test_runner.py --jobs=1 wallet_backup.py