### PR TITLE
ci: promote wallet remaining transaction gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1649,10 +1649,10 @@
   },
   {
     "name": "wallet_importprunedfunds.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited importprunedfunds/removeprunedfunds boundary under the legacy-compatible PQC profile: proof import rejection for unaffiliated addresses, watch-only descriptor import, private-key import, balance/listing updates, removal behavior, transaction decode errors, proof mismatch errors, malformed merkleblock rejection, and missing-block rejection."
   },
   {
     "name": "wallet_keypool.py",
@@ -1742,10 +1742,10 @@
   },
   {
     "name": "wallet_orphanedreward.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited orphaned block reward boundary under the legacy-compatible PQC profile: spending mature rewards plus existing balance, orphaning a reward, abandoning descendants, preserving abandoned status across reload, and keeping descendant transactions abandoned after the reward returns to the active chain."
   },
   {
     "name": "wallet_pq_active_ranged.py",
@@ -1911,10 +1911,10 @@
   },
   {
     "name": "wallet_timelock.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited wallet timelock boundary under the legacy-compatible PQC profile: confirmed timelocked sends keep received-by-address, received-by-label, listreceived, trusted balance, and unspent coin state stable when mock time changes finality."
   },
   {
     "name": "wallet_transactiontime_rescan.py",
@@ -1939,9 +1939,9 @@
   },
   {
     "name": "wallet_v3_txs.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited wallet v3/TRUC boundary under the legacy-compatible PQC profile: version-mixing spend availability, v3 UTXO visibility, conflicting sibling handling, mempool conflict removal, max parent/child weight checks, user input weight preservation, createpsbt/send/sendall/funded-PSBT v3 flows, TRUC weight-limit errors, non-TRUC mixing rejection, multiple unconfirmed TRUC output rejection, and third-generation spend rejection."
   }
 ]

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -38,6 +38,7 @@ wallet_gethdkeys.py
 wallet_groups.py
 wallet_hd.py
 wallet_importdescriptors.py
+wallet_importprunedfunds.py
 wallet_keypool.py
 wallet_keypool_topup.py
 wallet_labels.py
@@ -49,6 +50,7 @@ wallet_miniscript.py
 wallet_miniscript_decaying_multisig_descriptor_psbt.py
 wallet_multisig_descriptor_psbt.py
 wallet_multiwallet.py
+wallet_orphanedreward.py
 wallet_pq_active_ranged.py
 wallet_pq_backup_recovery.py
 wallet_pq_create_tx.py
@@ -69,6 +71,8 @@ wallet_signrawtransactionwithwallet.py
 wallet_simulaterawtx.py
 wallet_spend_unconfirmed.py
 wallet_startup.py
+wallet_timelock.py
 wallet_transactiontime_rescan.py
 wallet_txn_clone.py
 wallet_txn_doublespend.py
+wallet_v3_txs.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `74` |
-| `pq_backlog` | `51` |
+| `pq_required` | `78` |
+| `pq_backlog` | `47` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -92,31 +92,35 @@ Current required PQ-first gates:
 47. `wallet_groups.py`
 48. `wallet_hd.py`
 49. `wallet_importdescriptors.py`
-50. `wallet_keypool.py`
-51. `wallet_keypool_topup.py`
-52. `wallet_labels.py`
-53. `wallet_listdescriptors.py`
-54. `wallet_listreceivedby.py`
-55. `wallet_listsinceblock.py`
-56. `wallet_listtransactions.py`
-57. `wallet_miniscript.py`
-58. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-59. `wallet_multisig_descriptor_psbt.py`
-60. `wallet_multiwallet.py`
-61. `wallet_reindex.py`
-62. `wallet_reorgsrestore.py`
-63. `wallet_rescan_unconfirmed.py`
-64. `wallet_resendwallettransactions.py`
-65. `wallet_send.py`
-66. `wallet_sendall.py`
-67. `wallet_sendmany.py`
-68. `wallet_signrawtransactionwithwallet.py`
-69. `wallet_simulaterawtx.py`
-70. `wallet_spend_unconfirmed.py`
-71. `wallet_startup.py`
-72. `wallet_transactiontime_rescan.py`
-73. `wallet_txn_clone.py`
-74. `wallet_txn_doublespend.py`
+50. `wallet_importprunedfunds.py`
+51. `wallet_keypool.py`
+52. `wallet_keypool_topup.py`
+53. `wallet_labels.py`
+54. `wallet_listdescriptors.py`
+55. `wallet_listreceivedby.py`
+56. `wallet_listsinceblock.py`
+57. `wallet_listtransactions.py`
+58. `wallet_miniscript.py`
+59. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+60. `wallet_multisig_descriptor_psbt.py`
+61. `wallet_multiwallet.py`
+62. `wallet_orphanedreward.py`
+63. `wallet_reindex.py`
+64. `wallet_reorgsrestore.py`
+65. `wallet_rescan_unconfirmed.py`
+66. `wallet_resendwallettransactions.py`
+67. `wallet_send.py`
+68. `wallet_sendall.py`
+69. `wallet_sendmany.py`
+70. `wallet_signrawtransactionwithwallet.py`
+71. `wallet_simulaterawtx.py`
+72. `wallet_spend_unconfirmed.py`
+73. `wallet_startup.py`
+74. `wallet_timelock.py`
+75. `wallet_transactiontime_rescan.py`
+76. `wallet_txn_clone.py`
+77. `wallet_txn_doublespend.py`
+78. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -244,6 +248,12 @@ transaction no-op behavior, CSV/CLTV witness signing, descriptor import
 validation, duplicate imports and label updates, multisig and ranged descriptor
 imports, private-key-enabled wallet constraints, and descriptor persistence
 under the current PQC profile.
