### PR TITLE
ci: promote versionbits warning gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -483,10 +483,10 @@
   },
   {
     "name": "feature_versionbits_warning.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Consensus or chainstate-facing coverage should receive an explicit PQ migration decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the narrow PQBTC unknown-versionbits warning gate: the suite mines regtest periods around the unknown-versionbits threshold, verifies warnings stay clear before activation, then confirms the expected mining/network warnings and alertnotify output after unknown rules activate; broader deployment semantics and Taproot replacement behavior remain separate surfaces."
   },
   {
     "name": "interface_bitcoin_cli.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -21,6 +21,7 @@ feature_taproot_replacement_active_boundary.py
 feature_taproot_replacement_active_semantic_guard.py
 feature_taproot_replacement_active_positive_seam.py
 feature_utxo_set_hash.py
+feature_versionbits_warning.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `91` |
-| `pq_backlog` | `34` |
+| `pq_required` | `92` |
+| `pq_backlog` | `33` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -77,63 +77,64 @@ Current required PQ-first gates:
 32. `feature_reindex_readonly.py`
 33. `feature_remove_pruned_files_on_startup.py`
 34. `feature_utxo_set_hash.py`
-35. `rpc_psbt.py`
-36. `wallet_abandonconflict.py`
-37. `wallet_address_types.py`
-38. `wallet_assumeutxo.py`
-39. `wallet_avoid_mixing_output_types.py`
-40. `wallet_avoidreuse.py`
-41. `wallet_backup.py`
-42. `wallet_balance.py`
-43. `wallet_basic.py`
-44. `wallet_blank.py`
-45. `wallet_bumpfee.py`
-46. `wallet_change_address.py`
-47. `wallet_coinbase_category.py`
-48. `wallet_conflicts.py`
-49. `wallet_create_tx.py`
-50. `wallet_createwallet.py`
-51. `wallet_createwalletdescriptor.py`
-52. `wallet_crosschain.py`
-53. `wallet_descriptor.py`
-54. `wallet_disable.py`
-55. `wallet_encryption.py`
-56. `wallet_fallbackfee.py`
-57. `wallet_fast_rescan.py`
-58. `wallet_fundrawtransaction.py`
-59. `wallet_gethdkeys.py`
-60. `wallet_groups.py`
-61. `wallet_hd.py`
-62. `wallet_importdescriptors.py`
-63. `wallet_importprunedfunds.py`
-64. `wallet_keypool.py`
-65. `wallet_keypool_topup.py`
-66. `wallet_labels.py`
-67. `wallet_listdescriptors.py`
-68. `wallet_listreceivedby.py`
-69. `wallet_listsinceblock.py`
-70. `wallet_listtransactions.py`
-71. `wallet_miniscript.py`
-72. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-73. `wallet_multisig_descriptor_psbt.py`
-74. `wallet_multiwallet.py`
-75. `wallet_orphanedreward.py`
-76. `wallet_reindex.py`
-77. `wallet_reorgsrestore.py`
-78. `wallet_rescan_unconfirmed.py`
-79. `wallet_resendwallettransactions.py`
-80. `wallet_send.py`
-81. `wallet_sendall.py`
-82. `wallet_sendmany.py`
-83. `wallet_signrawtransactionwithwallet.py`
-84. `wallet_simulaterawtx.py`
-85. `wallet_spend_unconfirmed.py`
-86. `wallet_startup.py`
-87. `wallet_timelock.py`
-88. `wallet_transactiontime_rescan.py`
-89. `wallet_txn_clone.py`
-90. `wallet_txn_doublespend.py`
-91. `wallet_v3_txs.py`
+35. `feature_versionbits_warning.py`
+36. `rpc_psbt.py`
+37. `wallet_abandonconflict.py`
+38. `wallet_address_types.py`
+39. `wallet_assumeutxo.py`
+40. `wallet_avoid_mixing_output_types.py`
+41. `wallet_avoidreuse.py`
+42. `wallet_backup.py`
+43. `wallet_balance.py`
+44. `wallet_basic.py`
+45. `wallet_blank.py`
+46. `wallet_bumpfee.py`
+47. `wallet_change_address.py`
+48. `wallet_coinbase_category.py`
+49. `wallet_conflicts.py`
+50. `wallet_create_tx.py`
+51. `wallet_createwallet.py`
+52. `wallet_createwalletdescriptor.py`
+53. `wallet_crosschain.py`
+54. `wallet_descriptor.py`
+55. `wallet_disable.py`
+56. `wallet_encryption.py`
+57. `wallet_fallbackfee.py`
+58. `wallet_fast_rescan.py`
+59. `wallet_fundrawtransaction.py`
+60. `wallet_gethdkeys.py`
+61. `wallet_groups.py`
+62. `wallet_hd.py`
+63. `wallet_importdescriptors.py`
+64. `wallet_importprunedfunds.py`
+65. `wallet_keypool.py`
+66. `wallet_keypool_topup.py`
+67. `wallet_labels.py`
+68. `wallet_listdescriptors.py`
+69. `wallet_listreceivedby.py`
+70. `wallet_listsinceblock.py`
+71. `wallet_listtransactions.py`
+72. `wallet_miniscript.py`
+73. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+74. `wallet_multisig_descriptor_psbt.py`
+75. `wallet_multiwallet.py`
+76. `wallet_orphanedreward.py`
+77. `wallet_reindex.py`
+78. `wallet_reorgsrestore.py`
+79. `wallet_rescan_unconfirmed.py`
+80. `wallet_resendwallettransactions.py`
+81. `wallet_send.py`
+82. `wallet_sendall.py`
+83. `wallet_sendmany.py`
+84. `wallet_signrawtransactionwithwallet.py`
+85. `wallet_simulaterawtx.py`
+86. `wallet_spend_unconfirmed.py`
+87. `wallet_startup.py`
+88. `wallet_timelock.py`
+89. `wallet_transactiontime_rescan.py`
+90. `wallet_txn_clone.py`
+91. `wallet_txn_doublespend.py`
+92. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -320,6 +321,11 @@ rollover, read-only and host-level immutable treatment of the first blk file
 when supported, successful `-reindex -fastprune` restart, the expected
 `Reindexing finished` marker, preserved chain height, and cleanup permission
 restoration.
+The unknown-versionbits warning confidence gap is now also part of the
+required gate: `feature_versionbits_warning.py` covers warning-free behavior
+below the unknown-bit threshold, active unknown-rules warnings through mining
+and network info, and `alertnotify` output once the unknown versionbit
+activates on regtest.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_VERSIONBITS_WARNING_POSTURE.md
+++ b/docs/FEATURE_VERSIONBITS_WARNING_POSTURE.md
@@ -1,0 +1,59 @@
+# PQBTC `feature_versionbits_warning.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: FEATURE-VERSIONBITS-WARNING-POSTURE-v1
+## Frozen-By: track-a-phase1-20260503
+## Consensus-Relevant: YES
+
+## Purpose
+
+Define the owned Track A contract for unknown versionbits warning behavior on
+the current PQBTC regtest profile.
+
+## Current Owned Surface
+
+The current passing
+[feature_versionbits_warning.py](../test/functional/feature_versionbits_warning.py)
+suite owns a narrow warning-surface slice:
+
+- one regtest node mines a full versionbits period using its deterministic
+  address
+- blocks just below the unknown-bit threshold do not emit versionbits warnings
+  through `getmininginfo()` or `getnetworkinfo()`
+- blocks at the unknown-bit threshold are accepted into the active warning
+  path after the next period
+- after restart and IBD exit, the node reports the expected unknown-rules
+  warning through mining and network info
+- `alertnotify` writes the unknown-rules warning to the configured alert file
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- new softfork deployment semantics are owned here
+- Taproot replacement activation or active-boundary semantics are owned here
+- mempool, mining-template, or wallet behavior is owned here
+
+Those remain separate follow-on surfaces.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-03:
+
+- `build/test/functional/test_runner.py --jobs=1 feature_versionbits_warning.py`
+  - result: passed
+  - current posture:
+    - warnings remain clear before the unknown-bit threshold
+    - mining, network, and alertnotify warnings appear after unknown rules
+      activate
+
+## Interpretation
+
+- `feature_versionbits_warning.py` is now a required PQBTC validation-warning
+  gate
+- it remains bounded to unknown versionbits warning and alert plumbing
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded
+  `pq_backlog` migration decision, likely from the remaining validation,
+  mempool, or mining backlog

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-05-01
+## Updated: 2026-05-03
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -30,6 +30,8 @@ keep `feature_reindex_init.py` init-time block-index recovery behavior in the
 same gate, and
 keep `feature_reindex_readonly.py` immutable/read-only blockstore reindex
 behavior in the same gate, and
+keep `feature_versionbits_warning.py` unknown-versionbits warning behavior in
+the same gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
@@ -113,8 +115,9 @@ Alternate rebalance:
    - Why alternate: if the asset-dependent coinstats compatibility path stays
      blocked locally, the restart/reindex family is now covered by required
      gates for generic restart-time reindex, init-time block-index recovery,
-     and read-only blockstore recovery, so the next local step should be a
-     fresh bounded migration decision outside the restart/reindex family,
+     and read-only blockstore recovery, and the unknown-versionbits warning
+     surface is now covered by the required gate, so the next local step should
+     be a fresh bounded migration decision outside those surfaces,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -126,7 +129,7 @@ Alternate rebalance:
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
      tranches, or the current block storage, prune-lifecycle,
      bootstrap/import, txoutset-hash, txoutset/index, restart/reindex,
-     init-recovery, and read-only blockstore tranches.
+     init-recovery, read-only blockstore, and versionbits-warning tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available.
@@ -947,13 +950,14 @@ Still deferred:
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
    - alternate: remaining repo-local `pq_backlog` triage outside the
-     restart/reindex family
+     restart/reindex and versionbits-warning surfaces
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
    - the restart/reindex family is now fully represented in the required gate,
-     so any local alternate should be a fresh bounded migration decision
-     outside that family
+     and the unknown-versionbits warning surface is now represented in the
+     required gate, so any local alternate should be a fresh bounded migration
+     decision outside those surfaces
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1007,11 +1011,13 @@ Still deferred:
    `feature_reindex_init.py` contract.
 40. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-41. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+41. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+   current `feature_versionbits_warning.py` contract.
+42. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-42. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+43. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-43. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+44. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1691,6 +1697,16 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the local alternate should be a fresh bounded
   `pq_backlog` migration decision outside the restart/reindex family.
+- 2026-05-03: `feature_versionbits_warning.py` is now promoted into the
+  canonical `pq_required` gate and locally revalidated with the build-tree
+  functional runner. The owned boundary covers warning-free behavior below the
+  unknown-bit threshold, active unknown-rules warnings through mining and
+  network info, and `alertnotify` output once the unknown versionbit activates
+  on regtest. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the local alternate should be another bounded
+  `pq_backlog` migration decision from the remaining validation, mempool, or
+  mining backlog.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1822,6 +1838,9 @@ Aineko must ask before:
   `feature_reindex_init.py` passes targeted validation in the current tree.
 - There is no current blocker in the read-only blockstore reindex surface:
   `feature_reindex_readonly.py` passes targeted validation in the current
+  tree.
+- There is no current blocker in the unknown-versionbits warning surface:
+  `feature_versionbits_warning.py` passes targeted validation in the current
   tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.


### PR DESCRIPTION
Summary
- Promote feature_versionbits_warning.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=92, pq_backlog=33, dual_profile=142, legacy_only=9.
- Add FEATURE_VERSIONBITS_WARNING_POSTURE.md and refresh Track A handoff; prior-release coinstats compatibility remains asset-blocked.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_versionbits_warning.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.