### PR TITLE
ci: promote reindex gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -351,10 +351,10 @@
   },
   {
     "name": "feature_reindex.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes a narrow PQBTC restart/reindex boundary: repeated `-reindex` and `-reindex-chainstate` restarts recover the same three-block chain, manual out-of-order blk file swapping still recovers the full 12-block chain with the expected debug markers, and an interrupted `-blockfilterindex -reindex` run later resumes without wiping the existing blockfilter LevelDB; init-error recovery and immutable/read-only blockstore handling remain separate follow-on surfaces."
+    "notes": "Now promoted into pq_required as the narrow PQBTC restart/reindex gate: repeated `-reindex` and `-reindex-chainstate` restarts recover the same three-block chain, manual out-of-order blk file swapping still recovers the full 12-block chain with the expected debug markers, and an interrupted `-blockfilterindex -reindex` run later resumes without wiping the existing blockfilter LevelDB; init-error recovery and immutable/read-only blockstore handling remain separate follow-on surfaces."
   },
   {
     "name": "feature_reindex_init.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -11,6 +11,7 @@ feature_pq_block_limits.py
 feature_pq_reorg.py
 feature_pqsig_basic.py
 feature_pqsig_multisig.py
+feature_reindex.py
 feature_remove_pruned_files_on_startup.py
 feature_taproot_replacement_deployment.py
 feature_taproot_replacement_compat.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `88` |
-| `pq_backlog` | `37` |
+| `pq_required` | `89` |
+| `pq_backlog` | `36` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -72,65 +72,66 @@ Current required PQ-first gates:
 27. `feature_fastprune.py`
 28. `feature_index_prune.py`
 29. `feature_loadblock.py`
-30. `feature_remove_pruned_files_on_startup.py`
-31. `feature_utxo_set_hash.py`
-32. `rpc_psbt.py`
-33. `wallet_abandonconflict.py`
-34. `wallet_address_types.py`
-35. `wallet_assumeutxo.py`
-36. `wallet_avoid_mixing_output_types.py`
-37. `wallet_avoidreuse.py`
-38. `wallet_backup.py`
-39. `wallet_balance.py`
-40. `wallet_basic.py`
-41. `wallet_blank.py`
-42. `wallet_bumpfee.py`
-43. `wallet_change_address.py`
-44. `wallet_coinbase_category.py`
-45. `wallet_conflicts.py`
-46. `wallet_create_tx.py`
-47. `wallet_createwallet.py`
-48. `wallet_createwalletdescriptor.py`
-49. `wallet_crosschain.py`
-50. `wallet_descriptor.py`
-51. `wallet_disable.py`
-52. `wallet_encryption.py`
-53. `wallet_fallbackfee.py`
-54. `wallet_fast_rescan.py`
-55. `wallet_fundrawtransaction.py`
-56. `wallet_gethdkeys.py`
-57. `wallet_groups.py`
-58. `wallet_hd.py`
-59. `wallet_importdescriptors.py`
-60. `wallet_importprunedfunds.py`
-61. `wallet_keypool.py`
-62. `wallet_keypool_topup.py`
-63. `wallet_labels.py`
-64. `wallet_listdescriptors.py`
-65. `wallet_listreceivedby.py`
-66. `wallet_listsinceblock.py`
-67. `wallet_listtransactions.py`
-68. `wallet_miniscript.py`
-69. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-70. `wallet_multisig_descriptor_psbt.py`
-71. `wallet_multiwallet.py`
-72. `wallet_orphanedreward.py`
-73. `wallet_reindex.py`
-74. `wallet_reorgsrestore.py`
-75. `wallet_rescan_unconfirmed.py`
-76. `wallet_resendwallettransactions.py`
-77. `wallet_send.py`
-78. `wallet_sendall.py`
-79. `wallet_sendmany.py`
-80. `wallet_signrawtransactionwithwallet.py`
-81. `wallet_simulaterawtx.py`
-82. `wallet_spend_unconfirmed.py`
-83. `wallet_startup.py`
-84. `wallet_timelock.py`
-85. `wallet_transactiontime_rescan.py`
-86. `wallet_txn_clone.py`
-87. `wallet_txn_doublespend.py`
-88. `wallet_v3_txs.py`
+30. `feature_reindex.py`
+31. `feature_remove_pruned_files_on_startup.py`
+32. `feature_utxo_set_hash.py`
+33. `rpc_psbt.py`
+34. `wallet_abandonconflict.py`
+35. `wallet_address_types.py`
+36. `wallet_assumeutxo.py`
+37. `wallet_avoid_mixing_output_types.py`
+38. `wallet_avoidreuse.py`
+39. `wallet_backup.py`
+40. `wallet_balance.py`
+41. `wallet_basic.py`
+42. `wallet_blank.py`
+43. `wallet_bumpfee.py`
+44. `wallet_change_address.py`
+45. `wallet_coinbase_category.py`
+46. `wallet_conflicts.py`
+47. `wallet_create_tx.py`
+48. `wallet_createwallet.py`
+49. `wallet_createwalletdescriptor.py`
+50. `wallet_crosschain.py`
+51. `wallet_descriptor.py`
+52. `wallet_disable.py`
+53. `wallet_encryption.py`
+54. `wallet_fallbackfee.py`
+55. `wallet_fast_rescan.py`
+56. `wallet_fundrawtransaction.py`
+57. `wallet_gethdkeys.py`
+58. `wallet_groups.py`
+59. `wallet_hd.py`
+60. `wallet_importdescriptors.py`
+61. `wallet_importprunedfunds.py`
+62. `wallet_keypool.py`
+63. `wallet_keypool_topup.py`
+64. `wallet_labels.py`
+65. `wallet_listdescriptors.py`
+66. `wallet_listreceivedby.py`
+67. `wallet_listsinceblock.py`
+68. `wallet_listtransactions.py`
+69. `wallet_miniscript.py`
+70. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+71. `wallet_multisig_descriptor_psbt.py`
+72. `wallet_multiwallet.py`
+73. `wallet_orphanedreward.py`
+74. `wallet_reindex.py`
+75. `wallet_reorgsrestore.py`
+76. `wallet_rescan_unconfirmed.py`
+77. `wallet_resendwallettransactions.py`
+78. `wallet_send.py`
+79. `wallet_sendall.py`
+80. `wallet_sendmany.py`
+81. `wallet_signrawtransactionwithwallet.py`
+82. `wallet_simulaterawtx.py`
+83. `wallet_spend_unconfirmed.py`
+84. `wallet_startup.py`
+85. `wallet_timelock.py`
+86. `wallet_transactiontime_rescan.py`
+87. `wallet_txn_clone.py`
+88. `wallet_txn_doublespend.py`
+89. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -303,6 +304,10 @@ The txoutset/index confidence gap is now also part of the required gate:
 indexed-vs-non-indexed `gettxoutsetinfo()` parity, verbose block accounting,
 restart, reindex, reindex-chainstate, reorg, and stale-index recovery on the
 bounded PQBTC dataset.
+The restart/reindex confidence gap is now also part of the required gate:
+`feature_reindex.py` covers repeated `-reindex` and `-reindex-chainstate`
+recovery, out-of-order blockfile recovery, expected debug markers, and
+interrupted blockfilter reindex resume without wiping the existing LevelDB.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_COINSTATSINDEX_POSTURE.md
+++ b/docs/FEATURE_COINSTATSINDEX_POSTURE.md
@@ -60,10 +60,9 @@ Targeted confidence pass run on 2026-04-30:
 - `feature_coinstatsindex.py` is now a required PQBTC txoutset/index gate
 - it remains bounded to the direct-mined raw `OP_TRUE` dataset and current
   local index/reorg/reindex behavior
-- the next clean actionable follow-on is
-  [feature_reindex.py](../test/functional/feature_reindex.py), which is already
-  green under the current harness and is the cheaper adjacent restart/index
-  freeze
+- the adjacent restart/index follow-on,
+  [feature_reindex.py](../test/functional/feature_reindex.py), is now covered
+  by the required gate
 - the environment-dependent alternate is
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py),
   which stays relevant when previous-release test data is available

