### PR TITLE
ci: promote pruning gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -337,10 +337,10 @@
   },
   {
     "name": "feature_pruning.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Consensus or chainstate-facing coverage should receive an explicit PQ migration decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the broad PQBTC pruning gate: it covers automatic and manual pruning over large block files, stale-block and deep-reorg retention, redownload of previously pruned block data, prune command-line validation, scanblocks behavior over pruned data, pruneheight handling when undo data is absent, and wallet load/rescan boundaries where wallet support is compiled; blockstore XOR/external storage and prune-plus-index behavior remain separate required gates."
   },
   {
     "name": "feature_rbf.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -14,6 +14,7 @@ feature_pq_block_limits.py
 feature_pq_reorg.py
 feature_pqsig_basic.py
 feature_pqsig_multisig.py
+feature_pruning.py
 feature_reindex.py
 feature_reindex_init.py
 feature_reindex_readonly.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `95` |
-| `pq_backlog` | `30` |
+| `pq_required` | `96` |
+| `pq_backlog` | `29` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -75,69 +75,70 @@ Current required PQ-first gates:
 30. `feature_fastprune.py`
 31. `feature_index_prune.py`
 32. `feature_loadblock.py`
-33. `feature_reindex.py`
-34. `feature_reindex_init.py`
-35. `feature_reindex_readonly.py`
-36. `feature_remove_pruned_files_on_startup.py`
-37. `feature_utxo_set_hash.py`
-38. `feature_versionbits_warning.py`
-39. `rpc_psbt.py`
-40. `wallet_abandonconflict.py`
-41. `wallet_address_types.py`
-42. `wallet_assumeutxo.py`
-43. `wallet_avoid_mixing_output_types.py`
-44. `wallet_avoidreuse.py`
-45. `wallet_backup.py`
-46. `wallet_balance.py`
-47. `wallet_basic.py`
-48. `wallet_blank.py`
-49. `wallet_bumpfee.py`
-50. `wallet_change_address.py`
-51. `wallet_coinbase_category.py`
-52. `wallet_conflicts.py`
-53. `wallet_create_tx.py`
-54. `wallet_createwallet.py`
-55. `wallet_createwalletdescriptor.py`
-56. `wallet_crosschain.py`
-57. `wallet_descriptor.py`
-58. `wallet_disable.py`
-59. `wallet_encryption.py`
-60. `wallet_fallbackfee.py`
-61. `wallet_fast_rescan.py`
-62. `wallet_fundrawtransaction.py`
-63. `wallet_gethdkeys.py`
-64. `wallet_groups.py`
-65. `wallet_hd.py`
-66. `wallet_importdescriptors.py`
-67. `wallet_importprunedfunds.py`
-68. `wallet_keypool.py`
-69. `wallet_keypool_topup.py`
-70. `wallet_labels.py`
-71. `wallet_listdescriptors.py`
-72. `wallet_listreceivedby.py`
-73. `wallet_listsinceblock.py`
-74. `wallet_listtransactions.py`
-75. `wallet_miniscript.py`
-76. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-77. `wallet_multisig_descriptor_psbt.py`
-78. `wallet_multiwallet.py`
-79. `wallet_orphanedreward.py`
-80. `wallet_reindex.py`
-81. `wallet_reorgsrestore.py`
-82. `wallet_rescan_unconfirmed.py`
-83. `wallet_resendwallettransactions.py`
-84. `wallet_send.py`
-85. `wallet_sendall.py`
-86. `wallet_sendmany.py`
-87. `wallet_signrawtransactionwithwallet.py`
-88. `wallet_simulaterawtx.py`
-89. `wallet_spend_unconfirmed.py`
-90. `wallet_startup.py`
-91. `wallet_timelock.py`
-92. `wallet_transactiontime_rescan.py`
-93. `wallet_txn_clone.py`
-94. `wallet_txn_doublespend.py`
-95. `wallet_v3_txs.py`
+33. `feature_pruning.py`
+34. `feature_reindex.py`
+35. `feature_reindex_init.py`
+36. `feature_reindex_readonly.py`
+37. `feature_remove_pruned_files_on_startup.py`
+38. `feature_utxo_set_hash.py`
+39. `feature_versionbits_warning.py`
+40. `rpc_psbt.py`
+41. `wallet_abandonconflict.py`
+42. `wallet_address_types.py`
+43. `wallet_assumeutxo.py`
+44. `wallet_avoid_mixing_output_types.py`
+45. `wallet_avoidreuse.py`
+46. `wallet_backup.py`
+47. `wallet_balance.py`
+48. `wallet_basic.py`
+49. `wallet_blank.py`
+50. `wallet_bumpfee.py`
+51. `wallet_change_address.py`
+52. `wallet_coinbase_category.py`
+53. `wallet_conflicts.py`
+54. `wallet_create_tx.py`
+55. `wallet_createwallet.py`
+56. `wallet_createwalletdescriptor.py`
+57. `wallet_crosschain.py`
+58. `wallet_descriptor.py`
+59. `wallet_disable.py`
+60. `wallet_encryption.py`
+61. `wallet_fallbackfee.py`
+62. `wallet_fast_rescan.py`
+63. `wallet_fundrawtransaction.py`
+64. `wallet_gethdkeys.py`
+65. `wallet_groups.py`
+66. `wallet_hd.py`
+67. `wallet_importdescriptors.py`
+68. `wallet_importprunedfunds.py`
+69. `wallet_keypool.py`
+70. `wallet_keypool_topup.py`
+71. `wallet_labels.py`
+72. `wallet_listdescriptors.py`
+73. `wallet_listreceivedby.py`
+74. `wallet_listsinceblock.py`
+75. `wallet_listtransactions.py`
+76. `wallet_miniscript.py`
+77. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+78. `wallet_multisig_descriptor_psbt.py`
+79. `wallet_multiwallet.py`
+80. `wallet_orphanedreward.py`
+81. `wallet_reindex.py`
+82. `wallet_reorgsrestore.py`
+83. `wallet_rescan_unconfirmed.py`
+84. `wallet_resendwallettransactions.py`
+85. `wallet_send.py`
+86. `wallet_sendall.py`
+87. `wallet_sendmany.py`
+88. `wallet_signrawtransactionwithwallet.py`
+89. `wallet_simulaterawtx.py`
+90. `wallet_spend_unconfirmed.py`
+91. `wallet_startup.py`
+92. `wallet_timelock.py`
+93. `wallet_transactiontime_rescan.py`
+94. `wallet_txn_clone.py`
+95. `wallet_txn_doublespend.py`
+96. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -345,6 +346,12 @@ The CSV activation confidence gap is now also part of the required gate:
 and BIP113; pre-activation acceptance; post-activation rejection and acceptance
 across relative locktime, CHECKSEQUENCEVERIFY, and MedianTimePast nLockTime
 cases; and exact block rejection reasons.
+The broad pruning confidence gap is now also part of the required gate:
+`feature_pruning.py` covers automatic and manual pruning over large block
+files, stale-block and deep-reorg retention, redownload of previously pruned
+block data, invalid prune option handling, `scanblocks` errors over pruned
+data, pruneheight accounting when undo data is absent, and wallet load/rescan
+boundaries where wallet support is compiled.
 The remaining key backlog families are:
 
 1. mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_PRUNING_POSTURE.md
+++ b/docs/FEATURE_PRUNING_POSTURE.md
@@ -1,0 +1,74 @@
+# PQBTC `feature_pruning.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: FEATURE-PRUNING-POSTURE-v1
+## Updated: 2026-05-03
+## Frozen-By: track-a-phase1-20260503
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for the broad pruning lifecycle on the
+current PQBTC node profile.
+
+## Current Owned Surface
+
+The current passing
+[feature_pruning.py](../test/functional/feature_pruning.py) suite owns the
+general pruning contract:
+
+- automatic pruning waits until the minimum retain window is available, then
+  removes old blk/rev files after additional large blocks are mined
+- high stale-block rates can temporarily keep disk usage above target without
+  corrupting the active chain
+- a pruned node survives a deep reorg while retaining enough recent history to
+  reorganize safely
+- a previously pruned block can be redownloaded from a peer when it is needed
+  for a later reorg
+- manual pruning by block height and timestamp preserves expected no-op,
+  future-height, negative-height, and pruneheight behavior
+- startup rejects invalid prune combinations, including negative prune values,
+  values below the minimum, `-prune` with `-txindex`, and `-prune` with
+  `-reindex-chainstate`
+- wallet load/rescan behavior on pruned nodes remains covered when wallet
+  support is compiled, including the expected rejection when rescan would need
+  pruned data
+- `scanblocks` cannot return pruned data when false-positive filtering requires
+  unavailable block data
+- fetching a block without undo data does not incorrectly advance pruneheight
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- external `-blocksdir` storage behavior is owned here
+- XORed block-file storage behavior is owned here
+- prune-plus-index restart/recovery behavior is owned here
+- previous-release compatibility behavior is owned here
+- wallet spend, signing, or funding semantics are broadened by this gate
+
+Those remain separate required or blocked follow-on surfaces.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-03:
+
+- `build/test/functional/test_runner.py --jobs=1 feature_pruning.py`
+  - result: passed
+  - current posture:
+    - broad automatic/manual pruning behavior passes under the current PQBTC
+      profile
+    - deep reorg and redownload behavior remain functional on a pruned node
+    - scanblocks and pruneheight boundaries preserve expected pruned-data
+      errors and accounting
+
+## Interpretation
+
+- `feature_pruning.py` is now a required broad pruning lifecycle gate
+- it complements the narrower required storage/prune gates without replacing
+  them
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded
+  `pq_backlog` migration decision from the remaining validation, mempool, or
+  mining backlog

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -23,6 +23,7 @@ freeze the new `wallet_miniscript.py`, `rpc_createmultisig.py`,
 `feature_remove_pruned_files_on_startup.py`, and `feature_index_prune.py`
 block storage and prune-lifecycle behavior in the canonical `pq_required`
 gate, keep `feature_loadblock.py` bootstrap/import behavior in the same gate,
+keep `feature_pruning.py` broad pruning lifecycle behavior in the same gate,
 keep `feature_utxo_set_hash.py` txoutset-hash behavior in the same gate, and
 keep `feature_coinstatsindex.py` txoutset/index behavior in the same gate, and
 keep `feature_reindex.py` restart/reindex behavior in the same gate, and
@@ -134,7 +135,7 @@ Alternate rebalance:
      transaction-construction, simulation, raw-signing, and import-descriptor
      tranches, or the current import-pruned-funds, timelock, orphaned reward,
      v3/TRUC transaction, descriptor-creation, and cross-chain wallet-file
-     tranches, or the current block storage, prune-lifecycle,
+     tranches, or the current block storage, prune-lifecycle, broad pruning,
      bootstrap/import, txoutset-hash, txoutset/index, restart/reindex,
      init-recovery, read-only blockstore, versionbits-warning, and
      sequence-lock, CLTV, and CSV-activation tranches.
@@ -958,16 +959,16 @@ Still deferred:
 47. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
    - alternate: remaining repo-local `pq_backlog` triage outside the
-     restart/reindex, versionbits-warning, sequence-lock, CLTV, and
-     CSV-activation surfaces
+     restart/reindex, versionbits-warning, sequence-lock, CLTV,
+     CSV-activation, and broad-pruning surfaces
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
    - the restart/reindex family is now fully represented in the required gate,
-     and the unknown-versionbits warning, BIP68 sequence-lock, and CLTV
-     and CSV activation surfaces are now represented in the required gate, so
-     any local alternate should be a fresh bounded migration decision outside
-     those surfaces
+     and the unknown-versionbits warning, BIP68 sequence-lock, CLTV,
+     CSV activation, and broad pruning surfaces are now represented in the
+     required gate, so any local alternate should be a fresh bounded migration
+     decision outside those surfaces
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1021,19 +1022,21 @@ Still deferred:
    `feature_cltv.py` contract.
 40. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
    `feature_csv_activation.py` contract.
-41. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
+41. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
+   `feature_pruning.py` contract.
+42. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
    `feature_reindex.py` contract.
-42. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
+43. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
    `feature_reindex_init.py` contract.
-43. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
+44. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-44. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+45. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
    current `feature_versionbits_warning.py` contract.
-45. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+46. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-46. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+47. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-47. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+48. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1752,6 +1755,17 @@ Aineko must ask before:
   release assets exist; otherwise the local alternate should be another
   bounded `pq_backlog` migration decision from the remaining validation,
   mempool, or mining backlog.
+- 2026-05-03: `feature_pruning.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers automatic and manual pruning over large
+  block files, stale-block and deep-reorg retention, redownload of previously
+  pruned block data, invalid prune option handling, `scanblocks` behavior over
+  pruned data, pruneheight handling when undo data is absent, and wallet
+  load/rescan boundaries where wallet support is compiled. The next owned
+  follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+  PQBTC release assets exist; otherwise the local alternate should be another
+  bounded `pq_backlog` migration decision from the remaining validation,
+  mempool, or mining backlog.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1893,6 +1907,8 @@ Aineko must ask before:
   `feature_cltv.py` passes targeted validation in the current tree.
 - There is no current blocker in the CSV activation surface:
   `feature_csv_activation.py` passes targeted validation in the current tree.
+- There is no current blocker in the broad pruning surface:
+  `feature_pruning.py` passes targeted validation in the current tree.
 - `wallet_backwards_compatibility.py` remains blocked locally until
   previous-release fixtures are available.
 - `wallet_migration.py` remains blocked locally until previous-release fixtures


### PR DESCRIPTION
## Summary
- promote feature_pruning.py from pq_backlog to pq_required
- add feature_pruning.py to the required PQ functional gate list in inventory order
- add FEATURE_PRUNING_POSTURE.md and refresh Track A / CI completeness docs

## Validation
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 feature_pruning.py

## Notes
- no source or functional behavior changes
- feature_coinstatsindex_compatibility.py remains blocked until real prior PQBTC release assets exist