### PR TITLE
ci: promote utxo set hash gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -476,10 +476,10 @@
   },
   {
     "name": "feature_utxo_set_hash.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes a narrow PQBTC txoutset-hash boundary: the inherited default MiniWallet self-transfer path remains deferred after a reproduced `scriptpubkey (-26)` failure, while the owned path uses one raw OP_TRUE MiniWallet coinbase spend mined directly by `generateblock(...)`, preserves manual MuHash equality with `gettxoutsetinfo(\"muhash\")`, and fixes the current PQBTC `hash_serialized_3` / `muhash` constants for that exact chainstate sequence."
+    "notes": "Now promoted into pq_required as the narrow PQBTC txoutset-hash gate: the inherited default MiniWallet self-transfer path remains deferred after a reproduced `scriptpubkey (-26)` failure, while the owned path uses one raw OP_TRUE MiniWallet coinbase spend mined directly by `generateblock(...)`, preserves manual MuHash equality with `gettxoutsetinfo(\"muhash\")`, and fixes the current PQBTC `hash_serialized_3` / `muhash` constants for that exact chainstate sequence."
   },
   {
     "name": "feature_versionbits_warning.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -16,6 +16,7 @@ feature_taproot_replacement_compat.py
 feature_taproot_replacement_active_boundary.py
 feature_taproot_replacement_active_semantic_guard.py
 feature_taproot_replacement_active_positive_seam.py
+feature_utxo_set_hash.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `86` |
-| `pq_backlog` | `39` |
+| `pq_required` | `87` |
+| `pq_backlog` | `38` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -72,63 +72,64 @@ Current required PQ-first gates:
 27. `feature_index_prune.py`
 28. `feature_loadblock.py`
 29. `feature_remove_pruned_files_on_startup.py`
-30. `rpc_psbt.py`
-31. `wallet_abandonconflict.py`
-32. `wallet_address_types.py`
-33. `wallet_assumeutxo.py`
-34. `wallet_avoid_mixing_output_types.py`
-35. `wallet_avoidreuse.py`
-36. `wallet_backup.py`
-37. `wallet_balance.py`
-38. `wallet_basic.py`
-39. `wallet_blank.py`
-40. `wallet_bumpfee.py`
-41. `wallet_change_address.py`
-42. `wallet_coinbase_category.py`
-43. `wallet_conflicts.py`
-44. `wallet_create_tx.py`
-45. `wallet_createwallet.py`
-46. `wallet_createwalletdescriptor.py`
-47. `wallet_crosschain.py`
-48. `wallet_descriptor.py`
-49. `wallet_disable.py`
-50. `wallet_encryption.py`
-51. `wallet_fallbackfee.py`
-52. `wallet_fast_rescan.py`
-53. `wallet_fundrawtransaction.py`
-54. `wallet_gethdkeys.py`
-55. `wallet_groups.py`
-56. `wallet_hd.py`
-57. `wallet_importdescriptors.py`
-58. `wallet_importprunedfunds.py`
-59. `wallet_keypool.py`
-60. `wallet_keypool_topup.py`
-61. `wallet_labels.py`
-62. `wallet_listdescriptors.py`
-63. `wallet_listreceivedby.py`
-64. `wallet_listsinceblock.py`
-65. `wallet_listtransactions.py`
-66. `wallet_miniscript.py`
-67. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-68. `wallet_multisig_descriptor_psbt.py`
-69. `wallet_multiwallet.py`
-70. `wallet_orphanedreward.py`
-71. `wallet_reindex.py`
-72. `wallet_reorgsrestore.py`
-73. `wallet_rescan_unconfirmed.py`
-74. `wallet_resendwallettransactions.py`
-75. `wallet_send.py`
-76. `wallet_sendall.py`
-77. `wallet_sendmany.py`
-78. `wallet_signrawtransactionwithwallet.py`
-79. `wallet_simulaterawtx.py`
-80. `wallet_spend_unconfirmed.py`
-81. `wallet_startup.py`
-82. `wallet_timelock.py`
-83. `wallet_transactiontime_rescan.py`
-84. `wallet_txn_clone.py`
-85. `wallet_txn_doublespend.py`
-86. `wallet_v3_txs.py`
+30. `feature_utxo_set_hash.py`
+31. `rpc_psbt.py`
+32. `wallet_abandonconflict.py`
+33. `wallet_address_types.py`
+34. `wallet_assumeutxo.py`
+35. `wallet_avoid_mixing_output_types.py`
+36. `wallet_avoidreuse.py`
+37. `wallet_backup.py`
+38. `wallet_balance.py`
+39. `wallet_basic.py`
+40. `wallet_blank.py`
+41. `wallet_bumpfee.py`
+42. `wallet_change_address.py`
+43. `wallet_coinbase_category.py`
+44. `wallet_conflicts.py`
+45. `wallet_create_tx.py`
+46. `wallet_createwallet.py`
+47. `wallet_createwalletdescriptor.py`
+48. `wallet_crosschain.py`
+49. `wallet_descriptor.py`
+50. `wallet_disable.py`
+51. `wallet_encryption.py`
+52. `wallet_fallbackfee.py`
+53. `wallet_fast_rescan.py`
+54. `wallet_fundrawtransaction.py`
+55. `wallet_gethdkeys.py`
+56. `wallet_groups.py`
+57. `wallet_hd.py`
+58. `wallet_importdescriptors.py`
+59. `wallet_importprunedfunds.py`
+60. `wallet_keypool.py`
+61. `wallet_keypool_topup.py`
+62. `wallet_labels.py`
+63. `wallet_listdescriptors.py`
+64. `wallet_listreceivedby.py`
+65. `wallet_listsinceblock.py`
+66. `wallet_listtransactions.py`
+67. `wallet_miniscript.py`
+68. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+69. `wallet_multisig_descriptor_psbt.py`
+70. `wallet_multiwallet.py`
+71. `wallet_orphanedreward.py`
+72. `wallet_reindex.py`
+73. `wallet_reorgsrestore.py`
+74. `wallet_rescan_unconfirmed.py`
+75. `wallet_resendwallettransactions.py`
+76. `wallet_send.py`
+77. `wallet_sendall.py`
+78. `wallet_sendmany.py`
+79. `wallet_signrawtransactionwithwallet.py`
+80. `wallet_simulaterawtx.py`
+81. `wallet_spend_unconfirmed.py`
+82. `wallet_startup.py`
+83. `wallet_timelock.py`
+84. `wallet_transactiontime_rescan.py`
+85. `wallet_txn_clone.py`
+86. `wallet_txn_doublespend.py`
+87. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -292,6 +293,10 @@ The bootstrap/import confidence gap is now also part of the required gate:
 `feature_loadblock.py` covers linearized `bootstrap.dat` production from live
 PQBTC regtest block files and `-loadblock` import convergence on a disconnected
 peer.
+The txoutset-hash confidence gap is now also part of the required gate:
+`feature_utxo_set_hash.py` covers the bounded raw `OP_TRUE` chainstate
+sequence, manual MuHash equality, and fixed PQBTC `hash_serialized_3` /
+`muhash` constants.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_UTXO_SET_HASH_POSTURE.md
+++ b/docs/FEATURE_UTXO_SET_HASH_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-UTXO-SET-HASH-POSTURE-v1
+## Updated: 2026-04-30
 ## Frozen-By: track-a-phase1-20260413
 ## Consensus-Relevant: YES
 
@@ -31,15 +32,14 @@ This posture note does **not** mean:
 
 - the inherited default `MiniWalletMode.ADDRESS_OP_TRUE` send path is owned
 - adjacent coinstats index behavior is owned
-- this suite is promoted into `pq_required`
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-13:
+Targeted confidence pass run on 2026-04-30:
 
-- `python3 test/functional/feature_utxo_set_hash.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_utxo_set_hash.py`
   - result: passed
   - current posture:
     - the raw `OP_TRUE` chainstate path preserves manual MuHash equality
@@ -50,12 +50,12 @@ Targeted confidence pass run on 2026-04-13:
 
 ## Interpretation
 
-- `feature_utxo_set_hash.py` is now a fixed PQBTC txoutset-hash slice
-- it remains `pq_backlog`, not a required PQ-first gate
+- `feature_utxo_set_hash.py` is now a required PQBTC txoutset-hash gate
+- it remains bounded to the raw `OP_TRUE` chainstate sequence and fixed
+  PQBTC hash constants
 - the next clean follow-on is
   [feature_coinstatsindex.py](../test/functional/feature_coinstatsindex.py),
-  which currently fails on the same inherited MiniWallet path and is the
-  nearest adjacent txoutset/index boundary
+  which is the nearest adjacent txoutset/index boundary
 - the lower-risk alternate is
   [feature_reindex.py](../test/functional/feature_reindex.py), which is
   already green under the current harness

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -23,12 +23,13 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 `feature_remove_pruned_files_on_startup.py`, and `feature_index_prune.py`
 block storage and prune-lifecycle behavior in the canonical `pq_required`
 gate, keep `feature_loadblock.py` bootstrap/import behavior in the same gate,
-and keep
+keep `feature_utxo_set_hash.py` txoutset-hash behavior in the same gate, and
+keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
-`feature_utxo_set_hash.py`, `feature_coinstatsindex.py`, and
+`feature_coinstatsindex.py`, and
 `feature_reindex.py`, `feature_reindex_init.py`, and
 `feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, keep
 `feature_assumeutxo.py`, `wallet_assumeutxo.py`, `feature_assumevalid.py`,
@@ -104,11 +105,11 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. `feature_utxo_set_hash.py`
+2. `feature_coinstatsindex.py`
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, the next bounded local chainstate follow-on is
-     `feature_utxo_set_hash.py`, now that bootstrap/import behavior is
-     required,
+     `feature_coinstatsindex.py`, now that the adjacent txoutset-hash behavior
+     is required,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -118,10 +119,11 @@ Alternate rebalance:
      transaction-construction, simulation, raw-signing, and import-descriptor
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
-     tranches, or the current block storage, prune-lifecycle, and
-     bootstrap/import tranches. `wallet_backwards_compatibility.py`,
-     `wallet_migration.py`, and `feature_coinstatsindex_compatibility.py` stay
-     blocked until prior-release assets are available.
+     tranches, or the current block storage, prune-lifecycle,
+     bootstrap/import, and txoutset-hash tranches.
+     `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
+     `feature_coinstatsindex_compatibility.py` stay blocked until
+     prior-release assets are available.
 
 Still deferred:
 
@@ -411,10 +413,9 @@ Still deferred:
    - explicit deferral of the inherited default MiniWallet send path after its
      reproduced `scriptpubkey (-26)` failure
    Minimum validation target:
-   - `python3 test/functional/feature_utxo_set_hash.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_utxo_set_hash.py`
    Still deferred inside this suite:
    - adjacent coinstats-index coverage
-   - promotion into `pq_required`
 19. `feature_coinstatsindex.py` now owns:
    - one raw `OP_TRUE` MiniWallet funding path in place of the inherited
      default MiniWallet mempool self-transfer path
@@ -943,12 +944,12 @@ Still deferred:
      real prior PQBTC release assets exist
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `feature_utxo_set_hash.py`
+   - alternate: `feature_coinstatsindex.py`
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - `feature_utxo_set_hash.py` is the next bounded local chainstate follow-on
-     now that bootstrap/import behavior is required
+   - `feature_coinstatsindex.py` is the next bounded local txoutset/index
+     follow-on now that txoutset-hash behavior is required
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1642,6 +1643,14 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the local chainstate alternate is
   `feature_utxo_set_hash.py`.
+- 2026-04-30: `feature_utxo_set_hash.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers the bounded raw `OP_TRUE` chainstate
+  sequence, manual MuHash equality, and fixed PQBTC `hash_serialized_3` /
+  `muhash` constants. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the local txoutset/index alternate is
+  `feature_coinstatsindex.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1763,6 +1772,8 @@ Aineko must ask before:
   `feature_index_prune.py` pass targeted validation in the current tree.
 - There is no current blocker in the bootstrap/import surface:
   `feature_loadblock.py` passes targeted validation in the current tree.
+- There is no current blocker in the txoutset-hash surface:
+  `feature_utxo_set_hash.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_utxo_set_hash.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=87, pq_backlog=38, dual_profile=142, legacy_only=9.
- Refresh the UTXO set hash posture and Track A handoff; feature_coinstatsindex.py is now the local txoutset/index alternate while prior-release compatibility remains asset-blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_utxo_set_hash.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.