+The inherited remaining wallet transaction-breadth confidence gap is now also
+part of the required gate: `wallet_importprunedfunds.py`,
+`wallet_timelock.py`, `wallet_orphanedreward.py`, and `wallet_v3_txs.py` cover
+imported pruned-fund proof handling, timelocked-send accounting stability,
+orphaned block reward abandonment and reload behavior, and v3/TRUC wallet
+transaction handling under the current PQC profile.
 The inherited wallet startup confidence gap is now also part of the required
 gate: `wallet_startup.py` covers default wallet auto-load, persisted
 `load_on_startup` wallet creation flags, `unloadwallet` startup-list removal,

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -68,10 +68,14 @@ same gate, then
 keep `wallet_importdescriptors.py` and
 `wallet_signrawtransactionwithwallet.py` descriptor import and raw-signing
 behavior in the same gate, then
+keep `wallet_importprunedfunds.py`, `wallet_timelock.py`,
+`wallet_orphanedreward.py`, and `wallet_v3_txs.py` remaining wallet
+transaction-breadth behavior in the same gate, then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with remaining wallet transaction
-breadth beyond the current raw-signing/import gate as the local alternate while
-`wallet_migration.py` remains blocked on previous-release fixtures.
+when real prior PQBTC release assets exist, with the small remaining local
+wallet backlog beyond the current transaction-breadth gate as the local
+alternate while `wallet_migration.py` remains blocked on previous-release
+fixtures.
 
 ## Current Working Thesis
 
@@ -95,7 +99,7 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. remaining wallet transaction breadth beyond the current raw-signing/import
+2. small remaining local wallet backlog beyond the current transaction-breadth
    gate
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, this is the next wallet-facing surface to rebalance
@@ -106,8 +110,9 @@ Alternate rebalance:
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
      coin-selection, spend-policy, bumpfee/conflict, basic wallet,
      transaction-construction, simulation, raw-signing, and import-descriptor
-     tranches. `wallet_migration.py` stays blocked until previous-release
-     fixtures are available.
+     tranches, or the current import-pruned-funds, timelock, orphaned reward,
+     and v3/TRUC transaction tranche. `wallet_migration.py` stays blocked until
+     previous-release fixtures are available.
 
 Still deferred:
 
@@ -876,24 +881,56 @@ Still deferred:
    Still deferred inside this suite:
    - `wallet_migration.py`, which is skipped locally because previous-release
      fixtures are unavailable
