### PR TITLE
ci: promote block storage prune gates

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -85,17 +85,17 @@
   },
   {
     "name": "feature_blocksdir.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes the external -blocksdir storage-layout contract: missing-path init failure, external blk/rev storage under the chosen blocksdir, local chain-path block index retention, no silent top-level datadir blocks fallback, and restart persistence with the same external blocksdir; broader block-file mutation and XOR handling remain separate follow-on surfaces."
+    "notes": "Now promoted into pq_required as the external -blocksdir storage-layout gate: missing-path init failure, external blk/rev storage under the chosen blocksdir, local chain-path block index retention, no silent top-level datadir blocks fallback, and restart persistence with the same external blocksdir; broader block-file mutation and bootstrap/import behavior remain separate follow-on surfaces."
   },
   {
     "name": "feature_blocksxor.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes the narrow -blocksxor storage boundary: non-wallet block-file seeding under -fastprune, manual un-XOR rewrite of mined blk/rev files with the stored XOR key, explicit restart rejection when -blocksxor=0 is requested while a random key still exists, successful restart after deleting the key, full verifychain integrity validation, and recreation of the null XOR key; broader corruption, reindex, prune, and chainstate migration decisions remain separate follow-on surfaces."
+    "notes": "Now promoted into pq_required as the narrow -blocksxor storage gate: non-wallet block-file seeding under -fastprune, manual un-XOR rewrite of mined blk/rev files with the stored XOR key, explicit restart rejection when -blocksxor=0 is requested while a random key still exists, successful restart after deleting the key, full verifychain integrity validation, and recreation of the null XOR key; broader corruption, generic reindex, bootstrap/import, and chainstate migration decisions remain separate follow-on surfaces."
   },
   {
     "name": "feature_cltv.py",
@@ -162,10 +162,10 @@
   },
   {
     "name": "feature_fastprune.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes the narrow -fastprune large-block admission boundary: one large witness-annex block mined through the non-signing MiniWallet ADDRESS_OP_TRUE path is accepted under -fastprune and advances the initialized chain without crash or hang; broader prune lifecycle, restart, reindex, and prune-plus-index interaction remain separate follow-on surfaces."
+    "notes": "Now promoted into pq_required as the narrow -fastprune large-block admission gate: one large witness-annex block mined through the non-signing MiniWallet ADDRESS_OP_TRUE path is accepted under -fastprune and advances the initialized chain without crash or hang; broader generic restart/reindex and bootstrap/import interaction remain separate follow-on surfaces."
   },
   {
     "name": "feature_fee_estimation.py",
@@ -218,10 +218,10 @@
   },
   {
     "name": "feature_index_prune.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes the prune-plus-index matrix: linear RPC sync for blockfilter/coinstats indices under prune, index accessibility before and after pruning, exact prune-to-index-height restart continuity, prune-past-index-height init failures until -reindex, recovery after -reindex, and explicit prune-lock handling in the reorg path; broader bootstrap/loadblock import behavior remains separate."
+    "notes": "Now promoted into pq_required as the prune-plus-index matrix gate: linear RPC sync for blockfilter/coinstats indices under prune, index accessibility before and after pruning, exact prune-to-index-height restart continuity, prune-past-index-height init failures until -reindex, recovery after -reindex, and explicit prune-lock handling in the reorg path; broader bootstrap/loadblock import behavior remains separate."
   },
   {
     "name": "feature_init.py",
@@ -372,10 +372,10 @@
   },
   {
     "name": "feature_remove_pruned_files_on_startup.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes the prune-lifecycle cleanup boundary under -fastprune -prune=1: multi-file blk/rev creation, immediate prune-triggered deletion where open file descriptors permit it, explicit Windows delayed-delete behavior, cleanup completion after restart once descriptors are closed, and -reindex recreation of a fresh blk00000/rev00000 baseline; broader prune-plus-index interaction remains a separate follow-on surface."
+    "notes": "Now promoted into pq_required as the prune-lifecycle cleanup gate under -fastprune -prune=1: multi-file blk/rev creation, immediate prune-triggered deletion where open file descriptors permit it, explicit Windows delayed-delete behavior, cleanup completion after restart once descriptors are closed, and -reindex recreation of a fresh blk00000/rev00000 baseline; broader bootstrap/import interaction remains a separate follow-on surface."
   },
   {
     "name": "feature_segwit.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -1,10 +1,15 @@
 feature_assumeutxo.py
 feature_assumevalid.py
 feature_block.py
+feature_blocksdir.py
+feature_blocksxor.py
+feature_fastprune.py
+feature_index_prune.py
 feature_pq_block_limits.py
 feature_pq_reorg.py
 feature_pqsig_basic.py
 feature_pqsig_multisig.py
+feature_remove_pruned_files_on_startup.py
 feature_taproot_replacement_deployment.py
 feature_taproot_replacement_compat.py
 feature_taproot_replacement_active_boundary.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `80` |
-| `pq_backlog` | `45` |
+| `pq_required` | `85` |
+| `pq_backlog` | `40` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -66,63 +66,68 @@ Current required PQ-first gates:
 21. `feature_assumeutxo.py`
 22. `feature_assumevalid.py`
 23. `feature_block.py`
-24. `rpc_psbt.py`
-25. `wallet_abandonconflict.py`
-26. `wallet_address_types.py`
-27. `wallet_assumeutxo.py`
-28. `wallet_avoid_mixing_output_types.py`
-29. `wallet_avoidreuse.py`
-30. `wallet_backup.py`
-31. `wallet_balance.py`
-32. `wallet_basic.py`
-33. `wallet_blank.py`
-34. `wallet_bumpfee.py`
-35. `wallet_change_address.py`
-36. `wallet_coinbase_category.py`
-37. `wallet_conflicts.py`
-38. `wallet_create_tx.py`
-39. `wallet_createwallet.py`
-40. `wallet_createwalletdescriptor.py`
-41. `wallet_crosschain.py`
-42. `wallet_descriptor.py`
-43. `wallet_disable.py`
-44. `wallet_encryption.py`
-45. `wallet_fallbackfee.py`
-46. `wallet_fast_rescan.py`
-47. `wallet_fundrawtransaction.py`
-48. `wallet_gethdkeys.py`
-49. `wallet_groups.py`
-50. `wallet_hd.py`
-51. `wallet_importdescriptors.py`
-52. `wallet_importprunedfunds.py`
-53. `wallet_keypool.py`
-54. `wallet_keypool_topup.py`
-55. `wallet_labels.py`
-56. `wallet_listdescriptors.py`
-57. `wallet_listreceivedby.py`
-58. `wallet_listsinceblock.py`
-59. `wallet_listtransactions.py`
-60. `wallet_miniscript.py`
-61. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-62. `wallet_multisig_descriptor_psbt.py`
-63. `wallet_multiwallet.py`
-64. `wallet_orphanedreward.py`
-65. `wallet_reindex.py`
-66. `wallet_reorgsrestore.py`
-67. `wallet_rescan_unconfirmed.py`
-68. `wallet_resendwallettransactions.py`
-69. `wallet_send.py`
-70. `wallet_sendall.py`
-71. `wallet_sendmany.py`
-72. `wallet_signrawtransactionwithwallet.py`
-73. `wallet_simulaterawtx.py`
-74. `wallet_spend_unconfirmed.py`
-75. `wallet_startup.py`
-76. `wallet_timelock.py`
-77. `wallet_transactiontime_rescan.py`
-78. `wallet_txn_clone.py`
-79. `wallet_txn_doublespend.py`
-80. `wallet_v3_txs.py`
+24. `feature_blocksdir.py`
+25. `feature_blocksxor.py`
+26. `feature_fastprune.py`
+27. `feature_index_prune.py`
+28. `feature_remove_pruned_files_on_startup.py`
+29. `rpc_psbt.py`
+30. `wallet_abandonconflict.py`
+31. `wallet_address_types.py`
+32. `wallet_assumeutxo.py`
+33. `wallet_avoid_mixing_output_types.py`
+34. `wallet_avoidreuse.py`
+35. `wallet_backup.py`
+36. `wallet_balance.py`
+37. `wallet_basic.py`
+38. `wallet_blank.py`
+39. `wallet_bumpfee.py`
+40. `wallet_change_address.py`
+41. `wallet_coinbase_category.py`
+42. `wallet_conflicts.py`
+43. `wallet_create_tx.py`
+44. `wallet_createwallet.py`
+45. `wallet_createwalletdescriptor.py`
+46. `wallet_crosschain.py`
+47. `wallet_descriptor.py`
+48. `wallet_disable.py`
+49. `wallet_encryption.py`
+50. `wallet_fallbackfee.py`
+51. `wallet_fast_rescan.py`
+52. `wallet_fundrawtransaction.py`
+53. `wallet_gethdkeys.py`
+54. `wallet_groups.py`
+55. `wallet_hd.py`
+56. `wallet_importdescriptors.py`
+57. `wallet_importprunedfunds.py`
+58. `wallet_keypool.py`
+59. `wallet_keypool_topup.py`
+60. `wallet_labels.py`
+61. `wallet_listdescriptors.py`
+62. `wallet_listreceivedby.py`
+63. `wallet_listsinceblock.py`
+64. `wallet_listtransactions.py`
+65. `wallet_miniscript.py`
+66. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+67. `wallet_multisig_descriptor_psbt.py`
+68. `wallet_multiwallet.py`
+69. `wallet_orphanedreward.py`
+70. `wallet_reindex.py`
+71. `wallet_reorgsrestore.py`
+72. `wallet_rescan_unconfirmed.py`
+73. `wallet_resendwallettransactions.py`
+74. `wallet_send.py`
+75. `wallet_sendall.py`
+76. `wallet_sendmany.py`
+77. `wallet_signrawtransactionwithwallet.py`
+78. `wallet_simulaterawtx.py`
+79. `wallet_spend_unconfirmed.py`
+80. `wallet_startup.py`
+81. `wallet_timelock.py`
+82. `wallet_transactiontime_rescan.py`
+83. `wallet_txn_clone.py`
+84. `wallet_txn_doublespend.py`
+85. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -276,6 +281,12 @@ closed in this tranche by promoting the fixed invalid-signature burial-depth
 validation slice into the same required PQ path. The full-block confidence gap
 is narrowed in this tranche by promoting the bounded invalid-branch, transport,
 and resurrection `feature_block.py` surface into the same required PQ path.
+The block storage and prune-lifecycle confidence gap is now also part of the
+required gate: `feature_blocksdir.py`, `feature_blocksxor.py`,
+`feature_fastprune.py`, `feature_remove_pruned_files_on_startup.py`, and
+`feature_index_prune.py` cover external block storage, XORed blk/rev handling,
+large-block admission under `-fastprune`, pruned-file cleanup on startup, and
+blockfilter/coinstats index behavior under prune.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_BLOCKSDIR_POSTURE.md
+++ b/docs/FEATURE_BLOCKSDIR_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-BLOCKSDIR-POSTURE-v1
+## Updated: 2026-04-29
 ## Frozen-By: track-a-phase1-20260412
 ## Consensus-Relevant: NO
 
@@ -29,18 +30,17 @@ small storage-layout contract:
 This posture note does **not** mean:
 
 - broader block-file corruption or mutation handling is covered
-- XORed block-file behavior is covered here
 - pruning, reindex, or transport-layer block-delivery semantics are owned by
   this suite
-- this suite should move into `pq_required`
+- bootstrap or `-loadblock` import behavior is covered
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-12:
+Targeted confidence pass run on 2026-04-29:
 
-- `python3 test/functional/feature_blocksdir.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
   - result: passed
   - current posture:
     - missing external blocksdir still fails at init
@@ -51,10 +51,8 @@ Targeted confidence pass run on 2026-04-12:
 
 ## Interpretation
 
-- `feature_blocksdir.py` is now an owned external-storage configuration slice
+- `feature_blocksdir.py` is now a required external-storage configuration gate
 - it is a storage-layout contract, not a broader chainstate or block-format
   migration surface
-- the next adjacent tranche is
-  [feature_blocksxor.py](../test/functional/feature_blocksxor.py), where the
-  first current Track A break is in the inherited `MiniWallet`-based block-file
-  setup path
+- adjacent XOR, fastprune, prune-cleanup, and prune-plus-index behavior is now
+  covered by the same required storage/prune gate family

--- a/docs/FEATURE_BLOCKSXOR_POSTURE.md
+++ b/docs/FEATURE_BLOCKSXOR_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-BLOCKSXOR-POSTURE-v1
+## Updated: 2026-04-29
 ## Frozen-By: track-a-phase1-20260412
 ## Consensus-Relevant: NO
 
@@ -33,17 +34,17 @@ small storage-integrity contract:
 This posture note does **not** mean:
 
 - broader block-file corruption handling is covered
-- prune/reindex lifecycle behavior is owned here
+- generic reindex behavior is owned here
+- bootstrap or `-loadblock` import behavior is owned here
 - transport or P2P block-delivery semantics are owned here
-- this suite should move into `pq_required`
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-12:
+Targeted confidence pass run on 2026-04-29:
 
-- `python3 test/functional/feature_blocksxor.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
   - result: passed
   - current posture:
     - deterministic coinbase mining creates multiple XORed blk/rev files under
@@ -56,10 +57,8 @@ Targeted confidence pass run on 2026-04-12:
 
 ## Interpretation
 
-- `feature_blocksxor.py` is now an owned block-storage integrity slice
+- `feature_blocksxor.py` is now a required block-storage integrity gate
 - it is a narrow XOR-key and blk/rev file handling contract, not a broader
   chainstate or pruning migration surface
-- the next adjacent tranche is
-  [feature_fastprune.py](../test/functional/feature_fastprune.py), which is the
-  smallest remaining storage-adjacent follow-on to freeze after `blocksdir` and
-  `blocksxor`
+- adjacent `-fastprune`, prune-cleanup, and prune-plus-index behavior is now
+  covered by the same required storage/prune gate family

--- a/docs/FEATURE_FASTPRUNE_POSTURE.md
+++ b/docs/FEATURE_FASTPRUNE_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-FASTPRUNE-POSTURE-v1
+## Updated: 2026-04-29
 ## Frozen-By: track-a-phase1-20260412
 ## Consensus-Relevant: NO
 
@@ -29,18 +30,18 @@ small block-assembly contract:
 
 This posture note does **not** mean:
 
-- prune lifecycle or file-deletion behavior is covered
-- restart or reindex behavior is covered
-- prune-plus-index interaction is covered
-- this suite should move into `pq_required`
+- generic restart or reindex behavior is covered
+- bootstrap or `-loadblock` import behavior is covered
+- broad pruning behavior outside the exact required storage/prune family is
+  covered
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-12:
+Targeted confidence pass run on 2026-04-29:
 
-- `python3 test/functional/feature_fastprune.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
   - result: passed
   - current posture:
     - `-fastprune` still accepts the large-annex block path
@@ -50,11 +51,7 @@ Targeted confidence pass run on 2026-04-12:
 
 ## Interpretation
 
-- `feature_fastprune.py` is now an owned narrow large-block admission slice
+- `feature_fastprune.py` is now a required narrow large-block admission gate
 - it is not a general pruning or storage-lifecycle migration surface
-- the next adjacent tranche is
-  [feature_remove_pruned_files_on_startup.py](../test/functional/feature_remove_pruned_files_on_startup.py),
-  which is the smallest prune-lifecycle follow-on after `blocksdir`,
-  `blocksxor`, and `fastprune`
-- the broader alternate remains
-  [feature_index_prune.py](../test/functional/feature_index_prune.py)
+- adjacent prune-cleanup and prune-plus-index behavior is now covered by the
+  same required storage/prune gate family

--- a/docs/FEATURE_INDEX_PRUNE_POSTURE.md
+++ b/docs/FEATURE_INDEX_PRUNE_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-INDEX-PRUNE-POSTURE-v1
+## Updated: 2026-04-29
 ## Frozen-By: track-a-phase1-20260412
 ## Consensus-Relevant: NO
 
@@ -34,7 +35,6 @@ a bounded prune-plus-index matrix:
 
 This posture note does **not** mean:
 
-- this suite should move into `pq_required`
 - bootstrap or `-loadblock` import behavior is covered
 - broader block-file import or external-storage behavior is covered
 
@@ -42,9 +42,9 @@ Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-12:
+Targeted confidence pass run on 2026-04-29:
 
-- `python3 test/functional/feature_index_prune.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
   - result: passed
   - current posture:
     - blockfilter and coinstats indices remain usable before and after pruning
@@ -56,10 +56,7 @@ Targeted confidence pass run on 2026-04-12:
 
 ## Interpretation
 
-- `feature_index_prune.py` is now an owned prune-plus-index matrix
+- `feature_index_prune.py` is now a required prune-plus-index matrix gate
 - it is a higher-cost prune surface, but still a bounded functional contract
-- the next clean follow-on is
-  [feature_pq_block_limits.py](../test/functional/feature_pq_block_limits.py),
-  which is a cheaper PQ-native block-profile slice
-- the slower storage-import alternate remains
+- the next clean local storage/import follow-on is
   [feature_loadblock.py](../test/functional/feature_loadblock.py)

--- a/docs/FEATURE_REMOVE_PRUNED_FILES_ON_STARTUP_POSTURE.md
+++ b/docs/FEATURE_REMOVE_PRUNED_FILES_ON_STARTUP_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-REMOVE-PRUNED-FILES-ON-STARTUP-POSTURE-v1
+## Updated: 2026-04-29
 ## Frozen-By: track-a-phase1-20260412
 ## Consensus-Relevant: NO
 
@@ -31,18 +32,16 @@ suite owns a small prune-lifecycle contract:
 
 This posture note does **not** mean:
 
-- prune-plus-index interaction is covered
-- blockfilter or coinstats index recovery under prune is covered
-- broader reorg or index prune-lock behavior is covered
-- this suite should move into `pq_required`
+- broader index recovery outside the bounded prune-plus-index matrix is covered
+- bootstrap or `-loadblock` import behavior is covered
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-12:
+Targeted confidence pass run on 2026-04-29:
 
-- `python3 test/functional/feature_remove_pruned_files_on_startup.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
   - result: passed
   - current posture:
     - prune-triggered blk/rev removal still behaves as expected under
@@ -55,10 +54,8 @@ Targeted confidence pass run on 2026-04-12:
 
 ## Interpretation
 
-- `feature_remove_pruned_files_on_startup.py` is now an owned prune-lifecycle
-  cleanup slice
+- `feature_remove_pruned_files_on_startup.py` is now a required
+  prune-lifecycle cleanup gate
 - it is not the broader prune-plus-index migration surface
-- the next adjacent tranche is
-  [feature_index_prune.py](../test/functional/feature_index_prune.py), which is
-  the broader prune-plus-index matrix and is already green under the current
-  harness
+- adjacent prune-plus-index behavior is now covered by the same required
+  storage/prune gate family

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -18,9 +18,11 @@ Keep the decaying miniscript multisig funding/signing/finalization surface in
 `wallet_miniscript_decaying_multisig_descriptor_psbt.py` frozen, keep the
 current `feature_block.py` invalid-branch/transport/mempool tranche frozen,
 freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
-`wallet_multisig_descriptor_psbt.py`, `feature_blocksdir.py`,
-`feature_blocksxor.py`, `feature_fastprune.py`, and
-`feature_remove_pruned_files_on_startup.py`, `feature_index_prune.py`, and
+`wallet_multisig_descriptor_psbt.py`, keep `feature_blocksdir.py`,
+`feature_blocksxor.py`, `feature_fastprune.py`,
+`feature_remove_pruned_files_on_startup.py`, and `feature_index_prune.py`
+block storage and prune-lifecycle behavior in the canonical `pq_required`
+gate, and keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
@@ -101,11 +103,11 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. local non-wallet `pq_backlog` inventory review
+2. `feature_loadblock.py`
    - Why alternate: if the asset-dependent coinstats compatibility path stays
-     blocked locally, the unblocked wallet-local backlog has been exhausted
-     except for previous-release-dependent suites. Choose the next local
-     tranche from non-wallet `pq_backlog` only after an inventory review,
+     blocked locally, the next bounded local storage/import follow-on is
+     `feature_loadblock.py`, now that the external blocksdir, blocksxor,
+     fastprune, prune-cleanup, and prune-plus-index family is required,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -115,8 +117,9 @@ Alternate rebalance:
      transaction-construction, simulation, raw-signing, and import-descriptor
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
-     tranches. `wallet_backwards_compatibility.py` and `wallet_migration.py`
-     stay blocked until previous-release fixtures are available.
+     tranches. `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
+     `feature_coinstatsindex_compatibility.py` stay blocked until prior-release
+     assets are available.
 
 Still deferred:
 
@@ -225,11 +228,10 @@ Still deferred:
      `blocks/` directory while the external blocksdir is active
    - restart persistence with the same external blocksdir
    Minimum validation target:
-   - `python3 test/functional/feature_blocksdir.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
    Still deferred inside this suite:
    - block-file mutation/corruption handling
-   - XORed block-file handling
-   - promotion into `pq_required`
+   - broader bootstrap/loadblock import behavior
 7. `feature_blocksxor.py` now owns:
    - non-wallet block-file seeding via deterministic mining under
      `-blocksxor=1 -fastprune=1`
@@ -242,11 +244,11 @@ Still deferred:
      by `verifychain(checklevel=2, nblocks=0)` integrity validation
    - null XOR key recreation after the successful un-XOR restart path
    Minimum validation target:
-   - `python3 test/functional/feature_blocksxor.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
    Still deferred inside this suite:
    - broader block-file corruption handling
-   - prune/reindex lifecycle coverage
-   - promotion into `pq_required`
+   - generic reindex behavior beyond the current storage/prune gate
+   - broader bootstrap/loadblock import behavior
 8. `feature_fastprune.py` now owns:
    - startup under `-fastprune`
    - one large witness-annex block assembled through the non-signing
@@ -256,12 +258,10 @@ Still deferred:
    - explicit chain-height advancement from the initialized 200-block harness
      to 201
    Minimum validation target:
-   - `python3 test/functional/feature_fastprune.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
    Still deferred inside this suite:
-   - prune lifecycle and file-deletion handling
-   - restart and reindex behavior
-   - prune-plus-index interaction
-   - promotion into `pq_required`
+   - generic restart and reindex behavior beyond the current storage/prune gate
+   - broader bootstrap/loadblock import behavior
 9. `feature_remove_pruned_files_on_startup.py` now owns:
    - mining enough blocks under `-fastprune -prune=1` to create multiple
      blk/rev files before pruning
@@ -273,11 +273,10 @@ Still deferred:
    - `-reindex` recreation of a fresh `blk00000.dat` / `rev00000.dat`
      baseline after wiping the previous pruned file set
    Minimum validation target:
-   - `python3 test/functional/feature_remove_pruned_files_on_startup.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
    Still deferred inside this suite:
-   - prune-plus-index interaction
-   - broader index recovery and prune-lock semantics
-   - promotion into `pq_required`
+   - broader index recovery outside the bounded prune-plus-index matrix
+   - broader bootstrap/loadblock import behavior
 10. `feature_index_prune.py` now owns:
    - linear RPC block sync under prune for blockfilter/coinstats index nodes
    - index accessibility at tip before and after pruning begins
@@ -289,9 +288,8 @@ Still deferred:
    - recovery after restarting with `-reindex`
    - explicit prune-lock movement in the reorg path
    Minimum validation target:
-   - `python3 test/functional/feature_index_prune.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py`
    Still deferred inside this suite:
-   - promotion into `pq_required`
    - broader bootstrap/loadblock import behavior
 11. `feature_pq_block_limits.py` now owns:
    - exact `getblocktemplate` block weight limit reporting at `4_000_000`
@@ -943,11 +941,13 @@ Still deferred:
      real prior PQBTC release assets exist
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: local non-wallet `pq_backlog` tranche selected after inventory
-     review
+   - alternate: `feature_loadblock.py`
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
+   - `feature_loadblock.py` is the next bounded storage/import follow-on now
+     that external blocksdir, blocksxor, fastprune, prune-cleanup, and
+     prune-plus-index behavior are required
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1622,8 +1622,17 @@ Aineko must ask before:
   `wallet_migration.py` remain blocked locally because previous-release
   fixtures are unavailable. The next owned follow-on remains
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
-  assets exist; otherwise choose any next local tranche from non-wallet
-  `pq_backlog` after inventory review.
+  assets exist; otherwise the next local step is a non-wallet backlog tranche.
+- 2026-04-29: `feature_blocksdir.py`, `feature_blocksxor.py`,
+  `feature_fastprune.py`, `feature_remove_pruned_files_on_startup.py`, and
+  `feature_index_prune.py` are now promoted into the canonical `pq_required`
+  gate and locally revalidated with the build-tree functional runner. The
+  owned boundary covers external block storage, XORed blk/rev handling,
+  `-fastprune` large-block admission, pruned-file cleanup on startup, and
+  blockfilter/coinstats index behavior under prune. The next owned follow-on
+  remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
+  release assets exist; otherwise the local storage/import alternate is
+  `feature_loadblock.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1739,6 +1748,10 @@ Aineko must ask before:
   descriptor-creation and cross-chain wallet-file surfaces:
   `wallet_createwalletdescriptor.py` and `wallet_crosschain.py` pass targeted
   validation in the current tree.
+- There is no current blocker in the block storage and prune-lifecycle
+  surfaces: `feature_blocksdir.py`, `feature_blocksxor.py`,
+  `feature_fastprune.py`, `feature_remove_pruned_files_on_startup.py`, and
+  `feature_index_prune.py` pass targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_blocksdir.py, feature_blocksxor.py, feature_fastprune.py, feature_remove_pruned_files_on_startup.py, and feature_index_prune.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=85, pq_backlog=40, dual_profile=142, legacy_only=9.
- Refresh the storage/prune posture docs and Track A handoff; feature_loadblock.py is now the local storage/import alternate while prior-release compatibility remains asset-blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_blocksdir.py feature_blocksxor.py feature_fastprune.py feature_remove_pruned_files_on_startup.py feature_index_prune.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.