--- a/docs/FEATURE_REINDEX_POSTURE.md
+++ b/docs/FEATURE_REINDEX_POSTURE.md
@@ -2,6 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-REINDEX-POSTURE-v1
+## Updated: 2026-04-30
 ## Frozen-By: track-a-phase1-20260413
 ## Consensus-Relevant: YES
 
@@ -35,15 +36,14 @@ This posture note does **not** mean:
 
 - init-time block-index failure recovery is owned here
 - read-only or immutable blockstore restart behavior is owned here
-- this suite is promoted into `pq_required`
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-13:
+Targeted confidence pass run on 2026-04-30:
 
-- `python3 test/functional/feature_reindex.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_reindex.py`
   - result: passed
   - current posture:
     - `-reindex` and `-reindex-chainstate` both return to the expected chain
@@ -53,8 +53,9 @@ Targeted confidence pass run on 2026-04-13:
 
 ## Interpretation
 
-- `feature_reindex.py` is now a fixed PQBTC restart/reindex slice
-- it remains `pq_backlog`, not a required PQ-first gate
+- `feature_reindex.py` is now a required PQBTC restart/reindex gate
+- it remains bounded to restart-time reindex, reindex-chainstate,
+  out-of-order blockfile recovery, and interrupted blockfilter reindex resume
 - the next clean actionable follow-on is
   [feature_reindex_init.py](../test/functional/feature_reindex_init.py), which
   freezes the adjacent init-error recovery path and is already green here

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -25,12 +25,13 @@ block storage and prune-lifecycle behavior in the canonical `pq_required`
 gate, keep `feature_loadblock.py` bootstrap/import behavior in the same gate,
 keep `feature_utxo_set_hash.py` txoutset-hash behavior in the same gate, and
 keep `feature_coinstatsindex.py` txoutset/index behavior in the same gate, and
