### PR TITLE
ci: promote reindex readonly gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -365,10 +365,10 @@
   },
   {
     "name": "feature_reindex_readonly.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Now freezes a narrow PQBTC immutable/read-only blockstore reindex boundary: under `-fastprune`, the first blk file is made read-only and locally immutable when the host supports it, restart under `-reindex -fastprune` completes with the expected `Reindexing finished` marker and the same chain height, and mutability is restored for cleanup; generic reindex behavior remains covered by the other reindex slices."
+    "notes": "Now promoted into pq_required as the narrow PQBTC immutable/read-only blockstore reindex gate: under `-fastprune`, the first blk file is made read-only and locally immutable when the host supports it, restart under `-reindex -fastprune` completes with the expected `Reindexing finished` marker and the same chain height, and mutability is restored for cleanup; generic reindex behavior remains covered by the other reindex slices."
   },
   {
     "name": "feature_remove_pruned_files_on_startup.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -13,6 +13,7 @@ feature_pqsig_basic.py
 feature_pqsig_multisig.py
 feature_reindex.py
 feature_reindex_init.py
+feature_reindex_readonly.py
 feature_remove_pruned_files_on_startup.py
 feature_taproot_replacement_deployment.py
 feature_taproot_replacement_compat.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `90` |
-| `pq_backlog` | `35` |
+| `pq_required` | `91` |
+| `pq_backlog` | `34` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -74,65 +74,66 @@ Current required PQ-first gates:
 29. `feature_loadblock.py`
 30. `feature_reindex.py`
 31. `feature_reindex_init.py`
-32. `feature_remove_pruned_files_on_startup.py`
-33. `feature_utxo_set_hash.py`
-34. `rpc_psbt.py`
-35. `wallet_abandonconflict.py`
-36. `wallet_address_types.py`
-37. `wallet_assumeutxo.py`
-38. `wallet_avoid_mixing_output_types.py`
-39. `wallet_avoidreuse.py`
-40. `wallet_backup.py`
-41. `wallet_balance.py`
-42. `wallet_basic.py`
-43. `wallet_blank.py`
-44. `wallet_bumpfee.py`
-45. `wallet_change_address.py`
-46. `wallet_coinbase_category.py`
-47. `wallet_conflicts.py`
-48. `wallet_create_tx.py`
-49. `wallet_createwallet.py`
-50. `wallet_createwalletdescriptor.py`
-51. `wallet_crosschain.py`
-52. `wallet_descriptor.py`
-53. `wallet_disable.py`
-54. `wallet_encryption.py`
-55. `wallet_fallbackfee.py`
-56. `wallet_fast_rescan.py`
-57. `wallet_fundrawtransaction.py`
-58. `wallet_gethdkeys.py`
-59. `wallet_groups.py`
-60. `wallet_hd.py`
-61. `wallet_importdescriptors.py`
-62. `wallet_importprunedfunds.py`
-63. `wallet_keypool.py`
-64. `wallet_keypool_topup.py`
-65. `wallet_labels.py`
-66. `wallet_listdescriptors.py`
-67. `wallet_listreceivedby.py`
-68. `wallet_listsinceblock.py`
-69. `wallet_listtransactions.py`
-70. `wallet_miniscript.py`
-71. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-72. `wallet_multisig_descriptor_psbt.py`
-73. `wallet_multiwallet.py`
-74. `wallet_orphanedreward.py`
-75. `wallet_reindex.py`
-76. `wallet_reorgsrestore.py`
-77. `wallet_rescan_unconfirmed.py`
-78. `wallet_resendwallettransactions.py`
-79. `wallet_send.py`
-80. `wallet_sendall.py`
-81. `wallet_sendmany.py`
-82. `wallet_signrawtransactionwithwallet.py`
-83. `wallet_simulaterawtx.py`
-84. `wallet_spend_unconfirmed.py`
-85. `wallet_startup.py`
-86. `wallet_timelock.py`
-87. `wallet_transactiontime_rescan.py`
-88. `wallet_txn_clone.py`
-89. `wallet_txn_doublespend.py`
-90. `wallet_v3_txs.py`
+32. `feature_reindex_readonly.py`
+33. `feature_remove_pruned_files_on_startup.py`
+34. `feature_utxo_set_hash.py`
+35. `rpc_psbt.py`
+36. `wallet_abandonconflict.py`
+37. `wallet_address_types.py`
+38. `wallet_assumeutxo.py`
+39. `wallet_avoid_mixing_output_types.py`
+40. `wallet_avoidreuse.py`
+41. `wallet_backup.py`
+42. `wallet_balance.py`
+43. `wallet_basic.py`
+44. `wallet_blank.py`
+45. `wallet_bumpfee.py`
+46. `wallet_change_address.py`
+47. `wallet_coinbase_category.py`
+48. `wallet_conflicts.py`
+49. `wallet_create_tx.py`
+50. `wallet_createwallet.py`
+51. `wallet_createwalletdescriptor.py`
+52. `wallet_crosschain.py`
+53. `wallet_descriptor.py`
+54. `wallet_disable.py`
+55. `wallet_encryption.py`
+56. `wallet_fallbackfee.py`
+57. `wallet_fast_rescan.py`
+58. `wallet_fundrawtransaction.py`
+59. `wallet_gethdkeys.py`
+60. `wallet_groups.py`
+61. `wallet_hd.py`
+62. `wallet_importdescriptors.py`
+63. `wallet_importprunedfunds.py`
+64. `wallet_keypool.py`
+65. `wallet_keypool_topup.py`
+66. `wallet_labels.py`
+67. `wallet_listdescriptors.py`
+68. `wallet_listreceivedby.py`
+69. `wallet_listsinceblock.py`
+70. `wallet_listtransactions.py`
+71. `wallet_miniscript.py`
+72. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+73. `wallet_multisig_descriptor_psbt.py`
+74. `wallet_multiwallet.py`
+75. `wallet_orphanedreward.py`
+76. `wallet_reindex.py`
+77. `wallet_reorgsrestore.py`
+78. `wallet_rescan_unconfirmed.py`
+79. `wallet_resendwallettransactions.py`
+80. `wallet_send.py`
+81. `wallet_sendall.py`
+82. `wallet_sendmany.py`
+83. `wallet_signrawtransactionwithwallet.py`
+84. `wallet_simulaterawtx.py`
+85. `wallet_spend_unconfirmed.py`
+86. `wallet_startup.py`
+87. `wallet_timelock.py`
+88. `wallet_transactiontime_rescan.py`
+89. `wallet_txn_clone.py`
+90. `wallet_txn_doublespend.py`
+91. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -313,6 +314,12 @@ The init-time block-index recovery confidence gap is now also part of the
 required gate: `feature_reindex_init.py` covers missing `blocks/index` startup
 failure, explicit `-reindex` / `-reindex-chainstate` recovery guidance, the
 noninteractive reindex-acceptance path, and return to height `200`.
+The read-only blockstore reindex confidence gap is now also part of the
+required gate: `feature_reindex_readonly.py` covers `-fastprune` blockfile
+rollover, read-only and host-level immutable treatment of the first blk file
+when supported, successful `-reindex -fastprune` restart, the expected
+`Reindexing finished` marker, preserved chain height, and cleanup permission
+restoration.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_REINDEX_INIT_POSTURE.md
+++ b/docs/FEATURE_REINDEX_INIT_POSTURE.md
@@ -47,9 +47,9 @@ Targeted confidence pass run on 2026-05-01:
 ## Interpretation
 
 - `feature_reindex_init.py` is now a required PQBTC init-recovery gate
-- the next clean actionable follow-on is
+- the adjacent read-only blockstore follow-on,
   [feature_reindex_readonly.py](../test/functional/feature_reindex_readonly.py),
   which extends the same restart family into immutable/read-only blockstore
-  handling
-- the environment-dependent alternate remains
+  handling, is now covered by the required gate
+- the environment-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)

