### PR TITLE
ci: promote reindex init gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -358,10 +358,10 @@
   },
   {
     "name": "feature_reindex_init.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes a narrow PQBTC init-recovery boundary: removing the on-disk `blocks/index` directory causes the expected block-database init failure with explicit reindex guidance, and the current noninteractive reindex-acceptance recovery path returns the node to height 200; broader restart-time reindex behavior and immutable/read-only blockstore handling remain separate follow-on surfaces."
+    "notes": "Now promoted into pq_required as the narrow PQBTC init-recovery gate: removing the on-disk `blocks/index` directory causes the expected block-database init failure with explicit reindex guidance, and the current noninteractive reindex-acceptance recovery path returns the node to height 200; broader restart-time reindex behavior and immutable/read-only blockstore handling remain separate follow-on surfaces."
   },
   {
     "name": "feature_reindex_readonly.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -12,6 +12,7 @@ feature_pq_reorg.py
 feature_pqsig_basic.py
 feature_pqsig_multisig.py
 feature_reindex.py
+feature_reindex_init.py
 feature_remove_pruned_files_on_startup.py
 feature_taproot_replacement_deployment.py
 feature_taproot_replacement_compat.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `89` |
-| `pq_backlog` | `36` |
+| `pq_required` | `90` |
+| `pq_backlog` | `35` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -73,65 +73,66 @@ Current required PQ-first gates:
 28. `feature_index_prune.py`
 29. `feature_loadblock.py`
 30. `feature_reindex.py`
-31. `feature_remove_pruned_files_on_startup.py`
-32. `feature_utxo_set_hash.py`
-33. `rpc_psbt.py`
-34. `wallet_abandonconflict.py`
-35. `wallet_address_types.py`
-36. `wallet_assumeutxo.py`
-37. `wallet_avoid_mixing_output_types.py`
-38. `wallet_avoidreuse.py`
-39. `wallet_backup.py`
-40. `wallet_balance.py`
-41. `wallet_basic.py`
-42. `wallet_blank.py`
-43. `wallet_bumpfee.py`
-44. `wallet_change_address.py`
-45. `wallet_coinbase_category.py`
-46. `wallet_conflicts.py`
-47. `wallet_create_tx.py`
-48. `wallet_createwallet.py`
-49. `wallet_createwalletdescriptor.py`
-50. `wallet_crosschain.py`
-51. `wallet_descriptor.py`
-52. `wallet_disable.py`
-53. `wallet_encryption.py`
-54. `wallet_fallbackfee.py`
-55. `wallet_fast_rescan.py`
-56. `wallet_fundrawtransaction.py`
-57. `wallet_gethdkeys.py`
-58. `wallet_groups.py`
-59. `wallet_hd.py`
-60. `wallet_importdescriptors.py`
-61. `wallet_importprunedfunds.py`
-62. `wallet_keypool.py`
-63. `wallet_keypool_topup.py`
-64. `wallet_labels.py`
-65. `wallet_listdescriptors.py`
-66. `wallet_listreceivedby.py`
-67. `wallet_listsinceblock.py`
-68. `wallet_listtransactions.py`
-69. `wallet_miniscript.py`
-70. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-71. `wallet_multisig_descriptor_psbt.py`
-72. `wallet_multiwallet.py`
-73. `wallet_orphanedreward.py`
-74. `wallet_reindex.py`
-75. `wallet_reorgsrestore.py`
-76. `wallet_rescan_unconfirmed.py`
-77. `wallet_resendwallettransactions.py`
-78. `wallet_send.py`
-79. `wallet_sendall.py`
-80. `wallet_sendmany.py`
-81. `wallet_signrawtransactionwithwallet.py`
-82. `wallet_simulaterawtx.py`
-83. `wallet_spend_unconfirmed.py`
-84. `wallet_startup.py`
-85. `wallet_timelock.py`
-86. `wallet_transactiontime_rescan.py`
-87. `wallet_txn_clone.py`
-88. `wallet_txn_doublespend.py`
-89. `wallet_v3_txs.py`
+31. `feature_reindex_init.py`
+32. `feature_remove_pruned_files_on_startup.py`
+33. `feature_utxo_set_hash.py`
+34. `rpc_psbt.py`
+35. `wallet_abandonconflict.py`
+36. `wallet_address_types.py`
+37. `wallet_assumeutxo.py`
+38. `wallet_avoid_mixing_output_types.py`
+39. `wallet_avoidreuse.py`
+40. `wallet_backup.py`
+41. `wallet_balance.py`
+42. `wallet_basic.py`
+43. `wallet_blank.py`
+44. `wallet_bumpfee.py`
+45. `wallet_change_address.py`
+46. `wallet_coinbase_category.py`
+47. `wallet_conflicts.py`
+48. `wallet_create_tx.py`
+49. `wallet_createwallet.py`
+50. `wallet_createwalletdescriptor.py`
+51. `wallet_crosschain.py`
+52. `wallet_descriptor.py`
+53. `wallet_disable.py`
+54. `wallet_encryption.py`
+55. `wallet_fallbackfee.py`
+56. `wallet_fast_rescan.py`
+57. `wallet_fundrawtransaction.py`
+58. `wallet_gethdkeys.py`
+59. `wallet_groups.py`
+60. `wallet_hd.py`
+61. `wallet_importdescriptors.py`
+62. `wallet_importprunedfunds.py`
+63. `wallet_keypool.py`
+64. `wallet_keypool_topup.py`
+65. `wallet_labels.py`
+66. `wallet_listdescriptors.py`
+67. `wallet_listreceivedby.py`
+68. `wallet_listsinceblock.py`
+69. `wallet_listtransactions.py`
+70. `wallet_miniscript.py`
+71. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+72. `wallet_multisig_descriptor_psbt.py`
+73. `wallet_multiwallet.py`
+74. `wallet_orphanedreward.py`
+75. `wallet_reindex.py`
+76. `wallet_reorgsrestore.py`
+77. `wallet_rescan_unconfirmed.py`
+78. `wallet_resendwallettransactions.py`
+79. `wallet_send.py`
+80. `wallet_sendall.py`
+81. `wallet_sendmany.py`
+82. `wallet_signrawtransactionwithwallet.py`
+83. `wallet_simulaterawtx.py`
+84. `wallet_spend_unconfirmed.py`
+85. `wallet_startup.py`
+86. `wallet_timelock.py`
+87. `wallet_transactiontime_rescan.py`
+88. `wallet_txn_clone.py`
+89. `wallet_txn_doublespend.py`
+90. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -308,6 +309,10 @@ The restart/reindex confidence gap is now also part of the required gate:
 `feature_reindex.py` covers repeated `-reindex` and `-reindex-chainstate`
 recovery, out-of-order blockfile recovery, expected debug markers, and
 interrupted blockfilter reindex resume without wiping the existing LevelDB.
+The init-time block-index recovery confidence gap is now also part of the
+required gate: `feature_reindex_init.py` covers missing `blocks/index` startup
+failure, explicit `-reindex` / `-reindex-chainstate` recovery guidance, the
+noninteractive reindex-acceptance path, and return to height `200`.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_REINDEX_INIT_POSTURE.md
+++ b/docs/FEATURE_REINDEX_INIT_POSTURE.md
@@ -31,15 +31,14 @@ This posture note does **not** mean:
 - broader restart-time `-reindex` and `-reindex-chainstate` behavior is owned
   here
 - immutable or read-only blockstore behavior is owned here
-- this suite is promoted into `pq_required`
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-13:
+Targeted confidence pass run on 2026-05-01:
 
-- `python3 test/functional/feature_reindex_init.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_reindex_init.py`
   - result: passed
   - current posture:
     - the missing block-index directory triggers the expected init error
@@ -47,8 +46,7 @@ Targeted confidence pass run on 2026-04-13:
 
 ## Interpretation
 
-- `feature_reindex_init.py` is now a fixed PQBTC init-recovery slice
-- it remains `pq_backlog`, not a required PQ-first gate
+- `feature_reindex_init.py` is now a required PQBTC init-recovery gate
 - the next clean actionable follow-on is
   [feature_reindex_readonly.py](../test/functional/feature_reindex_readonly.py),
   which extends the same restart family into immutable/read-only blockstore

--- a/docs/FEATURE_REINDEX_POSTURE.md
+++ b/docs/FEATURE_REINDEX_POSTURE.md
@@ -56,9 +56,10 @@ Targeted confidence pass run on 2026-04-30:
 - `feature_reindex.py` is now a required PQBTC restart/reindex gate
 - it remains bounded to restart-time reindex, reindex-chainstate,
   out-of-order blockfile recovery, and interrupted blockfilter reindex resume
-- the next clean actionable follow-on is
+- the adjacent init-recovery follow-on,
   [feature_reindex_init.py](../test/functional/feature_reindex_init.py), which
-  freezes the adjacent init-error recovery path and is already green here
-- the environment-sensitive alternate is
+  freezes the adjacent init-error recovery path, is now covered by the
+  required gate
+- the next clean actionable follow-on is
   [feature_reindex_readonly.py](../test/functional/feature_reindex_readonly.py),
   which exercises immutable/read-only blockstore restart behavior

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-04-29
+## Updated: 2026-05-01
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -26,12 +26,13 @@ gate, keep `feature_loadblock.py` bootstrap/import behavior in the same gate,
 keep `feature_utxo_set_hash.py` txoutset-hash behavior in the same gate, and
 keep `feature_coinstatsindex.py` txoutset/index behavior in the same gate, and
 keep `feature_reindex.py` restart/reindex behavior in the same gate, and
+keep `feature_reindex_init.py` init-time block-index recovery behavior in the
+same gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
-`feature_reindex_init.py`, and
 `feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, keep
 `feature_assumeutxo.py`, `wallet_assumeutxo.py`, `feature_assumevalid.py`,
 `feature_block.py`, the restored `rpc_psbt.py`, `wallet_miniscript.py`,
@@ -106,11 +107,11 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. `feature_reindex_init.py`
+2. `feature_reindex_readonly.py`
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, the next bounded local chainstate follow-on is
-     `feature_reindex_init.py`, now that restart-time reindex behavior is
-     required,
+     `feature_reindex_readonly.py`, now that restart-time reindex and
+     init-time block-index recovery behavior are required,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -121,8 +122,8 @@ Alternate rebalance:
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
      tranches, or the current block storage, prune-lifecycle,
-     bootstrap/import, txoutset-hash, txoutset/index, and restart/reindex
-     tranches.
+     bootstrap/import, txoutset-hash, txoutset/index, restart/reindex, and
+     init-recovery tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available.
@@ -459,11 +460,10 @@ Still deferred:
    - the current noninteractive reindex-acceptance recovery path
    - successful recovery back to height `200` after that init failure
    Minimum validation target:
-   - `python3 test/functional/feature_reindex_init.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_reindex_init.py`
    Still deferred inside this suite:
    - broader restart-time reindex behavior
    - immutable/read-only blockstore restart behavior
-   - promotion into `pq_required`
 22. `feature_reindex_readonly.py` now owns:
    - forced creation of a second blk file under `-fastprune`
    - explicit read-only plus host-level immutable treatment of the first blk
@@ -944,12 +944,13 @@ Still deferred:
      real prior PQBTC release assets exist
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `feature_reindex_init.py`
+   - alternate: `feature_reindex_readonly.py`
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - `feature_reindex_init.py` is the next bounded local restart/index
-     follow-on now that restart-time reindex behavior is required
+   - `feature_reindex_readonly.py` is the next bounded local restart/index
+     follow-on now that restart-time reindex and init-time block-index
+     recovery behavior are required
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1669,6 +1670,14 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the local restart/index alternate is
   `feature_reindex_init.py`.
+- 2026-05-01: `feature_reindex_init.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers missing `blocks/index` startup failure,
+  explicit `-reindex` / `-reindex-chainstate` recovery guidance, the
+  noninteractive reindex-acceptance path, and return to height `200`. The next
+  owned follow-on remains `feature_coinstatsindex_compatibility.py` when real
+  prior PQBTC release assets exist; otherwise the local restart/index
+  alternate is `feature_reindex_readonly.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1796,6 +1805,8 @@ Aineko must ask before:
   `feature_coinstatsindex.py` passes targeted validation in the current tree.
 - There is no current blocker in the restart/reindex surface:
   `feature_reindex.py` passes targeted validation in the current tree.
+- There is no current blocker in the init-time block-index recovery surface:
+  `feature_reindex_init.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_reindex_init.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=90, pq_backlog=35, dual_profile=142, legacy_only=9.
- Refresh the reindex init posture, adjacent reindex posture, and Track A handoff; feature_reindex_readonly.py is now the local restart/index alternate while prior-release coinstats compatibility remains asset-blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_reindex_init.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.