-   - import-pruned-funds, timelock, orphaned reward, v3 transaction, signer,
-     and remaining wallet transaction breadth
-45. Recommended next PR after this tranche:
+   - import-pruned-funds, timelock, orphaned reward, and v3 transaction
+     behavior now covered by adjacent required gates; the small remaining local
+     wallet backlog stays separate
+45. `wallet_importprunedfunds.py`, `wallet_timelock.py`,
+   `wallet_orphanedreward.py`, and `wallet_v3_txs.py` now own:
+   - restored inherited import-pruned-funds, timelock, orphaned reward, and
+     v3/TRUC wallet behavior under the current legacy-compatible PQC profile
+   - `importprunedfunds` and `removeprunedfunds` proof import rejection for
+     unaffiliated addresses, watch-only descriptor import, private-key import,
+     balance/listing updates, removal behavior, transaction decode errors,
+     proof mismatch errors, malformed merkleblock rejection, and missing-block
+     rejection
+   - confirmed timelocked send accounting stability across received-by-address,
+     received-by-label, listreceived, trusted balance, and unspent coin state
+     when mock time changes finality
+   - orphaned block reward handling, descendant abandonment, reload
+     persistence, and preserving abandoned descendants when the reward returns
+     to the active chain
+   - wallet v3/TRUC behavior for version-mixing spend availability, v3 UTXO
+     visibility, conflicting sibling handling, mempool conflict removal, parent
+     and child weight checks, user input weight preservation, `createpsbt`,
+     `send`, `sendall`, funded-PSBT v3 flows, TRUC weight-limit errors,
+     non-TRUC mixing rejection, multiple unconfirmed TRUC output rejection, and
+     third-generation spend rejection
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_importprunedfunds.py wallet_timelock.py wallet_orphanedreward.py wallet_v3_txs.py`
+   Fixed posture note:
+   - `WALLET_REMAINING_TRANSACTION_BREADTH_POSTURE.md`
+   Still deferred inside this suite:
+   - `wallet_migration.py`, which is skipped locally because previous-release
+     fixtures are unavailable
+   - `wallet_crosschain.py`, `wallet_createwalletdescriptor.py`, and
+     `wallet_backwards_compatibility.py`
+46. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: remaining wallet transaction breadth beyond this
-     raw-signing/import gate
+   - alternate: small remaining local wallet backlog beyond this
+     transaction-breadth gate
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - import-pruned-funds, timelock, orphaned reward, v3 transaction, signer, and
-     other remaining wallet transaction work remain useful after the current
+   - crosschain, createwalletdescriptor, and backwards-compatibility work remain
+     useful after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
      coin-selection, spend-policy, bumpfee/conflict, basic wallet,
      transaction-construction, simulation, raw-signing, and import-descriptor
-     gates are frozen, but additional wallet work stays behind the
-     asset-dependent compatibility slice once prior PQBTC release assets are
-     available
+     gates are frozen, and after the current import-pruned-funds, timelock,
+     orphaned reward, and v3/TRUC transaction gate is frozen, but additional
+     wallet work stays behind the asset-dependent compatibility slice once
+     prior PQBTC release assets are available
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -1539,6 +1576,17 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist, with remaining wallet transaction breadth beyond this
   raw-signing/import gate as the local alternate.
+- 2026-04-29: `wallet_importprunedfunds.py`, `wallet_timelock.py`,
+  `wallet_orphanedreward.py`, and `wallet_v3_txs.py` are now promoted into the
+  canonical `pq_required` gate and locally revalidated with the build-tree
+  functional runner. The owned boundary covers restored inherited
+  import-pruned-funds, timelock, orphaned reward, and v3/TRUC wallet behavior
+  under the current legacy-compatible PQC profile. `wallet_migration.py`
+  remains blocked locally because previous-release fixtures are unavailable.
+  The next owned follow-on remains `feature_coinstatsindex_compatibility.py`
+  when real prior PQBTC release assets exist, with `wallet_crosschain.py`,
+  `wallet_createwalletdescriptor.py`, and `wallet_backwards_compatibility.py`
+  as the local alternate backlog.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1645,6 +1693,11 @@ Aineko must ask before:
   and raw-signing surfaces: `wallet_importdescriptors.py` and
   `wallet_signrawtransactionwithwallet.py` pass targeted validation in the
   current tree.
+- There is no current blocker in the restored inherited wallet
+  import-pruned-funds, timelock, orphaned reward, and v3/TRUC surfaces:
+  `wallet_importprunedfunds.py`, `wallet_timelock.py`,
+  `wallet_orphanedreward.py`, and `wallet_v3_txs.py` pass targeted validation
+  in the current tree.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures
   are available.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence

--- a/docs/WALLET_RAW_SIGNING_IMPORT_POSTURE.md
+++ b/docs/WALLET_RAW_SIGNING_IMPORT_POSTURE.md
@@ -38,8 +38,9 @@ This promotion does not define:
 - replacement-path Taproot or bech32m wallet semantics beyond existing tests
 - new PQ-only active-manager RPC behavior
 - wallet migration or backwards-compatibility release-asset behavior
-- import-pruned-funds, timelock, orphaned reward, v3 transaction, or signer
-  behavior outside these raw-signing and descriptor-import contracts
+- inherited wallet crosschain, backwards-compatibility, or
+  `createwalletdescriptor` behavior outside these raw-signing and
+  descriptor-import contracts
 - prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 ## Confidence Snapshot
@@ -65,5 +66,6 @@ PQC-compatible legacy profile.
 `wallet_migration.py` remains blocked locally because the previous-release
 fixtures are unavailable. The preferred Track A follow-on remains
 `feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist locally. Until then, the repo-local wallet alternate moves to remaining
