### PR TITLE
ci: promote wallet accounting listing gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1501,10 +1501,10 @@
   },
   {
     "name": "wallet_balance.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited wallet balance accounting boundary under the legacy-compatible PQC profile: mined and immature balances, getbalance argument handling, unconfirmed and conflicted balances, non-mempool transaction trust, replacement/reorg balance behavior, lastprocessedblock reporting, and import-triggered balance updates."
   },
   {
     "name": "wallet_basic.py",
@@ -1536,10 +1536,10 @@
   },
   {
     "name": "wallet_coinbase_category.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited coinbase transaction category boundary under the legacy-compatible PQC profile: immature, generated, orphaned, and mature coinbase category reporting across mining and invalidation."
   },
   {
     "name": "wallet_conflicts.py",
@@ -1670,10 +1670,10 @@
   },
   {
     "name": "wallet_labels.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited wallet label RPC boundary under the legacy-compatible PQC profile: listlabels parameter validation, setlabel/getaddressesbylabel/listlabels/listaddressgroupings behavior, label persistence across sends, and watch-only label handling."
   },
   {
     "name": "wallet_listdescriptors.py",
@@ -1684,24 +1684,24 @@
   },
   {
     "name": "wallet_listreceivedby.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited received-by RPC boundary under the legacy-compatible PQC profile: listreceivedbyaddress/listreceivedbylabel/getreceivedbyaddress/getreceivedbylabel behavior, label filtering, immature coinbase inclusion, matured rewards, and invalidated-block exclusion."
   },
   {
     "name": "wallet_listsinceblock.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited listsinceblock boundary under the legacy-compatible PQC profile: no-blockhash and invalid-blockhash handling, target confirmations, reorg and disk-read-error behavior, double-spend/double-send reporting, spend filtering, descriptor lookup, change inclusion, OP_RETURN handling, and label filtering."
   },
   {
     "name": "wallet_listtransactions.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited listtransactions/gettransaction boundary under the legacy-compatible PQC profile: simple sends, confirmation updates, send-to-self and sendmany accounting, BIP125 replaceability reporting, external-address receives, labels, coin-join-style transactions, parameter validation, OP_RETURN output reporting, and from-me status changes."
   },
   {
     "name": "wallet_migration.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -16,7 +16,9 @@ rpc_psbt.py
 wallet_address_types.py
 wallet_assumeutxo.py
 wallet_backup.py
+wallet_balance.py
 wallet_blank.py
+wallet_coinbase_category.py
 wallet_createwallet.py
 wallet_descriptor.py
 wallet_disable.py
@@ -27,7 +29,11 @@ wallet_gethdkeys.py
 wallet_hd.py
 wallet_keypool.py
 wallet_keypool_topup.py
+wallet_labels.py
 wallet_listdescriptors.py
+wallet_listreceivedby.py
+wallet_listsinceblock.py
+wallet_listtransactions.py
 wallet_miniscript.py
 wallet_miniscript_decaying_multisig_descriptor_psbt.py
 wallet_multisig_descriptor_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `52` |
-| `pq_backlog` | `73` |
+| `pq_required` | `58` |
+| `pq_backlog` | `67` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -70,31 +70,37 @@ Current required PQ-first gates:
 25. `wallet_address_types.py`
 26. `wallet_assumeutxo.py`
 27. `wallet_backup.py`
-28. `wallet_blank.py`
-29. `wallet_createwallet.py`
-30. `wallet_descriptor.py`
-31. `wallet_disable.py`
-32. `wallet_encryption.py`
-33. `wallet_fast_rescan.py`
-34. `wallet_fundrawtransaction.py`
-35. `wallet_gethdkeys.py`
-36. `wallet_hd.py`
-37. `wallet_keypool.py`
-38. `wallet_keypool_topup.py`
-39. `wallet_listdescriptors.py`
-40. `wallet_miniscript.py`
-41. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-42. `wallet_multisig_descriptor_psbt.py`
-43. `wallet_multiwallet.py`
-44. `wallet_reindex.py`
-45. `wallet_reorgsrestore.py`
-46. `wallet_rescan_unconfirmed.py`
-47. `wallet_resendwallettransactions.py`
-48. `wallet_send.py`
-49. `wallet_sendall.py`
-50. `wallet_sendmany.py`
-51. `wallet_startup.py`
-52. `wallet_transactiontime_rescan.py`
+28. `wallet_balance.py`
+29. `wallet_blank.py`
+30. `wallet_coinbase_category.py`
+31. `wallet_createwallet.py`
+32. `wallet_descriptor.py`
+33. `wallet_disable.py`
+34. `wallet_encryption.py`
+35. `wallet_fast_rescan.py`
+36. `wallet_fundrawtransaction.py`
+37. `wallet_gethdkeys.py`
+38. `wallet_hd.py`
+39. `wallet_keypool.py`
+40. `wallet_keypool_topup.py`
+41. `wallet_labels.py`
+42. `wallet_listdescriptors.py`
+43. `wallet_listreceivedby.py`
+44. `wallet_listsinceblock.py`
+45. `wallet_listtransactions.py`
+46. `wallet_miniscript.py`
+47. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+48. `wallet_multisig_descriptor_psbt.py`
+49. `wallet_multiwallet.py`
+50. `wallet_reindex.py`
+51. `wallet_reorgsrestore.py`
+52. `wallet_rescan_unconfirmed.py`
+53. `wallet_resendwallettransactions.py`
+54. `wallet_send.py`
+55. `wallet_sendall.py`
+56. `wallet_sendmany.py`
+57. `wallet_startup.py`
+58. `wallet_transactiontime_rescan.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -183,6 +189,13 @@ is now also part of the required gate: `wallet_descriptor.py`,
 runtime behavior, wallet encryption, HD key reporting, HD backup/restore,
 keypool refill/exhaustion, restored keypool top-up, and descriptor listing
 under the current PQC profile.
+The inherited wallet accounting, labels, and transaction-listing confidence
+gap is now also part of the required gate: `wallet_balance.py`,
+`wallet_coinbase_category.py`, `wallet_labels.py`, `wallet_listreceivedby.py`,
+`wallet_listsinceblock.py`, and `wallet_listtransactions.py` cover balance
+accounting, coinbase category reporting, label RPCs, received-by accounting,
+since-block listing, and transaction listing/gettransaction behavior under the
+current PQC profile.
 The inherited wallet startup confidence gap is now also part of the required
 gate: `wallet_startup.py` covers default wallet auto-load, persisted
 `load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -51,10 +51,14 @@ keep the `wallet_descriptor.py`, `wallet_disable.py`, `wallet_encryption.py`,
 `wallet_gethdkeys.py`, `wallet_hd.py`, `wallet_keypool.py`,
 `wallet_keypool_topup.py`, and `wallet_listdescriptors.py`
 key-management and descriptor-maintenance behavior in the same gate, then
+keep `wallet_balance.py`, `wallet_coinbase_category.py`, `wallet_labels.py`,
+`wallet_listreceivedby.py`, `wallet_listsinceblock.py`, and
+`wallet_listtransactions.py` accounting, label, and transaction-listing
+behavior in the same gate, then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with wallet accounting, labels, and
-transaction-listing surfaces beyond the current key-management gate as the
-local alternate.
+when real prior PQBTC release assets exist, with coin-selection grouping and
+adjacent spend-policy surfaces beyond the current accounting/listing gate as
+the local alternate.
 
 ## Current Working Thesis
 
@@ -78,15 +82,16 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. wallet accounting, labels, and transaction-listing surfaces beyond the
-   current key-management gate
+2. coin-selection grouping and adjacent spend-policy surfaces beyond the
+   current accounting/listing gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to rebalance
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
-     HD, keypool, and descriptor-listing tranches.
+     HD, keypool, descriptor-listing, accounting, label, and transaction-listing
+     tranches.
 
 Still deferred:
 
@@ -720,19 +725,45 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_descriptor.py wallet_disable.py wallet_encryption.py wallet_gethdkeys.py wallet_hd.py wallet_keypool.py wallet_keypool_topup.py wallet_listdescriptors.py`
    Still deferred inside this suite:
-   - wallet accounting, label, transaction-listing, and conflict semantics
-40. Recommended next PR after this tranche:
+   - wallet accounting, label, and transaction-listing semantics now covered
+     by adjacent required gates; conflict semantics remain separate
+40. `wallet_balance.py`, `wallet_coinbase_category.py`, `wallet_labels.py`,
+   `wallet_listreceivedby.py`, `wallet_listsinceblock.py`, and
+   `wallet_listtransactions.py` now own:
+   - restored inherited wallet accounting, label, received-by, since-block,
+     and transaction-listing behavior under the current legacy-compatible PQC
+     profile
+   - mined, immature, trusted, untrusted, conflicted, and imported-output
+     balance accounting
+   - `getbalance`, `getbalances`, `getwalletinfo`, and `gettransaction`
+     last-processed-block reporting
+   - immature, generated, orphaned, and mature coinbase category reporting
+   - label RPC validation, assignment, grouping, send persistence, and
+     watch-only label handling
+   - received-by address/label accounting, immature coinbase inclusion,
+     matured rewards, and invalidated-block exclusion
+   - `listsinceblock` and `listtransactions` behavior for reorgs,
+     double-spends, double-sends, spend filtering, descriptor lookup, change
+     inclusion, OP_RETURN output, labels, BIP125 replaceability, parameter
+     validation, and from-me status changes
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_balance.py wallet_coinbase_category.py wallet_labels.py wallet_listreceivedby.py wallet_listsinceblock.py wallet_listtransactions.py`
+   Still deferred inside this suite:
+   - coin-selection grouping, bumpfee, abandoned-conflict, and broader conflict
+     semantics
+41. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: wallet accounting, labels, and transaction-listing surfaces
-     beyond this key-management gate
+   - alternate: coin-selection grouping and adjacent spend-policy surfaces
+     beyond this accounting/listing gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - wallet accounting/listing work remains useful once the current startup,
-     blank-wallet, createwallet, multiwallet, descriptor, encryption, HD,
-     keypool, and descriptor-listing gates are frozen, but additional wallet
-     work stays behind the asset-dependent compatibility slice once prior PQBTC
-     release assets are available
+   - coin-selection grouping and spend-policy work remains useful once the
+     current startup, blank-wallet, createwallet, multiwallet, descriptor,
+     encryption, HD, keypool, descriptor-listing, accounting, label, and
+     transaction-listing gates are frozen, but additional wallet work stays
+     behind the asset-dependent compatibility slice once prior PQBTC release
+     assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -1323,6 +1354,17 @@ Aineko must ask before:
   next owned follow-on remains `feature_coinstatsindex_compatibility.py` when
   real prior PQBTC release assets exist, with wallet accounting, labels, and
   transaction-listing surfaces as the local alternate.
+- 2026-04-27: `wallet_balance.py`, `wallet_coinbase_category.py`,
+  `wallet_labels.py`, `wallet_listreceivedby.py`, `wallet_listsinceblock.py`,
+  and `wallet_listtransactions.py` are now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited balance accounting,
+  coinbase category reporting, label RPCs, received-by accounting,
+  since-block listing, and transaction-listing/gettransaction behavior under
+  the current legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with coin-selection grouping and adjacent spend-policy surfaces
+  as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1407,5 +1449,10 @@ Aineko must ask before:
   `wallet_disable.py`, `wallet_encryption.py`, `wallet_gethdkeys.py`,
   `wallet_hd.py`, `wallet_keypool.py`, `wallet_keypool_topup.py`, and
   `wallet_listdescriptors.py` pass targeted validation in the current tree.
+- There is no current blocker in the restored inherited wallet accounting,
+  label, and transaction-listing surfaces: `wallet_balance.py`,
+  `wallet_coinbase_category.py`, `wallet_labels.py`,
+  `wallet_listreceivedby.py`, `wallet_listsinceblock.py`, and
+  `wallet_listtransactions.py` pass targeted validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_ACCOUNTING_LISTING_POSTURE.md
+++ b/docs/WALLET_ACCOUNTING_LISTING_POSTURE.md
@@ -1,0 +1,79 @@
+# PQBTC Wallet Accounting And Listing Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-ACCOUNTING-LISTING-POSTURE-v1
+## Updated: 2026-04-27
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited wallet accounting, label, received-by, since-block, and
+transaction-listing contracts under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+The following suites are now required PQ gates:
+
+- [wallet_balance.py](../test/functional/wallet_balance.py)
+- [wallet_coinbase_category.py](../test/functional/wallet_coinbase_category.py)
+- [wallet_labels.py](../test/functional/wallet_labels.py)
+- [wallet_listreceivedby.py](../test/functional/wallet_listreceivedby.py)
+- [wallet_listsinceblock.py](../test/functional/wallet_listsinceblock.py)
+- [wallet_listtransactions.py](../test/functional/wallet_listtransactions.py)
+
+The owned boundary covers:
+
+- mined, immature, trusted, untrusted, conflicted, and imported-output balance
+  accounting
+- `getbalance`, `getbalances`, `getwalletinfo`, and `gettransaction`
+  last-processed-block reporting
+- coinbase transaction category reporting across immature, generated,
+  orphaned, and mature states
+- label RPC validation, label assignment, address grouping, send persistence,
+  and watch-only label handling
+- `listreceivedbyaddress`, `listreceivedbylabel`, `getreceivedbyaddress`, and
+  `getreceivedbylabel` behavior for labels, immature coinbase inclusion,
+  matured rewards, and invalidated blocks
+- `listsinceblock` behavior for no block hash, invalid block hashes,
+  target confirmations, reorgs, disk-read errors, double spends, double sends,
+  spend filtering, descriptor lookup, change inclusion, OP_RETURN output, and
+  label filtering
+- `listtransactions` and `gettransaction` behavior for simple sends,
+  confirmation updates, send-to-self, `sendmany`, BIP125 replaceability,
+  external-address receives, labels, coin-join-style transactions, parameter
+  validation, OP_RETURN output, and from-me status changes
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet migration or backwards-compatibility release-asset behavior
+- coin-selection grouping, bumpfee, abandoned-conflict, or broader conflict
+  semantics outside these listing/accounting contracts
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-27:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_balance.py wallet_coinbase_category.py wallet_labels.py wallet_listreceivedby.py wallet_listsinceblock.py wallet_listtransactions.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=58`, `pq_backlog=67`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet balance, coinbase
+category, label, received-by, since-block, and transaction-listing contracts
+that already pass under the current PQC-compatible legacy profile. The
+preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to coin-selection grouping and adjacent spend-policy
+surfaces beyond this accounting/listing gate.

--- a/docs/WALLET_KEYMANAGEMENT_POSTURE.md
+++ b/docs/WALLET_KEYMANAGEMENT_POSTURE.md
@@ -73,6 +73,8 @@ The canonical PQ gate now includes the inherited descriptor wallet,
 no-wallet runtime, encryption, HD key, keypool, and descriptor listing
 contracts that already pass under the current PQC-compatible legacy profile.
 The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist locally. Until then, the repo-local
-wallet alternate moves to wallet accounting, labels, and transaction-listing
-surfaces beyond this key-management gate.
+when real prior PQBTC release assets exist locally. The subsequent accounting
+and listing promotion covers the adjacent balance, label, received-by,
+since-block, and transaction-listing surfaces. Until compatibility assets exist,
+the repo-local wallet alternate is coin-selection grouping and adjacent
+spend-policy surfaces beyond that accounting/listing gate.


### PR DESCRIPTION
Summary:
- Promote wallet_balance.py, wallet_coinbase_category.py, wallet_labels.py, wallet_listreceivedby.py, wallet_listsinceblock.py, and wallet_listtransactions.py from pq_backlog to pq_required.
- Add the suites to the PQ functional gate in inventory order and update counts to pq_required=58, pq_backlog=67, dual_profile=142, legacy_only=9.
- Add a wallet accounting/listing posture doc and update Track A handoff so feature_coinstatsindex_compatibility.py remains preferred when release assets exist, with coin-selection grouping and adjacent spend-policy as the local alternate.

Tests:
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 wallet_balance.py wallet_coinbase_category.py wallet_labels.py wallet_listreceivedby.py wallet_listsinceblock.py wallet_listtransactions.py