--- a/docs/FEATURE_REINDEX_POSTURE.md
+++ b/docs/FEATURE_REINDEX_POSTURE.md
@@ -60,6 +60,7 @@ Targeted confidence pass run on 2026-04-30:
   [feature_reindex_init.py](../test/functional/feature_reindex_init.py), which
   freezes the adjacent init-error recovery path, is now covered by the
   required gate
-- the next clean actionable follow-on is
+- the adjacent read-only blockstore follow-on,
   [feature_reindex_readonly.py](../test/functional/feature_reindex_readonly.py),
-  which exercises immutable/read-only blockstore restart behavior
+  which exercises immutable/read-only blockstore restart behavior, is now
+  covered by the required gate

--- a/docs/FEATURE_REINDEX_READONLY_POSTURE.md
+++ b/docs/FEATURE_REINDEX_READONLY_POSTURE.md
@@ -33,15 +33,14 @@ This posture note does **not** mean:
 
 - generic `-reindex` and `-reindex-chainstate` restart behavior is owned here
 - init-time block-index failure recovery is owned here
-- this suite is promoted into `pq_required`
 
 Those remain separate follow-on surfaces.
 
 ## Confidence Snapshot
 
-Targeted confidence pass run on 2026-04-13:
+Targeted confidence pass run on 2026-05-01:
 
-- `python3 test/functional/feature_reindex_readonly.py`
+- `build/test/functional/test_runner.py --jobs=1 feature_reindex_readonly.py`
   - result: passed
   - current posture:
     - the local host used `chflags` to make the block file immutable
@@ -50,11 +49,12 @@ Targeted confidence pass run on 2026-04-13:
 
 ## Interpretation
 
