### PR TITLE
ci: extend asan promotion timeout

### DIFF
--- a/.github/workflows/promotion-matrix.yml
+++ b/.github/workflows/promotion-matrix.yml
@@ -529,7 +529,7 @@ jobs:
           - name: 'ASan + LSan + UBSan + integer, no depends, USDT'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md' # has to match container in ci/test/00_setup_env_native_asan.sh for tracing tools
             fallback-runner: 'ubuntu-24.04'
-            timeout-minutes: 120
+            timeout-minutes: 240
             file-env: './ci/test/00_setup_env_native_asan.sh'
 
           - name: 'macOS-cross, gui, no tests'


### PR DESCRIPTION
## Summary
- increase the Promotion Matrix ASan + LSan + UBSan + integer job timeout from 120 to 240 minutes
- keep the promoted feature_pruning.py gate in pq_required rather than weakening coverage

## Why
- post-merge Promotion Matrix reached only feature_pruning.py remaining, then hit the 120-minute job limit without sanitizer failures

## Validation
- git diff --check
- python3 ci/test/check_ci_inventory.py