### PR TITLE
ci: promote wallet transaction construction gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1508,10 +1508,10 @@
   },
   {
     "name": "wallet_basic.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited broad basic wallet behavior boundary under the legacy-compatible PQC profile: wallet balances and UTXO visibility, gettxout/mempool interactions, lockunspent persistence and validation, send/settxfee behavior, watch-only and descriptor import checks, immature and mature coinbase handling, and address/accounting edge cases."
   },
   {
     "name": "wallet_blank.py",
@@ -1550,10 +1550,10 @@
   },
   {
     "name": "wallet_create_tx.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited wallet transaction-creation boundary under the legacy-compatible PQC profile: anti-fee-sniping locktime behavior, transaction-size maxtxfee rejection, too-long mempool chain rejection, and current wallet transaction version behavior."
   },
   {
     "name": "wallet_createwallet.py",
@@ -1882,10 +1882,10 @@
   },
   {
     "name": "wallet_simulaterawtx.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited simulaterawtransaction boundary under the legacy-compatible PQC profile: multiwallet balance deltas, watch-only descriptor visibility, funded raw transaction fee/payment accounting, duplicate-spend rejection, missing-input rejection, chained simulated transactions, and mined-input rejection."
   },
   {
     "name": "wallet_spend_unconfirmed.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -20,11 +20,13 @@ wallet_avoid_mixing_output_types.py
 wallet_avoidreuse.py
 wallet_backup.py
 wallet_balance.py
+wallet_basic.py
 wallet_blank.py
 wallet_bumpfee.py
 wallet_change_address.py
 wallet_coinbase_category.py
 wallet_conflicts.py
+wallet_create_tx.py
 wallet_createwallet.py
 wallet_descriptor.py
 wallet_disable.py
@@ -62,6 +64,7 @@ wallet_resendwallettransactions.py
 wallet_send.py
 wallet_sendall.py
 wallet_sendmany.py
+wallet_simulaterawtx.py
 wallet_spend_unconfirmed.py
 wallet_startup.py
 wallet_transactiontime_rescan.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `69` |
-| `pq_backlog` | `56` |
+| `pq_required` | `72` |
+| `pq_backlog` | `53` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -74,44 +74,47 @@ Current required PQ-first gates:
 29. `wallet_avoidreuse.py`
 30. `wallet_backup.py`
 31. `wallet_balance.py`
-32. `wallet_blank.py`
-33. `wallet_bumpfee.py`
-34. `wallet_change_address.py`
-35. `wallet_coinbase_category.py`
-36. `wallet_conflicts.py`
-37. `wallet_createwallet.py`
-38. `wallet_descriptor.py`
-39. `wallet_disable.py`
-40. `wallet_encryption.py`
-41. `wallet_fallbackfee.py`
-42. `wallet_fast_rescan.py`
-43. `wallet_fundrawtransaction.py`
-44. `wallet_gethdkeys.py`
-45. `wallet_groups.py`
-46. `wallet_hd.py`
-47. `wallet_keypool.py`
-48. `wallet_keypool_topup.py`
-49. `wallet_labels.py`
-50. `wallet_listdescriptors.py`
-51. `wallet_listreceivedby.py`
-52. `wallet_listsinceblock.py`
-53. `wallet_listtransactions.py`
-54. `wallet_miniscript.py`
-55. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-56. `wallet_multisig_descriptor_psbt.py`
-57. `wallet_multiwallet.py`
-58. `wallet_reindex.py`
-59. `wallet_reorgsrestore.py`
-60. `wallet_rescan_unconfirmed.py`
-61. `wallet_resendwallettransactions.py`
-62. `wallet_send.py`
-63. `wallet_sendall.py`
-64. `wallet_sendmany.py`
-65. `wallet_spend_unconfirmed.py`
-66. `wallet_startup.py`
-67. `wallet_transactiontime_rescan.py`
-68. `wallet_txn_clone.py`
-69. `wallet_txn_doublespend.py`
+32. `wallet_basic.py`
+33. `wallet_blank.py`
+34. `wallet_bumpfee.py`
+35. `wallet_change_address.py`
+36. `wallet_coinbase_category.py`
+37. `wallet_conflicts.py`
+38. `wallet_create_tx.py`
+39. `wallet_createwallet.py`
+40. `wallet_descriptor.py`
+41. `wallet_disable.py`
+42. `wallet_encryption.py`
+43. `wallet_fallbackfee.py`
+44. `wallet_fast_rescan.py`
+45. `wallet_fundrawtransaction.py`
+46. `wallet_gethdkeys.py`
+47. `wallet_groups.py`
+48. `wallet_hd.py`
+49. `wallet_keypool.py`
+50. `wallet_keypool_topup.py`
+51. `wallet_labels.py`
+52. `wallet_listdescriptors.py`
+53. `wallet_listreceivedby.py`
+54. `wallet_listsinceblock.py`
+55. `wallet_listtransactions.py`
+56. `wallet_miniscript.py`
+57. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+58. `wallet_multisig_descriptor_psbt.py`
+59. `wallet_multiwallet.py`
+60. `wallet_reindex.py`
+61. `wallet_reorgsrestore.py`
+62. `wallet_rescan_unconfirmed.py`
+63. `wallet_resendwallettransactions.py`
+64. `wallet_send.py`
+65. `wallet_sendall.py`
+66. `wallet_sendmany.py`
+67. `wallet_simulaterawtx.py`
+68. `wallet_spend_unconfirmed.py`
+69. `wallet_startup.py`
+70. `wallet_transactiontime_rescan.py`
+71. `wallet_txn_clone.py`
+72. `wallet_txn_doublespend.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -221,6 +224,16 @@ also part of the required gate: `wallet_abandonconflict.py`,
 fee bumping and PSBT fee bumping, wallet conflict tracking, cloned/malleated
 transaction accounting, and double-spend transaction accounting under the
 current PQC profile.
+The inherited wallet transaction-construction, simulation, and broad basic
+behavior confidence gap is now also part of the required gate:
+`wallet_basic.py`, `wallet_create_tx.py`, and `wallet_simulaterawtx.py` cover
+basic wallet balance and UTXO visibility, lockunspent persistence and
+validation, inherited transaction creation, anti-fee-sniping locktime
+behavior, transaction-size and mempool-chain rejection, current wallet
+transaction version behavior, raw transaction balance simulation, watch-only
+descriptor visibility, duplicate-spend rejection, missing-input rejection,
+chained simulated transactions, and mined-input rejection under the current
+PQC profile.
 The inherited wallet startup confidence gap is now also part of the required
 gate: `wallet_startup.py` covers default wallet auto-load, persisted
 `load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,

--- a/docs/PQ_WALLET_CREATE_TX_POSTURE.md
+++ b/docs/PQ_WALLET_CREATE_TX_POSTURE.md
@@ -8,9 +8,10 @@
 ## Purpose
 
 Freeze the owned direct wallet transaction-creation contract for PQ-only active
-wallets without reopening the full inherited
+wallets. The full inherited
 [wallet_create_tx.py](../test/functional/wallet_create_tx.py)
-surface.
+surface is now frozen separately in
+[WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md](./WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md).
 
 ## Owned Surface
 
@@ -40,15 +41,15 @@ The higher-level `send` RPC contract is frozen separately in
 
 ## Non-Goals In This Tranche
 
-This tranche does not own the full inherited
-[wallet_create_tx.py](../test/functional/wallet_create_tx.py)
-surface. It explicitly does not take on:
+This tranche does not own the full inherited transaction-construction surface.
+That broader surface is now frozen separately in
+[WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md](./WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md).
+This PQ-only posture note does not take on:
 
 - `maxtxfee` coverage
 - too-long mempool chain handling
-- broad inherited dual-profile wallet rehabilitation
-
-Those remain separate backlog or legacy-compatibility decisions.
+- broad inherited dual-profile wallet rehabilitation outside the promoted
+  construction and simulation gate
 
 ## Confidence
 

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-27
+## Updated: 2026-04-28
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -62,10 +62,13 @@ same gate, then
 keep `wallet_abandonconflict.py`, `wallet_bumpfee.py`, `wallet_conflicts.py`,
 `wallet_txn_clone.py`, and `wallet_txn_doublespend.py` fee-bump and
 transaction-conflict behavior in the same gate, then
+keep `wallet_basic.py`, `wallet_create_tx.py`, and `wallet_simulaterawtx.py`
+transaction construction, simulation, and broad basic wallet behavior in the
+same gate, then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with transaction construction,
-transaction simulation, and remaining wallet transaction breadth beyond the
-current bumpfee/conflict gate as the local alternate.
+when real prior PQBTC release assets exist, with inherited raw transaction
+signing, descriptor import, migration, and remaining wallet transaction
+breadth beyond the current construction/simulation gate as the local alternate.
 
 ## Current Working Thesis
 
@@ -89,8 +92,9 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. transaction construction, transaction simulation, and remaining wallet
-   transaction breadth beyond the current bumpfee/conflict gate
+2. inherited raw transaction signing, descriptor import, migration, and
+   remaining wallet transaction breadth beyond the current construction and
+   simulation gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to rebalance
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
@@ -98,7 +102,8 @@ Alternate rebalance:
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
-     coin-selection, spend-policy, and bumpfee/conflict tranches.
+     coin-selection, spend-policy, bumpfee/conflict, basic wallet,
+     transaction-construction, and simulation tranches.
 
 Still deferred:
 
@@ -734,8 +739,9 @@ Still deferred:
    Still deferred inside this suite:
    - wallet accounting, label, and transaction-listing semantics now covered
      by adjacent required gates; conflict semantics now covered by adjacent
-     required gates; generic transaction construction and simulation remain
-     separate
+     required gates; transaction construction and simulation now covered by
+     adjacent required gates; raw signing, descriptor import, and migration
+     remain separate
 40. `wallet_balance.py`, `wallet_coinbase_category.py`, `wallet_labels.py`,
    `wallet_listreceivedby.py`, `wallet_listsinceblock.py`, and
    `wallet_listtransactions.py` now own:
@@ -759,8 +765,9 @@ Still deferred:
    - `build/test/functional/test_runner.py --jobs=1 wallet_balance.py wallet_coinbase_category.py wallet_labels.py wallet_listreceivedby.py wallet_listsinceblock.py wallet_listtransactions.py`
    Still deferred inside this suite:
    - coin-selection grouping and bumpfee/conflict semantics now covered by
-     adjacent required gates; generic transaction construction and simulation
-     remain separate
+     adjacent required gates; transaction construction and simulation now
+     covered by adjacent required gates; raw signing, descriptor import, and
+     migration remain separate
 41. `wallet_avoid_mixing_output_types.py`, `wallet_avoidreuse.py`,
    `wallet_change_address.py`, `wallet_fallbackfee.py`, `wallet_groups.py`,
    and `wallet_spend_unconfirmed.py` now own:
@@ -784,8 +791,9 @@ Still deferred:
    - `build/test/functional/test_runner.py --jobs=1 wallet_avoid_mixing_output_types.py wallet_avoidreuse.py wallet_change_address.py wallet_fallbackfee.py wallet_groups.py wallet_spend_unconfirmed.py`
    Still deferred inside this suite:
    - bumpfee and conflict semantics now covered by adjacent required gates;
-     generic transaction construction, transaction simulation, and broad basic
-     wallet behavior remain separate
+     transaction construction, transaction simulation, and broad basic wallet
+     behavior now covered by adjacent required gates; raw signing, descriptor
+     import, and migration remain separate
 42. `wallet_abandonconflict.py`, `wallet_bumpfee.py`,
    `wallet_conflicts.py`, `wallet_txn_clone.py`, and
    `wallet_txn_doublespend.py` now own:
@@ -814,21 +822,47 @@ Still deferred:
    Fixed posture note:
    - `WALLET_BUMPFEE_CONFLICT_POSTURE.md`
    Still deferred inside this suite:
-   - generic transaction construction, transaction simulation, and broad basic
-     wallet behavior
-43. Recommended next PR after this tranche:
+   - transaction construction, transaction simulation, and broad basic wallet
+     behavior now covered by adjacent required gates; inherited raw transaction
+     signing, descriptor import, and migration breadth remain separate
+43. `wallet_basic.py`, `wallet_create_tx.py`, and
+   `wallet_simulaterawtx.py` now own:
+   - restored inherited basic wallet behavior, transaction creation, and raw
+     transaction simulation under the current legacy-compatible PQC profile
+   - basic wallet balances, UTXO visibility, `gettxout` mempool interactions,
+     `lockunspent` persistence and validation, fee-setting behavior,
+     descriptor imports, watch-only visibility, mature and immature coinbase
+     handling, and address/accounting edge cases
+   - anti-fee-sniping locktime behavior, transaction-size `maxtxfee`
+     rejection, too-long mempool chain rejection, and current wallet
+     transaction version behavior
+   - `simulaterawtransaction` multiwallet balance deltas, watch-only descriptor
+     visibility, funded raw transaction fee/payment accounting,
+     duplicate-spend rejection, missing-input rejection, chained simulated
+     transactions, and mined-input rejection
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_create_tx.py wallet_simulaterawtx.py wallet_basic.py`
+   Fixed posture note:
+   - `WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md`
+   Still deferred inside this suite:
+   - inherited raw transaction signing, descriptor import breadth, migration,
+     and prior-release compatibility
+44. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: transaction construction, transaction simulation, and remaining
-     wallet transaction breadth beyond this bumpfee/conflict gate
+   - alternate: inherited raw transaction signing, descriptor import, migration,
+     and remaining wallet transaction breadth beyond this construction and
+     simulation gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - transaction construction and simulation work remains useful once the current
+   - raw transaction signing, descriptor import, and migration work remain useful
+     after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
-     coin-selection, spend-policy, and bumpfee/conflict gates are frozen, but
-     additional wallet work stays behind the asset-dependent compatibility slice
-     once prior PQBTC release assets are available
+     coin-selection, spend-policy, bumpfee/conflict, basic wallet,
+     transaction-construction, and simulation gates are frozen, but additional
+     wallet work stays behind the asset-dependent compatibility slice once prior
+     PQBTC release assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -1454,6 +1488,16 @@ Aineko must ask before:
   real prior PQBTC release assets exist, with transaction construction,
   transaction simulation, and remaining wallet transaction breadth beyond this
   bumpfee/conflict gate as the local alternate.
+- 2026-04-28: `wallet_basic.py`, `wallet_create_tx.py`, and
+  `wallet_simulaterawtx.py` are now promoted into the canonical `pq_required`
+  gate and locally revalidated with the build-tree functional runner. The
+  owned boundary covers restored inherited basic wallet behavior, transaction
+  creation, and raw transaction simulation under the current
+  legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with inherited raw transaction signing, descriptor import,
+  migration, and remaining wallet transaction breadth beyond this construction
+  and simulation gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1548,5 +1592,13 @@ Aineko must ask before:
   `wallet_avoidreuse.py`, `wallet_change_address.py`,
   `wallet_fallbackfee.py`, `wallet_groups.py`, and
   `wallet_spend_unconfirmed.py` pass targeted validation in the current tree.
+- There is no current blocker in the restored inherited wallet bumpfee and
+  transaction-conflict surfaces: `wallet_abandonconflict.py`,
+  `wallet_bumpfee.py`, `wallet_conflicts.py`, `wallet_txn_clone.py`, and
+  `wallet_txn_doublespend.py` pass targeted validation in the current tree.
+- There is no current blocker in the restored inherited wallet
+  transaction-construction, simulation, and broad basic wallet surfaces:
+  `wallet_basic.py`, `wallet_create_tx.py`, and `wallet_simulaterawtx.py` pass
+  targeted validation in the current tree.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_ACCOUNTING_LISTING_POSTURE.md
+++ b/docs/WALLET_ACCOUNTING_LISTING_POSTURE.md
@@ -79,5 +79,7 @@ promotion covers the adjacent coin-selection grouping, change selection,
 avoid-reuse, fallback-fee, and unconfirmed-input surfaces. The subsequent
 bumpfee/conflict promotion covers adjacent fee-bump, abandoned-conflict, clone,
 double-spend, and conflict-tracking surfaces. Until compatibility assets exist,
-the repo-local wallet alternate is transaction construction, transaction
-simulation, and remaining wallet transaction breadth beyond those gates.
+the subsequent transaction-construction promotion covers inherited basic wallet
+behavior, transaction creation, and raw transaction simulation. The current
+repo-local wallet alternate is inherited raw transaction signing, descriptor
+import, migration, and remaining wallet transaction breadth beyond those gates.

--- a/docs/WALLET_BUMPFEE_CONFLICT_POSTURE.md
+++ b/docs/WALLET_BUMPFEE_CONFLICT_POSTURE.md
@@ -52,7 +52,7 @@ This promotion does not define:
 - new PQ-only active-manager RPC behavior
 - wallet migration or backwards-compatibility release-asset behavior
 - generic transaction construction, transaction simulation, or broad basic
-  wallet behavior outside these fee-bump and conflict contracts
+  wallet behavior inside these fee-bump and conflict contracts
 - prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 ## Confidence Snapshot
@@ -74,5 +74,9 @@ already pass under the current PQC-compatible legacy profile.
 
 The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
 when real prior PQBTC release assets exist locally. Until then, the repo-local
-wallet alternate moves to transaction construction, transaction simulation, and
-remaining wallet transaction breadth beyond this bumpfee/conflict gate.
+wallet alternate moved to transaction construction, transaction simulation, and
+basic wallet behavior beyond this bumpfee/conflict gate; that adjacent surface
+is now covered by `WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md`, so the current
+local alternate is inherited raw transaction signing, descriptor import,
+migration, and remaining wallet transaction breadth beyond the construction and
+simulation gate.

--- a/docs/WALLET_SPEND_POLICY_POSTURE.md
+++ b/docs/WALLET_SPEND_POLICY_POSTURE.md
@@ -71,6 +71,8 @@ The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py
 when real prior PQBTC release assets exist locally. Until then, the repo-local
 wallet alternate moved to `wallet_bumpfee.py` and adjacent
 transaction-conflict surfaces beyond this spend-policy gate; that adjacent
-surface is now covered by `WALLET_BUMPFEE_CONFLICT_POSTURE.md`, so the current
-local alternate is transaction construction, transaction simulation, and
-remaining wallet transaction breadth beyond the bumpfee/conflict gate.
+surface is now covered by `WALLET_BUMPFEE_CONFLICT_POSTURE.md`. The subsequent
+transaction-construction promotion covers inherited basic wallet behavior,
+transaction creation, and raw transaction simulation, so the current local
+alternate is inherited raw transaction signing, descriptor import, migration,
+and remaining wallet transaction breadth beyond those gates.

--- a/docs/WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md
+++ b/docs/WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md
@@ -1,0 +1,71 @@
+# PQBTC Wallet Transaction Construction Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-TRANSACTION-CONSTRUCTION-POSTURE-v1
+## Updated: 2026-04-28
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited wallet basic behavior, transaction creation, and raw
+transaction simulation contracts under the current legacy-compatible PQC
+profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+The following suites are now required PQ gates:
+
+- [wallet_basic.py](../test/functional/wallet_basic.py)
+- [wallet_create_tx.py](../test/functional/wallet_create_tx.py)
+- [wallet_simulaterawtx.py](../test/functional/wallet_simulaterawtx.py)
+
+The owned boundary covers:
+
+- basic wallet balances, UTXO visibility, `gettxout` mempool interactions,
+  `lockunspent` persistence and validation, fee-setting behavior, descriptor
+  imports, watch-only visibility, mature and immature coinbase handling, and
+  address/accounting edge cases
+- inherited wallet transaction creation with anti-fee-sniping locktime
+  behavior, transaction-size `maxtxfee` rejection, too-long mempool chain
+  rejection, and current wallet transaction version behavior
+- `simulaterawtransaction` multiwallet balance deltas, watch-only descriptor
+  visibility, funded raw transaction fee/payment accounting, duplicate-spend
+  rejection, missing-input rejection, chained simulated transactions, and
+  mined-input rejection
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet migration or backwards-compatibility release-asset behavior
+- inherited raw transaction signing, descriptor import breadth, or migration
+  behavior outside these construction and simulation contracts
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-28:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_create_tx.py wallet_simulaterawtx.py wallet_basic.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=72`, `pq_backlog=53`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet transaction creation,
+raw transaction simulation, and broad basic wallet behavior that already pass
+under the current PQC-compatible legacy profile.
+
+The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
+when real prior PQBTC release assets exist locally. Until then, the repo-local
+wallet alternate moves to inherited raw transaction signing, descriptor import,
+migration, and remaining wallet transaction breadth beyond this construction
+and simulation gate.


### PR DESCRIPTION
## Summary
- Promotes `wallet_basic.py`, `wallet_create_tx.py`, and `wallet_simulaterawtx.py` from `pq_backlog` to `pq_required`.
- Updates `ci/test/pq_functional_tests.txt` and CI completeness counts to `pq_required=72`, `pq_backlog=53`, `dual_profile=142`, `legacy_only=9`.
- Adds `WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md` and refreshes Track A handoff docs so the local alternate moves to inherited raw transaction signing, descriptor import, migration, and remaining wallet transaction breadth while `feature_coinstatsindex_compatibility.py` stays asset-blocked.

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `git diff --check`
- `git diff --cached --check`
- `build/test/functional/test_runner.py --jobs=1 wallet_create_tx.py wallet_simulaterawtx.py wallet_basic.py