### PR TITLE
[codex] promote mempool accept gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -472,7 +472,7 @@
     "policy_class": "pq_backlog",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Consensus or chainstate-facing coverage should receive an explicit PQ migration decision in later CI follow-up."
+    "notes": "Previous-release-dependent chainstate coverage; skipped locally until real prior PQBTC release assets are available to the compatibility harness."
   },
   {
     "name": "feature_utxo_set_hash.py",
@@ -567,10 +567,10 @@
   },
   {
     "name": "mempool_accept.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited raw transaction mempool-acceptance and resource-envelope gate: the suite exercises testmempoolaccept input validation, already-known and missing-input handling, policy reject reasons, fee/feerate checks, standardness boundaries, package-independent RBF replacement, anchor behavior, and confirmed bare-multisig policy under the current legacy-compatible PQC profile; broader mempool family coverage remains separate."
   },
   {
     "name": "mempool_accept_wtxid.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -26,6 +26,7 @@ feature_taproot_replacement_active_semantic_guard.py
 feature_taproot_replacement_active_positive_seam.py
 feature_utxo_set_hash.py
 feature_versionbits_warning.py
+mempool_accept.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `96` |
-| `pq_backlog` | `29` |
+| `pq_required` | `97` |
+| `pq_backlog` | `28` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -54,91 +54,92 @@ Current required PQ-first gates:
 9. `feature_taproot_replacement_active_positive_seam.py`
 10. `mempool_pq_limits.py`
 11. `mempool_pq_stress.py`
-12. `wallet_pq_active_ranged.py`
-13. `wallet_pq_backup_recovery.py`
-14. `wallet_pq_create_tx.py`
-15. `wallet_pq_descriptors.py`
-16. `wallet_pq_psbt.py`
-17. `wallet_pq_send.py`
-18. `wallet_pq_sendall.py`
-19. `wallet_pq_sendmany.py`
-20. `wallet_pq_signrawtransaction.py`
-21. `feature_assumeutxo.py`
-22. `feature_assumevalid.py`
-23. `feature_bip68_sequence.py`
-24. `feature_block.py`
-25. `feature_blocksdir.py`
-26. `feature_blocksxor.py`
-27. `feature_cltv.py`
-28. `feature_coinstatsindex.py`
-29. `feature_csv_activation.py`
-30. `feature_fastprune.py`
-31. `feature_index_prune.py`
-32. `feature_loadblock.py`
-33. `feature_pruning.py`
-34. `feature_reindex.py`
-35. `feature_reindex_init.py`
-36. `feature_reindex_readonly.py`
-37. `feature_remove_pruned_files_on_startup.py`
-38. `feature_utxo_set_hash.py`
-39. `feature_versionbits_warning.py`
-40. `rpc_psbt.py`
-41. `wallet_abandonconflict.py`
-42. `wallet_address_types.py`
-43. `wallet_assumeutxo.py`
-44. `wallet_avoid_mixing_output_types.py`
-45. `wallet_avoidreuse.py`
-46. `wallet_backup.py`
-47. `wallet_balance.py`
-48. `wallet_basic.py`
-49. `wallet_blank.py`
-50. `wallet_bumpfee.py`
-51. `wallet_change_address.py`
-52. `wallet_coinbase_category.py`
-53. `wallet_conflicts.py`
-54. `wallet_create_tx.py`
-55. `wallet_createwallet.py`
-56. `wallet_createwalletdescriptor.py`
-57. `wallet_crosschain.py`
-58. `wallet_descriptor.py`
-59. `wallet_disable.py`
-60. `wallet_encryption.py`
-61. `wallet_fallbackfee.py`
-62. `wallet_fast_rescan.py`
-63. `wallet_fundrawtransaction.py`
-64. `wallet_gethdkeys.py`
-65. `wallet_groups.py`
-66. `wallet_hd.py`
-67. `wallet_importdescriptors.py`
-68. `wallet_importprunedfunds.py`
-69. `wallet_keypool.py`
-70. `wallet_keypool_topup.py`
-71. `wallet_labels.py`
-72. `wallet_listdescriptors.py`
-73. `wallet_listreceivedby.py`
-74. `wallet_listsinceblock.py`
-75. `wallet_listtransactions.py`
-76. `wallet_miniscript.py`
-77. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-78. `wallet_multisig_descriptor_psbt.py`
-79. `wallet_multiwallet.py`
-80. `wallet_orphanedreward.py`
-81. `wallet_reindex.py`
-82. `wallet_reorgsrestore.py`
-83. `wallet_rescan_unconfirmed.py`
-84. `wallet_resendwallettransactions.py`
-85. `wallet_send.py`
-86. `wallet_sendall.py`
-87. `wallet_sendmany.py`
-88. `wallet_signrawtransactionwithwallet.py`
-89. `wallet_simulaterawtx.py`
-90. `wallet_spend_unconfirmed.py`
-91. `wallet_startup.py`
-92. `wallet_timelock.py`
-93. `wallet_transactiontime_rescan.py`
-94. `wallet_txn_clone.py`
-95. `wallet_txn_doublespend.py`
-96. `wallet_v3_txs.py`
+12. `mempool_accept.py`
+13. `wallet_pq_active_ranged.py`
+14. `wallet_pq_backup_recovery.py`
+15. `wallet_pq_create_tx.py`
+16. `wallet_pq_descriptors.py`
+17. `wallet_pq_psbt.py`
+18. `wallet_pq_send.py`
+19. `wallet_pq_sendall.py`
+20. `wallet_pq_sendmany.py`
+21. `wallet_pq_signrawtransaction.py`
+22. `feature_assumeutxo.py`
+23. `feature_assumevalid.py`
+24. `feature_bip68_sequence.py`
+25. `feature_block.py`
+26. `feature_blocksdir.py`
+27. `feature_blocksxor.py`
+28. `feature_cltv.py`
+29. `feature_coinstatsindex.py`
+30. `feature_csv_activation.py`
+31. `feature_fastprune.py`
+32. `feature_index_prune.py`
+33. `feature_loadblock.py`
+34. `feature_pruning.py`
+35. `feature_reindex.py`
+36. `feature_reindex_init.py`
+37. `feature_reindex_readonly.py`
+38. `feature_remove_pruned_files_on_startup.py`
+39. `feature_utxo_set_hash.py`
+40. `feature_versionbits_warning.py`
+41. `rpc_psbt.py`
+42. `wallet_abandonconflict.py`
+43. `wallet_address_types.py`
+44. `wallet_assumeutxo.py`
+45. `wallet_avoid_mixing_output_types.py`
+46. `wallet_avoidreuse.py`
+47. `wallet_backup.py`
+48. `wallet_balance.py`
+49. `wallet_basic.py`
+50. `wallet_blank.py`
+51. `wallet_bumpfee.py`
+52. `wallet_change_address.py`
+53. `wallet_coinbase_category.py`
+54. `wallet_conflicts.py`
+55. `wallet_create_tx.py`
+56. `wallet_createwallet.py`
+57. `wallet_createwalletdescriptor.py`
+58. `wallet_crosschain.py`
+59. `wallet_descriptor.py`
+60. `wallet_disable.py`
+61. `wallet_encryption.py`
+62. `wallet_fallbackfee.py`
+63. `wallet_fast_rescan.py`
+64. `wallet_fundrawtransaction.py`
+65. `wallet_gethdkeys.py`
+66. `wallet_groups.py`
+67. `wallet_hd.py`
+68. `wallet_importdescriptors.py`
+69. `wallet_importprunedfunds.py`
+70. `wallet_keypool.py`
+71. `wallet_keypool_topup.py`
+72. `wallet_labels.py`
+73. `wallet_listdescriptors.py`
+74. `wallet_listreceivedby.py`
+75. `wallet_listsinceblock.py`
+76. `wallet_listtransactions.py`
+77. `wallet_miniscript.py`
+78. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+79. `wallet_multisig_descriptor_psbt.py`
+80. `wallet_multiwallet.py`
+81. `wallet_orphanedreward.py`
+82. `wallet_reindex.py`
+83. `wallet_reorgsrestore.py`
+84. `wallet_rescan_unconfirmed.py`
+85. `wallet_resendwallettransactions.py`
+86. `wallet_send.py`
+87. `wallet_sendall.py`
+88. `wallet_sendmany.py`
+89. `wallet_signrawtransactionwithwallet.py`
+90. `wallet_simulaterawtx.py`
+91. `wallet_spend_unconfirmed.py`
+92. `wallet_startup.py`
+93. `wallet_timelock.py`
+94. `wallet_transactiontime_rescan.py`
+95. `wallet_txn_clone.py`
+96. `wallet_txn_doublespend.py`
+97. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -352,9 +353,15 @@ files, stale-block and deep-reorg retention, redownload of previously pruned
 block data, invalid prune option handling, `scanblocks` errors over pruned
 data, pruneheight accounting when undo data is absent, and wallet load/rescan
 boundaries where wallet support is compiled.
+The inherited raw transaction mempool-acceptance confidence gap is now also
+part of the required gate: `mempool_accept.py` covers `testmempoolaccept`
+argument validation, already-known and missing-input handling, standardness and
+resource-envelope reject reasons, fee and replacement checks, relative
+locktime policy, anchor behavior, and confirmed bare-multisig policy under the
+current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
-1. mempool and mining policy suites not yet given explicit PQ gating treatment
+1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment
 2. additional chainstate and validation-facing feature tests that still need a later PQ migration decision
 3. broader dual-profile and legacy-only coverage that still needs durable ownership and migration boundaries
 

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -1,0 +1,75 @@
+# PQBTC `mempool_accept.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-ACCEPT-POSTURE-v1
+## Updated: 2026-05-04
+## Frozen-By: track-a-phase1-20260504
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited raw transaction mempool
+acceptance and resource-envelope checks under the current legacy-compatible
+PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_accept.py](../test/functional/mempool_accept.py) suite owns the broad
+single-node `testmempoolaccept` and raw transaction policy surface:
+
+- malformed RPC arguments, empty batches, oversized batches, and undecodable
+  transactions keep their expected RPC errors
+- already-known, already-in-block, missing-input, duplicate-input, coinbase,
+  and prevout-null transactions keep their expected reject reasons
+- base fee, maxfeerate, negative-feerate, replacement, and finality checks
+  continue to report stable acceptance or rejection
+- nonstandard version, scriptPubKey, bare multisig, scriptSig, dust, standard
+  transaction-size, small non-witness-size, and OP_RETURN policy boundaries
+  remain covered
+- relative locktime, CLTV-style locktime, and BIP68 sequence policy checks
+  remain exercised through mempool admission
+- anchor output standardness and nested-anchor rejection remain covered
+- confirmed bare-multisig spending remains accepted under the current
+  legacy-compatible PQC profile
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool functional suite is owned by this tranche
+- package relay, package RBF, expiry, persistence, reorg, TRUC, or mining
+  template behavior is covered here
+- PQ-native witness-size stress replaces this inherited policy surface
+- prior-release compatibility suites can run without real prior PQBTC release
+  assets
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-04:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_accept.py`
+  - result: passed
+  - current posture:
+    - inherited raw transaction mempool acceptance passes under the current
+      legacy-compatible PQC profile
+    - standardness and resource-envelope reject reasons remain stable
+    - anchor and confirmed bare-multisig policy cases remain covered
+
+The adjacent previous-release-dependent
+[feature_unsupported_utxo_db.py](../test/functional/feature_unsupported_utxo_db.py)
+probe was also run and skipped because previous releases are not available in
+this worktree.
+
+## Interpretation
+
+- `mempool_accept.py` is now a required inherited mempool acceptance gate
+- it complements, but does not replace,
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-05-03
+## Updated: 2026-05-04
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -41,7 +41,9 @@ keep `feature_csv_activation.py` BIP68/BIP112/BIP113 CSV activation behavior
 in the same gate, and
 keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
-`mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, freeze the new
+`mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, keep
+`mempool_accept.py` inherited raw transaction mempool-acceptance behavior in
+the same gate, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
 `feature_assumevalid.py` boundaries, keep
@@ -141,7 +143,8 @@ Alternate rebalance:
      sequence-lock, CLTV, and CSV-activation tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
-     prior-release assets are available.
+     prior-release assets are available; `feature_unsupported_utxo_db.py` is
+     also previous-release dependent and skipped locally without those assets.
 
 Still deferred:
 
@@ -956,11 +959,40 @@ Still deferred:
      skipped locally because previous-release fixtures are unavailable
    - `feature_coinstatsindex_compatibility.py`, which remains blocked until
      real prior PQBTC release assets exist
-47. Recommended next PR after this tranche:
+47. `mempool_accept.py` now owns:
+   - inherited raw transaction mempool acceptance under the current
+     legacy-compatible PQC profile
+   - `testmempoolaccept` RPC argument validation for malformed, empty,
+     oversized, and undecodable batches
+   - already-known, already-in-block, already-in-mempool, missing-input,
+     duplicate-input, coinbase, and prevout-null rejection paths
+   - fee, maxfeerate, negative-feerate, replacement, non-final, and BIP68
+     sequence-lock acceptance or rejection behavior
+   - version, scriptPubKey, bare-multisig, scriptSig, dust, standard
+     transaction-size, small non-witness-size, and OP_RETURN policy boundaries
+   - anchor output standardness, nested-anchor rejection, and confirmed
+     bare-multisig spending policy
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_accept.py`
+   Fixture probe:
+   - `build/test/functional/test_runner.py --jobs=1 feature_unsupported_utxo_db.py`
+   - expected local outcome: `feature_unsupported_utxo_db.py` skipped because
+     previous-release fixtures are unavailable
+   Fixed posture note:
+   - `MEMPOOL_ACCEPT_POSTURE.md`
+   Still deferred inside this suite:
+   - remaining mempool package, persistence, expiry, reorg, TRUC, wtxid, and
+     mining policy suites
+   - `feature_unsupported_utxo_db.py` and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+48. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: remaining repo-local `pq_backlog` triage outside the
-     restart/reindex, versionbits-warning, sequence-lock, CLTV,
-     CSV-activation, and broad-pruning surfaces
+   - alternate: `mempool_accept_wtxid.py` as the next local mempool acceptance
+     candidate if it passes targeted validation, otherwise continue bounded
+     repo-local `pq_backlog` triage outside the restart/reindex,
+     versionbits-warning, sequence-lock, CLTV, CSV-activation, broad-pruning,
+     and current `mempool_accept.py` surfaces
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -969,6 +1001,9 @@ Still deferred:
      CSV activation, and broad pruning surfaces are now represented in the
      required gate, so any local alternate should be a fresh bounded migration
      decision outside those surfaces
