### PR TITLE
ci: promote loadblock gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -232,10 +232,10 @@
   },
   {
     "name": "feature_loadblock.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "PQBTC bootstrap/import backlog surface: a disconnected peer imports a linearized bootstrap.dat generated from the live source node's block files and current regtest message-start bytes, reaches height 100 under -loadblock, and converges on the source node's best block hash."
+    "notes": "Now promoted into pq_required as the PQBTC bootstrap/import gate: a disconnected peer imports a linearized bootstrap.dat generated from the live source node's block files and current regtest message-start bytes, reaches height 100 under -loadblock, and converges on the source node's best block hash; pruning-plus-bootstrap, index rebuild, malformed import, and interrupted import recovery remain separate follow-on surfaces."
   },
   {
     "name": "feature_logging.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -5,6 +5,7 @@ feature_blocksdir.py
 feature_blocksxor.py
 feature_fastprune.py
 feature_index_prune.py
+feature_loadblock.py
 feature_pq_block_limits.py
 feature_pq_reorg.py
 feature_pqsig_basic.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `85` |
-| `pq_backlog` | `40` |
+| `pq_required` | `86` |
+| `pq_backlog` | `39` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -70,64 +70,65 @@ Current required PQ-first gates:
 25. `feature_blocksxor.py`
 26. `feature_fastprune.py`
 27. `feature_index_prune.py`
-28. `feature_remove_pruned_files_on_startup.py`
-29. `rpc_psbt.py`
-30. `wallet_abandonconflict.py`
-31. `wallet_address_types.py`
-32. `wallet_assumeutxo.py`
-33. `wallet_avoid_mixing_output_types.py`
-34. `wallet_avoidreuse.py`
-35. `wallet_backup.py`
-36. `wallet_balance.py`
-37. `wallet_basic.py`
-38. `wallet_blank.py`
-39. `wallet_bumpfee.py`
-40. `wallet_change_address.py`
-41. `wallet_coinbase_category.py`
-42. `wallet_conflicts.py`
-43. `wallet_create_tx.py`
-44. `wallet_createwallet.py`
-45. `wallet_createwalletdescriptor.py`
-46. `wallet_crosschain.py`
-47. `wallet_descriptor.py`
-48. `wallet_disable.py`
-49. `wallet_encryption.py`
-50. `wallet_fallbackfee.py`
-51. `wallet_fast_rescan.py`
-52. `wallet_fundrawtransaction.py`
-53. `wallet_gethdkeys.py`
-54. `wallet_groups.py`
-55. `wallet_hd.py`
-56. `wallet_importdescriptors.py`
-57. `wallet_importprunedfunds.py`
-58. `wallet_keypool.py`
-59. `wallet_keypool_topup.py`
-60. `wallet_labels.py`
-61. `wallet_listdescriptors.py`
-62. `wallet_listreceivedby.py`
-63. `wallet_listsinceblock.py`
-64. `wallet_listtransactions.py`
-65. `wallet_miniscript.py`
-66. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-67. `wallet_multisig_descriptor_psbt.py`
-68. `wallet_multiwallet.py`
-69. `wallet_orphanedreward.py`
-70. `wallet_reindex.py`
-71. `wallet_reorgsrestore.py`
-72. `wallet_rescan_unconfirmed.py`
-73. `wallet_resendwallettransactions.py`
-74. `wallet_send.py`
-75. `wallet_sendall.py`
-76. `wallet_sendmany.py`
-77. `wallet_signrawtransactionwithwallet.py`
-78. `wallet_simulaterawtx.py`
-79. `wallet_spend_unconfirmed.py`
-80. `wallet_startup.py`
-81. `wallet_timelock.py`
-82. `wallet_transactiontime_rescan.py`
-83. `wallet_txn_clone.py`
-84. `wallet_txn_doublespend.py`
-85. `wallet_v3_txs.py`
+28. `feature_loadblock.py`
+29. `feature_remove_pruned_files_on_startup.py`
+30. `rpc_psbt.py`
+31. `wallet_abandonconflict.py`
+32. `wallet_address_types.py`
+33. `wallet_assumeutxo.py`
+34. `wallet_avoid_mixing_output_types.py`
+35. `wallet_avoidreuse.py`
+36. `wallet_backup.py`
+37. `wallet_balance.py`
+38. `wallet_basic.py`
+39. `wallet_blank.py`
+40. `wallet_bumpfee.py`
+41. `wallet_change_address.py`
+42. `wallet_coinbase_category.py`
+43. `wallet_conflicts.py`
+44. `wallet_create_tx.py`
+45. `wallet_createwallet.py`
+46. `wallet_createwalletdescriptor.py`
+47. `wallet_crosschain.py`
+48. `wallet_descriptor.py`
+49. `wallet_disable.py`
+50. `wallet_encryption.py`
+51. `wallet_fallbackfee.py`
+52. `wallet_fast_rescan.py`
+53. `wallet_fundrawtransaction.py`
+54. `wallet_gethdkeys.py`
+55. `wallet_groups.py`
+56. `wallet_hd.py`
+57. `wallet_importdescriptors.py`
+58. `wallet_importprunedfunds.py`
+59. `wallet_keypool.py`
+60. `wallet_keypool_topup.py`
+61. `wallet_labels.py`
+62. `wallet_listdescriptors.py`
+63. `wallet_listreceivedby.py`
+64. `wallet_listsinceblock.py`
+65. `wallet_listtransactions.py`
+66. `wallet_miniscript.py`
+67. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+68. `wallet_multisig_descriptor_psbt.py`
+69. `wallet_multiwallet.py`
+70. `wallet_orphanedreward.py`
+71. `wallet_reindex.py`
+72. `wallet_reorgsrestore.py`
+73. `wallet_rescan_unconfirmed.py`
+74. `wallet_resendwallettransactions.py`
+75. `wallet_send.py`
+76. `wallet_sendall.py`
+77. `wallet_sendmany.py`
+78. `wallet_signrawtransactionwithwallet.py`
+79. `wallet_simulaterawtx.py`
+80. `wallet_spend_unconfirmed.py`
+81. `wallet_startup.py`
+82. `wallet_timelock.py`
+83. `wallet_transactiontime_rescan.py`
+84. `wallet_txn_clone.py`
+85. `wallet_txn_doublespend.py`
+86. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -287,6 +288,10 @@ required gate: `feature_blocksdir.py`, `feature_blocksxor.py`,
 `feature_index_prune.py` cover external block storage, XORed blk/rev handling,
 large-block admission under `-fastprune`, pruned-file cleanup on startup, and
 blockfilter/coinstats index behavior under prune.
+The bootstrap/import confidence gap is now also part of the required gate:
+`feature_loadblock.py` covers linearized `bootstrap.dat` production from live
+PQBTC regtest block files and `-loadblock` import convergence on a disconnected
+peer.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_INDEX_PRUNE_POSTURE.md
+++ b/docs/FEATURE_INDEX_PRUNE_POSTURE.md
@@ -58,5 +58,6 @@ Targeted confidence pass run on 2026-04-29:
 
 - `feature_index_prune.py` is now a required prune-plus-index matrix gate
 - it is a higher-cost prune surface, but still a bounded functional contract
-- the next clean local storage/import follow-on is
-  [feature_loadblock.py](../test/functional/feature_loadblock.py)
+- the adjacent storage/import follow-on,
+  [feature_loadblock.py](../test/functional/feature_loadblock.py), is now
+  covered by the required gate

--- a/docs/FEATURE_LOADBLOCK_POSTURE.md
+++ b/docs/FEATURE_LOADBLOCK_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-LOADBLOCK-POSTURE-v1
+## Updated: 2026-04-29
 ## Frozen-By: track-a-phase1-20260413
 ## Consensus-Relevant: YES
 
@@ -39,9 +40,9 @@ Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-13:
+Targeted confidence pass run on 2026-04-29:
 
-- `python3 test/functional/feature_loadblock.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_loadblock.py`
   - result: passed
   - current posture:
     - linearization succeeds against the live PQBTC regtest block files
@@ -50,9 +51,10 @@ Targeted confidence pass run on 2026-04-13:
 
 ## Interpretation
 
-- `feature_loadblock.py` is now a fixed PQBTC bootstrap/import slice
-- it remains `pq_backlog`, not a required PQ-first gate
-- the next clean follow-on shifts back to wallet-level inherited miniscript
-  funding/signing work
+- `feature_loadblock.py` is now a required PQBTC bootstrap/import gate
+- it remains bounded to linearized bootstrap import on the current regtest
+  profile
+- the next clean local chainstate follow-on is
+  [feature_utxo_set_hash.py](../test/functional/feature_utxo_set_hash.py)
 - broader prune, reindex, malformed-import, and interrupted-import behavior
   remain deferred

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -22,11 +22,12 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 `feature_blocksxor.py`, `feature_fastprune.py`,
 `feature_remove_pruned_files_on_startup.py`, and `feature_index_prune.py`
 block storage and prune-lifecycle behavior in the canonical `pq_required`
-gate, and keep
+gate, keep `feature_loadblock.py` bootstrap/import behavior in the same gate,
+and keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
-`feature_loadblock.py`, `wallet_miniscript.py`, and
+`wallet_miniscript.py`, and
 `feature_utxo_set_hash.py`, `feature_coinstatsindex.py`, and
 `feature_reindex.py`, `feature_reindex_init.py`, and
 `feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, keep
@@ -103,11 +104,11 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. `feature_loadblock.py`
+2. `feature_utxo_set_hash.py`
    - Why alternate: if the asset-dependent coinstats compatibility path stays
-     blocked locally, the next bounded local storage/import follow-on is
-     `feature_loadblock.py`, now that the external blocksdir, blocksxor,
-     fastprune, prune-cleanup, and prune-plus-index family is required,
+     blocked locally, the next bounded local chainstate follow-on is
+     `feature_utxo_set_hash.py`, now that bootstrap/import behavior is
+     required,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -117,9 +118,10 @@ Alternate rebalance:
      transaction-construction, simulation, raw-signing, and import-descriptor
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
-     tranches. `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
-     `feature_coinstatsindex_compatibility.py` stay blocked until prior-release
-     assets are available.
+     tranches, or the current block storage, prune-lifecycle, and
+     bootstrap/import tranches. `wallet_backwards_compatibility.py`,
+     `wallet_migration.py`, and `feature_coinstatsindex_compatibility.py` stay
+     blocked until prior-release assets are available.
 
 Still deferred:
 
@@ -393,7 +395,7 @@ Still deferred:
    - blocking completion of import up to height `100`
    - convergence on the same best block hash as the source node after import
    Minimum validation target:
-   - `python3 test/functional/feature_loadblock.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_loadblock.py`
    Still deferred inside this suite:
    - pruning-plus-bootstrap interaction
    - index rebuild or reindex interaction
@@ -941,13 +943,12 @@ Still deferred:
      real prior PQBTC release assets exist
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `feature_loadblock.py`
+   - alternate: `feature_utxo_set_hash.py`
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - `feature_loadblock.py` is the next bounded storage/import follow-on now
-     that external blocksdir, blocksxor, fastprune, prune-cleanup, and
-     prune-plus-index behavior are required
+   - `feature_utxo_set_hash.py` is the next bounded local chainstate follow-on
+     now that bootstrap/import behavior is required
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1633,6 +1634,14 @@ Aineko must ask before:
   remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
   release assets exist; otherwise the local storage/import alternate is
   `feature_loadblock.py`.
+- 2026-04-29: `feature_loadblock.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers linearized `bootstrap.dat` production from
+  live PQBTC regtest block files and `-loadblock` import convergence on a
+  disconnected peer. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the local chainstate alternate is
+  `feature_utxo_set_hash.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1752,6 +1761,8 @@ Aineko must ask before:
   surfaces: `feature_blocksdir.py`, `feature_blocksxor.py`,
   `feature_fastprune.py`, `feature_remove_pruned_files_on_startup.py`, and
   `feature_index_prune.py` pass targeted validation in the current tree.
+- There is no current blocker in the bootstrap/import surface:
+  `feature_loadblock.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_loadblock.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=86, pq_backlog=39, dual_profile=142, legacy_only=9.
- Refresh the loadblock/index-prune posture and Track A handoff; feature_utxo_set_hash.py is now the local chainstate alternate while prior-release compatibility remains asset-blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_loadblock.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.