+keep `feature_reindex.py` restart/reindex behavior in the same gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
-`feature_reindex.py`, `feature_reindex_init.py`, and
+`feature_reindex_init.py`, and
 `feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, keep
 `feature_assumeutxo.py`, `wallet_assumeutxo.py`, `feature_assumevalid.py`,
 `feature_block.py`, the restored `rpc_psbt.py`, `wallet_miniscript.py`,
@@ -105,10 +106,10 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. `feature_reindex.py`
+2. `feature_reindex_init.py`
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, the next bounded local chainstate follow-on is
-     `feature_reindex.py`, now that the adjacent txoutset/index behavior is
+     `feature_reindex_init.py`, now that restart-time reindex behavior is
      required,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
@@ -120,7 +121,8 @@ Alternate rebalance:
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
      tranches, or the current block storage, prune-lifecycle,
-     bootstrap/import, txoutset-hash, and txoutset/index tranches.
+     bootstrap/import, txoutset-hash, txoutset/index, and restart/reindex
+     tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available.
@@ -446,11 +448,10 @@ Still deferred:
      later startup that reopens, rather than wipes, the existing blockfilter
      LevelDB
    Minimum validation target:
-   - `python3 test/functional/feature_reindex.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_reindex.py`
    Still deferred inside this suite:
    - init-time block-index failure recovery
    - immutable/read-only blockstore restart behavior
-   - promotion into `pq_required`
 21. `feature_reindex_init.py` now owns:
    - explicit removal of the on-disk `blocks/index` directory before startup
    - the exact init-time block-database failure message that instructs the
@@ -943,12 +944,12 @@ Still deferred:
      real prior PQBTC release assets exist
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `feature_reindex.py`
+   - alternate: `feature_reindex_init.py`
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - `feature_reindex.py` is the next bounded local restart/index follow-on
-     now that txoutset/index behavior is required
+   - `feature_reindex_init.py` is the next bounded local restart/index
+     follow-on now that restart-time reindex behavior is required
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1659,6 +1660,15 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the local restart/index alternate is
   `feature_reindex.py`.
+- 2026-04-30: `feature_reindex.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers repeated `-reindex` and
+  `-reindex-chainstate` recovery, out-of-order blockfile recovery, expected
+  debug markers, and interrupted blockfilter reindex resume without wiping the
+  existing LevelDB. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the local restart/index alternate is
+  `feature_reindex_init.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1784,6 +1794,8 @@ Aineko must ask before:
   `feature_utxo_set_hash.py` passes targeted validation in the current tree.
 - There is no current blocker in the txoutset/index surface:
   `feature_coinstatsindex.py` passes targeted validation in the current tree.
+- There is no current blocker in the restart/reindex surface:
+  `feature_reindex.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_reindex.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=89, pq_backlog=36, dual_profile=142, legacy_only=9.
- Refresh the reindex/coinstats posture docs plus Track A handoff; feature_reindex_init.py is now the local restart/index alternate while prior-release coinstats compatibility remains asset-blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_reindex.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.