+   - the first inherited mempool acceptance gate is now frozen, so the adjacent
+     local mempool follow-on is `mempool_accept_wtxid.py` only after a fresh
+     targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1004,39 +1039,41 @@ Still deferred:
    `mempool_pq_limits.py` contract.
 31. Use `MEMPOOL_PQ_STRESS_POSTURE.md` as the fixed note for the current
    `mempool_pq_stress.py` contract.
-32. Use `FEATURE_PQSIG_BASIC_POSTURE.md` as the fixed note for the current
+32. Use `MEMPOOL_ACCEPT_POSTURE.md` as the fixed note for the current
+   `mempool_accept.py` contract.
+33. Use `FEATURE_PQSIG_BASIC_POSTURE.md` as the fixed note for the current
    `feature_pqsig_basic.py` contract.
-33. Use `FEATURE_PQSIG_MULTISIG_POSTURE.md` as the fixed note for the current
+34. Use `FEATURE_PQSIG_MULTISIG_POSTURE.md` as the fixed note for the current
    `feature_pqsig_multisig.py` contract.
-34. Use `FEATURE_LOADBLOCK_POSTURE.md` as the fixed note for the current
+35. Use `FEATURE_LOADBLOCK_POSTURE.md` as the fixed note for the current
    `feature_loadblock.py` contract.
