### PR TITLE
[codex] Promote wallet startup gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1896,10 +1896,10 @@
   },
   {
     "name": "wallet_startup.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "tracking_issue": "#12",
+    "notes": "Required gate for restored inherited wallet startup/load-on-startup behavior under the current legacy-compatible PQC profile: default wallet auto-loads when no other wallets exist, createwallet load_on_startup flags persist across restart, unloadwallet can remove startup persistence, and loadwallet can add startup persistence."
   },
   {
     "name": "wallet_taproot.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -37,4 +37,5 @@ wallet_resendwallettransactions.py
 wallet_send.py
 wallet_sendall.py
 wallet_sendmany.py
+wallet_startup.py
 wallet_transactiontime_rescan.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `40` |
-| `pq_backlog` | `85` |
+| `pq_required` | `41` |
+| `pq_backlog` | `84` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -82,7 +82,8 @@ Current required PQ-first gates:
 37. `wallet_send.py`
 38. `wallet_sendall.py`
 39. `wallet_sendmany.py`
-40. `wallet_transactiontime_rescan.py`
+40. `wallet_startup.py`
+41. `wallet_transactiontime_rescan.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -151,6 +152,10 @@ required gate: `wallet_backup.py` covers `backupwallet`/`restorewallet`
 balance preservation after transaction churn, invalid and missing backup-file
 rejection, destination-path safety, backup-to-source failure, unnamed restore,
 and pruned-node restore behavior under the current PQC profile.
+The inherited wallet startup confidence gap is now also part of the required
+gate: `wallet_startup.py` covers default wallet auto-load, persisted
+`load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,
+and `loadwallet` startup-list addition under the current PQC profile.
 The replacement-path confidence gap is closed in this tranche by promoting the
 full deterministic Taproot replacement functional stack into the required PQ
 gate.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -42,10 +42,11 @@ boundary and `wallet_rescan_unconfirmed.py` unconfirmed-rescan boundary, then
 keep `wallet_reorgsrestore.py` wallet reorg-restore behavior in the same gate,
 keep `wallet_transactiontime_rescan.py` transaction-time rescan behavior in the
 same gate, keep `wallet_backup.py` backup/restore behavior in the same gate,
-then return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with broader inherited wallet
-lifecycle coverage beyond the current backup/restore gate as the local
-alternate.
+keep `wallet_startup.py` load-on-startup behavior in the same gate, then
+return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist, with adjacent inherited wallet
+creation/blank/multiwallet lifecycle coverage beyond the current startup gate
+as the local alternate.
 
 ## Current Working Thesis
 
@@ -69,13 +70,14 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet lifecycle coverage beyond the current
-   `wallet_backup.py` gate
+2. adjacent inherited wallet creation/blank/multiwallet lifecycle coverage
+   beyond the current `wallet_startup.py` gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to reopen without
      re-litigating the now-owned descriptor, miniscript, address/RPC, raw
      funding, inherited send-path, rebroadcast, reindex, fast-rescan, and
-     unconfirmed-rescan/reorg-restore/transaction-time-rescan/backup tranches.
+     unconfirmed-rescan/reorg-restore/transaction-time-rescan/backup/startup
+     tranches.
 
 Still deferred:
 
@@ -638,10 +640,24 @@ Still deferred:
    - `build/test/functional/test_runner.py --jobs=1 wallet_backup.py`
    Still deferred inside this suite:
    - broader wallet backwards-compatibility and migration semantics
-35. Recommended next PR after this tranche:
+35. `wallet_startup.py` now owns:
+   - restored inherited wallet startup and load-on-startup behavior under the
+     current legacy-compatible PQC profile
+   - node startup with no wallets loaded and an empty wallet directory
+   - unnamed default wallet auto-load after restart when no other wallets exist
+   - `createwallet(..., load_on_startup=true)` persistence across restart
+   - `createwallet(..., load_on_startup=false)` exclusion from restart loading
+   - `unloadwallet(..., load_on_startup=false)` removing startup persistence
+   - `loadwallet(..., load_on_startup=true)` adding startup persistence
+   - final restart state matching the configured startup wallet set
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_startup.py`
+   Still deferred inside this suite:
+   - broader wallet creation, blank-wallet, and multiwallet semantics
+36. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet lifecycle coverage beyond the current
-     backup/restore gate
+   - alternate: adjacent inherited wallet creation/blank/multiwallet lifecycle
+     coverage beyond the current startup gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -1192,6 +1208,18 @@ Aineko must ask before:
   The next owned follow-on remains `feature_coinstatsindex_compatibility.py`
   when real prior PQBTC release assets exist, with broader inherited wallet
   lifecycle coverage beyond this backup/restore gate as the local alternate.
+- 2026-04-26: `wallet_startup.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited wallet startup and
+  load-on-startup behavior under the current legacy-compatible PQC profile:
+  empty wallet startup, unnamed default wallet auto-load, persisted
+  `load_on_startup` flags from `createwallet`, startup-list removal through
+  `unloadwallet`, startup-list addition through `loadwallet`, and final restart
+  state matching the configured startup wallet set. The next owned follow-on
+  remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
+  release assets exist, with adjacent inherited wallet
+  creation/blank/multiwallet lifecycle coverage beyond this startup gate as the
+  local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1263,5 +1291,7 @@ Aineko must ask before:
   in the current tree.
 - There is no current blocker in the restored inherited wallet backup/restore
   surface: `wallet_backup.py` passes targeted validation in the current tree.
+- There is no current blocker in the restored inherited wallet startup surface:
+  `wallet_startup.py` passes targeted validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_STARTUP_POSTURE.md
+++ b/docs/WALLET_STARTUP_POSTURE.md
@@ -1,0 +1,57 @@
+# PQBTC `wallet_startup.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-STARTUP-POSTURE-v1
+## Updated: 2026-04-26
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_startup.py](../test/functional/wallet_startup.py) wallet startup and
+load-on-startup contract under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_startup.py` is now a required PQ gate for restored inherited wallet
+startup behavior. The owned boundary covers:
+
+- node startup with no wallets loaded and an empty wallet directory
+- default unnamed wallet auto-load after restart when no other wallets exist
+- `createwallet(..., load_on_startup=true)` persistence across restart
+- `createwallet(..., load_on_startup=false)` exclusion from restart loading
+- `unloadwallet(..., load_on_startup=false)` removing startup persistence
+- `loadwallet(..., load_on_startup=true)` adding startup persistence
+- final restart state matching the configured startup wallet set
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- broader wallet creation, blank-wallet, or multiwallet semantics
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-26:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_startup.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=41`, `pq_backlog=84`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet startup and
+load-on-startup contract that already passes under the current PQC-compatible
+legacy profile. The preferred Track A follow-on remains
+`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
+exist locally. Until then, the repo-local wallet alternate moves to adjacent
+wallet creation, blank-wallet, and multiwallet lifecycle surfaces.


### PR DESCRIPTION
## Summary
- promote wallet_startup.py from pq_backlog to pq_required
- add the required gate entry in inventory order and update CI completeness counts to pq_required=41 / pq_backlog=84
- add wallet startup posture docs and update Track A handoff toward adjacent wallet creation/blank/multiwallet follow-ons

## Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- build/test/functional/test_runner.py --jobs=1 wallet_startup.py