### PR TITLE
ci: promote wallet multiwallet gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1735,10 +1735,10 @@
   },
   {
     "name": "wallet_multiwallet.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited multiwallet lifecycle boundary under the legacy-compatible PQC profile: wallet directory scanning, path validation, symlink rejection, dynamic load/unload and creation, per-wallet balance and fee isolation, concurrent load rejection, backup/restore across multiple wallets, and exclusive database locking; broader wallet lifecycle breadth remains a separate follow-on surface."
   },
   {
     "name": "wallet_orphanedreward.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -23,6 +23,7 @@ wallet_fundrawtransaction.py
 wallet_miniscript.py
 wallet_miniscript_decaying_multisig_descriptor_psbt.py
 wallet_multisig_descriptor_psbt.py
+wallet_multiwallet.py
 wallet_pq_active_ranged.py
 wallet_pq_backup_recovery.py
 wallet_pq_create_tx.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `43` |
-| `pq_backlog` | `82` |
+| `pq_required` | `44` |
+| `pq_backlog` | `81` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -77,15 +77,16 @@ Current required PQ-first gates:
 32. `wallet_miniscript.py`
 33. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
 34. `wallet_multisig_descriptor_psbt.py`
-35. `wallet_reindex.py`
-36. `wallet_reorgsrestore.py`
-37. `wallet_rescan_unconfirmed.py`
-38. `wallet_resendwallettransactions.py`
-39. `wallet_send.py`
-40. `wallet_sendall.py`
-41. `wallet_sendmany.py`
-42. `wallet_startup.py`
-43. `wallet_transactiontime_rescan.py`
+35. `wallet_multiwallet.py`
+36. `wallet_reindex.py`
+37. `wallet_reorgsrestore.py`
+38. `wallet_rescan_unconfirmed.py`
+39. `wallet_resendwallettransactions.py`
+40. `wallet_send.py`
+41. `wallet_sendall.py`
+42. `wallet_sendmany.py`
+43. `wallet_startup.py`
+44. `wallet_transactiontime_rescan.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -161,6 +162,11 @@ invalid option combinations, disabled-private-key and blank-wallet creation,
 descriptor import behavior, encryption, empty-passphrase warnings,
 `avoid_reuse`, legacy-wallet rejection, and wallet version logging under the
 current PQC profile.
+The inherited multiwallet lifecycle confidence gap is now also part of the
+required gate: `wallet_multiwallet.py` covers wallet directory scanning, wallet
+path validation and symlink rejection, dynamic load/unload and creation,
+per-wallet balance and fee isolation, concurrent load rejection, multiwallet
+backup/restore, and exclusive database locking under the current PQC profile.
 The inherited wallet startup confidence gap is now also part of the required
 gate: `wallet_startup.py` covers default wallet auto-load, persisted
 `load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -45,10 +45,11 @@ same gate, keep `wallet_backup.py` backup/restore behavior in the same gate,
 keep `wallet_startup.py` load-on-startup behavior in the same gate, then
 keep `wallet_blank.py` blank descriptor-wallet behavior and
 `wallet_createwallet.py` wallet creation behavior in the same gate, then
+keep `wallet_multiwallet.py` multiwallet lifecycle behavior in the same gate,
+then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with adjacent inherited multiwallet
-lifecycle coverage beyond the current creation/blank gates as the local
-alternate.
+when real prior PQBTC release assets exist, with broader inherited wallet
+lifecycle breadth beyond the current multiwallet gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -72,19 +73,17 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. `wallet_multiwallet.py`
+2. broader inherited wallet lifecycle breadth beyond `wallet_multiwallet.py`
    - Why alternate: if the asset-dependent coinstats compatibility path stays
-     blocked locally, this is the next wallet-facing lifecycle surface to
-     reopen without re-litigating the now-owned descriptor, miniscript,
-     address/RPC, raw funding, inherited send-path, rebroadcast, reindex,
-     fast-rescan, unconfirmed-rescan, reorg-restore,
-     transaction-time-rescan, backup, startup, blank-wallet, and createwallet
-     tranches.
+     blocked locally, this is the next wallet-facing surface to rebalance
+     without re-litigating the now-owned descriptor, miniscript, address/RPC,
+     raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
+     unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
+     startup, blank-wallet, createwallet, and multiwallet tranches.
 
 Still deferred:
 
-3. broader inherited wallet lifecycle breadth beyond `wallet_multiwallet.py`
-4. TapMiniscript activation or replacement semantics
+3. TapMiniscript activation or replacement semantics
 
 ## Current Queue
 
@@ -655,8 +654,8 @@ Still deferred:
    - `build/test/functional/test_runner.py --jobs=1 wallet_startup.py`
    Still deferred inside this suite:
    - broader wallet creation, blank-wallet, and multiwallet semantics now
-     covered by adjacent required gates or tracked as the next lifecycle
-     follow-on
+     covered by adjacent required gates or tracked as broader lifecycle
+     follow-ons
 36. `wallet_blank.py` now owns:
    - restored inherited blank descriptor-wallet behavior under the current
      legacy-compatible PQC profile
@@ -666,7 +665,7 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_blank.py`
    Still deferred inside this suite:
-   - broader wallet creation arguments and multiwallet lifecycle semantics
+   - broader wallet creation arguments and lifecycle semantics
 37. `wallet_createwallet.py` now owns:
    - restored inherited `createwallet` argument and lifecycle behavior under
      the current legacy-compatible PQC profile
@@ -677,15 +676,29 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_createwallet.py`
    Still deferred inside this suite:
-   - broader multiwallet path, load/unload, backup, and locking behavior
-38. Recommended next PR after this tranche:
+   - broader lifecycle breadth beyond the adjacent multiwallet gate
+38. `wallet_multiwallet.py` now owns:
+   - restored inherited multiwallet lifecycle behavior under the current
+     legacy-compatible PQC profile
+   - wallet directory scanning and wallet-file creation
+   - wallet path validation, invalid walletdir startup failures, duplicate
+     wallet arguments, and symlinked wallet path rejection
+   - dynamic wallet loading, creation, unloading, and concurrent load rejection
+   - per-wallet balance, endpoint selection, and `settxfee` isolation
+   - multiwallet backup/restore round trips and exclusive database locking
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_multiwallet.py`
+   Still deferred inside this suite:
+   - broader wallet lifecycle breadth outside the multiwallet contract
+39. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `wallet_multiwallet.py`
+   - alternate: broader inherited wallet lifecycle breadth beyond
+     `wallet_multiwallet.py`
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - `wallet_multiwallet.py` is the next adjacent wallet lifecycle surface once
-     the current startup, blank-wallet, and createwallet gates are frozen, but
+   - broader wallet lifecycle work remains useful once the current startup,
+     blank-wallet, createwallet, and multiwallet gates are frozen, but
      additional wallet work stays behind the asset-dependent compatibility slice
      once prior PQBTC release assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
@@ -1254,6 +1267,18 @@ Aineko must ask before:
   version logging. The next owned follow-on remains
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist, with `wallet_multiwallet.py` as the local alternate.
+- 2026-04-26: `wallet_multiwallet.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited multiwallet lifecycle
+  behavior under the current legacy-compatible PQC profile: wallet directory
+  scanning, wallet-file creation, path validation, invalid walletdir startup
+  failures, duplicate wallet arguments, symlinked wallet path rejection,
+  dynamic wallet loading/creation/unloading, concurrent load rejection,
+  per-wallet balance and fee isolation, multiwallet backup/restore round
+  trips, and exclusive database locking. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with broader inherited wallet lifecycle breadth beyond this
+  multiwallet gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1330,5 +1355,8 @@ Aineko must ask before:
 - There is no current blocker in the restored inherited blank-wallet and
   createwallet surfaces: `wallet_blank.py` and `wallet_createwallet.py` pass
   targeted validation in the current tree.
+- There is no current blocker in the restored inherited multiwallet lifecycle
+  surface: `wallet_multiwallet.py` passes targeted validation in the current
+  tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_BLANK_POSTURE.md
+++ b/docs/WALLET_BLANK_POSTURE.md
@@ -52,5 +52,7 @@ The canonical PQ gate now includes the inherited blank descriptor-wallet
 lifecycle contract that already passes under the current PQC-compatible legacy
 profile. The preferred Track A follow-on remains
 `feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist locally. Until then, the repo-local wallet alternate moves to
+exist locally. The subsequent multiwallet promotion covers the adjacent
+multiwallet lifecycle surface. Until compatibility assets exist, the repo-local
+wallet alternate is broader inherited wallet lifecycle breadth beyond
 `wallet_multiwallet.py`.

--- a/docs/WALLET_CREATEWALLET_POSTURE.md
+++ b/docs/WALLET_CREATEWALLET_POSTURE.md
@@ -57,5 +57,7 @@ Targeted confidence on 2026-04-26:
 The canonical PQ gate now includes the inherited `createwallet` lifecycle
 contract that already passes under the current PQC-compatible legacy profile.
 The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist locally. Until then, the repo-local
-wallet alternate moves to `wallet_multiwallet.py`.
+when real prior PQBTC release assets exist locally. The subsequent multiwallet
+promotion covers the adjacent multiwallet lifecycle surface. Until
+compatibility assets exist, the repo-local wallet alternate is broader
+inherited wallet lifecycle breadth beyond `wallet_multiwallet.py`.

--- a/docs/WALLET_MULTIWALLET_POSTURE.md
+++ b/docs/WALLET_MULTIWALLET_POSTURE.md
@@ -1,0 +1,63 @@
+# PQBTC `wallet_multiwallet.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-MULTIWALLET-POSTURE-v1
+## Updated: 2026-04-26
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited
+[wallet_multiwallet.py](../test/functional/wallet_multiwallet.py) multiwallet
+lifecycle contract under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+`wallet_multiwallet.py` is now a required PQ gate for restored inherited
+multiwallet lifecycle behavior. The owned boundary covers:
+
+- wallet directory scanning and listwalletdir warnings
+- wallet file creation under the default wallet directory
+- wallet path validation, duplicate wallet arguments, and invalid walletdir
+  startup failures
+- symlinked wallet path rejection
+- external wallet path creation and loading
+- dynamic wallet loading, creation, and unloading
+- concurrent load/unload rejection for a wallet that is already loading
+- per-wallet balance, endpoint selection, and `settxfee` isolation
+- multiple-wallet RPC endpoint error behavior
+- multiwallet backup and restore round trips
+- exclusive database locking across two nodes
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet migration or backwards-compatibility release-asset behavior
+- broader wallet lifecycle breadth outside the multiwallet contract
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-26:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_multiwallet.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=44`, `pq_backlog=81`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited multiwallet lifecycle contract
+that already passes under the current PQC-compatible legacy profile. The
+preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to broader inherited wallet lifecycle breadth beyond
+this multiwallet gate.

--- a/docs/WALLET_STARTUP_POSTURE.md
+++ b/docs/WALLET_STARTUP_POSTURE.md
@@ -54,5 +54,7 @@ load-on-startup contract that already passes under the current PQC-compatible
 legacy profile. The preferred Track A follow-on remains
 `feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
 exist locally. The subsequent creation/blank promotion covers the adjacent
-creation surfaces; until compatibility assets exist, the repo-local wallet
-alternate is now `wallet_multiwallet.py`.
+creation surfaces, and the subsequent multiwallet promotion covers the adjacent
+multiwallet lifecycle surface. Until compatibility assets exist, the repo-local
+wallet alternate is broader inherited wallet lifecycle breadth beyond
+`wallet_multiwallet.py`.


### PR DESCRIPTION
Summary:
- Promote wallet_multiwallet.py from pq_backlog to pq_required.
- Add the suite to the PQ functional gate in inventory order and update counts to pq_required=44, pq_backlog=81, dual_profile=142, legacy_only=9.
- Add a multiwallet posture doc and update Track A handoff so feature_coinstatsindex_compatibility.py remains preferred when release assets exist, with broader wallet lifecycle breadth as the local alternate.

Tests:
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 wallet_multiwallet.py