-35. Use `WALLET_MINISCRIPT_POSTURE.md` as the fixed note for the current
+36. Use `WALLET_MINISCRIPT_POSTURE.md` as the fixed note for the current
    `wallet_miniscript.py` contract.
-36. Use `FEATURE_UTXO_SET_HASH_POSTURE.md` as the fixed note for the current
+37. Use `FEATURE_UTXO_SET_HASH_POSTURE.md` as the fixed note for the current
    `feature_utxo_set_hash.py` contract.
-37. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
+38. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
    `feature_coinstatsindex.py` contract.
-38. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
+39. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
    `feature_bip68_sequence.py` contract.
-39. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
+40. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
    `feature_cltv.py` contract.
-40. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
+41. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
    `feature_csv_activation.py` contract.
-41. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
+42. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
    `feature_pruning.py` contract.
-42. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
+43. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
    `feature_reindex.py` contract.
-43. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
+44. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
    `feature_reindex_init.py` contract.
-44. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
+45. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-45. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+46. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
    current `feature_versionbits_warning.py` contract.
-46. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+47. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-47. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+48. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-48. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+49. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1106,6 +1143,7 @@ Aineko must ask before:
 - `FEATURE_PQ_REORG_POSTURE.md`
 - `MEMPOOL_PQ_LIMITS_POSTURE.md`
 - `MEMPOOL_PQ_STRESS_POSTURE.md`
