### PR TITLE
ci: promote cltv gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -99,10 +99,10 @@
   },
   {
     "name": "feature_cltv.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Consensus or chainstate-facing coverage should receive an explicit PQ migration decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the narrow PQBTC CLTV activation gate: it covers buried BIP65 deployment metadata at the configured test height, pre-activation acceptance of CLTV-invalid transactions in blocks, post-activation block-version enforcement, exact mempool and block rejection reasons for CLTV failures, and acceptance of a valid CLTV spend; full CSV activation semantics remain a separate follow-on surface."
   },
   {
     "name": "feature_coinstatsindex.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -4,6 +4,7 @@ feature_bip68_sequence.py
 feature_block.py
 feature_blocksdir.py
 feature_blocksxor.py
+feature_cltv.py
 feature_coinstatsindex.py
 feature_fastprune.py
 feature_index_prune.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `93` |
-| `pq_backlog` | `32` |
+| `pq_required` | `94` |
+| `pq_backlog` | `31` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -69,73 +69,74 @@ Current required PQ-first gates:
 24. `feature_block.py`
 25. `feature_blocksdir.py`
 26. `feature_blocksxor.py`
-27. `feature_coinstatsindex.py`
-28. `feature_fastprune.py`
-29. `feature_index_prune.py`
-30. `feature_loadblock.py`
-31. `feature_reindex.py`
-32. `feature_reindex_init.py`
-33. `feature_reindex_readonly.py`
-34. `feature_remove_pruned_files_on_startup.py`
-35. `feature_utxo_set_hash.py`
-36. `feature_versionbits_warning.py`
-37. `rpc_psbt.py`
-38. `wallet_abandonconflict.py`
-39. `wallet_address_types.py`
-40. `wallet_assumeutxo.py`
-41. `wallet_avoid_mixing_output_types.py`
-42. `wallet_avoidreuse.py`
-43. `wallet_backup.py`
-44. `wallet_balance.py`
-45. `wallet_basic.py`
-46. `wallet_blank.py`
-47. `wallet_bumpfee.py`
-48. `wallet_change_address.py`
-49. `wallet_coinbase_category.py`
-50. `wallet_conflicts.py`
-51. `wallet_create_tx.py`
-52. `wallet_createwallet.py`
-53. `wallet_createwalletdescriptor.py`
-54. `wallet_crosschain.py`
-55. `wallet_descriptor.py`
-56. `wallet_disable.py`
-57. `wallet_encryption.py`
-58. `wallet_fallbackfee.py`
-59. `wallet_fast_rescan.py`
-60. `wallet_fundrawtransaction.py`
-61. `wallet_gethdkeys.py`
-62. `wallet_groups.py`
-63. `wallet_hd.py`
-64. `wallet_importdescriptors.py`
-65. `wallet_importprunedfunds.py`
-66. `wallet_keypool.py`
-67. `wallet_keypool_topup.py`
-68. `wallet_labels.py`
-69. `wallet_listdescriptors.py`
-70. `wallet_listreceivedby.py`
-71. `wallet_listsinceblock.py`
-72. `wallet_listtransactions.py`
-73. `wallet_miniscript.py`
-74. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-75. `wallet_multisig_descriptor_psbt.py`
-76. `wallet_multiwallet.py`
-77. `wallet_orphanedreward.py`
-78. `wallet_reindex.py`
-79. `wallet_reorgsrestore.py`
-80. `wallet_rescan_unconfirmed.py`
-81. `wallet_resendwallettransactions.py`
-82. `wallet_send.py`
-83. `wallet_sendall.py`
-84. `wallet_sendmany.py`
-85. `wallet_signrawtransactionwithwallet.py`
-86. `wallet_simulaterawtx.py`
-87. `wallet_spend_unconfirmed.py`
-88. `wallet_startup.py`
-89. `wallet_timelock.py`
-90. `wallet_transactiontime_rescan.py`
-91. `wallet_txn_clone.py`
-92. `wallet_txn_doublespend.py`
-93. `wallet_v3_txs.py`
+27. `feature_cltv.py`
+28. `feature_coinstatsindex.py`
+29. `feature_fastprune.py`
+30. `feature_index_prune.py`
+31. `feature_loadblock.py`
+32. `feature_reindex.py`
+33. `feature_reindex_init.py`
+34. `feature_reindex_readonly.py`
+35. `feature_remove_pruned_files_on_startup.py`
+36. `feature_utxo_set_hash.py`
+37. `feature_versionbits_warning.py`
+38. `rpc_psbt.py`
+39. `wallet_abandonconflict.py`
+40. `wallet_address_types.py`
+41. `wallet_assumeutxo.py`
+42. `wallet_avoid_mixing_output_types.py`
+43. `wallet_avoidreuse.py`
+44. `wallet_backup.py`
+45. `wallet_balance.py`
+46. `wallet_basic.py`
+47. `wallet_blank.py`
+48. `wallet_bumpfee.py`
+49. `wallet_change_address.py`
+50. `wallet_coinbase_category.py`
+51. `wallet_conflicts.py`
+52. `wallet_create_tx.py`
+53. `wallet_createwallet.py`
+54. `wallet_createwalletdescriptor.py`
+55. `wallet_crosschain.py`
+56. `wallet_descriptor.py`
+57. `wallet_disable.py`
+58. `wallet_encryption.py`
+59. `wallet_fallbackfee.py`
+60. `wallet_fast_rescan.py`
+61. `wallet_fundrawtransaction.py`
+62. `wallet_gethdkeys.py`
+63. `wallet_groups.py`
+64. `wallet_hd.py`
+65. `wallet_importdescriptors.py`
+66. `wallet_importprunedfunds.py`
+67. `wallet_keypool.py`
+68. `wallet_keypool_topup.py`
+69. `wallet_labels.py`
+70. `wallet_listdescriptors.py`
+71. `wallet_listreceivedby.py`
+72. `wallet_listsinceblock.py`
+73. `wallet_listtransactions.py`
+74. `wallet_miniscript.py`
+75. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+76. `wallet_multisig_descriptor_psbt.py`
+77. `wallet_multiwallet.py`
+78. `wallet_orphanedreward.py`
+79. `wallet_reindex.py`
+80. `wallet_reorgsrestore.py`
+81. `wallet_rescan_unconfirmed.py`
+82. `wallet_resendwallettransactions.py`
+83. `wallet_send.py`
+84. `wallet_sendall.py`
+85. `wallet_sendmany.py`
+86. `wallet_signrawtransactionwithwallet.py`
+87. `wallet_simulaterawtx.py`
+88. `wallet_spend_unconfirmed.py`
+89. `wallet_startup.py`
+90. `wallet_timelock.py`
+91. `wallet_transactiontime_rescan.py`
+92. `wallet_txn_clone.py`
+93. `wallet_txn_doublespend.py`
+94. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -333,6 +334,11 @@ The BIP68 sequence-lock confidence gap is now also part of the required gate:
 inputs, pre-CSV-activation block acceptance for BIP68-invalid spends, mempool
 cleanup after reorg, suite-local CSV activation, and version-2 relay
 standardness.
+The CLTV confidence gap is now also part of the required gate:
+`feature_cltv.py` covers buried BIP65 deployment metadata, pre-activation
+acceptance of CLTV-invalid transactions in blocks, post-activation block
+version enforcement, exact mempool and block rejection reasons for CLTV
+failures, and valid CLTV spend acceptance.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_BIP68_SEQUENCE_POSTURE.md
+++ b/docs/FEATURE_BIP68_SEQUENCE_POSTURE.md
@@ -57,6 +57,8 @@ Targeted confidence pass run on 2026-05-03:
   activation boundary
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
-- without those assets, the local follow-on should be another bounded
-  `pq_backlog` migration decision, with `feature_cltv.py` and
-  `feature_csv_activation.py` as adjacent validation candidates
+- the adjacent CLTV validation follow-on,
+  [feature_cltv.py](../test/functional/feature_cltv.py), is now covered by
+  the required gate
+- without prior-release assets, the next local validation follow-on is
+  [feature_csv_activation.py](../test/functional/feature_csv_activation.py)

--- a/docs/FEATURE_CLTV_POSTURE.md
+++ b/docs/FEATURE_CLTV_POSTURE.md
@@ -1,0 +1,60 @@
+# PQBTC `feature_cltv.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: FEATURE-CLTV-POSTURE-v1
+## Frozen-By: track-a-phase1-20260503
+## Consensus-Relevant: YES
+
+## Purpose
+
+Define the owned Track A contract for CLTV activation and validation behavior
+on the current PQBTC regtest profile.
+
+## Current Owned Surface
+
+The current passing
+[feature_cltv.py](../test/functional/feature_cltv.py) suite owns a narrow
+CLTV activation slice:
+
+- buried BIP65 deployment metadata reports inactive, then active, at the
+  configured regtest activation height
+- before activation, CLTV-invalid transactions can still appear in a block
+- after activation, version-3 blocks are rejected with the expected
+  `bad-version(0x00000003)` marker
+- all five representative CLTV failure modes are rejected by
+  `testmempoolaccept` with the expected `mempool-script-verify-flag-failed`
+  details
+- the same invalid spends are rejected in blocks with the expected
+  `block-script-verify-flag-failed` debug marker
+- a version-4 block containing a valid CLTV spend is accepted after activation
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- full CSV activation behavior across BIP68, BIP112, and BIP113 is owned here
+- broad mempool policy, mining-template, or wallet behavior is owned here
+- Taproot replacement activation semantics are owned here
+
+Those remain separate follow-on surfaces.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-03:
+
+- `build/test/functional/test_runner.py --jobs=1 feature_cltv.py`
+  - result: passed
+  - current posture:
+    - CLTV activation metadata, pre-activation acceptance, post-activation
+      version enforcement, invalid-spend rejection, and valid-spend acceptance
+      pass under the current PQBTC profile
+
+## Interpretation
+
+- `feature_cltv.py` is now a required PQBTC CLTV validation gate
+- it remains bounded to CLTV activation and CHECKLOCKTIMEVERIFY script
+  validation
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the adjacent local validation follow-on is
+  [feature_csv_activation.py](../test/functional/feature_csv_activation.py)

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -34,6 +34,8 @@ keep `feature_versionbits_warning.py` unknown-versionbits warning behavior in
 the same gate, and
 keep `feature_bip68_sequence.py` BIP68 sequence-lock behavior in the same
 gate, and
+keep `feature_cltv.py` CLTV activation and validation behavior in the same
+gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
@@ -118,9 +120,9 @@ Alternate rebalance:
      blocked locally, the restart/reindex family is now covered by required
      gates for generic restart-time reindex, init-time block-index recovery,
      and read-only blockstore recovery, and the unknown-versionbits warning
-     and BIP68 sequence-lock surfaces are now covered by the required gate, so
-     the next local step should be a fresh bounded migration decision outside
-     those surfaces,
+     BIP68 sequence-lock, and CLTV surfaces are now covered by the required
+     gate, so the next local step should be a fresh bounded migration decision
+     outside those surfaces,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -133,7 +135,7 @@ Alternate rebalance:
      tranches, or the current block storage, prune-lifecycle,
      bootstrap/import, txoutset-hash, txoutset/index, restart/reindex,
      init-recovery, read-only blockstore, versionbits-warning, and
-     sequence-lock tranches.
+     sequence-lock and CLTV tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available.
@@ -954,14 +956,14 @@ Still deferred:
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
    - alternate: remaining repo-local `pq_backlog` triage outside the
-     restart/reindex, versionbits-warning, and sequence-lock surfaces
+     restart/reindex, versionbits-warning, sequence-lock, and CLTV surfaces
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
    - the restart/reindex family is now fully represented in the required gate,
-     and the unknown-versionbits warning and BIP68 sequence-lock surfaces are
-     now represented in the required gate, so any local alternate should be a
-     fresh bounded migration decision outside those surfaces
+     and the unknown-versionbits warning, BIP68 sequence-lock, and CLTV
+     surfaces are now represented in the required gate, so any local alternate
+     should be a fresh bounded migration decision outside those surfaces
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1011,19 +1013,21 @@ Still deferred:
    `feature_coinstatsindex.py` contract.
 38. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
    `feature_bip68_sequence.py` contract.
-39. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
+39. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
+   `feature_cltv.py` contract.
+40. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
    `feature_reindex.py` contract.
-40. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
+41. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
    `feature_reindex_init.py` contract.
-41. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
+42. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-42. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+43. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
    current `feature_versionbits_warning.py` contract.
-43. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+44. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-44. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+45. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-45. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+46. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1723,6 +1727,15 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local validation candidates are
   `feature_cltv.py` and `feature_csv_activation.py`.
+- 2026-05-03: `feature_cltv.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers buried BIP65 deployment metadata,
+  pre-activation acceptance of CLTV-invalid transactions in blocks,
+  post-activation block-version enforcement, exact mempool and block rejection
+  reasons for CLTV failures, and valid CLTV spend acceptance. The next owned
+  follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+  PQBTC release assets exist; otherwise the adjacent local validation
+  candidate is `feature_csv_activation.py`.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1860,6 +1873,8 @@ Aineko must ask before:
   tree.
 - There is no current blocker in the BIP68 sequence-lock surface:
   `feature_bip68_sequence.py` passes targeted validation in the current tree.
+- There is no current blocker in the CLTV validation surface:
+  `feature_cltv.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_cltv.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=94, pq_backlog=31, dual_profile=142, legacy_only=9.
- Add FEATURE_CLTV_POSTURE.md and refresh Track A handoff; feature_csv_activation.py remains the adjacent validation follow-on.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_cltv.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.