### PR TITLE
ci: promote wallet crosschain descriptor gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1564,18 +1564,18 @@
   },
   {
     "name": "wallet_createwalletdescriptor.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "taproot_matrix_bucket": "deferred",
     "owner": "@scottdhughes",
     "tracking_issue": "#23",
-    "notes": "Inherited xpub descriptor builder with bech32/wpkh and bech32m/tr coverage plus an explicit PQ-only rejection boundary; kept in pq_backlog and classified as deferred in the #23 migration matrix."
+    "notes": "Now freezes the inherited createwalletdescriptor boundary under the legacy-compatible PQC profile: xpub-based bech32/wpkh and bech32m/tr descriptor creation, active descriptor key selection, duplicate/invalid HD-key validation, encrypted-wallet unlock behavior, and explicit PQ-only active-manager rejection without mutating wallet state; replacement descriptor semantics remain deferred in the #23 migration matrix."
   },
   {
     "name": "wallet_crosschain.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Now freezes the inherited cross-chain wallet file safety boundary under the legacy-compatible PQC profile: wallets and backups from a different genesis/network are rejected by loadwallet and restorewallet with wallet verification failure."
   },
   {
     "name": "wallet_descriptor.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -28,6 +28,8 @@ wallet_coinbase_category.py
 wallet_conflicts.py
 wallet_create_tx.py
 wallet_createwallet.py
+wallet_createwalletdescriptor.py
+wallet_crosschain.py
 wallet_descriptor.py
 wallet_disable.py
 wallet_encryption.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `78` |
-| `pq_backlog` | `47` |
+| `pq_required` | `80` |
+| `pq_backlog` | `45` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -82,45 +82,47 @@ Current required PQ-first gates:
 37. `wallet_conflicts.py`
 38. `wallet_create_tx.py`
 39. `wallet_createwallet.py`
-40. `wallet_descriptor.py`
-41. `wallet_disable.py`
-42. `wallet_encryption.py`
-43. `wallet_fallbackfee.py`
-44. `wallet_fast_rescan.py`
-45. `wallet_fundrawtransaction.py`
-46. `wallet_gethdkeys.py`
-47. `wallet_groups.py`
-48. `wallet_hd.py`
-49. `wallet_importdescriptors.py`
-50. `wallet_importprunedfunds.py`
-51. `wallet_keypool.py`
-52. `wallet_keypool_topup.py`
-53. `wallet_labels.py`
-54. `wallet_listdescriptors.py`
-55. `wallet_listreceivedby.py`
-56. `wallet_listsinceblock.py`
-57. `wallet_listtransactions.py`
-58. `wallet_miniscript.py`
-59. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-60. `wallet_multisig_descriptor_psbt.py`
-61. `wallet_multiwallet.py`
-62. `wallet_orphanedreward.py`
-63. `wallet_reindex.py`
-64. `wallet_reorgsrestore.py`
-65. `wallet_rescan_unconfirmed.py`
-66. `wallet_resendwallettransactions.py`
-67. `wallet_send.py`
-68. `wallet_sendall.py`
-69. `wallet_sendmany.py`
-70. `wallet_signrawtransactionwithwallet.py`
-71. `wallet_simulaterawtx.py`
-72. `wallet_spend_unconfirmed.py`
-73. `wallet_startup.py`
-74. `wallet_timelock.py`
-75. `wallet_transactiontime_rescan.py`
-76. `wallet_txn_clone.py`
-77. `wallet_txn_doublespend.py`
-78. `wallet_v3_txs.py`
+40. `wallet_createwalletdescriptor.py`
+41. `wallet_crosschain.py`
+42. `wallet_descriptor.py`
+43. `wallet_disable.py`
+44. `wallet_encryption.py`
+45. `wallet_fallbackfee.py`
+46. `wallet_fast_rescan.py`
+47. `wallet_fundrawtransaction.py`
+48. `wallet_gethdkeys.py`
+49. `wallet_groups.py`
+50. `wallet_hd.py`
+51. `wallet_importdescriptors.py`
+52. `wallet_importprunedfunds.py`
+53. `wallet_keypool.py`
+54. `wallet_keypool_topup.py`
+55. `wallet_labels.py`
+56. `wallet_listdescriptors.py`
+57. `wallet_listreceivedby.py`
+58. `wallet_listsinceblock.py`
+59. `wallet_listtransactions.py`
+60. `wallet_miniscript.py`
+61. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+62. `wallet_multisig_descriptor_psbt.py`
+63. `wallet_multiwallet.py`
+64. `wallet_orphanedreward.py`
+65. `wallet_reindex.py`
+66. `wallet_reorgsrestore.py`
+67. `wallet_rescan_unconfirmed.py`
+68. `wallet_resendwallettransactions.py`
+69. `wallet_send.py`
+70. `wallet_sendall.py`
+71. `wallet_sendmany.py`
+72. `wallet_signrawtransactionwithwallet.py`
+73. `wallet_simulaterawtx.py`
+74. `wallet_spend_unconfirmed.py`
+75. `wallet_startup.py`
+76. `wallet_timelock.py`
+77. `wallet_transactiontime_rescan.py`
+78. `wallet_txn_clone.py`
+79. `wallet_txn_doublespend.py`
+80. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -196,6 +198,12 @@ invalid option combinations, disabled-private-key and blank-wallet creation,
 descriptor import behavior, encryption, empty-passphrase warnings,
 `avoid_reuse`, legacy-wallet rejection, and wallet version logging under the
 current PQC profile.
+The inherited wallet descriptor-creation and cross-chain wallet-file
+confidence gap is now also part of the required gate:
+`wallet_createwalletdescriptor.py` and `wallet_crosschain.py` cover xpub-based
+descriptor creation, bech32/bech32m descriptor manager creation, PQ-only
+active-manager rejection, and cross-genesis wallet load/restore rejection under
+the current PQC profile.
 The inherited multiwallet lifecycle confidence gap is now also part of the
 required gate: `wallet_multiwallet.py` covers wallet directory scanning, wallet
 path validation and symlink rejection, dynamic load/unload and creation,

--- a/docs/CREATEWALLETDESCRIPTOR_POSTURE.md
+++ b/docs/CREATEWALLETDESCRIPTOR_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: CREATEWALLETDESCRIPTOR-POSTURE-v1
+## Updated: 2026-04-29
 ## Frozen-By: track-a-phase1-20260406
 ## Consensus-Relevant: NO
 
@@ -73,9 +74,11 @@ And the fixed public watch-only side is exercised in:
 
 Under the all-PQ stance:
 
-- the current `createwalletdescriptor` behavior is inherited and deferred
+- the current `createwalletdescriptor` behavior is inherited and required as a
+  legacy-compatible PQC gate
+- replacement descriptor semantics remain deferred
 - it remains useful as reference coverage for descriptor-wallet plumbing
-- it is not an owned PQ-native milestone by itself
+- it is not evidence that PQ-native descriptor creation is solved
 
 Current UX improvement:
 
@@ -108,23 +111,19 @@ Reasoning:
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-12:
+Targeted confidence pass run on 2026-04-29:
 
-- `python3 test/functional/wallet_createwalletdescriptor.py`
+- `build/test/functional/test_runner.py --jobs=1 wallet_crosschain.py wallet_createwalletdescriptor.py`
   - result: passed
   - relevant guard: inherited xpub creation still works for `bech32` /
     `bech32m`, while PQ-only active-manager wallets reject both families with
     the current PQ-specific xpub-only RPC error and without mutating
-    descriptor, HD-key, or active-manager state
-- `python3 test/functional/wallet_pq_active_ranged.py`
-  - result: passed
-  - relevant guard: dedicated PQ setup remains on
-    `createpqwalletmanagers`, and restore/reload rejection coverage for active
-    `pqpriv(...)` managers stays owned there
+    descriptor, HD-key, or active-manager state; cross-chain wallets and
+    backups from a different genesis/network are rejected on load and restore
 
 Interpretation:
 
-- inherited descriptor creation remains healthy
+- inherited descriptor creation is now part of the canonical required gate
 - PQ-only wallets are explicitly rejected by this inherited RPC
 - PQ-native setup remains explicit and test-backed on
   `createpqwalletmanagers` without overloading the inherited RPC

--- a/docs/TAPROOT_MIGRATION_MATRIX.md
+++ b/docs/TAPROOT_MIGRATION_MATRIX.md
@@ -164,7 +164,7 @@ annex, mempool, relay, policy, wallet, descriptor, address, RPC, or PSBT behavio
 | `rpc_createmultisig.py` | `dual_profile` | `deferred` | Contains Taproot-adjacent bech32m coverage, but replacement-specific semantics are not yet defined. |
 | `rpc_psbt.py` | `pq_required` | `deferred` | Required for the restored pre-taproot PSBT decode/finalize contract, while Taproot-facing replacement semantics remain undefined. |
 | `wallet_address_types.py` | `pq_required` | `deferred` | Required for restored inherited address-type smoke coverage, inherited mixed-address `sendmany`, and PQ-only inherited-address RPC rejection boundaries, while replacement-specific semantics remain undefined. |
-| `wallet_createwalletdescriptor.py` | `pq_backlog` | `deferred` | Contains `tr(...)` descriptor creation paths, but replacement descriptor semantics are not yet defined. |
+| `wallet_createwalletdescriptor.py` | `pq_required` | `deferred` | Required for the inherited xpub descriptor-creation and explicit PQ-only rejection boundary, while replacement descriptor semantics remain undefined. |
 | `wallet_miniscript.py` | `pq_required` | `deferred` | Required for the restored wallet-side miniscript funding/signing/finalization contract, while TapMiniscript replacement meaning remains undefined. |
 | `wallet_miniscript_decaying_multisig_descriptor_psbt.py` | `pq_required` | `deferred` | Required for the decaying miniscript multisig funding/signing/finalization contract, while future replacement-path meaning remains separate. |
 

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-28
+## Updated: 2026-04-29
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -71,11 +71,13 @@ behavior in the same gate, then
 keep `wallet_importprunedfunds.py`, `wallet_timelock.py`,
 `wallet_orphanedreward.py`, and `wallet_v3_txs.py` remaining wallet
 transaction-breadth behavior in the same gate, then
+keep `wallet_createwalletdescriptor.py` and `wallet_crosschain.py`
+descriptor-creation and cross-chain wallet-file behavior in the same gate,
+then
 return the next owned follow-on to `feature_coinstatsindex_compatibility.py`
-when real prior PQBTC release assets exist, with the small remaining local
-wallet backlog beyond the current transaction-breadth gate as the local
-alternate while `wallet_migration.py` remains blocked on previous-release
-fixtures.
+when real prior PQBTC release assets exist. Locally,
+`wallet_backwards_compatibility.py` and `wallet_migration.py` remain blocked
+until previous-release fixtures are available.
 
 ## Current Working Thesis
 
@@ -99,10 +101,11 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. small remaining local wallet backlog beyond the current transaction-breadth
-   gate
+2. local non-wallet `pq_backlog` inventory review
    - Why alternate: if the asset-dependent coinstats compatibility path stays
-     blocked locally, this is the next wallet-facing surface to rebalance
+     blocked locally, the unblocked wallet-local backlog has been exhausted
+     except for previous-release-dependent suites. Choose the next local
+     tranche from non-wallet `pq_backlog` only after an inventory review,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -111,8 +114,9 @@ Alternate rebalance:
      coin-selection, spend-policy, bumpfee/conflict, basic wallet,
      transaction-construction, simulation, raw-signing, and import-descriptor
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
-     and v3/TRUC transaction tranche. `wallet_migration.py` stays blocked until
-     previous-release fixtures are available.
+     v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
+     tranches. `wallet_backwards_compatibility.py` and `wallet_migration.py`
+     stay blocked until previous-release fixtures are available.
 
 Still deferred:
 
@@ -912,25 +916,47 @@ Still deferred:
    Still deferred inside this suite:
    - `wallet_migration.py`, which is skipped locally because previous-release
      fixtures are unavailable
-   - `wallet_crosschain.py`, `wallet_createwalletdescriptor.py`, and
-     `wallet_backwards_compatibility.py`
-46. Recommended next PR after this tranche:
+   - `wallet_crosschain.py` and `wallet_createwalletdescriptor.py` are now
+     covered by the adjacent required descriptor-creation/cross-chain gate;
+     `wallet_backwards_compatibility.py` remains previous-release blocked
+46. `wallet_createwalletdescriptor.py` and `wallet_crosschain.py` now own:
+   - restored inherited xpub descriptor creation and cross-chain wallet-file
+     safety behavior under the current legacy-compatible PQC profile
+   - `createwalletdescriptor` xpub-based bech32/wpkh and bech32m/tr descriptor
+     manager creation, active descriptor key selection, duplicate/invalid
+     HD-key validation, encrypted-wallet unlock behavior, and explicit
+     PQ-only active-manager rejection without mutating wallet state
+   - wallet and backup rejection from a different genesis/network through
+     `loadwallet` and `restorewallet`
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_crosschain.py wallet_createwalletdescriptor.py`
+   Compatibility probe:
+   - `build/test/functional/test_runner.py --jobs=1 wallet_crosschain.py wallet_createwalletdescriptor.py wallet_backwards_compatibility.py`
+   - expected local outcome: `wallet_backwards_compatibility.py` skipped
+     because previous-release fixtures are unavailable
+   Fixed posture note:
+   - `WALLET_CROSSCHAIN_DESCRIPTOR_CREATION_POSTURE.md`
+   Still deferred inside this suite:
+   - `wallet_backwards_compatibility.py` and `wallet_migration.py`, which are
+     skipped locally because previous-release fixtures are unavailable
+   - `feature_coinstatsindex_compatibility.py`, which remains blocked until
+     real prior PQBTC release assets exist
+47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: small remaining local wallet backlog beyond this
-     transaction-breadth gate
+   - alternate: local non-wallet `pq_backlog` tranche selected after inventory
+     review
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - crosschain, createwalletdescriptor, and backwards-compatibility work remain
-     useful after the current
+   - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
+     useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
      HD, keypool, descriptor-listing, accounting, label, transaction-listing,
      coin-selection, spend-policy, bumpfee/conflict, basic wallet,
      transaction-construction, simulation, raw-signing, and import-descriptor
      gates are frozen, and after the current import-pruned-funds, timelock,
-     orphaned reward, and v3/TRUC transaction gate is frozen, but additional
-     wallet work stays behind the asset-dependent compatibility slice once
-     prior PQBTC release assets are available
+     orphaned reward, v3/TRUC transaction, descriptor-creation, and
+     cross-chain wallet-file gates are frozen
 19. Use `FEATURE_BLOCK_POSTURE.md` as the fixed note for the current
    `feature_block.py` contract.
 20. Use `PSBT_REPLACEMENT_TRANCHE.md` as the current owned miniscript/PSBT
@@ -1587,6 +1613,17 @@ Aineko must ask before:
   when real prior PQBTC release assets exist, with `wallet_crosschain.py`,
   `wallet_createwalletdescriptor.py`, and `wallet_backwards_compatibility.py`
   as the local alternate backlog.
+- 2026-04-29: `wallet_createwalletdescriptor.py` and `wallet_crosschain.py`
+  are now promoted into the canonical `pq_required` gate and locally
+  revalidated with the build-tree functional runner. The owned boundary covers
+  inherited xpub descriptor creation, explicit PQ-only active-manager
+  rejection, and cross-genesis wallet load/restore rejection under the current
+  legacy-compatible PQC profile. `wallet_backwards_compatibility.py` and
+  `wallet_migration.py` remain blocked locally because previous-release
+  fixtures are unavailable. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise choose any next local tranche from non-wallet
+  `pq_backlog` after inventory review.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1698,6 +1735,12 @@ Aineko must ask before:
   `wallet_importprunedfunds.py`, `wallet_timelock.py`,
   `wallet_orphanedreward.py`, and `wallet_v3_txs.py` pass targeted validation
   in the current tree.
+- There is no current blocker in the restored inherited wallet
+  descriptor-creation and cross-chain wallet-file surfaces:
+  `wallet_createwalletdescriptor.py` and `wallet_crosschain.py` pass targeted
+  validation in the current tree.
+- `wallet_backwards_compatibility.py` remains blocked locally until
+  previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures
   are available.
 - There is no current `OPS_SLO` blocker. The refreshed `2026-04-06` evidence

--- a/docs/WALLET_CROSSCHAIN_DESCRIPTOR_CREATION_POSTURE.md
+++ b/docs/WALLET_CROSSCHAIN_DESCRIPTOR_CREATION_POSTURE.md
@@ -1,0 +1,64 @@
+# PQBTC Wallet Cross-Chain And Descriptor-Creation Posture
+
+## Status: ACTIVE
+## Spec-ID: WALLET-CROSSCHAIN-DESCRIPTOR-CREATION-POSTURE-v1
+## Updated: 2026-04-29
+## Consensus-Relevant: NO
+
+## Purpose
+
+Freeze the inherited cross-chain wallet-file safety boundary and inherited
+xpub descriptor-creation boundary under the current legacy-compatible PQC
+profile.
+
+This tranche is a gate promotion only. It does not change RPC, wallet,
+descriptor, policy, relay, or consensus behavior.
+
+## Owned Surface
+
+The following suites are now required PQ gates:
+
+- [wallet_createwalletdescriptor.py](../test/functional/wallet_createwalletdescriptor.py)
+- [wallet_crosschain.py](../test/functional/wallet_crosschain.py)
+
+The owned boundary covers:
+
+- `createwalletdescriptor` xpub-based `bech32`/`wpkh(...)` and
+  `bech32m`/`tr(...)` descriptor creation
+- active descriptor key selection, duplicate and invalid HD-key validation,
+  and encrypted-wallet unlock behavior
+- explicit PQ-only active-manager rejection without mutating wallet state
+- rejection of wallets and backups from a different genesis/network by
+  `loadwallet` and `restorewallet`
+
+## Non-Goals In This Tranche
+
+This promotion does not define:
+
+- PQ-native descriptor creation
+- replacement descriptor semantics
+- wallet migration or backwards-compatibility release-asset behavior
+- prior-release compatibility for `feature_coinstatsindex_compatibility.py`
+
+## Confidence Snapshot
+
+Targeted confidence on 2026-04-29:
+
+- `build/test/functional/test_runner.py --jobs=1 wallet_crosschain.py wallet_createwalletdescriptor.py`
+  - result: passed
+- `build/test/functional/test_runner.py --jobs=1 wallet_crosschain.py wallet_createwalletdescriptor.py wallet_backwards_compatibility.py`
+  - result: promoted suites passed; `wallet_backwards_compatibility.py`
+    skipped because previous releases are unavailable locally
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts after this promotion: `pq_required=80`, `pq_backlog=45`,
+    `dual_profile=142`, `legacy_only=9`
+
+## Interpretation
+
+The canonical PQ gate now includes these inherited wallet surfaces.
+
+`wallet_migration.py` and `wallet_backwards_compatibility.py` remain blocked
+locally because previous-release fixtures are unavailable. The preferred Track
+A follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+PQBTC release assets exist locally.

--- a/docs/WALLET_REMAINING_TRANSACTION_BREADTH_POSTURE.md
+++ b/docs/WALLET_REMAINING_TRANSACTION_BREADTH_POSTURE.md
@@ -48,8 +48,8 @@ This promotion does not define:
 - replacement-path Taproot or bech32m wallet semantics beyond existing tests
 - new PQ-only active-manager RPC behavior
 - wallet migration or backwards-compatibility release-asset behavior
-- inherited wallet crosschain, backwards-compatibility, or
-  `createwalletdescriptor` behavior outside these transaction-breadth contracts
+- inherited wallet backwards-compatibility behavior outside these
+  transaction-breadth contracts
 - prior-release compatibility for `feature_coinstatsindex_compatibility.py`
 
 ## Confidence Snapshot
@@ -69,9 +69,11 @@ The canonical PQ gate now includes the inherited wallet import-pruned-funds,
 timelock, orphaned reward, and v3/TRUC wallet behavior that already passes
 under the current PQC-compatible legacy profile.
 
-`wallet_migration.py` remains blocked locally because the previous-release
-fixtures are unavailable. The preferred Track A follow-on remains
-`feature_coinstatsindex_compatibility.py` when real prior PQBTC release assets
-exist locally. Until then, the repo-local wallet alternate moves to the small
-remaining local wallet backlog: `wallet_crosschain.py`,
-`wallet_createwalletdescriptor.py`, and `wallet_backwards_compatibility.py`.
+The repo-local wallet alternate moved to `wallet_crosschain.py` and
+`wallet_createwalletdescriptor.py`; those surfaces are now covered by
+[WALLET_CROSSCHAIN_DESCRIPTOR_CREATION_POSTURE.md](./WALLET_CROSSCHAIN_DESCRIPTOR_CREATION_POSTURE.md).
+
+`wallet_migration.py` and `wallet_backwards_compatibility.py` remain blocked
+locally because previous-release fixtures are unavailable. The preferred Track
+A follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+PQBTC release assets exist locally.


### PR DESCRIPTION
Summary
- Promote wallet_createwalletdescriptor.py and wallet_crosschain.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=80, pq_backlog=45, dual_profile=142, legacy_only=9.
- Add the cross-chain/descriptor-creation posture and refresh Track A handoff state while keeping previous-release suites blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 wallet_crosschain.py wallet_createwalletdescriptor.py
- build/test/functional/test_runner.py --jobs=1 wallet_crosschain.py wallet_createwalletdescriptor.py wallet_backwards_compatibility.py (promoted suites passed; wallet_backwards_compatibility.py skipped because previous releases are unavailable locally)

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.