+- `MEMPOOL_ACCEPT_POSTURE.md`
 - `TEST_COST_POSTURE.md`
 - `POST_RC_EPICS.md`
 - `CI_COMPLETENESS.md`
@@ -1766,6 +1804,17 @@ Aineko must ask before:
   PQBTC release assets exist; otherwise the local alternate should be another
   bounded `pq_backlog` migration decision from the remaining validation,
   mempool, or mining backlog.
+- 2026-05-04: `mempool_accept.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers inherited raw transaction
+  `testmempoolaccept` behavior, reject-reason stability, fee and replacement
+  checks, standardness and resource-envelope policy, anchor output handling,
+  and confirmed bare-multisig policy under the current legacy-compatible PQC
+  profile. `feature_unsupported_utxo_db.py` was probed and skipped locally
+  because previous-release assets are unavailable. The next owned follow-on
+  remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
+  release assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_accept_wtxid.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1809,6 +1858,8 @@ Aineko must ask before:
 
 - `feature_coinstatsindex_compatibility.py` remains blocked until real prior
   PQBTC release assets are available to the compatibility harness.
+- `feature_unsupported_utxo_db.py` remains blocked locally until real prior
+  PQBTC release assets are available to the previous-release harness.
 - There is no current blocker in the restored broad wallet
   funding/signing/finalization surface: `rpc_psbt.py`,
   `wallet_miniscript.py`,


### PR DESCRIPTION
## Summary

Promotes `mempool_accept.py` from `pq_backlog` to `pq_required` as the next repo-local Track A gate after the asset-dependent `feature_unsupported_utxo_db.py` probe skipped in this worktree.

This is a metadata and handoff tranche only. It does not change mempool, policy, wallet, consensus, RPC, or test behavior.

## What Changed

- Moves `mempool_accept.py` to `pq_required` in `ci/test/functional_suite_inventory.json`.
- Adds `mempool_accept.py` to `ci/test/pq_functional_tests.txt` in exact inventory order, before the existing PQ mempool gates.
- Updates `docs/CI_COMPLETENESS.md` counts to `pq_required=97`, `pq_backlog=28`, `dual_profile=142`, `legacy_only=9` and adds the gate to the required list.
- Adds `docs/MEMPOOL_ACCEPT_POSTURE.md` to define the owned inherited raw transaction mempool acceptance surface.
- Updates `docs/TRACK_A_STATUS.md` to document the promotion, the local `feature_unsupported_utxo_db.py` skip, and the next preferred/alternate follow-ons.

## Validation

- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_accept.py`
- `build/test/functional/test_runner.py --jobs=1 feature_unsupported_utxo_db.py` skipped because previous releases are unavailable locally
- `git diff --check`
