### PR TITLE
ci: promote csv activation gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -127,10 +127,10 @@
   },
   {
     "name": "feature_csv_activation.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Consensus or chainstate-facing coverage should receive an explicit PQ migration decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the narrow PQBTC CSV activation gate: it covers suite-local activation for BIP68, BIP112, and BIP113, pre-activation acceptance, post-activation rejection and acceptance across relative locktime, CHECKSEQUENCEVERIFY, and MedianTimePast nLockTime cases, and exact block rejection reasons; broader mempool/package and mining-template policy remain separate follow-on surfaces."
   },
   {
     "name": "feature_dbcrash.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -6,6 +6,7 @@ feature_blocksdir.py
 feature_blocksxor.py
 feature_cltv.py
 feature_coinstatsindex.py
+feature_csv_activation.py
 feature_fastprune.py
 feature_index_prune.py
 feature_loadblock.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `94` |
-| `pq_backlog` | `31` |
+| `pq_required` | `95` |
+| `pq_backlog` | `30` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -71,72 +71,73 @@ Current required PQ-first gates:
 26. `feature_blocksxor.py`
 27. `feature_cltv.py`
 28. `feature_coinstatsindex.py`
-29. `feature_fastprune.py`
-30. `feature_index_prune.py`
-31. `feature_loadblock.py`
-32. `feature_reindex.py`
-33. `feature_reindex_init.py`
-34. `feature_reindex_readonly.py`
-35. `feature_remove_pruned_files_on_startup.py`
-36. `feature_utxo_set_hash.py`
-37. `feature_versionbits_warning.py`
-38. `rpc_psbt.py`
-39. `wallet_abandonconflict.py`
-40. `wallet_address_types.py`
-41. `wallet_assumeutxo.py`
-42. `wallet_avoid_mixing_output_types.py`
-43. `wallet_avoidreuse.py`
-44. `wallet_backup.py`
-45. `wallet_balance.py`
-46. `wallet_basic.py`
-47. `wallet_blank.py`
-48. `wallet_bumpfee.py`
-49. `wallet_change_address.py`
-50. `wallet_coinbase_category.py`
-51. `wallet_conflicts.py`
-52. `wallet_create_tx.py`
-53. `wallet_createwallet.py`
-54. `wallet_createwalletdescriptor.py`
-55. `wallet_crosschain.py`
-56. `wallet_descriptor.py`
-57. `wallet_disable.py`
-58. `wallet_encryption.py`
-59. `wallet_fallbackfee.py`
-60. `wallet_fast_rescan.py`
-61. `wallet_fundrawtransaction.py`
-62. `wallet_gethdkeys.py`
-63. `wallet_groups.py`
-64. `wallet_hd.py`
-65. `wallet_importdescriptors.py`
-66. `wallet_importprunedfunds.py`
-67. `wallet_keypool.py`
-68. `wallet_keypool_topup.py`
-69. `wallet_labels.py`
-70. `wallet_listdescriptors.py`
-71. `wallet_listreceivedby.py`
-72. `wallet_listsinceblock.py`
-73. `wallet_listtransactions.py`
-74. `wallet_miniscript.py`
-75. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-76. `wallet_multisig_descriptor_psbt.py`
-77. `wallet_multiwallet.py`
-78. `wallet_orphanedreward.py`
-79. `wallet_reindex.py`
-80. `wallet_reorgsrestore.py`
-81. `wallet_rescan_unconfirmed.py`
-82. `wallet_resendwallettransactions.py`
-83. `wallet_send.py`
-84. `wallet_sendall.py`
-85. `wallet_sendmany.py`
-86. `wallet_signrawtransactionwithwallet.py`
-87. `wallet_simulaterawtx.py`
-88. `wallet_spend_unconfirmed.py`
-89. `wallet_startup.py`
-90. `wallet_timelock.py`
-91. `wallet_transactiontime_rescan.py`
-92. `wallet_txn_clone.py`
-93. `wallet_txn_doublespend.py`
-94. `wallet_v3_txs.py`
+29. `feature_csv_activation.py`
+30. `feature_fastprune.py`
+31. `feature_index_prune.py`
+32. `feature_loadblock.py`
+33. `feature_reindex.py`
+34. `feature_reindex_init.py`
+35. `feature_reindex_readonly.py`
+36. `feature_remove_pruned_files_on_startup.py`
+37. `feature_utxo_set_hash.py`
+38. `feature_versionbits_warning.py`
+39. `rpc_psbt.py`
+40. `wallet_abandonconflict.py`
+41. `wallet_address_types.py`
+42. `wallet_assumeutxo.py`
+43. `wallet_avoid_mixing_output_types.py`
+44. `wallet_avoidreuse.py`
+45. `wallet_backup.py`
+46. `wallet_balance.py`
+47. `wallet_basic.py`
+48. `wallet_blank.py`
+49. `wallet_bumpfee.py`
+50. `wallet_change_address.py`
+51. `wallet_coinbase_category.py`
+52. `wallet_conflicts.py`
+53. `wallet_create_tx.py`
+54. `wallet_createwallet.py`
+55. `wallet_createwalletdescriptor.py`
+56. `wallet_crosschain.py`
+57. `wallet_descriptor.py`
+58. `wallet_disable.py`
+59. `wallet_encryption.py`
+60. `wallet_fallbackfee.py`
+61. `wallet_fast_rescan.py`
+62. `wallet_fundrawtransaction.py`
+63. `wallet_gethdkeys.py`
+64. `wallet_groups.py`
+65. `wallet_hd.py`
+66. `wallet_importdescriptors.py`
+67. `wallet_importprunedfunds.py`
+68. `wallet_keypool.py`
+69. `wallet_keypool_topup.py`
+70. `wallet_labels.py`
+71. `wallet_listdescriptors.py`
+72. `wallet_listreceivedby.py`
+73. `wallet_listsinceblock.py`
+74. `wallet_listtransactions.py`
+75. `wallet_miniscript.py`
+76. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+77. `wallet_multisig_descriptor_psbt.py`
+78. `wallet_multiwallet.py`
+79. `wallet_orphanedreward.py`
+80. `wallet_reindex.py`
+81. `wallet_reorgsrestore.py`
+82. `wallet_rescan_unconfirmed.py`
+83. `wallet_resendwallettransactions.py`
+84. `wallet_send.py`
+85. `wallet_sendall.py`
+86. `wallet_sendmany.py`
+87. `wallet_signrawtransactionwithwallet.py`
+88. `wallet_simulaterawtx.py`
+89. `wallet_spend_unconfirmed.py`
+90. `wallet_startup.py`
+91. `wallet_timelock.py`
+92. `wallet_transactiontime_rescan.py`
+93. `wallet_txn_clone.py`
+94. `wallet_txn_doublespend.py`
+95. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -339,6 +340,11 @@ The CLTV confidence gap is now also part of the required gate:
 acceptance of CLTV-invalid transactions in blocks, post-activation block
 version enforcement, exact mempool and block rejection reasons for CLTV
 failures, and valid CLTV spend acceptance.
+The CSV activation confidence gap is now also part of the required gate:
+`feature_csv_activation.py` covers suite-local activation for BIP68, BIP112,
+and BIP113; pre-activation acceptance; post-activation rejection and acceptance
+across relative locktime, CHECKSEQUENCEVERIFY, and MedianTimePast nLockTime
+cases; and exact block rejection reasons.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_CLTV_POSTURE.md
+++ b/docs/FEATURE_CLTV_POSTURE.md
@@ -56,5 +56,9 @@ Targeted confidence pass run on 2026-05-03:
   validation
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
-- without those assets, the adjacent local validation follow-on is
-  [feature_csv_activation.py](../test/functional/feature_csv_activation.py)
+- the adjacent CSV activation follow-on,
+  [feature_csv_activation.py](../test/functional/feature_csv_activation.py),
+  is now covered by the required gate
+- without prior-release assets, the local follow-on should be another bounded
+  `pq_backlog` migration decision from the remaining validation, mempool, or
+  mining backlog

--- a/docs/FEATURE_CSV_ACTIVATION_POSTURE.md
+++ b/docs/FEATURE_CSV_ACTIVATION_POSTURE.md
@@ -1,0 +1,61 @@
+# PQBTC `feature_csv_activation.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: FEATURE-CSV-ACTIVATION-POSTURE-v1
+## Frozen-By: track-a-phase1-20260503
+## Consensus-Relevant: YES
+
+## Purpose
+
+Define the owned Track A contract for CSV activation behavior on the current
+PQBTC regtest profile.
+
+## Current Owned Surface
+
+The current passing
+[feature_csv_activation.py](../test/functional/feature_csv_activation.py)
+suite owns a narrow CSV activation slice:
+
+- the suite activates CSV at the configured regtest activation height
+- before activation, representative BIP68, BIP112, and BIP113 transactions are
+  accepted in blocks
+- after activation, BIP113 MedianTimePast nLockTime failures are rejected with
+  `bad-txns-nonfinal`
+- BIP68 relative locktime spends are rejected or accepted as height and time
+  locks mature
+- BIP112 CHECKSEQUENCEVERIFY failures for negative, empty-stack, and
+  unsatisfied-lock cases are rejected with the expected script-failure reasons
+- both transaction versions exercised by the suite follow the expected
+  activation semantics
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- broad mempool package policy is owned here
+- mining-template policy or fee-selection behavior is owned here
+- wallet timelock behavior is owned here
+
+Those remain separate follow-on surfaces.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-03:
+
+- `build/test/functional/test_runner.py --jobs=1 feature_csv_activation.py`
+  - result: passed
+  - current posture:
+    - BIP68, BIP112, and BIP113 activation behavior passes under the current
+      PQBTC profile
+    - expected block rejection reasons are preserved after activation
+
+## Interpretation
+
+- `feature_csv_activation.py` is now a required PQBTC CSV activation gate
+- it remains bounded to suite-local BIP68, BIP112, and BIP113 activation
+  semantics
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded
+  `pq_backlog` migration decision from the remaining validation, mempool, or
+  mining backlog

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -36,6 +36,8 @@ keep `feature_bip68_sequence.py` BIP68 sequence-lock behavior in the same
 gate, and
 keep `feature_cltv.py` CLTV activation and validation behavior in the same
 gate, and
+keep `feature_csv_activation.py` BIP68/BIP112/BIP113 CSV activation behavior
+in the same gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
@@ -120,9 +122,9 @@ Alternate rebalance:
      blocked locally, the restart/reindex family is now covered by required
      gates for generic restart-time reindex, init-time block-index recovery,
      and read-only blockstore recovery, and the unknown-versionbits warning
-     BIP68 sequence-lock, and CLTV surfaces are now covered by the required
-     gate, so the next local step should be a fresh bounded migration decision
-     outside those surfaces,
+     BIP68 sequence-lock, CLTV, and CSV activation surfaces are now covered by
+     the required gate, so the next local step should be a fresh bounded
+     migration decision outside those surfaces,
      without re-litigating the now-owned descriptor, miniscript, address/RPC,
      raw funding, inherited send-path, rebroadcast, reindex, fast-rescan,
      unconfirmed-rescan, reorg-restore, transaction-time-rescan, backup,
@@ -135,7 +137,7 @@ Alternate rebalance:
      tranches, or the current block storage, prune-lifecycle,
      bootstrap/import, txoutset-hash, txoutset/index, restart/reindex,
      init-recovery, read-only blockstore, versionbits-warning, and
-     sequence-lock and CLTV tranches.
+     sequence-lock, CLTV, and CSV-activation tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available.
@@ -956,14 +958,16 @@ Still deferred:
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
    - alternate: remaining repo-local `pq_backlog` triage outside the
-     restart/reindex, versionbits-warning, sequence-lock, and CLTV surfaces
+     restart/reindex, versionbits-warning, sequence-lock, CLTV, and
+     CSV-activation surfaces
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
    - the restart/reindex family is now fully represented in the required gate,
      and the unknown-versionbits warning, BIP68 sequence-lock, and CLTV
-     surfaces are now represented in the required gate, so any local alternate
-     should be a fresh bounded migration decision outside those surfaces
+     and CSV activation surfaces are now represented in the required gate, so
+     any local alternate should be a fresh bounded migration decision outside
+     those surfaces
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1015,19 +1019,21 @@ Still deferred:
    `feature_bip68_sequence.py` contract.
 39. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
    `feature_cltv.py` contract.
-40. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
+40. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
+   `feature_csv_activation.py` contract.
+41. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
    `feature_reindex.py` contract.
-41. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
+42. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
    `feature_reindex_init.py` contract.
-42. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
+43. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-43. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+44. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
    current `feature_versionbits_warning.py` contract.
-44. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+45. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-45. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+46. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-46. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+47. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1734,8 +1740,18 @@ Aineko must ask before:
   post-activation block-version enforcement, exact mempool and block rejection
   reasons for CLTV failures, and valid CLTV spend acceptance. The next owned
   follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
-  PQBTC release assets exist; otherwise the adjacent local validation
-  candidate is `feature_csv_activation.py`.
+  PQBTC release assets exist; otherwise the adjacent CSV activation surface is
+  now covered by the required gate.
+- 2026-05-03: `feature_csv_activation.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers suite-local activation for BIP68, BIP112,
+  and BIP113; pre-activation acceptance; post-activation rejection and
+  acceptance across relative locktime, CHECKSEQUENCEVERIFY, and MedianTimePast
+  nLockTime cases; and exact block rejection reasons. The next owned follow-on
+  remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
+  release assets exist; otherwise the local alternate should be another
+  bounded `pq_backlog` migration decision from the remaining validation,
+  mempool, or mining backlog.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1875,6 +1891,8 @@ Aineko must ask before:
   `feature_bip68_sequence.py` passes targeted validation in the current tree.
 - There is no current blocker in the CLTV validation surface:
   `feature_cltv.py` passes targeted validation in the current tree.
+- There is no current blocker in the CSV activation surface:
+  `feature_csv_activation.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
Summary
- Promote feature_csv_activation.py from pq_backlog to pq_required.
- Update pq_functional_tests order and CI completeness counts to pq_required=95, pq_backlog=30, dual_profile=142, legacy_only=9.
- Add FEATURE_CSV_ACTIVATION_POSTURE.md and refresh Track A handoff; broader mempool/mining backlog remains separate.

Validation
- python3 ci/test/check_ci_inventory.py
- git diff --check
- git diff --cached --check
- build/test/functional/test_runner.py --jobs=1 feature_csv_activation.py

Public interfaces
- No RPC, wallet, consensus, P2P, descriptor, or policy behavior changes.