### PR TITLE
ci: promote coinstatsindex gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -106,10 +106,10 @@
   },
   {
     "name": "feature_coinstatsindex.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes a narrow PQBTC txoutset/index boundary: the inherited default MiniWallet mempool self-transfer path remains deferred after a reproduced `scriptpubkey (-26)` failure, while the owned path uses direct-mined raw OP_TRUE transactions for the initial spend and the later parent/child plus OP_RETURN accounting sequence, preserving indexed-vs-non-indexed `gettxoutsetinfo()` parity, verbose `block_info` expectations, and restart/reorg/reindex behavior on that bounded dataset."
+    "notes": "Now promoted into pq_required as the narrow PQBTC txoutset/index gate: the inherited default MiniWallet mempool self-transfer path remains deferred after a reproduced `scriptpubkey (-26)` failure, while the owned path uses direct-mined raw OP_TRUE transactions for the initial spend and the later parent/child plus OP_RETURN accounting sequence, preserving indexed-vs-non-indexed `gettxoutsetinfo()` parity, verbose `block_info` expectations, and restart/reorg/reindex behavior on that bounded dataset; previous-release coinstats compatibility remains asset-blocked."
   },
   {
     "name": "feature_coinstatsindex_compatibility.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -3,6 +3,7 @@ feature_assumevalid.py
 feature_block.py
 feature_blocksdir.py
 feature_blocksxor.py
+feature_coinstatsindex.py
 feature_fastprune.py
 feature_index_prune.py
 feature_loadblock.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `87` |
-| `pq_backlog` | `38` |
+| `pq_required` | `88` |
+| `pq_backlog` | `37` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -68,68 +68,69 @@ Current required PQ-first gates:
 23. `feature_block.py`
 24. `feature_blocksdir.py`
 25. `feature_blocksxor.py`
-26. `feature_fastprune.py`
-27. `feature_index_prune.py`
-28. `feature_loadblock.py`
-29. `feature_remove_pruned_files_on_startup.py`
-30. `feature_utxo_set_hash.py`
-31. `rpc_psbt.py`
-32. `wallet_abandonconflict.py`
-33. `wallet_address_types.py`
-34. `wallet_assumeutxo.py`
-35. `wallet_avoid_mixing_output_types.py`
-36. `wallet_avoidreuse.py`
-37. `wallet_backup.py`
-38. `wallet_balance.py`
-39. `wallet_basic.py`
-40. `wallet_blank.py`
-41. `wallet_bumpfee.py`
-42. `wallet_change_address.py`
-43. `wallet_coinbase_category.py`
-44. `wallet_conflicts.py`
-45. `wallet_create_tx.py`
-46. `wallet_createwallet.py`
-47. `wallet_createwalletdescriptor.py`
-48. `wallet_crosschain.py`
-49. `wallet_descriptor.py`
-50. `wallet_disable.py`
-51. `wallet_encryption.py`
-52. `wallet_fallbackfee.py`
-53. `wallet_fast_rescan.py`
-54. `wallet_fundrawtransaction.py`
-55. `wallet_gethdkeys.py`
-56. `wallet_groups.py`
-57. `wallet_hd.py`
-58. `wallet_importdescriptors.py`
-59. `wallet_importprunedfunds.py`
-60. `wallet_keypool.py`
-61. `wallet_keypool_topup.py`
-62. `wallet_labels.py`
-63. `wallet_listdescriptors.py`
-64. `wallet_listreceivedby.py`
-65. `wallet_listsinceblock.py`
-66. `wallet_listtransactions.py`
-67. `wallet_miniscript.py`
-68. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-69. `wallet_multisig_descriptor_psbt.py`
-70. `wallet_multiwallet.py`
-71. `wallet_orphanedreward.py`
-72. `wallet_reindex.py`
-73. `wallet_reorgsrestore.py`
-74. `wallet_rescan_unconfirmed.py`
-75. `wallet_resendwallettransactions.py`
-76. `wallet_send.py`
-77. `wallet_sendall.py`
-78. `wallet_sendmany.py`
-79. `wallet_signrawtransactionwithwallet.py`
-80. `wallet_simulaterawtx.py`
-81. `wallet_spend_unconfirmed.py`
-82. `wallet_startup.py`
-83. `wallet_timelock.py`
-84. `wallet_transactiontime_rescan.py`
-85. `wallet_txn_clone.py`
-86. `wallet_txn_doublespend.py`
-87. `wallet_v3_txs.py`
+26. `feature_coinstatsindex.py`
+27. `feature_fastprune.py`
+28. `feature_index_prune.py`
+29. `feature_loadblock.py`
+30. `feature_remove_pruned_files_on_startup.py`
+31. `feature_utxo_set_hash.py`
+32. `rpc_psbt.py`
+33. `wallet_abandonconflict.py`
+34. `wallet_address_types.py`
+35. `wallet_assumeutxo.py`
+36. `wallet_avoid_mixing_output_types.py`
+37. `wallet_avoidreuse.py`
+38. `wallet_backup.py`
+39. `wallet_balance.py`
+40. `wallet_basic.py`
+41. `wallet_blank.py`
+42. `wallet_bumpfee.py`
+43. `wallet_change_address.py`
+44. `wallet_coinbase_category.py`
+45. `wallet_conflicts.py`
+46. `wallet_create_tx.py`
+47. `wallet_createwallet.py`
+48. `wallet_createwalletdescriptor.py`
+49. `wallet_crosschain.py`
+50. `wallet_descriptor.py`
+51. `wallet_disable.py`
+52. `wallet_encryption.py`
+53. `wallet_fallbackfee.py`
+54. `wallet_fast_rescan.py`
+55. `wallet_fundrawtransaction.py`
+56. `wallet_gethdkeys.py`
+57. `wallet_groups.py`
+58. `wallet_hd.py`
+59. `wallet_importdescriptors.py`
+60. `wallet_importprunedfunds.py`
+61. `wallet_keypool.py`
+62. `wallet_keypool_topup.py`
+63. `wallet_labels.py`
+64. `wallet_listdescriptors.py`
+65. `wallet_listreceivedby.py`
+66. `wallet_listsinceblock.py`
+67. `wallet_listtransactions.py`
+68. `wallet_miniscript.py`
+69. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+70. `wallet_multisig_descriptor_psbt.py`
+71. `wallet_multiwallet.py`
+72. `wallet_orphanedreward.py`
+73. `wallet_reindex.py`
+74. `wallet_reorgsrestore.py`
+75. `wallet_rescan_unconfirmed.py`
+76. `wallet_resendwallettransactions.py`
+77. `wallet_send.py`
+78. `wallet_sendall.py`
+79. `wallet_sendmany.py`
+80. `wallet_signrawtransactionwithwallet.py`
+81. `wallet_simulaterawtx.py`
+82. `wallet_spend_unconfirmed.py`
+83. `wallet_startup.py`
+84. `wallet_timelock.py`
+85. `wallet_transactiontime_rescan.py`
+86. `wallet_txn_clone.py`
+87. `wallet_txn_doublespend.py`
+88. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -297,6 +298,11 @@ The txoutset-hash confidence gap is now also part of the required gate:
 `feature_utxo_set_hash.py` covers the bounded raw `OP_TRUE` chainstate
 sequence, manual MuHash equality, and fixed PQBTC `hash_serialized_3` /
 `muhash` constants.
+The txoutset/index confidence gap is now also part of the required gate:
+`feature_coinstatsindex.py` covers direct-mined raw `OP_TRUE` txoutset deltas,
+indexed-vs-non-indexed `gettxoutsetinfo()` parity, verbose block accounting,
+restart, reindex, reindex-chainstate, reorg, and stale-index recovery on the
+bounded PQBTC dataset.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_COINSTATSINDEX_POSTURE.md
+++ b/docs/FEATURE_COINSTATSINDEX_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-COINSTATSINDEX-POSTURE-v1
+## Updated: 2026-04-30
 ## Frozen-By: track-a-phase1-20260413
 ## Consensus-Relevant: YES
 
@@ -36,15 +37,14 @@ This posture note does **not** mean:
 
 - the inherited default MiniWallet mempool/send path is owned
 - previous-release coinstats index compatibility is owned in this local harness
-- this suite is promoted into `pq_required`
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-13:
+Targeted confidence pass run on 2026-04-30:
 
-- `python3 test/functional/feature_coinstatsindex.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex.py`
   - result: passed
   - current posture:
     - indexed and non-indexed `gettxoutsetinfo()` results still agree on the
@@ -57,8 +57,9 @@ Targeted confidence pass run on 2026-04-13:
 
 ## Interpretation
 
-- `feature_coinstatsindex.py` is now a fixed PQBTC txoutset/index slice
-- it remains `pq_backlog`, not a required PQ-first gate
+- `feature_coinstatsindex.py` is now a required PQBTC txoutset/index gate
+- it remains bounded to the direct-mined raw `OP_TRUE` dataset and current
+  local index/reorg/reindex behavior
 - the next clean actionable follow-on is
   [feature_reindex.py](../test/functional/feature_reindex.py), which is already
   green under the current harness and is the cheaper adjacent restart/index

--- a/docs/FEATURE_UTXO_SET_HASH_POSTURE.md
+++ b/docs/FEATURE_UTXO_SET_HASH_POSTURE.md
@@ -53,9 +53,9 @@ Targeted confidence pass run on 2026-04-30:
 - `feature_utxo_set_hash.py` is now a required PQBTC txoutset-hash gate
 - it remains bounded to the raw `OP_TRUE` chainstate sequence and fixed
   PQBTC hash constants
-- the next clean follow-on is
+- the adjacent txoutset/index follow-on,
   [feature_coinstatsindex.py](../test/functional/feature_coinstatsindex.py),
-  which is the nearest adjacent txoutset/index boundary
+  is now covered by the required gate
 - the lower-risk alternate is
   [feature_reindex.py](../test/functional/feature_reindex.py), which is
   already green under the current harness

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -24,12 +24,12 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 block storage and prune-lifecycle behavior in the canonical `pq_required`
 gate, keep `feature_loadblock.py` bootstrap/import behavior in the same gate,
 keep `feature_utxo_set_hash.py` txoutset-hash behavior in the same gate, and
+keep `feature_coinstatsindex.py` txoutset/index behavior in the same gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
-`feature_coinstatsindex.py`, and
 `feature_reindex.py`, `feature_reindex_init.py`, and
 `feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, keep
 `feature_assumeutxo.py`, `wallet_assumeutxo.py`, `feature_assumevalid.py`,
@@ -105,11 +105,11 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. `feature_coinstatsindex.py`
+2. `feature_reindex.py`
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, the next bounded local chainstate follow-on is
-     `feature_coinstatsindex.py`, now that the adjacent txoutset-hash behavior
-     is required,
+     `feature_reindex.py`, now that the adjacent txoutset/index behavior is
+     required,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -120,7 +120,7 @@ Alternate rebalance:
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
      tranches, or the current block storage, prune-lifecycle,
-     bootstrap/import, and txoutset-hash tranches.
+     bootstrap/import, txoutset-hash, and txoutset/index tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available.
@@ -430,10 +430,9 @@ Still deferred:
    - explicit deferral of the inherited default MiniWallet mempool path after
      its reproduced `scriptpubkey (-26)` failure
    Minimum validation target:
-   - `python3 test/functional/feature_coinstatsindex.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex.py`
    Still deferred inside this suite:
    - previous-release coinstats index compatibility
-   - promotion into `pq_required`
 20. `feature_reindex.py` now owns:
    - repeated restart-time `-reindex` recovery to the same three-block height
    - repeated restart-time `-reindex-chainstate` recovery to the same
@@ -944,12 +943,12 @@ Still deferred:
      real prior PQBTC release assets exist
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `feature_coinstatsindex.py`
+   - alternate: `feature_reindex.py`
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - `feature_coinstatsindex.py` is the next bounded local txoutset/index
-     follow-on now that txoutset-hash behavior is required
+   - `feature_reindex.py` is the next bounded local restart/index follow-on
+     now that txoutset/index behavior is required
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1651,6 +1650,15 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the local txoutset/index alternate is
   `feature_coinstatsindex.py`.
+- 2026-04-30: `feature_coinstatsindex.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers direct-mined raw `OP_TRUE` txoutset deltas,
+  indexed-vs-non-indexed `gettxoutsetinfo()` parity, verbose block accounting,
+  restart, reindex, reindex-chainstate, reorg, and stale-index recovery on the
+  bounded PQBTC dataset. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the local restart/index alternate is
+  `feature_reindex.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1774,6 +1782,8 @@ Aineko must ask before:
   `feature_loadblock.py` passes targeted validation in the current tree.
 - There is no current blocker in the txoutset-hash surface:
   `feature_utxo_set_hash.py` passes targeted validation in the current tree.
+- There is no current blocker in the txoutset/index surface:
+  `feature_coinstatsindex.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_coinstatsindex.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=88, pq_backlog=37, dual_profile=142, legacy_only=9.
- Refresh the coinstatsindex and UTXO posture docs plus Track A handoff; feature_reindex.py is now the local restart/index alternate while prior-release coinstats compatibility remains asset-blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.