### PR TITLE
ci: promote wallet bumpfee conflict gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1444,10 +1444,10 @@
   },
   {
     "name": "wallet_abandonconflict.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited abandoned/conflicted transaction boundary under the legacy-compatible PQC profile: abandontransaction behavior, balance/listing visibility, abandoned transactions in listsinceblock, and double-spend conflict handling."
   },
   {
     "name": "wallet_address_types.py",
@@ -1522,10 +1522,10 @@
   },
   {
     "name": "wallet_bumpfee.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited bumpfee/psbtbumpfee boundary under the legacy-compatible PQC profile: option, fee-rate, confirmation-target, and estimate-mode validation; original_change_index and outputs handling; simple bumpfee, non-RBF replacement, non-owned inputs/PSBT, descendants and abandoned descendants, dust/change/drop-to-fee behavior, maxtxfee, watch-only PSBT, successor/re-bump behavior, spent-coin failure, metadata persistence, locked-wallet rejection, change address reuse, confirmed-output availability, replaced-output feerate checks, and walletincrementalrelayfee behavior."
   },
   {
     "name": "wallet_change_address.py",
@@ -1543,10 +1543,10 @@
   },
   {
     "name": "wallet_conflicts.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited wallet conflict tracking boundary under the legacy-compatible PQC profile: block and mempool conflicts, reorg conflict state, inactive formerly conflicted transactions, conflict removal, combined block and mempool conflict handling, and parent mempool conflicts."
   },
   {
     "name": "wallet_create_tx.py",
@@ -1925,17 +1925,17 @@
   },
   {
     "name": "wallet_txn_clone.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited cloned/malleated transaction accounting boundary under the legacy-compatible PQC profile, including default, --segwit, and --mineblock variants."
   },
   {
     "name": "wallet_txn_doublespend.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited double-spend transaction accounting boundary under the legacy-compatible PQC profile, including default and --mineblock variants."
   },
   {
     "name": "wallet_v3_txs.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -13,6 +13,7 @@ feature_taproot_replacement_active_positive_seam.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py
+wallet_abandonconflict.py
 wallet_address_types.py
 wallet_assumeutxo.py
 wallet_avoid_mixing_output_types.py
@@ -20,8 +21,10 @@ wallet_avoidreuse.py
 wallet_backup.py
 wallet_balance.py
 wallet_blank.py
+wallet_bumpfee.py
 wallet_change_address.py
 wallet_coinbase_category.py
+wallet_conflicts.py
 wallet_createwallet.py
 wallet_descriptor.py
 wallet_disable.py
@@ -62,3 +65,5 @@ wallet_sendmany.py
 wallet_spend_unconfirmed.py
 wallet_startup.py
 wallet_transactiontime_rescan.py
+wallet_txn_clone.py
+wallet_txn_doublespend.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `64` |
-| `pq_backlog` | `61` |
+| `pq_required` | `69` |
+| `pq_backlog` | `56` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -67,46 +67,51 @@ Current required PQ-first gates:
 22. `feature_assumevalid.py`
 23. `feature_block.py`
 24. `rpc_psbt.py`
-25. `wallet_address_types.py`
-26. `wallet_assumeutxo.py`
-27. `wallet_avoid_mixing_output_types.py`
-28. `wallet_avoidreuse.py`
-29. `wallet_backup.py`
-30. `wallet_balance.py`
-31. `wallet_blank.py`
-32. `wallet_change_address.py`
-33. `wallet_coinbase_category.py`
-34. `wallet_createwallet.py`
-35. `wallet_descriptor.py`
-36. `wallet_disable.py`
-37. `wallet_encryption.py`
-38. `wallet_fallbackfee.py`
-39. `wallet_fast_rescan.py`
-40. `wallet_fundrawtransaction.py`
-41. `wallet_gethdkeys.py`
-42. `wallet_groups.py`
-43. `wallet_hd.py`
-44. `wallet_keypool.py`
-45. `wallet_keypool_topup.py`
-46. `wallet_labels.py`
-47. `wallet_listdescriptors.py`
-48. `wallet_listreceivedby.py`
-49. `wallet_listsinceblock.py`
-50. `wallet_listtransactions.py`
-51. `wallet_miniscript.py`
-52. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-53. `wallet_multisig_descriptor_psbt.py`
-54. `wallet_multiwallet.py`
-55. `wallet_reindex.py`
-56. `wallet_reorgsrestore.py`
-57. `wallet_rescan_unconfirmed.py`
-58. `wallet_resendwallettransactions.py`
-59. `wallet_send.py`
-60. `wallet_sendall.py`
-61. `wallet_sendmany.py`
-62. `wallet_spend_unconfirmed.py`
-63. `wallet_startup.py`
-64. `wallet_transactiontime_rescan.py`
+25. `wallet_abandonconflict.py`
+26. `wallet_address_types.py`
+27. `wallet_assumeutxo.py`
+28. `wallet_avoid_mixing_output_types.py`
+29. `wallet_avoidreuse.py`
+30. `wallet_backup.py`
+31. `wallet_balance.py`
+32. `wallet_blank.py`
+33. `wallet_bumpfee.py`
+34. `wallet_change_address.py`
+35. `wallet_coinbase_category.py`
+36. `wallet_conflicts.py`
+37. `wallet_createwallet.py`
+38. `wallet_descriptor.py`
+39. `wallet_disable.py`
+40. `wallet_encryption.py`
+41. `wallet_fallbackfee.py`
+42. `wallet_fast_rescan.py`
+43. `wallet_fundrawtransaction.py`
+44. `wallet_gethdkeys.py`
+45. `wallet_groups.py`
+46. `wallet_hd.py`
+47. `wallet_keypool.py`
+48. `wallet_keypool_topup.py`
+49. `wallet_labels.py`
+50. `wallet_listdescriptors.py`
+51. `wallet_listreceivedby.py`
+52. `wallet_listsinceblock.py`
+53. `wallet_listtransactions.py`
+54. `wallet_miniscript.py`
+55. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+56. `wallet_multisig_descriptor_psbt.py`
+57. `wallet_multiwallet.py`
+58. `wallet_reindex.py`
+59. `wallet_reorgsrestore.py`
+60. `wallet_rescan_unconfirmed.py`
+61. `wallet_resendwallettransactions.py`
+62. `wallet_send.py`
+63. `wallet_sendall.py`
+64. `wallet_sendmany.py`
+65. `wallet_spend_unconfirmed.py`
+66. `wallet_startup.py`
+67. `wallet_transactiontime_rescan.py`
+68. `wallet_txn_clone.py`
+69. `wallet_txn_doublespend.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -209,6 +214,13 @@ also part of the required gate: `wallet_avoid_mixing_output_types.py`,
 grouping, avoid-reuse coin selection, change-address selection, fallback-fee
 RBF creation, grouped UTXO selection, avoid-partial-spends behavior, and
 unconfirmed-input spend policy under the current PQC profile.
+The inherited wallet bumpfee and transaction-conflict confidence gap is now
+also part of the required gate: `wallet_abandonconflict.py`,
+`wallet_bumpfee.py`, `wallet_conflicts.py`, `wallet_txn_clone.py`, and
+`wallet_txn_doublespend.py` cover abandoned/conflicted transaction handling,
+fee bumping and PSBT fee bumping, wallet conflict tracking, cloned/malleated
+transaction accounting, and double-spend transaction accounting under the
+current PQC profile.
 The inherited wallet startup confidence gap is now also part of the required
 gate: `wallet_startup.py` covers default wallet auto-load, persisted
 `load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -59,10 +59,13 @@ keep `wallet_avoid_mixing_output_types.py`, `wallet_avoidreuse.py`,
 `wallet_change_address.py`, `wallet_fallbackfee.py`, `wallet_groups.py`, and
 `wallet_spend_unconfirmed.py` coin-selection and spend-policy behavior in the
 same gate, then
+keep `wallet_abandonconflict.py`, `wallet_bumpfee.py`, `wallet_conflicts.py`,
+`wallet_txn_clone.py`, and `wallet_txn_doublespend.py` fee-bump and
+transaction-conflict behavior in the same gate, then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with `wallet_bumpfee.py` and
-adjacent transaction-conflict surfaces beyond the current spend-policy gate as
-the local alternate.
+when real prior PQBTC release assets exist, with transaction construction,
+transaction simulation, and remaining wallet transaction breadth beyond the
+current bumpfee/conflict gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -86,8 +89,8 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. `wallet_bumpfee.py` and adjacent transaction-conflict surfaces beyond the
-   current spend-policy gate
+2. transaction construction, transaction simulation, and remaining wallet
+   transaction breadth beyond the current bumpfee/conflict gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to rebalance
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
@@ -95,7 +98,7 @@ Alternate rebalance:
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
-     coin-selection, and spend-policy tranches.
+     coin-selection, spend-policy, and bumpfee/conflict tranches.
 
 Still deferred:
 
@@ -730,7 +733,9 @@ Still deferred:
    - `build/test/functional/test_runner.py --jobs=1 wallet_descriptor.py wallet_disable.py wallet_encryption.py wallet_gethdkeys.py wallet_hd.py wallet_keypool.py wallet_keypool_topup.py wallet_listdescriptors.py`
    Still deferred inside this suite:
    - wallet accounting, label, and transaction-listing semantics now covered
-     by adjacent required gates; conflict semantics remain separate
+     by adjacent required gates; conflict semantics now covered by adjacent
+     required gates; generic transaction construction and simulation remain
+     separate
 40. `wallet_balance.py`, `wallet_coinbase_category.py`, `wallet_labels.py`,
    `wallet_listreceivedby.py`, `wallet_listsinceblock.py`, and
    `wallet_listtransactions.py` now own:
@@ -753,8 +758,9 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_balance.py wallet_coinbase_category.py wallet_labels.py wallet_listreceivedby.py wallet_listsinceblock.py wallet_listtransactions.py`
    Still deferred inside this suite:
-   - coin-selection grouping now covered by adjacent required gates; bumpfee,
-     abandoned-conflict, and broader conflict semantics remain separate
+   - coin-selection grouping and bumpfee/conflict semantics now covered by
+     adjacent required gates; generic transaction construction and simulation
+     remain separate
 41. `wallet_avoid_mixing_output_types.py`, `wallet_avoidreuse.py`,
    `wallet_change_address.py`, `wallet_fallbackfee.py`, `wallet_groups.py`,
    and `wallet_spend_unconfirmed.py` now own:
@@ -777,21 +783,52 @@ Still deferred:
    Minimum validation target:
    - `build/test/functional/test_runner.py --jobs=1 wallet_avoid_mixing_output_types.py wallet_avoidreuse.py wallet_change_address.py wallet_fallbackfee.py wallet_groups.py wallet_spend_unconfirmed.py`
    Still deferred inside this suite:
-   - broad `bumpfee`, abandoned-conflict, transaction clone, double-spend, and
-     broader conflict semantics
-42. Recommended next PR after this tranche:
+   - bumpfee and conflict semantics now covered by adjacent required gates;
+     generic transaction construction, transaction simulation, and broad basic
+     wallet behavior remain separate
+42. `wallet_abandonconflict.py`, `wallet_bumpfee.py`,
+   `wallet_conflicts.py`, `wallet_txn_clone.py`, and
+   `wallet_txn_doublespend.py` now own:
+   - restored inherited fee-bump, abandoned-conflict, clone, double-spend, and
+     wallet conflict-tracking behavior under the current legacy-compatible PQC
+     profile
+   - abandoned transaction handling, balance/listing visibility, abandoned
+     transactions in `listsinceblock`, and double-spend conflict handling
+   - `bumpfee` and `psbtbumpfee` option validation, fee-rate validation,
+     confirmation-target validation, estimate-mode validation, change handling,
+     non-RBF replacement rejection, non-owned input and PSBT behavior,
+     descendant and abandoned-descendant behavior, dust/change/drop-to-fee
+     behavior, `maxtxfee`, watch-only PSBT behavior, successor and re-bump
+     behavior, spent-coin failure, metadata persistence, locked-wallet
+     rejection, change address reuse, confirmed-output availability,
+     replaced-output feerate checks, and `walletincrementalrelayfee` behavior
+   - block and mempool conflict tracking, reorg conflict state, inactive
+     formerly conflicted transactions, conflict removal, combined block and
+     mempool conflict handling, and parent mempool conflicts
+   - cloned or malleated transaction accounting across the default, `--segwit`,
+     and `--mineblock` variants
+   - double-spend transaction accounting across the default and `--mineblock`
+     variants
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_abandonconflict.py wallet_bumpfee.py wallet_conflicts.py wallet_txn_clone.py wallet_txn_doublespend.py`
+   Fixed posture note:
+   - `WALLET_BUMPFEE_CONFLICT_POSTURE.md`
+   Still deferred inside this suite:
+   - generic transaction construction, transaction simulation, and broad basic
+     wallet behavior
+43. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `wallet_bumpfee.py` and adjacent transaction-conflict surfaces
-     beyond this spend-policy gate
+   - alternate: transaction construction, transaction simulation, and remaining
+     wallet transaction breadth beyond this bumpfee/conflict gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - fee-bump and transaction-conflict work remains useful once the current
+   - transaction construction and simulation work remains useful once the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
-     coin-selection, and spend-policy gates are frozen, but additional wallet
-     work stays behind the asset-dependent compatibility slice once prior PQBTC
-     release assets are available
+     coin-selection, spend-policy, and bumpfee/conflict gates are frozen, but
+     additional wallet work stays behind the asset-dependent compatibility slice
+     once prior PQBTC release assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -1403,8 +1440,20 @@ Aineko must ask before:
   behavior, and unconfirmed-input spend policy under the current
   legacy-compatible PQC profile. The next owned follow-on remains
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
-  assets exist, with `wallet_bumpfee.py` and adjacent transaction-conflict
-  surfaces as the local alternate.
+  assets exist, with fee-bump and adjacent transaction-conflict surfaces as the
+  local alternate.
+- 2026-04-27: `wallet_abandonconflict.py`, `wallet_bumpfee.py`,
+  `wallet_conflicts.py`, `wallet_txn_clone.py`, and
+  `wallet_txn_doublespend.py` are now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited abandoned/conflicted
+  transaction handling, `bumpfee`/`psbtbumpfee` behavior, wallet conflict
+  tracking, cloned/malleated transaction accounting, and double-spend
+  transaction accounting under the current legacy-compatible PQC profile. The
+  next owned follow-on remains `feature_coinstatsindex_compatibility.py` when
+  real prior PQBTC release assets exist, with transaction construction,
+  transaction simulation, and remaining wallet transaction breadth beyond this
+  bumpfee/conflict gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full

--- a/docs/WALLET_ACCOUNTING_LISTING_POSTURE.md
+++ b/docs/WALLET_ACCOUNTING_LISTING_POSTURE.md
@@ -53,8 +53,8 @@ This promotion does not define:
 - replacement-path Taproot or bech32m wallet semantics beyond existing tests
 - new PQ-only active-manager RPC behavior
 - wallet migration or backwards-compatibility release-asset behavior
-- coin-selection grouping, bumpfee, abandoned-conflict, or broader conflict
-  semantics outside these listing/accounting contracts
+- generic transaction construction, transaction simulation, or broad basic
+  wallet behavior outside these listing/accounting contracts
 - prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 ## Confidence Snapshot
@@ -76,6 +76,8 @@ that already pass under the current PQC-compatible legacy profile. The
 preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
 when real prior PQBTC release assets exist locally. The subsequent spend-policy
 promotion covers the adjacent coin-selection grouping, change selection,
-avoid-reuse, fallback-fee, and unconfirmed-input surfaces. Until compatibility
-assets exist, the repo-local wallet alternate is `wallet_bumpfee.py` and
-adjacent transaction-conflict surfaces beyond that spend-policy gate.
+avoid-reuse, fallback-fee, and unconfirmed-input surfaces. The subsequent
+bumpfee/conflict promotion covers adjacent fee-bump, abandoned-conflict, clone,
+double-spend, and conflict-tracking surfaces. Until compatibility assets exist,
+the repo-local wallet alternate is transaction construction, transaction
+simulation, and remaining wallet transaction breadth beyond those gates.

--- a/docs/WALLET_BUMPFEE_CONFLICT_POSTURE.md
+++ b/docs/WALLET_BUMPFEE_CONFLICT_POSTURE.md
@@ -1,0 +1,78 @@
+# PQBTC Wallet Bumpfee And Conflict Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-BUMPFEE-CONFLICT-POSTURE-v1
+## Updated: 2026-04-27
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited wallet fee-bump, PSBT fee-bump, abandoned-conflict,
+clone, and double-spend accounting contracts under the current
+legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+The following suites are now required PQ gates:
+
+- [wallet_abandonconflict.py](../test/functional/wallet_abandonconflict.py)
+- [wallet_bumpfee.py](../test/functional/wallet_bumpfee.py)
+- [wallet_conflicts.py](../test/functional/wallet_conflicts.py)
+- [wallet_txn_clone.py](../test/functional/wallet_txn_clone.py)
+- [wallet_txn_doublespend.py](../test/functional/wallet_txn_doublespend.py)
+
+The owned boundary covers:
+
+- abandoned transaction handling, balance/listing visibility, abandoned
+  transactions in `listsinceblock`, and double-spend conflict handling
+- `bumpfee` and `psbtbumpfee` option validation, fee-rate validation,
+  confirmation-target validation, estimate-mode validation, change handling,
+  non-RBF replacement rejection, non-owned input and PSBT behavior,
+  descendant and abandoned-descendant behavior, dust/change/drop-to-fee
+  behavior, `maxtxfee`, watch-only PSBT behavior, successor and re-bump
+  behavior, spent-coin failure, metadata persistence, locked-wallet rejection,
+  change address reuse, confirmed-output availability, replaced-output
+  feerate checks, and `walletincrementalrelayfee` behavior
+- block and mempool conflict tracking, reorg conflict state, inactive formerly
+  conflicted transactions, conflict removal, combined block and mempool
+  conflict handling, and parent mempool conflicts
+- cloned or malleated transaction accounting across the default, `--segwit`,
+  and `--mineblock` variants
+- double-spend transaction accounting across the default and `--mineblock`
+  variants
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet migration or backwards-compatibility release-asset behavior
+- generic transaction construction, transaction simulation, or broad basic
+  wallet behavior outside these fee-bump and conflict contracts
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-27:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_abandonconflict.py wallet_bumpfee.py wallet_conflicts.py wallet_txn_clone.py wallet_txn_doublespend.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=69`, `pq_backlog=56`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet fee-bump,
+abandoned-conflict, clone, double-spend, and conflict-tracking contracts that
+already pass under the current PQC-compatible legacy profile.
+
+The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to transaction construction, transaction simulation, and
+remaining wallet transaction breadth beyond this bumpfee/conflict gate.

--- a/docs/WALLET_SPEND_POLICY_POSTURE.md
+++ b/docs/WALLET_SPEND_POLICY_POSTURE.md
@@ -47,8 +47,8 @@ This promotion does not define:
 - replacement-path Taproot or bech32m wallet semantics beyond existing tests
 - new PQ-only active-manager RPC behavior
 - wallet migration or backwards-compatibility release-asset behavior
-- broad `bumpfee`, abandoned-conflict, transaction clone, or double-spend
-  semantics outside these spend-policy contracts
+- generic transaction construction, transaction simulation, or broad basic
+  wallet behavior outside these spend-policy contracts
 - prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 ## Confidence Snapshot
@@ -69,5 +69,8 @@ avoid-reuse, change selection, fallback-fee, and unconfirmed-input spend-policy
 contracts that already pass under the current PQC-compatible legacy profile.
 The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
 when real prior PQBTC release assets exist locally. Until then, the repo-local
-wallet alternate moves to `wallet_bumpfee.py` and adjacent transaction-conflict
-surfaces beyond this spend-policy gate.
+wallet alternate moved to `wallet_bumpfee.py` and adjacent
+transaction-conflict surfaces beyond this spend-policy gate; that adjacent
+surface is now covered by `WALLET_BUMPFEE_CONFLICT_POSTURE.md`, so the current
+local alternate is transaction construction, transaction simulation, and
+remaining wallet transaction breadth beyond the bumpfee/conflict gate.


### PR DESCRIPTION
## Summary
- Promotes `wallet_abandonconflict.py`, `wallet_bumpfee.py`, `wallet_conflicts.py`, `wallet_txn_clone.py`, and `wallet_txn_doublespend.py` from `pq_backlog` to `pq_required`.
- Updates `ci/test/pq_functional_tests.txt` and CI completeness counts to `pq_required=69`, `pq_backlog=56`, `dual_profile=142`, `legacy_only=9`.
- Adds `WALLET_BUMPFEE_CONFLICT_POSTURE.md` and refreshes Track A handoff docs so the local alternate moves to transaction construction/simulation breadth while `feature_coinstatsindex_compatibility.py` stays asset-blocked.

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `git diff --check`
- `git diff --cached --check`
- `build/test/functional/test_runner.py --jobs=1 wallet_abandonconflict.py wallet_bumpfee.py wallet_conflicts.py wallet_txn_clone.py wallet_txn_doublespend.py