-- `feature_reindex_readonly.py` is now a fixed PQBTC read-only blockstore
-  reindex slice
-- it remains `pq_backlog`, not a required PQ-first gate
-- the next clean actionable follow-on is
-  [feature_assumevalid.py](../test/functional/feature_assumevalid.py), which is
-  a runnable local chainstate/validation slice and is already green here
-- the environment-dependent alternate remains
+- `feature_reindex_readonly.py` is now a required PQBTC read-only blockstore
+  reindex gate
+- the restart/reindex family is now covered by required gates for generic
+  restart-time reindex, init-time block-index recovery, and read-only
+  blockstore recovery
+- the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be a fresh bounded
+  `pq_backlog` migration decision outside the restart/reindex family

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -28,12 +28,14 @@ keep `feature_coinstatsindex.py` txoutset/index behavior in the same gate, and
 keep `feature_reindex.py` restart/reindex behavior in the same gate, and
 keep `feature_reindex_init.py` init-time block-index recovery behavior in the
 same gate, and
+keep `feature_reindex_readonly.py` immutable/read-only blockstore reindex
+behavior in the same gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
-`feature_reindex_readonly.py`, and `feature_assumevalid.py` boundaries, keep
+`feature_assumevalid.py` boundaries, keep
 `feature_assumeutxo.py`, `wallet_assumeutxo.py`, `feature_assumevalid.py`,
 `feature_block.py`, the restored `rpc_psbt.py`, `wallet_miniscript.py`,
 `wallet_miniscript_decaying_multisig_descriptor_psbt.py`, and
@@ -107,11 +109,12 @@ Preferred next owned tranche:
 
 Alternate rebalance:
 
-2. `feature_reindex_readonly.py`
+2. Remaining repo-local `pq_backlog` triage
    - Why alternate: if the asset-dependent coinstats compatibility path stays
-     blocked locally, the next bounded local chainstate follow-on is
-     `feature_reindex_readonly.py`, now that restart-time reindex and
-     init-time block-index recovery behavior are required,
+     blocked locally, the restart/reindex family is now covered by required
+     gates for generic restart-time reindex, init-time block-index recovery,
+     and read-only blockstore recovery, so the next local step should be a
+     fresh bounded migration decision outside the restart/reindex family,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -122,8 +125,8 @@ Alternate rebalance:
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
      tranches, or the current block storage, prune-lifecycle,
-     bootstrap/import, txoutset-hash, txoutset/index, restart/reindex, and
-     init-recovery tranches.
+     bootstrap/import, txoutset-hash, txoutset/index, restart/reindex,
+     init-recovery, and read-only blockstore tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available.
@@ -473,10 +476,9 @@ Still deferred:
    - explicit `Reindexing finished` log confirmation
    - restoration of file mutability and permissions for cleanup
    Minimum validation target:
-   - `python3 test/functional/feature_reindex_readonly.py`
+   - `build/test/functional/test_runner.py --jobs=1 feature_reindex_readonly.py`
    Still deferred inside this suite:
    - generic reindex behavior outside the immutable/read-only blockstore case
-   - promotion into `pq_required`
 23. `feature_assumevalid.py` now owns:
    - one handcrafted invalid-signature spend buried just over two weeks deep
    - rejection of that bad block at height `102` on the non-assumevalid node
@@ -944,13 +946,14 @@ Still deferred:
      real prior PQBTC release assets exist
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `feature_reindex_readonly.py`
+   - alternate: remaining repo-local `pq_backlog` triage outside the
+     restart/reindex family
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
-   - `feature_reindex_readonly.py` is the next bounded local restart/index
-     follow-on now that restart-time reindex and init-time block-index
-     recovery behavior are required
+   - the restart/reindex family is now fully represented in the required gate,
+     so any local alternate should be a fresh bounded migration decision
+     outside that family
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1678,6 +1681,16 @@ Aineko must ask before:
   owned follow-on remains `feature_coinstatsindex_compatibility.py` when real
   prior PQBTC release assets exist; otherwise the local restart/index
   alternate is `feature_reindex_readonly.py`.
+- 2026-05-01: `feature_reindex_readonly.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers `-fastprune` blockfile rollover,
+  read-only and host-level immutable treatment of the first blk file when
+  supported, successful `-reindex -fastprune` restart, the expected
+  `Reindexing finished` marker, preserved chain height, and cleanup permission
+  restoration. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the local alternate should be a fresh bounded
+  `pq_backlog` migration decision outside the restart/reindex family.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1807,6 +1820,9 @@ Aineko must ask before:
   `feature_reindex.py` passes targeted validation in the current tree.
 - There is no current blocker in the init-time block-index recovery surface:
   `feature_reindex_init.py` passes targeted validation in the current tree.
+- There is no current blocker in the read-only blockstore reindex surface:
+  `feature_reindex_readonly.py` passes targeted validation in the current
+  tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_reindex_readonly.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=91, pq_backlog=34, dual_profile=142, legacy_only=9.
- Refresh the reindex posture docs plus Track A handoff; the restart/reindex family is now represented in required gates, while prior-release coinstats compatibility remains asset-blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_reindex_readonly.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.