### PR TITLE
ci: promote wallet create and blank gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1515,10 +1515,10 @@
   },
   {
     "name": "wallet_blank.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the narrow blank descriptor-wallet lifecycle boundary: blank wallets preserve the blank flag across descriptor import and encryption, while descriptor metadata remains stable; broader createwallet and multiwallet lifecycle behavior remain separate follow-on surfaces."
   },
   {
     "name": "wallet_bumpfee.py",
@@ -1557,10 +1557,10 @@
   },
   {
     "name": "wallet_createwallet.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited createwallet argument and lifecycle boundary under the legacy-compatible PQC profile: invalid option combinations, disabled-private-key and blank-wallet creation, descriptor import behavior, encryption, empty-passphrase warnings, avoid_reuse, legacy-wallet rejection, and wallet version logging; broader multiwallet lifecycle behavior remains a separate follow-on surface."
   },
   {
     "name": "wallet_createwalletdescriptor.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -16,6 +16,8 @@ rpc_psbt.py
 wallet_address_types.py
 wallet_assumeutxo.py
 wallet_backup.py
+wallet_blank.py
+wallet_createwallet.py
 wallet_fast_rescan.py
 wallet_fundrawtransaction.py
 wallet_miniscript.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `41` |
-| `pq_backlog` | `84` |
+| `pq_required` | `43` |
+| `pq_backlog` | `82` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -70,20 +70,22 @@ Current required PQ-first gates:
 25. `wallet_address_types.py`
 26. `wallet_assumeutxo.py`
 27. `wallet_backup.py`
-28. `wallet_fast_rescan.py`
-29. `wallet_fundrawtransaction.py`
-30. `wallet_miniscript.py`
-31. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-32. `wallet_multisig_descriptor_psbt.py`
-33. `wallet_reindex.py`
-34. `wallet_reorgsrestore.py`
-35. `wallet_rescan_unconfirmed.py`
-36. `wallet_resendwallettransactions.py`
-37. `wallet_send.py`
-38. `wallet_sendall.py`
-39. `wallet_sendmany.py`
-40. `wallet_startup.py`
-41. `wallet_transactiontime_rescan.py`
+28. `wallet_blank.py`
+29. `wallet_createwallet.py`
+30. `wallet_fast_rescan.py`
+31. `wallet_fundrawtransaction.py`
+32. `wallet_miniscript.py`
+33. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+34. `wallet_multisig_descriptor_psbt.py`
+35. `wallet_reindex.py`
+36. `wallet_reorgsrestore.py`
+37. `wallet_rescan_unconfirmed.py`
+38. `wallet_resendwallettransactions.py`
+39. `wallet_send.py`
+40. `wallet_sendall.py`
+41. `wallet_sendmany.py`
+42. `wallet_startup.py`
+43. `wallet_transactiontime_rescan.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -152,6 +154,13 @@ required gate: `wallet_backup.py` covers `backupwallet`/`restorewallet`
 balance preservation after transaction churn, invalid and missing backup-file
 rejection, destination-path safety, backup-to-source failure, unnamed restore,
 and pruned-node restore behavior under the current PQC profile.
+The inherited wallet creation and blank-wallet confidence gap is now also part
+of the required gate: `wallet_blank.py` preserves blank descriptor-wallet flags
+across descriptor import and encryption, while `wallet_createwallet.py` covers
+invalid option combinations, disabled-private-key and blank-wallet creation,
+descriptor import behavior, encryption, empty-passphrase warnings,
+`avoid_reuse`, legacy-wallet rejection, and wallet version logging under the
+current PQC profile.
 The inherited wallet startup confidence gap is now also part of the required
 gate: `wallet_startup.py` covers default wallet auto-load, persisted
 `load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -43,10 +43,12 @@ keep `wallet_reorgsrestore.py` wallet reorg-restore behavior in the same gate,
 keep `wallet_transactiontime_rescan.py` transaction-time rescan behavior in the
 same gate, keep `wallet_backup.py` backup/restore behavior in the same gate,
 keep `wallet_startup.py` load-on-startup behavior in the same gate, then
+keep `wallet_blank.py` blank descriptor-wallet behavior and
+`wallet_createwallet.py` wallet creation behavior in the same gate, then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with adjacent inherited wallet
-creation/blank/multiwallet lifecycle coverage beyond the current startup gate
-as the local alternate.
+when real prior PQBTC release assets exist, with adjacent inherited multiwallet
+lifecycle coverage beyond the current creation/blank gates as the local
+alternate.
 
 ## Current Working Thesis
 
@@ -70,19 +72,18 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. adjacent inherited wallet creation/blank/multiwallet lifecycle coverage
-   beyond the current `wallet_startup.py` gate
+2. `wallet_multiwallet.py`
    - Why alternate: if the asset-dependent coinstats compatibility path stays
-     blocked locally, this is the next wallet-facing surface to reopen without
-     re-litigating the now-owned descriptor, miniscript, address/RPC, raw
-     funding, inherited send-path, rebroadcast, reindex, fast-rescan, and
-     unconfirmed-rescan/reorg-restore/transaction-time-rescan/backup/startup
+     blocked locally, this is the next wallet-facing lifecycle surface to
+     reopen without re-litigating the now-owned descriptor, miniscript,
+     address/RPC, raw funding, inherited send-path, rebroadcast, reindex,
+     fast-rescan, unconfirmed-rescan, reorg-restore,
+     transaction-time-rescan, backup, startup, blank-wallet, and createwallet
      tranches.
 
 Still deferred:
 
-3. broader inherited wallet lifecycle breadth beyond the next promoted wallet
-   lifecycle tranche
+3. broader inherited wallet lifecycle breadth beyond `wallet_multiwallet.py`
 4. TapMiniscript activation or replacement semantics
 
 ## Current Queue
@@ -653,17 +654,40 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_startup.py`
    Still deferred inside this suite:
-   - broader wallet creation, blank-wallet, and multiwallet semantics
-36. Recommended next PR after this tranche:
+   - broader wallet creation, blank-wallet, and multiwallet semantics now
+     covered by adjacent required gates or tracked as the next lifecycle
+     follow-on
+36. `wallet_blank.py` now owns:
+   - restored inherited blank descriptor-wallet behavior under the current
+     legacy-compatible PQC profile
+   - blank flag preservation after descriptor import
+   - blank flag preservation after blank-wallet encryption
+   - descriptor metadata stability across blank-wallet encryption
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_blank.py`
+   Still deferred inside this suite:
+   - broader wallet creation arguments and multiwallet lifecycle semantics
+37. `wallet_createwallet.py` now owns:
+   - restored inherited `createwallet` argument and lifecycle behavior under
+     the current legacy-compatible PQC profile
+   - invalid option combinations and disabled-private-key wallets
+   - blank-wallet creation with private keys disabled and enabled
+   - descriptor import behavior, wallet encryption, empty-passphrase warnings,
+     `avoid_reuse`, legacy-wallet rejection, and wallet version logging
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_createwallet.py`
+   Still deferred inside this suite:
+   - broader multiwallet path, load/unload, backup, and locking behavior
+38. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: adjacent inherited wallet creation/blank/multiwallet lifecycle
-     coverage beyond the current startup gate
+   - alternate: `wallet_multiwallet.py`
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - adjacent wallet lifecycle work remains useful, but additional wallet work
-     stays behind the asset-dependent compatibility slice once prior PQBTC
-     release assets are available
+   - `wallet_multiwallet.py` is the next adjacent wallet lifecycle surface once
+     the current startup, blank-wallet, and createwallet gates are frozen, but
+     additional wallet work stays behind the asset-dependent compatibility slice
+     once prior PQBTC release assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -1220,6 +1244,16 @@ Aineko must ask before:
   release assets exist, with adjacent inherited wallet
   creation/blank/multiwallet lifecycle coverage beyond this startup gate as the
   local alternate.
+- 2026-04-26: `wallet_blank.py` and `wallet_createwallet.py` are now promoted
+  into the canonical `pq_required` gate and locally revalidated with the
+  build-tree functional runner. The owned boundary covers blank
+  descriptor-wallet flag preservation across descriptor import and encryption,
+  plus restored inherited `createwallet` option validation, disabled-private-key
+  wallets, blank-wallet creation, descriptor import behavior, encryption,
+  empty-passphrase warnings, `avoid_reuse`, legacy-wallet rejection, and wallet
+  version logging. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with `wallet_multiwallet.py` as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1293,5 +1327,8 @@ Aineko must ask before:
   surface: `wallet_backup.py` passes targeted validation in the current tree.
 - There is no current blocker in the restored inherited wallet startup surface:
   `wallet_startup.py` passes targeted validation in the current tree.
+- There is no current blocker in the restored inherited blank-wallet and
+  createwallet surfaces: `wallet_blank.py` and `wallet_createwallet.py` pass
+  targeted validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_BLANK_POSTURE.md
+++ b/docs/WALLET_BLANK_POSTURE.md
@@ -1,0 +1,56 @@
+# PQBTC `wallet_blank.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-BLANK-POSTURE-v1
+## Updated: 2026-04-26
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_blank.py](../test/functional/wallet_blank.py) blank descriptor-wallet
+contract under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_blank.py` is now a required PQ gate for restored inherited blank-wallet
+lifecycle behavior. The owned boundary covers:
+
+- blank descriptor wallets created with private keys disabled
+- blank flag preservation after `importdescriptors`
+- blank descriptor wallets created with private keys enabled
+- blank flag preservation after `encryptwallet`
+- descriptor metadata stability across blank-wallet encryption
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- broader `createwallet` argument behavior beyond `wallet_createwallet.py`
+- broader multiwallet path, load/unload, backup, or locking behavior
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-26:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_blank.py wallet_createwallet.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=43`, `pq_backlog=82`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited blank descriptor-wallet
+lifecycle contract that already passes under the current PQC-compatible legacy
+profile. The preferred Track A follow-on remains
+`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
+exist locally. Until then, the repo-local wallet alternate moves to
+`wallet_multiwallet.py`.

--- a/docs/WALLET_CREATEWALLET_POSTURE.md
+++ b/docs/WALLET_CREATEWALLET_POSTURE.md
@@ -1,0 +1,61 @@
+# PQBTC `wallet_createwallet.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-CREATEWALLET-POSTURE-v1
+## Updated: 2026-04-26
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_createwallet.py](../test/functional/wallet_createwallet.py)
+`createwallet` argument and lifecycle contract under the current
+legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_createwallet.py` is now a required PQ gate for restored inherited wallet
+creation behavior. The owned boundary covers:
+
+- invalid `createwallet` argument combinations
+- disabled-private-key wallets and expected key-unavailability failures
+- blank wallets with private keys disabled and enabled
+- descriptor import behavior for watch-only and private-key material
+- blank-wallet encryption before descriptor seed import
+- born-encrypted wallets, unlock flow, signing, and keypool refill behavior
+- empty-passphrase warning behavior
+- `avoid_reuse` wallet creation
+- legacy-wallet creation rejection
+- wallet version logging across unload/load
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- broader multiwallet path, load/unload, backup, or locking behavior
+- wallet migration or backwards-compatibility release-asset behavior
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-26:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_blank.py wallet_createwallet.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=43`, `pq_backlog=82`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited `createwallet` lifecycle
+contract that already passes under the current PQC-compatible legacy profile.
+The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to `wallet_multiwallet.py`.

--- a/docs/WALLET_STARTUP_POSTURE.md
+++ b/docs/WALLET_STARTUP_POSTURE.md
@@ -53,5 +53,6 @@ The canonical PQ gate now includes the inherited wallet startup and
 load-on-startup contract that already passes under the current PQC-compatible
 legacy profile. The preferred Track A follow-on remains
 `feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist locally. Until then, the repo-local wallet alternate moves to adjacent
-wallet creation, blank-wallet, and multiwallet lifecycle surfaces.
+exist locally. The subsequent creation/blank promotion covers the adjacent
+creation surfaces; until compatibility assets exist, the repo-local wallet
+alternate is now `wallet_multiwallet.py`.


### PR DESCRIPTION
Summary:
- Promote wallet_blank.py and wallet_createwallet.py from pq_backlog to pq_required.
- Add the suites to the PQ functional gate in inventory order and update counts to pq_required=43, pq_backlog=82, dual_profile=142, legacy_only=9.
- Add posture docs and update Track A handoff so feature_coinstatsindex_compatibility.py remains preferred when release assets exist, with wallet_multiwallet.py as the local alternate.

Tests:
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 wallet_blank.py wallet_createwallet.py