### PR TITLE
ci: promote wallet key management gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1579,24 +1579,24 @@
   },
   {
     "name": "wallet_descriptor.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited descriptor-wallet maintenance boundary under the legacy-compatible PQC profile: descriptor wallet info, receive/change address derivation, send/receive behavior, encryption and unlock derivation, born-encrypted wallets, blank/disabled-private-key descriptor wallets, descriptor exports/imports, and legacy-key-type load rejection."
   },
   {
     "name": "wallet_disable.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the no-wallet runtime boundary under the legacy-compatible PQC profile: -disablewallet hides wallet RPCs while non-wallet address validation remains available."
   },
   {
     "name": "wallet_encryption.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited wallet encryption boundary under the legacy-compatible PQC profile: encryptwallet behavior, passphrase timeout limits, signing lock/unlock behavior, walletpassphrasechange, and no-private-key wallet encryption rejection."
   },
   {
     "name": "wallet_fallbackfee.py",
@@ -1621,10 +1621,10 @@
   },
   {
     "name": "wallet_gethdkeys.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited gethdkeys boundary under the legacy-compatible PQC profile: HD public/private key listing, encrypted-wallet access controls, imported ranged descriptor keys, non-HD exclusion, and multisig HD-key reporting."
   },
   {
     "name": "wallet_groups.py",
@@ -1635,10 +1635,10 @@
   },
   {
     "name": "wallet_hd.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited HD wallet backup/restore boundary under the legacy-compatible PQC profile: deterministic HD seed behavior, backup restore, keypool refill, and receive/change address recovery."
   },
   {
     "name": "wallet_importdescriptors.py",
@@ -1656,17 +1656,17 @@
   },
   {
     "name": "wallet_keypool.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited keypool and encryption interaction boundary under the legacy-compatible PQC profile: keypool exhaustion/refill, locked/encrypted wallet behavior, change-key use, address reuse constraints, and wallet unlock/keypool refill controls."
   },
   {
     "name": "wallet_keypool_topup.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited keypool backup top-up boundary under the legacy-compatible PQC profile: wallet backup, address generation across output types, restore from backup, keypool top-up, rescan, and restored balance detection."
   },
   {
     "name": "wallet_labels.py",
@@ -1677,10 +1677,10 @@
   },
   {
     "name": "wallet_listdescriptors.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited listdescriptors boundary under the legacy-compatible PQC profile: empty/default descriptor listings, sorted descriptor output, hardened derivation export, private descriptor visibility, encrypted/watch-only wallet behavior, and non-active combo descriptors."
   },
   {
     "name": "wallet_listreceivedby.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -18,8 +18,16 @@ wallet_assumeutxo.py
 wallet_backup.py
 wallet_blank.py
 wallet_createwallet.py
+wallet_descriptor.py
+wallet_disable.py
+wallet_encryption.py
 wallet_fast_rescan.py
 wallet_fundrawtransaction.py
+wallet_gethdkeys.py
+wallet_hd.py
+wallet_keypool.py
+wallet_keypool_topup.py
+wallet_listdescriptors.py
 wallet_miniscript.py
 wallet_miniscript_decaying_multisig_descriptor_psbt.py
 wallet_multisig_descriptor_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `44` |
-| `pq_backlog` | `81` |
+| `pq_required` | `52` |
+| `pq_backlog` | `73` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -72,21 +72,29 @@ Current required PQ-first gates:
 27. `wallet_backup.py`
 28. `wallet_blank.py`
 29. `wallet_createwallet.py`
-30. `wallet_fast_rescan.py`
-31. `wallet_fundrawtransaction.py`
-32. `wallet_miniscript.py`
-33. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-34. `wallet_multisig_descriptor_psbt.py`
-35. `wallet_multiwallet.py`
-36. `wallet_reindex.py`
-37. `wallet_reorgsrestore.py`
-38. `wallet_rescan_unconfirmed.py`
-39. `wallet_resendwallettransactions.py`
-40. `wallet_send.py`
-41. `wallet_sendall.py`
-42. `wallet_sendmany.py`
-43. `wallet_startup.py`
-44. `wallet_transactiontime_rescan.py`
+30. `wallet_descriptor.py`
+31. `wallet_disable.py`
+32. `wallet_encryption.py`
+33. `wallet_fast_rescan.py`
+34. `wallet_fundrawtransaction.py`
+35. `wallet_gethdkeys.py`
+36. `wallet_hd.py`
+37. `wallet_keypool.py`
+38. `wallet_keypool_topup.py`
+39. `wallet_listdescriptors.py`
+40. `wallet_miniscript.py`
+41. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+42. `wallet_multisig_descriptor_psbt.py`
+43. `wallet_multiwallet.py`
+44. `wallet_reindex.py`
+45. `wallet_reorgsrestore.py`
+46. `wallet_rescan_unconfirmed.py`
+47. `wallet_resendwallettransactions.py`
+48. `wallet_send.py`
+49. `wallet_sendall.py`
+50. `wallet_sendmany.py`
+51. `wallet_startup.py`
+52. `wallet_transactiontime_rescan.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -167,6 +175,14 @@ required gate: `wallet_multiwallet.py` covers wallet directory scanning, wallet
 path validation and symlink rejection, dynamic load/unload and creation,
 per-wallet balance and fee isolation, concurrent load rejection, multiwallet
 backup/restore, and exclusive database locking under the current PQC profile.
+The inherited wallet key-management and descriptor-maintenance confidence gap
+is now also part of the required gate: `wallet_descriptor.py`,
+`wallet_disable.py`, `wallet_encryption.py`, `wallet_gethdkeys.py`,
+`wallet_hd.py`, `wallet_keypool.py`, `wallet_keypool_topup.py`, and
+`wallet_listdescriptors.py` cover descriptor wallet maintenance, no-wallet
+runtime behavior, wallet encryption, HD key reporting, HD backup/restore,
+keypool refill/exhaustion, restored keypool top-up, and descriptor listing
+under the current PQC profile.
 The inherited wallet startup confidence gap is now also part of the required
 gate: `wallet_startup.py` covers default wallet auto-load, persisted
 `load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-26
+## Updated: 2026-04-27
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -47,9 +47,14 @@ keep `wallet_blank.py` blank descriptor-wallet behavior and
 `wallet_createwallet.py` wallet creation behavior in the same gate, then
 keep `wallet_multiwallet.py` multiwallet lifecycle behavior in the same gate,
 then
+keep the `wallet_descriptor.py`, `wallet_disable.py`, `wallet_encryption.py`,
+`wallet_gethdkeys.py`, `wallet_hd.py`, `wallet_keypool.py`,
+`wallet_keypool_topup.py`, and `wallet_listdescriptors.py`
+key-management and descriptor-maintenance behavior in the same gate, then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with broader inherited wallet
-lifecycle breadth beyond the current multiwallet gate as the local alternate.
+when real prior PQBTC release assets exist, with wallet accounting, labels, and
+transaction-listing surfaces beyond the current key-management gate as the
+local alternate.
 
 ## Current Working Thesis
 
@@ -73,13 +78,15 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. broader inherited wallet lifecycle breadth beyond `wallet_multiwallet.py`
+2. wallet accounting, labels, and transaction-listing surfaces beyond the
+   current key-management gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to rebalance
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
-     startup, blank-wallet, createwallet, and multiwallet tranches.
+     startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
+     HD, keypool, and descriptor-listing tranches.
 
 Still deferred:
 
@@ -689,18 +696,43 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_multiwallet.py`
    Still deferred inside this suite:
-   - broader wallet lifecycle breadth outside the multiwallet contract
-39. Recommended next PR after this tranche:
+   - broader wallet lifecycle breadth outside the multiwallet contract now
+     covered by adjacent key-management gates or tracked as accounting/list
+     follow-ons
+39. `wallet_descriptor.py`, `wallet_disable.py`, `wallet_encryption.py`,
+   `wallet_gethdkeys.py`, `wallet_hd.py`, `wallet_keypool.py`,
+   `wallet_keypool_topup.py`, and `wallet_listdescriptors.py` now own:
+   - restored inherited key-management, descriptor-maintenance, and no-wallet
+     runtime behavior under the current legacy-compatible PQC profile
+   - descriptor wallet info, receive/change derivation, send/receive behavior,
+     exports/imports, and legacy-key-type load rejection
+   - `-disablewallet` wallet RPC hiding with non-wallet address validation
+   - wallet encryption, passphrase timeout limits, signing lock/unlock,
+     passphrase changes, and no-private-key wallet encryption rejection
+   - `gethdkeys` reporting for public/private, encrypted, imported ranged,
+     non-HD, and multisig HD-key cases
+   - HD backup/restore, keypool refill, receive/change recovery, keypool
+     exhaustion/refill, locked/encrypted wallet behavior, and restored keypool
+     top-up balance detection
+   - descriptor listing for empty/default wallets, sorted output, hardened
+     derivations, private visibility, encrypted/watch-only wallets, and
+     non-active combo descriptors
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_descriptor.py wallet_disable.py wallet_encryption.py wallet_gethdkeys.py wallet_hd.py wallet_keypool.py wallet_keypool_topup.py wallet_listdescriptors.py`
+   Still deferred inside this suite:
+   - wallet accounting, label, transaction-listing, and conflict semantics
+40. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: broader inherited wallet lifecycle breadth beyond
-     `wallet_multiwallet.py`
+   - alternate: wallet accounting, labels, and transaction-listing surfaces
+     beyond this key-management gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - broader wallet lifecycle work remains useful once the current startup,
-     blank-wallet, createwallet, and multiwallet gates are frozen, but
-     additional wallet work stays behind the asset-dependent compatibility slice
-     once prior PQBTC release assets are available
+   - wallet accounting/listing work remains useful once the current startup,
+     blank-wallet, createwallet, multiwallet, descriptor, encryption, HD,
+     keypool, and descriptor-listing gates are frozen, but additional wallet
+     work stays behind the asset-dependent compatibility slice once prior PQBTC
+     release assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -1279,6 +1311,18 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist, with broader inherited wallet lifecycle breadth beyond this
   multiwallet gate as the local alternate.
+- 2026-04-27: `wallet_descriptor.py`, `wallet_disable.py`,
+  `wallet_encryption.py`, `wallet_gethdkeys.py`, `wallet_hd.py`,
+  `wallet_keypool.py`, `wallet_keypool_topup.py`, and
+  `wallet_listdescriptors.py` are now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited descriptor-wallet
+  maintenance, no-wallet runtime behavior, wallet encryption, HD key reporting,
+  HD backup/restore, keypool exhaustion/refill and restored top-up behavior,
+  and descriptor listing under the current legacy-compatible PQC profile. The
+  next owned follow-on remains `feature_coinstatsindex_compatibility.py` when
+  real prior PQBTC release assets exist, with wallet accounting, labels, and
+  transaction-listing surfaces as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1358,5 +1402,10 @@ Aineko must ask before:
 - There is no current blocker in the restored inherited multiwallet lifecycle
   surface: `wallet_multiwallet.py` passes targeted validation in the current
   tree.
+- There is no current blocker in the restored inherited wallet
+  key-management and descriptor-maintenance surfaces: `wallet_descriptor.py`,
+  `wallet_disable.py`, `wallet_encryption.py`, `wallet_gethdkeys.py`,
+  `wallet_hd.py`, `wallet_keypool.py`, `wallet_keypool_topup.py`, and
+  `wallet_listdescriptors.py` pass targeted validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_KEYMANAGEMENT_POSTURE.md
+++ b/docs/WALLET_KEYMANAGEMENT_POSTURE.md
@@ -1,0 +1,78 @@
+# PQBTC Wallet Key-Management Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-KEYMANAGEMENT-POSTURE-v1
+## Updated: 2026-04-27
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited wallet key-management, descriptor-maintenance, and
+no-wallet runtime contracts under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+The following suites are now required PQ gates:
+
+- [wallet_descriptor.py](../test/functional/wallet_descriptor.py)
+- [wallet_disable.py](../test/functional/wallet_disable.py)
+- [wallet_encryption.py](../test/functional/wallet_encryption.py)
+- [wallet_gethdkeys.py](../test/functional/wallet_gethdkeys.py)
+- [wallet_hd.py](../test/functional/wallet_hd.py)
+- [wallet_keypool.py](../test/functional/wallet_keypool.py)
+- [wallet_keypool_topup.py](../test/functional/wallet_keypool_topup.py)
+- [wallet_listdescriptors.py](../test/functional/wallet_listdescriptors.py)
+
+The owned boundary covers:
+
+- descriptor wallet info, receive/change derivation, send/receive behavior,
+  descriptor exports/imports, and legacy-key-type load rejection
+- `-disablewallet` behavior that hides wallet RPCs while keeping non-wallet
+  address validation available
+- wallet encryption, passphrase timeout limits, signing lock/unlock behavior,
+  passphrase changes, and no-private-key wallet encryption rejection
+- `gethdkeys` public/private key listing, encrypted-wallet access controls,
+  imported ranged descriptor keys, non-HD exclusion, and multisig HD-key
+  reporting
+- HD seed backup/restore, keypool refill, and receive/change recovery
+- keypool exhaustion/refill, locked/encrypted wallet behavior, change-key use,
+  address reuse constraints, and unlock/refill controls
+- wallet backup, address generation across output types, restore from backup,
+  keypool top-up, rescan, and restored balance detection
+- empty/default descriptor listing, sorted descriptor output, hardened
+  derivation export, private descriptor visibility, encrypted/watch-only wallet
+  behavior, and non-active combo descriptors
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet migration or backwards-compatibility release-asset behavior
+- broad wallet accounting, label, transaction-listing, or conflict semantics
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-27:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_descriptor.py wallet_disable.py wallet_encryption.py wallet_gethdkeys.py wallet_hd.py wallet_keypool.py wallet_keypool_topup.py wallet_listdescriptors.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=52`, `pq_backlog=73`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited descriptor wallet,
+no-wallet runtime, encryption, HD key, keypool, and descriptor listing
+contracts that already pass under the current PQC-compatible legacy profile.
+The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to wallet accounting, labels, and transaction-listing
+surfaces beyond this key-management gate.

--- a/docs/WALLET_MULTIWALLET_POSTURE.md
+++ b/docs/WALLET_MULTIWALLET_POSTURE.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: WALLET-MULTIWALLET-POSTURE-v1
-## Updated: 2026-04-26
+## Updated: 2026-04-27
 ## Consensus-Relevant: NO
 
 ## Purpose
@@ -58,6 +58,8 @@ Targeted confidence on 2026-04-26:
 The canonical PQ gate now includes the inherited multiwallet lifecycle contract
 that already passes under the current PQC-compatible legacy profile. The
 preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist locally. Until then, the repo-local
-wallet alternate moves to broader inherited wallet lifecycle breadth beyond
-this multiwallet gate.
+when real prior PQBTC release assets exist locally. The subsequent
+key-management promotion covers the adjacent descriptor, encryption, HD,
+keypool, and descriptor-listing surfaces. Until compatibility assets exist, the
+repo-local wallet alternate is wallet accounting, labels, and
+transaction-listing surfaces beyond that key-management gate.


### PR DESCRIPTION
Summary:
- Promote wallet_descriptor.py, wallet_disable.py, wallet_encryption.py, wallet_gethdkeys.py, wallet_hd.py, wallet_keypool.py, wallet_keypool_topup.py, and wallet_listdescriptors.py from pq_backlog to pq_required.
- Add the suites to the PQ functional gate in inventory order and update counts to pq_required=52, pq_backlog=73, dual_profile=142, legacy_only=9.
- Add a wallet key-management posture doc and update Track A handoff so feature_coinstatsindex_compatibility.py remains preferred when release assets exist, with wallet accounting/labels/transaction-listing as the local alternate.

Tests:
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 wallet_descriptor.py wallet_disable.py wallet_encryption.py wallet_gethdkeys.py wallet_hd.py wallet_keypool.py wallet_keypool_topup.py wallet_listdescriptors.py