### PR TITLE
ci: promote bip68 sequence gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -71,10 +71,10 @@
   },
   {
     "name": "feature_bip68_sequence.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Consensus or chainstate-facing coverage should receive an explicit PQ migration decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the narrow PQBTC BIP68 sequence-lock gate: it covers disable-flag behavior, sequence-lock rejection and acceptance for confirmed and unconfirmed inputs, pre-CSV-activation block acceptance for BIP68-invalid spends, mempool consistency after reorg, CSV activation at the configured test height, and version-2 relay standardness; CLTV and full CSV activation semantics remain separate follow-on surfaces."
   },
   {
     "name": "feature_block.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -1,5 +1,6 @@
 feature_assumeutxo.py
 feature_assumevalid.py
+feature_bip68_sequence.py
 feature_block.py
 feature_blocksdir.py
 feature_blocksxor.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `92` |
-| `pq_backlog` | `33` |
+| `pq_required` | `93` |
+| `pq_backlog` | `32` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -65,76 +65,77 @@ Current required PQ-first gates:
 20. `wallet_pq_signrawtransaction.py`
 21. `feature_assumeutxo.py`
 22. `feature_assumevalid.py`
-23. `feature_block.py`
-24. `feature_blocksdir.py`
-25. `feature_blocksxor.py`
-26. `feature_coinstatsindex.py`
-27. `feature_fastprune.py`
-28. `feature_index_prune.py`
-29. `feature_loadblock.py`
-30. `feature_reindex.py`
-31. `feature_reindex_init.py`
-32. `feature_reindex_readonly.py`
-33. `feature_remove_pruned_files_on_startup.py`
-34. `feature_utxo_set_hash.py`
-35. `feature_versionbits_warning.py`
-36. `rpc_psbt.py`
-37. `wallet_abandonconflict.py`
-38. `wallet_address_types.py`
-39. `wallet_assumeutxo.py`
-40. `wallet_avoid_mixing_output_types.py`
-41. `wallet_avoidreuse.py`
-42. `wallet_backup.py`
-43. `wallet_balance.py`
-44. `wallet_basic.py`
-45. `wallet_blank.py`
-46. `wallet_bumpfee.py`
-47. `wallet_change_address.py`
-48. `wallet_coinbase_category.py`
-49. `wallet_conflicts.py`
-50. `wallet_create_tx.py`
-51. `wallet_createwallet.py`
-52. `wallet_createwalletdescriptor.py`
-53. `wallet_crosschain.py`
-54. `wallet_descriptor.py`
-55. `wallet_disable.py`
-56. `wallet_encryption.py`
-57. `wallet_fallbackfee.py`
-58. `wallet_fast_rescan.py`
-59. `wallet_fundrawtransaction.py`
-60. `wallet_gethdkeys.py`
-61. `wallet_groups.py`
-62. `wallet_hd.py`
-63. `wallet_importdescriptors.py`
-64. `wallet_importprunedfunds.py`
-65. `wallet_keypool.py`
-66. `wallet_keypool_topup.py`
-67. `wallet_labels.py`
-68. `wallet_listdescriptors.py`
-69. `wallet_listreceivedby.py`
-70. `wallet_listsinceblock.py`
-71. `wallet_listtransactions.py`
-72. `wallet_miniscript.py`
-73. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-74. `wallet_multisig_descriptor_psbt.py`
-75. `wallet_multiwallet.py`
-76. `wallet_orphanedreward.py`
-77. `wallet_reindex.py`
-78. `wallet_reorgsrestore.py`
-79. `wallet_rescan_unconfirmed.py`
-80. `wallet_resendwallettransactions.py`
-81. `wallet_send.py`
-82. `wallet_sendall.py`
-83. `wallet_sendmany.py`
-84. `wallet_signrawtransactionwithwallet.py`
-85. `wallet_simulaterawtx.py`
-86. `wallet_spend_unconfirmed.py`
-87. `wallet_startup.py`
-88. `wallet_timelock.py`
-89. `wallet_transactiontime_rescan.py`
-90. `wallet_txn_clone.py`
-91. `wallet_txn_doublespend.py`
-92. `wallet_v3_txs.py`
+23. `feature_bip68_sequence.py`
+24. `feature_block.py`
+25. `feature_blocksdir.py`
+26. `feature_blocksxor.py`
+27. `feature_coinstatsindex.py`
+28. `feature_fastprune.py`
+29. `feature_index_prune.py`
+30. `feature_loadblock.py`
+31. `feature_reindex.py`
+32. `feature_reindex_init.py`
+33. `feature_reindex_readonly.py`
+34. `feature_remove_pruned_files_on_startup.py`
+35. `feature_utxo_set_hash.py`
+36. `feature_versionbits_warning.py`
+37. `rpc_psbt.py`
+38. `wallet_abandonconflict.py`
+39. `wallet_address_types.py`
+40. `wallet_assumeutxo.py`
+41. `wallet_avoid_mixing_output_types.py`
+42. `wallet_avoidreuse.py`
+43. `wallet_backup.py`
+44. `wallet_balance.py`
+45. `wallet_basic.py`
+46. `wallet_blank.py`
+47. `wallet_bumpfee.py`
+48. `wallet_change_address.py`
+49. `wallet_coinbase_category.py`
+50. `wallet_conflicts.py`
+51. `wallet_create_tx.py`
+52. `wallet_createwallet.py`
+53. `wallet_createwalletdescriptor.py`
+54. `wallet_crosschain.py`
+55. `wallet_descriptor.py`
+56. `wallet_disable.py`
+57. `wallet_encryption.py`
+58. `wallet_fallbackfee.py`
+59. `wallet_fast_rescan.py`
+60. `wallet_fundrawtransaction.py`
+61. `wallet_gethdkeys.py`
+62. `wallet_groups.py`
+63. `wallet_hd.py`
+64. `wallet_importdescriptors.py`
+65. `wallet_importprunedfunds.py`
+66. `wallet_keypool.py`
+67. `wallet_keypool_topup.py`
+68. `wallet_labels.py`
+69. `wallet_listdescriptors.py`
+70. `wallet_listreceivedby.py`
+71. `wallet_listsinceblock.py`
+72. `wallet_listtransactions.py`
+73. `wallet_miniscript.py`
+74. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+75. `wallet_multisig_descriptor_psbt.py`
+76. `wallet_multiwallet.py`
+77. `wallet_orphanedreward.py`
+78. `wallet_reindex.py`
+79. `wallet_reorgsrestore.py`
+80. `wallet_rescan_unconfirmed.py`
+81. `wallet_resendwallettransactions.py`
+82. `wallet_send.py`
+83. `wallet_sendall.py`
+84. `wallet_sendmany.py`
+85. `wallet_signrawtransactionwithwallet.py`
+86. `wallet_simulaterawtx.py`
+87. `wallet_spend_unconfirmed.py`
+88. `wallet_startup.py`
+89. `wallet_timelock.py`
+90. `wallet_transactiontime_rescan.py`
+91. `wallet_txn_clone.py`
+92. `wallet_txn_doublespend.py`
+93. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -326,6 +327,12 @@ required gate: `feature_versionbits_warning.py` covers warning-free behavior
 below the unknown-bit threshold, active unknown-rules warnings through mining
 and network info, and `alertnotify` output once the unknown versionbit
 activates on regtest.
+The BIP68 sequence-lock confidence gap is now also part of the required gate:
+`feature_bip68_sequence.py` covers sequence-lock disable-flag behavior,
+`non-BIP68-final` rejection and acceptance across confirmed and unconfirmed
+inputs, pre-CSV-activation block acceptance for BIP68-invalid spends, mempool
+cleanup after reorg, suite-local CSV activation, and version-2 relay
+standardness.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_BIP68_SEQUENCE_POSTURE.md
+++ b/docs/FEATURE_BIP68_SEQUENCE_POSTURE.md
@@ -1,0 +1,62 @@
+# PQBTC `feature_bip68_sequence.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: FEATURE-BIP68-SEQUENCE-POSTURE-v1
+## Frozen-By: track-a-phase1-20260503
+## Consensus-Relevant: YES
+
+## Purpose
+
+Define the owned Track A contract for BIP68 sequence-lock behavior on the
+current PQBTC regtest profile.
+
+## Current Owned Surface
+
+The current passing
+[feature_bip68_sequence.py](../test/functional/feature_bip68_sequence.py)
+suite owns a narrow BIP68 sequence-lock slice:
+
+- sequence-lock disable-flag behavior remains accepted where expected
+- non-final BIP68 spends are rejected with `non-BIP68-final`
+- confirmed-input sequence locks are checked across randomized input sets
+- unconfirmed-input sequence locks are checked for both height and time locks
+- mempool consistency is maintained when a reorg reintroduces sequence-locked
+  parents
+- before CSV activation, a BIP68-invalid spend can still be included in a
+  block
+- CSV activates at the configured regtest test height for this suite
+- version-2 transaction relay remains standard
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- CLTV activation behavior is owned here
+- full CSV activation semantics across BIP68, BIP112, and BIP113 are owned here
+- mempool package, mining-template, or wallet behavior is owned here
+
+Those remain separate follow-on surfaces.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-03:
+
+- `build/test/functional/test_runner.py --jobs=1 feature_bip68_sequence.py`
+  - result: passed
+  - current posture:
+    - BIP68 sequence-lock acceptance and rejection paths pass under the current
+      PQBTC profile
+    - pre-activation consensus behavior, reorg cleanup, CSV activation, and
+      version-2 relay standardness pass
+
+## Interpretation
+
+- `feature_bip68_sequence.py` is now a required PQBTC sequence-lock validation
+  gate
+- it remains bounded to BIP68 sequence-lock behavior and the suite-local CSV
+  activation boundary
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded
+  `pq_backlog` migration decision, with `feature_cltv.py` and
+  `feature_csv_activation.py` as adjacent validation candidates

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -32,6 +32,8 @@ keep `feature_reindex_readonly.py` immutable/read-only blockstore reindex
 behavior in the same gate, and
 keep `feature_versionbits_warning.py` unknown-versionbits warning behavior in
 the same gate, and
+keep `feature_bip68_sequence.py` BIP68 sequence-lock behavior in the same
+gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
@@ -116,8 +118,9 @@ Alternate rebalance:
      blocked locally, the restart/reindex family is now covered by required
      gates for generic restart-time reindex, init-time block-index recovery,
      and read-only blockstore recovery, and the unknown-versionbits warning
-     surface is now covered by the required gate, so the next local step should
-     be a fresh bounded migration decision outside those surfaces,
+     and BIP68 sequence-lock surfaces are now covered by the required gate, so
+     the next local step should be a fresh bounded migration decision outside
+     those surfaces,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -129,7 +132,8 @@ Alternate rebalance:
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
      tranches, or the current block storage, prune-lifecycle,
      bootstrap/import, txoutset-hash, txoutset/index, restart/reindex,
-     init-recovery, read-only blockstore, and versionbits-warning tranches.
+     init-recovery, read-only blockstore, versionbits-warning, and
+     sequence-lock tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available.
@@ -950,14 +954,14 @@ Still deferred:
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
    - alternate: remaining repo-local `pq_backlog` triage outside the
-     restart/reindex and versionbits-warning surfaces
+     restart/reindex, versionbits-warning, and sequence-lock surfaces
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
    - the restart/reindex family is now fully represented in the required gate,
-     and the unknown-versionbits warning surface is now represented in the
-     required gate, so any local alternate should be a fresh bounded migration
-     decision outside those surfaces
+     and the unknown-versionbits warning and BIP68 sequence-lock surfaces are
+     now represented in the required gate, so any local alternate should be a
+     fresh bounded migration decision outside those surfaces
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1005,19 +1009,21 @@ Still deferred:
    `feature_utxo_set_hash.py` contract.
 37. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
    `feature_coinstatsindex.py` contract.
-38. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
+38. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
+   `feature_bip68_sequence.py` contract.
+39. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
    `feature_reindex.py` contract.
-39. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
+40. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
    `feature_reindex_init.py` contract.
-40. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
+41. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-41. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+42. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
    current `feature_versionbits_warning.py` contract.
-42. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+43. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-43. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+44. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-44. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+45. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1707,6 +1713,16 @@ Aineko must ask before:
   assets exist; otherwise the local alternate should be another bounded
   `pq_backlog` migration decision from the remaining validation, mempool, or
   mining backlog.
+- 2026-05-03: `feature_bip68_sequence.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers sequence-lock disable-flag behavior,
+  `non-BIP68-final` rejection and acceptance across confirmed and unconfirmed
+  inputs, pre-CSV-activation block acceptance for BIP68-invalid spends,
+  mempool cleanup after reorg, suite-local CSV activation, and version-2 relay
+  standardness. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local validation candidates are
+  `feature_cltv.py` and `feature_csv_activation.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1842,6 +1858,8 @@ Aineko must ask before:
 - There is no current blocker in the unknown-versionbits warning surface:
   `feature_versionbits_warning.py` passes targeted validation in the current
   tree.
+- There is no current blocker in the BIP68 sequence-lock surface:
+  `feature_bip68_sequence.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_bip68_sequence.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=93, pq_backlog=32, dual_profile=142, legacy_only=9.
- Add FEATURE_BIP68_SEQUENCE_POSTURE.md and refresh Track A handoff; CLTV and full CSV activation remain separate validation follow-ons.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_bip68_sequence.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.