-wallet transaction breadth beyond this raw-signing/import gate.
+exist locally. Until then, the repo-local wallet alternate moved to remaining
+wallet transaction breadth beyond this raw-signing/import gate; that adjacent
+surface is now covered by `WALLET_REMAINING_TRANSACTION_BREADTH_POSTURE.md`.

--- a/docs/WALLET_REMAINING_TRANSACTION_BREADTH_POSTURE.md
+++ b/docs/WALLET_REMAINING_TRANSACTION_BREADTH_POSTURE.md
@@ -1,0 +1,77 @@
+# PQBTC Wallet Remaining Transaction Breadth Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-REMAINING-TRANSACTION-BREADTH-POSTURE-v1
+## Updated: 2026-04-29
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited wallet import-pruned-funds, timelock, orphaned reward, and
+v3/TRUC transaction contracts under the current legacy-compatible PQC profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+The following suites are now required PQ gates:
+
+- [wallet_importprunedfunds.py](../test/functional/wallet_importprunedfunds.py)
+- [wallet_orphanedreward.py](../test/functional/wallet_orphanedreward.py)
+- [wallet_timelock.py](../test/functional/wallet_timelock.py)
+- [wallet_v3_txs.py](../test/functional/wallet_v3_txs.py)
+
+The owned boundary covers:
+
+- `importprunedfunds` and `removeprunedfunds` proof import rejection for
+  unaffiliated addresses, watch-only descriptor import, private-key import,
+  balance/listing updates, removal behavior, transaction decode errors, proof
+  mismatch errors, malformed merkleblock rejection, and missing-block rejection
+- confirmed timelocked send accounting stability across received-by-address,
+  received-by-label, listreceived, trusted balance, and unspent coin state when
+  mock time changes finality
+- orphaned block reward handling, descendant abandonment, reload persistence,
+  and preserving abandoned descendants when the reward returns to the active
+  chain
+- wallet v3/TRUC behavior for version-mixing spend availability, v3 UTXO
+  visibility, conflicting sibling handling, mempool conflict removal, parent
+  and child weight checks, user input weight preservation, `createpsbt`,
+  `send`, `sendall`, funded-PSBT v3 flows, TRUC weight-limit errors,
+  non-TRUC mixing rejection, multiple unconfirmed TRUC output rejection, and
+  third-generation spend rejection
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- replacement-path Taproot or bech32m wallet semantics beyond existing tests
+- new PQ-only active-manager RPC behavior
+- wallet migration or backwards-compatibility release-asset behavior
+- inherited wallet crosschain, backwards-compatibility, or
+  `createwalletdescriptor` behavior outside these transaction-breadth contracts
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-29:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_importprunedfunds.py wallet_timelock.py wallet_orphanedreward.py wallet_v3_txs.py`
+  - result: passed
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=78`, `pq_backlog=47`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes the inherited wallet import-pruned-funds,
+timelock, orphaned reward, and v3/TRUC wallet behavior that already passes
+under the current PQC-compatible legacy profile.
+
+`wallet_migration.py` remains blocked locally because the previous-release
+fixtures are unavailable. The preferred Track A follow-on remains
+`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
+exist locally. Until then, the repo-local wallet alternate moves to the small
+remaining local wallet backlog: `wallet_crosschain.py`,
+`wallet_createwalletdescriptor.py`, and `wallet_backwards_compatibility.py`.


### PR DESCRIPTION
## Summary
- Promotes `wallet_importprunedfunds.py`, `wallet_timelock.py`, `wallet_orphanedreward.py`, and `wallet_v3_txs.py` from `pq_backlog` to `pq_required`.
- Updates `ci/test/pq_functional_tests.txt` and CI completeness counts to `pq_required=78`, `pq_backlog=47`, `dual_profile=142`, `legacy_only=9`.
- Adds `WALLET_REMAINING_TRANSACTION_BREADTH_POSTURE.md` and refreshes Track A handoff docs so `wallet_migration.py` remains blocked on previous-release fixtures while the remaining local wallet backlog is narrowed to crosschain/createwalletdescriptor/backwards-compatibility.

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `git diff --check`
- `git diff --cached --check`
- `build/test/functional/test_runner.py --jobs=1 wallet_importprunedfunds.py wallet_timelock.py wallet_orphanedreward.py wallet_v3_txs.py