### PR TITLE
ci: promote wallet raw signing import gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1642,10 +1642,10 @@
   },
   {
     "name": "wallet_importdescriptors.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited importdescriptors boundary under the legacy-compatible PQC profile: missing descriptor errors, pkh and sh(wpkh) descriptor imports, duplicate imports and label updates, internal-label rejection, invalid-key and checksum/range validation, multisig descriptor imports, ranged descriptor handling, private-key-enabled wallet constraints, and descriptor persistence across reload."
   },
   {
     "name": "wallet_importprunedfunds.py",
@@ -1875,10 +1875,10 @@
   },
   {
     "name": "wallet_signrawtransactionwithwallet.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited signrawtransactionwithwallet boundary under the legacy-compatible PQC profile: locked encrypted wallet rejection, invalid sighash validation, script verification error reporting, fully signed transaction no-op behavior, OP_1NEGATE signing, and CSV/CLTV witness signing behavior."
   },
   {
     "name": "wallet_simulaterawtx.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -37,6 +37,7 @@ wallet_fundrawtransaction.py
 wallet_gethdkeys.py
 wallet_groups.py
 wallet_hd.py
+wallet_importdescriptors.py
 wallet_keypool.py
 wallet_keypool_topup.py
 wallet_labels.py
@@ -64,6 +65,7 @@ wallet_resendwallettransactions.py
 wallet_send.py
 wallet_sendall.py
 wallet_sendmany.py
+wallet_signrawtransactionwithwallet.py
 wallet_simulaterawtx.py
 wallet_spend_unconfirmed.py
 wallet_startup.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `72` |
-| `pq_backlog` | `53` |
+| `pq_required` | `74` |
+| `pq_backlog` | `51` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -91,30 +91,32 @@ Current required PQ-first gates:
 46. `wallet_gethdkeys.py`
 47. `wallet_groups.py`
 48. `wallet_hd.py`
-49. `wallet_keypool.py`
-50. `wallet_keypool_topup.py`
-51. `wallet_labels.py`
-52. `wallet_listdescriptors.py`
-53. `wallet_listreceivedby.py`
-54. `wallet_listsinceblock.py`
-55. `wallet_listtransactions.py`
-56. `wallet_miniscript.py`
-57. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-58. `wallet_multisig_descriptor_psbt.py`
-59. `wallet_multiwallet.py`
-60. `wallet_reindex.py`
-61. `wallet_reorgsrestore.py`
-62. `wallet_rescan_unconfirmed.py`
-63. `wallet_resendwallettransactions.py`
-64. `wallet_send.py`
-65. `wallet_sendall.py`
-66. `wallet_sendmany.py`
-67. `wallet_simulaterawtx.py`
-68. `wallet_spend_unconfirmed.py`
-69. `wallet_startup.py`
-70. `wallet_transactiontime_rescan.py`
-71. `wallet_txn_clone.py`
-72. `wallet_txn_doublespend.py`
+49. `wallet_importdescriptors.py`
+50. `wallet_keypool.py`
+51. `wallet_keypool_topup.py`
+52. `wallet_labels.py`
+53. `wallet_listdescriptors.py`
+54. `wallet_listreceivedby.py`
+55. `wallet_listsinceblock.py`
+56. `wallet_listtransactions.py`
+57. `wallet_miniscript.py`
+58. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+59. `wallet_multisig_descriptor_psbt.py`
+60. `wallet_multiwallet.py`
+61. `wallet_reindex.py`
+62. `wallet_reorgsrestore.py`
+63. `wallet_rescan_unconfirmed.py`
+64. `wallet_resendwallettransactions.py`
+65. `wallet_send.py`
+66. `wallet_sendall.py`
+67. `wallet_sendmany.py`
+68. `wallet_signrawtransactionwithwallet.py`
+69. `wallet_simulaterawtx.py`
+70. `wallet_spend_unconfirmed.py`
+71. `wallet_startup.py`
+72. `wallet_transactiontime_rescan.py`
+73. `wallet_txn_clone.py`
+74. `wallet_txn_doublespend.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -234,6 +236,14 @@ transaction version behavior, raw transaction balance simulation, watch-only
 descriptor visibility, duplicate-spend rejection, missing-input rejection,
 chained simulated transactions, and mined-input rejection under the current
 PQC profile.
+The inherited wallet raw-signing and descriptor-import confidence gap is now
+also part of the required gate: `wallet_signrawtransactionwithwallet.py` and
+`wallet_importdescriptors.py` cover locked encrypted wallet rejection, invalid
+sighash validation, script verification error reporting, fully signed
+transaction no-op behavior, CSV/CLTV witness signing, descriptor import
+validation, duplicate imports and label updates, multisig and ranged descriptor
+imports, private-key-enabled wallet constraints, and descriptor persistence
+under the current PQC profile.
 The inherited wallet startup confidence gap is now also part of the required
 gate: `wallet_startup.py` covers default wallet auto-load, persisted
 `load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,

--- a/docs/PQ_WALLET_SIGNRAWTRANSACTION_POSTURE.md
+++ b/docs/PQ_WALLET_SIGNRAWTRANSACTION_POSTURE.md
@@ -9,9 +9,10 @@
 
 Freeze the owned PQ-only
 [signrawtransactionwithwallet](../src/wallet/rpc/spend.cpp)
-contract without reopening the broad inherited
+contract. The broad inherited
 [wallet_signrawtransactionwithwallet.py](../test/functional/wallet_signrawtransactionwithwallet.py)
-matrix.
+matrix is now frozen separately in
+[WALLET_RAW_SIGNING_IMPORT_POSTURE.md](./WALLET_RAW_SIGNING_IMPORT_POSTURE.md).
 
 ## Owned Surface
 
@@ -41,17 +42,17 @@ On PQ-only active wallets:
 
 ## Why This Slice Exists
 
-Track A already owns the PQ-native setup path, change/funding path, PSBT path,
-and operator-facing send family. This slice closes the remaining direct
-wallet-owned raw-signing gap without reopening inherited classical signing
-compatibility or the full historical `wallet_signrawtransactionwithwallet.py`
-matrix.
+Track A owns the PQ-native setup path, change/funding path, PSBT path,
+operator-facing send family, and inherited raw-signing/import-descriptor
+compatibility as separate gates. This slice remains the PQ-only
+wallet-owned raw-signing contract.
 
 ## Non-Goals In This Tranche
 
 This tranche does not own:
 
-- broad inherited `wallet_signrawtransactionwithwallet.py` behavior
+- broad inherited `wallet_signrawtransactionwithwallet.py` behavior, now frozen
+  separately in `WALLET_RAW_SIGNING_IMPORT_POSTURE.md`
 - mixed classical/PQ signing compatibility
 - `prevtxs` matrix coverage for legacy descriptor families
 - inherited classical PSBT finalize/decode compatibility in `rpc_psbt.py`

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -65,10 +65,13 @@ transaction-conflict behavior in the same gate, then
 keep `wallet_basic.py`, `wallet_create_tx.py`, and `wallet_simulaterawtx.py`
 transaction construction, simulation, and broad basic wallet behavior in the
 same gate, then
+keep `wallet_importdescriptors.py` and
+`wallet_signrawtransactionwithwallet.py` descriptor import and raw-signing
+behavior in the same gate, then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with inherited raw transaction
-signing, descriptor import, migration, and remaining wallet transaction
-breadth beyond the current construction/simulation gate as the local alternate.
+when real prior PQBTC release assets exist, with remaining wallet transaction
+breadth beyond the current raw-signing/import gate as the local alternate while
+`wallet_migration.py` remains blocked on previous-release fixtures.
 
 ## Current Working Thesis
 
@@ -92,9 +95,8 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. inherited raw transaction signing, descriptor import, migration, and
-   remaining wallet transaction breadth beyond the current construction and
-   simulation gate
+2. remaining wallet transaction breadth beyond the current raw-signing/import
+   gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to rebalance
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
@@ -103,7 +105,9 @@ Alternate rebalance:
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
      coin-selection, spend-policy, bumpfee/conflict, basic wallet,
-     transaction-construction, and simulation tranches.
+     transaction-construction, simulation, raw-signing, and import-descriptor
+     tranches. `wallet_migration.py` stays blocked until previous-release
+     fixtures are available.
 
 Still deferred:
 
@@ -845,24 +849,51 @@ Still deferred:
    Fixed posture note:
    - `WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md`
    Still deferred inside this suite:
-   - inherited raw transaction signing, descriptor import breadth, migration,
-     and prior-release compatibility
-44. Recommended next PR after this tranche:
+   - raw transaction signing and descriptor import now covered by adjacent
+     required gates; migration and prior-release compatibility remain blocked
+     without previous-release fixtures
+44. `wallet_importdescriptors.py` and
+   `wallet_signrawtransactionwithwallet.py` now own:
+   - restored inherited descriptor import and raw transaction signing behavior
+     under the current legacy-compatible PQC profile
+   - `importdescriptors` missing descriptor errors, checksum and range
+     validation, pkh and sh(wpkh) descriptor imports, duplicate imports and
+     label updates, internal-label rejection, invalid-key validation, multisig
+     descriptor imports, ranged descriptor handling, private-key-enabled wallet
+     constraints, and descriptor persistence across wallet reload
+   - `signrawtransactionwithwallet` locked encrypted wallet rejection, invalid
+     sighash validation, script verification error reporting, fully signed
+     transaction no-op behavior, OP_1NEGATE signing, and CSV/CLTV witness
+     signing
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_signrawtransactionwithwallet.py wallet_importdescriptors.py`
+   Migration probe:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_signrawtransactionwithwallet.py wallet_importdescriptors.py wallet_migration.py`
+   - expected local outcome: `wallet_migration.py` skipped because
+     previous-release fixtures are unavailable
+   Fixed posture note:
+   - `WALLET_RAW_SIGNING_IMPORT_POSTURE.md`
+   Still deferred inside this suite:
+   - `wallet_migration.py`, which is skipped locally because previous-release
+     fixtures are unavailable
+   - import-pruned-funds, timelock, orphaned reward, v3 transaction, signer,
+     and remaining wallet transaction breadth
+45. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: inherited raw transaction signing, descriptor import, migration,
-     and remaining wallet transaction breadth beyond this construction and
-     simulation gate
+   - alternate: remaining wallet transaction breadth beyond this
+     raw-signing/import gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - raw transaction signing, descriptor import, and migration work remain useful
-     after the current
+   - import-pruned-funds, timelock, orphaned reward, v3 transaction, signer, and
+     other remaining wallet transaction work remain useful after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
      coin-selection, spend-policy, bumpfee/conflict, basic wallet,
-     transaction-construction, and simulation gates are frozen, but additional
-     wallet work stays behind the asset-dependent compatibility slice once prior
-     PQBTC release assets are available
+     transaction-construction, simulation, raw-signing, and import-descriptor
+     gates are frozen, but additional wallet work stays behind the
+     asset-dependent compatibility slice once prior PQBTC release assets are
+     available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -1498,6 +1529,16 @@ Aineko must ask before:
   assets exist, with inherited raw transaction signing, descriptor import,
   migration, and remaining wallet transaction breadth beyond this construction
   and simulation gate as the local alternate.
+- 2026-04-28: `wallet_importdescriptors.py` and
+  `wallet_signrawtransactionwithwallet.py` are now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers restored inherited descriptor import and
+  raw transaction signing behavior under the current legacy-compatible PQC
+  profile. `wallet_migration.py` remains blocked locally because
+  previous-release fixtures are unavailable. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist, with remaining wallet transaction breadth beyond this
+  raw-signing/import gate as the local alternate.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1600,5 +1641,11 @@ Aineko must ask before:
   transaction-construction, simulation, and broad basic wallet surfaces:
   `wallet_basic.py`, `wallet_create_tx.py`, and `wallet_simulaterawtx.py` pass
   targeted validation in the current tree.
+- There is no current blocker in the restored inherited wallet descriptor-import
+  and raw-signing surfaces: `wallet_importdescriptors.py` and
+  `wallet_signrawtransactionwithwallet.py` pass targeted validation in the
+  current tree.
+- `wallet_migration.py` remains blocked locally until previous-release fixtures
+  are available.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence
   bundle satisfies the frozen signoff thresholds.

--- a/docs/WALLET_RAW_SIGNING_IMPORT_POSTURE.md
+++ b/docs/WALLET_RAW_SIGNING_IMPORT_POSTURE.md
@@ -1,0 +1,69 @@
+# PQBTC Wallet Raw-Signing And Import Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-RAW-SIGNING-IMPORT-POSTURE-v1
+## Updated: 2026-04-28
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited wallet raw transaction signing and descriptor import
+contracts under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+The following suites are now required PQ gates:
+
+- [wallet_importdescriptors.py](../test/functional/wallet_importdescriptors.py)
+- [wallet_signrawtransactionwithwallet.py](../test/functional/wallet_signrawtransactionwithwallet.py)
+
+The owned boundary covers:
+
+- `importdescriptors` missing descriptor errors, checksum and range validation,
+  pkh and sh(wpkh) descriptor imports, duplicate public-key imports, label
+  updates, internal-label rejection, invalid-key validation, multisig
+  descriptor imports, ranged descriptor handling, private-key-enabled wallet
+  constraints, and descriptor persistence across wallet reload
+- `signrawtransactionwithwallet` locked encrypted wallet rejection, invalid
+  sighash validation, script verification error reporting, fully signed
+  transaction no-op behavior, OP_1NEGATE signing, and CSV/CLTV witness signing
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet migration or backwards-compatibility release-asset behavior
+- import-pruned-funds, timelock, orphaned reward, v3 transaction, or signer
+  behavior outside these raw-signing and descriptor-import contracts
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-28:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_signrawtransactionwithwallet.py wallet_importdescriptors.py`
+  - result: passed
+- `build/test/functional/test_runner.py --jobs=1 wallet_signrawtransactionwithwallet.py wallet_importdescriptors.py wallet_migration.py`
+  - result: `wallet_migration.py` skipped because previous releases are
+    unavailable; the two promoted suites passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=74`, `pq_backlog=51`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet raw transaction signing
+and descriptor import behavior that already passes under the current
+PQC-compatible legacy profile.
+
+`wallet_migration.py` remains blocked locally because the previous-release
+fixtures are unavailable. The preferred Track A follow-on remains
+`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
+exist locally. Until then, the repo-local wallet alternate moves to remaining
+wallet transaction breadth beyond this raw-signing/import gate.

--- a/docs/WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md
+++ b/docs/WALLET_TRANSACTION_CONSTRUCTION_POSTURE.md
@@ -43,7 +43,7 @@ This promotion does not define:
 - replacement-path Taproot or bech32m wallet semantics beyond existing tests
 - new PQ-only active-manager RPC behavior
 - wallet migration or backwards-compatibility release-asset behavior
-- inherited raw transaction signing, descriptor import breadth, or migration
+- import-pruned-funds, timelock, orphaned reward, v3 transaction, or signer
   behavior outside these construction and simulation contracts
 - prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
@@ -66,6 +66,9 @@ under the current PQC-compatible legacy profile.
 
 The preferred Track A follow-on remains `feature_coinstatsindex_compatibility.py`
 when real prior PQBTC release assets exist locally. Until then, the repo-local
-wallet alternate moves to inherited raw transaction signing, descriptor import,
-migration, and remaining wallet transaction breadth beyond this construction
-and simulation gate.
+wallet alternate moved to inherited raw transaction signing and descriptor
+import beyond this construction and simulation gate; that adjacent surface is
+now covered by `WALLET_RAW_SIGNING_IMPORT_POSTURE.md`. `wallet_migration.py`
+remains blocked locally because previous-release fixtures are unavailable, so
+the current local alternate is remaining wallet transaction breadth beyond
+these gates.


### PR DESCRIPTION
## Summary
- Promotes `wallet_importdescriptors.py` and `wallet_signrawtransactionwithwallet.py` from `pq_backlog` to `pq_required`.
- Updates `ci/test/pq_functional_tests.txt` and CI completeness counts to `pq_required=74`, `pq_backlog=51`, `dual_profile=142`, `legacy_only=9`.
- Adds `WALLET_RAW_SIGNING_IMPORT_POSTURE.md` and refreshes Track A handoff docs so `wallet_migration.py` stays blocked on previous-release fixtures while the local alternate moves to remaining wallet transaction breadth.

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `git diff --check`
- `git diff --cached --check`
- `build/test/functional/test_runner.py --jobs=1 wallet_signrawtransactionwithwallet.py wallet_importdescriptors.py`
- `build/test/functional/test_runner.py --jobs=1 wallet_signrawtransactionwithwallet.py wallet_importdescriptors.py wallet_migration.py` (`wallet_migration.py` skipped because previous releases are unavailable)