### PR TITLE
[codex] promote mempool wtxid gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     name: 'lint'
     runs-on: ubuntu-24.04
     if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
-    timeout-minutes: 20
+    timeout-minutes: 45
     env:
       CONTAINER_NAME: "bitcoin-linter"
     steps:

--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -574,10 +574,10 @@
   },
   {
     "name": "mempool_accept_wtxid.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited wtxid/non-witness-data mempool acceptance gate: the suite exercises malleated witness children with identical txids and distinct wtxids, exact already-in-mempool reporting, same-nonwitness-data rejection, and rebroadcast of the canonical mempool wtxid under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_compatibility.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -27,6 +27,7 @@ feature_taproot_replacement_active_positive_seam.py
 feature_utxo_set_hash.py
 feature_versionbits_warning.py
 mempool_accept.py
+mempool_accept_wtxid.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `97` |
-| `pq_backlog` | `28` |
+| `pq_required` | `98` |
+| `pq_backlog` | `27` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -55,91 +55,92 @@ Current required PQ-first gates:
 10. `mempool_pq_limits.py`
 11. `mempool_pq_stress.py`
 12. `mempool_accept.py`
-13. `wallet_pq_active_ranged.py`
-14. `wallet_pq_backup_recovery.py`
-15. `wallet_pq_create_tx.py`
-16. `wallet_pq_descriptors.py`
-17. `wallet_pq_psbt.py`
-18. `wallet_pq_send.py`
-19. `wallet_pq_sendall.py`
-20. `wallet_pq_sendmany.py`
-21. `wallet_pq_signrawtransaction.py`
-22. `feature_assumeutxo.py`
-23. `feature_assumevalid.py`
-24. `feature_bip68_sequence.py`
-25. `feature_block.py`
-26. `feature_blocksdir.py`
-27. `feature_blocksxor.py`
-28. `feature_cltv.py`
-29. `feature_coinstatsindex.py`
-30. `feature_csv_activation.py`
-31. `feature_fastprune.py`
-32. `feature_index_prune.py`
-33. `feature_loadblock.py`
-34. `feature_pruning.py`
-35. `feature_reindex.py`
-36. `feature_reindex_init.py`
-37. `feature_reindex_readonly.py`
-38. `feature_remove_pruned_files_on_startup.py`
-39. `feature_utxo_set_hash.py`
-40. `feature_versionbits_warning.py`
-41. `rpc_psbt.py`
-42. `wallet_abandonconflict.py`
-43. `wallet_address_types.py`
-44. `wallet_assumeutxo.py`
-45. `wallet_avoid_mixing_output_types.py`
-46. `wallet_avoidreuse.py`
-47. `wallet_backup.py`
-48. `wallet_balance.py`
-49. `wallet_basic.py`
-50. `wallet_blank.py`
-51. `wallet_bumpfee.py`
-52. `wallet_change_address.py`
-53. `wallet_coinbase_category.py`
-54. `wallet_conflicts.py`
-55. `wallet_create_tx.py`
-56. `wallet_createwallet.py`
-57. `wallet_createwalletdescriptor.py`
-58. `wallet_crosschain.py`
-59. `wallet_descriptor.py`
-60. `wallet_disable.py`
-61. `wallet_encryption.py`
-62. `wallet_fallbackfee.py`
-63. `wallet_fast_rescan.py`
-64. `wallet_fundrawtransaction.py`
-65. `wallet_gethdkeys.py`
-66. `wallet_groups.py`
-67. `wallet_hd.py`
-68. `wallet_importdescriptors.py`
-69. `wallet_importprunedfunds.py`
-70. `wallet_keypool.py`
-71. `wallet_keypool_topup.py`
-72. `wallet_labels.py`
-73. `wallet_listdescriptors.py`
-74. `wallet_listreceivedby.py`
-75. `wallet_listsinceblock.py`
-76. `wallet_listtransactions.py`
-77. `wallet_miniscript.py`
-78. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-79. `wallet_multisig_descriptor_psbt.py`
-80. `wallet_multiwallet.py`
-81. `wallet_orphanedreward.py`
-82. `wallet_reindex.py`
-83. `wallet_reorgsrestore.py`
-84. `wallet_rescan_unconfirmed.py`
-85. `wallet_resendwallettransactions.py`
-86. `wallet_send.py`
-87. `wallet_sendall.py`
-88. `wallet_sendmany.py`
-89. `wallet_signrawtransactionwithwallet.py`
-90. `wallet_simulaterawtx.py`
-91. `wallet_spend_unconfirmed.py`
-92. `wallet_startup.py`
-93. `wallet_timelock.py`
-94. `wallet_transactiontime_rescan.py`
-95. `wallet_txn_clone.py`
-96. `wallet_txn_doublespend.py`
-97. `wallet_v3_txs.py`
+13. `mempool_accept_wtxid.py`
+14. `wallet_pq_active_ranged.py`
+15. `wallet_pq_backup_recovery.py`
+16. `wallet_pq_create_tx.py`
+17. `wallet_pq_descriptors.py`
+18. `wallet_pq_psbt.py`
+19. `wallet_pq_send.py`
+20. `wallet_pq_sendall.py`
+21. `wallet_pq_sendmany.py`
+22. `wallet_pq_signrawtransaction.py`
+23. `feature_assumeutxo.py`
+24. `feature_assumevalid.py`
+25. `feature_bip68_sequence.py`
+26. `feature_block.py`
+27. `feature_blocksdir.py`
+28. `feature_blocksxor.py`
+29. `feature_cltv.py`
+30. `feature_coinstatsindex.py`
+31. `feature_csv_activation.py`
+32. `feature_fastprune.py`
+33. `feature_index_prune.py`
+34. `feature_loadblock.py`
+35. `feature_pruning.py`
+36. `feature_reindex.py`
+37. `feature_reindex_init.py`
+38. `feature_reindex_readonly.py`
+39. `feature_remove_pruned_files_on_startup.py`
+40. `feature_utxo_set_hash.py`
+41. `feature_versionbits_warning.py`
+42. `rpc_psbt.py`
+43. `wallet_abandonconflict.py`
+44. `wallet_address_types.py`
+45. `wallet_assumeutxo.py`
+46. `wallet_avoid_mixing_output_types.py`
+47. `wallet_avoidreuse.py`
+48. `wallet_backup.py`
+49. `wallet_balance.py`
+50. `wallet_basic.py`
+51. `wallet_blank.py`
+52. `wallet_bumpfee.py`
+53. `wallet_change_address.py`
+54. `wallet_coinbase_category.py`
+55. `wallet_conflicts.py`
+56. `wallet_create_tx.py`
+57. `wallet_createwallet.py`
+58. `wallet_createwalletdescriptor.py`
+59. `wallet_crosschain.py`
+60. `wallet_descriptor.py`
+61. `wallet_disable.py`
+62. `wallet_encryption.py`
+63. `wallet_fallbackfee.py`
+64. `wallet_fast_rescan.py`
+65. `wallet_fundrawtransaction.py`
+66. `wallet_gethdkeys.py`
+67. `wallet_groups.py`
+68. `wallet_hd.py`
+69. `wallet_importdescriptors.py`
+70. `wallet_importprunedfunds.py`
+71. `wallet_keypool.py`
+72. `wallet_keypool_topup.py`
+73. `wallet_labels.py`
+74. `wallet_listdescriptors.py`
+75. `wallet_listreceivedby.py`
+76. `wallet_listsinceblock.py`
+77. `wallet_listtransactions.py`
+78. `wallet_miniscript.py`
+79. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+80. `wallet_multisig_descriptor_psbt.py`
+81. `wallet_multiwallet.py`
+82. `wallet_orphanedreward.py`
+83. `wallet_reindex.py`
+84. `wallet_reorgsrestore.py`
+85. `wallet_rescan_unconfirmed.py`
+86. `wallet_resendwallettransactions.py`
+87. `wallet_send.py`
+88. `wallet_sendall.py`
+89. `wallet_sendmany.py`
+90. `wallet_signrawtransactionwithwallet.py`
+91. `wallet_simulaterawtx.py`
+92. `wallet_spend_unconfirmed.py`
+93. `wallet_startup.py`
+94. `wallet_timelock.py`
+95. `wallet_transactiontime_rescan.py`
+96. `wallet_txn_clone.py`
+97. `wallet_txn_doublespend.py`
+98. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -359,6 +360,12 @@ argument validation, already-known and missing-input handling, standardness and
 resource-envelope reject reasons, fee and replacement checks, relative
 locktime policy, anchor behavior, and confirmed bare-multisig policy under the
 current legacy-compatible PQC profile.
+The inherited wtxid-aware mempool-acceptance confidence gap is now also part
+of the required gate: `mempool_accept_wtxid.py` covers same-`txid` /
+different-`wtxid` child transactions, exact already-in-mempool reporting,
+same-nonwitness-data rejection, no replacement by an alternate witness, and
+canonical mempool `wtxid` rebroadcast under the current legacy-compatible PQC
+profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -1,0 +1,72 @@
+# PQBTC `mempool_accept_wtxid.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-ACCEPT-WTXID-POSTURE-v1
+## Updated: 2026-05-04
+## Frozen-By: track-a-phase1-20260504
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited wtxid-aware mempool acceptance
+when two transactions share identical non-witness data but have different
+witnesses under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_accept_wtxid.py](../test/functional/mempool_accept_wtxid.py) suite
+owns the single-node wtxid/non-witness-data mempool boundary:
+
+- a parent transaction can be funded, signed, mined, and used to construct two
+  malleated child transactions
+- the two child transactions have the same `txid` and distinct `wtxid` values
+- the first child is accepted into the mempool and its stored mempool entry
+  reports the expected `wtxid`
+- `testmempoolaccept` reports `txn-already-in-mempool` for the exact same
+  child transaction
+- `testmempoolaccept` reports `txn-same-nonwitness-data-in-mempool` for the
+  alternate witness with the same non-witness data
+- repeated `sendrawtransaction` calls for either child do not replace the
+  already-accepted mempool transaction
+- newly connected peers are rebroadcast the canonical `wtxid` for the
+  transaction already in the mempool
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- the full mempool package, persistence, expiry, reorg, TRUC, or mining
+  policy families are owned here
+- package relay or package RBF behavior is covered
+- broad P2P relay behavior beyond this single-node wtxid rebroadcast check is
+  covered
+- prior-release compatibility suites can run without real prior PQBTC release
+  assets
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-04:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_accept_wtxid.py`
+  - result: passed
+  - current posture:
+    - same-`txid` / different-`wtxid` mempool handling remains stable
+    - exact already-in-mempool and same-nonwitness-data reject reasons remain
+      stable
+    - rebroadcast uses the canonical mempool `wtxid`
+
+## Interpretation
+
+- `mempool_accept_wtxid.py` is now a required inherited wtxid-aware mempool
+  acceptance gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -43,7 +43,8 @@ keep
 `feature_pq_block_limits.py`, `feature_pq_reorg.py`, and
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, keep
 `mempool_accept.py` inherited raw transaction mempool-acceptance behavior in
-the same gate, freeze the new
+the same gate, keep `mempool_accept_wtxid.py` inherited wtxid-aware
+mempool-acceptance behavior in the same gate, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
 `feature_assumevalid.py` boundaries, keep
@@ -140,11 +141,13 @@ Alternate rebalance:
      tranches, or the current block storage, prune-lifecycle, broad pruning,
      bootstrap/import, txoutset-hash, txoutset/index, restart/reindex,
      init-recovery, read-only blockstore, versionbits-warning, and
-     sequence-lock, CLTV, and CSV-activation tranches.
+     sequence-lock, CLTV, CSV-activation, raw mempool-acceptance, and
+     wtxid-aware mempool-acceptance tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
-     also previous-release dependent and skipped locally without those assets.
+     also previous-release dependent and skipped locally without those assets,
+     and `mempool_compatibility.py` is previous-release dependent too.
 
 Still deferred:
 
@@ -981,18 +984,38 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, expiry, reorg, TRUC, wtxid, and
-     mining policy suites
+   - remaining mempool package, persistence, expiry, reorg, TRUC, and mining
+     policy suites
    - `feature_unsupported_utxo_db.py` and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-48. Recommended next PR after this tranche:
+48. `mempool_accept_wtxid.py` now owns:
+   - inherited wtxid-aware mempool acceptance under the current
+     legacy-compatible PQC profile
+   - construction of two valid witness-malleated children with identical
+     non-witness data, identical `txid`, and distinct `wtxid` values
+   - mempool storage of the first child's expected `wtxid`
+   - exact `txn-already-in-mempool` reporting for the already-accepted child
+   - exact `txn-same-nonwitness-data-in-mempool` rejection for the alternate
+     witness
+   - no replacement of the canonical mempool transaction by repeated
+     `sendrawtransaction` calls
+   - rebroadcast of the canonical mempool `wtxid` to a newly connected peer
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_accept_wtxid.py`
+   Fixed posture note:
+   - `MEMPOOL_ACCEPT_WTXID_POSTURE.md`
+   Still deferred inside this suite:
+   - remaining mempool package, persistence, expiry, reorg, TRUC, datacarrier,
+     and mining policy suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+49. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_accept_wtxid.py` as the next local mempool acceptance
-     candidate if it passes targeted validation, otherwise continue bounded
-     repo-local `pq_backlog` triage outside the restart/reindex,
-     versionbits-warning, sequence-lock, CLTV, CSV-activation, broad-pruning,
-     and current `mempool_accept.py` surfaces
+   - alternate: `mempool_datacarrier.py` as the next local mempool policy
+     candidate if it passes targeted validation, while
+     `mempool_compatibility.py` stays previous-release blocked
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
      chainstate/index follow-on now that both assumeutxo slices are frozen
@@ -1001,8 +1024,8 @@ Still deferred:
      CSV activation, and broad pruning surfaces are now represented in the
      required gate, so any local alternate should be a fresh bounded migration
      decision outside those surfaces
-   - the first inherited mempool acceptance gate is now frozen, so the adjacent
-     local mempool follow-on is `mempool_accept_wtxid.py` only after a fresh
+   - the first two inherited mempool acceptance gates are now frozen, so the
+     adjacent local mempool follow-on is datacarrier policy only after a fresh
      targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
@@ -1041,39 +1064,41 @@ Still deferred:
    `mempool_pq_stress.py` contract.
 32. Use `MEMPOOL_ACCEPT_POSTURE.md` as the fixed note for the current
    `mempool_accept.py` contract.
-33. Use `FEATURE_PQSIG_BASIC_POSTURE.md` as the fixed note for the current
+33. Use `MEMPOOL_ACCEPT_WTXID_POSTURE.md` as the fixed note for the current
+   `mempool_accept_wtxid.py` contract.
+34. Use `FEATURE_PQSIG_BASIC_POSTURE.md` as the fixed note for the current
    `feature_pqsig_basic.py` contract.
-34. Use `FEATURE_PQSIG_MULTISIG_POSTURE.md` as the fixed note for the current
+35. Use `FEATURE_PQSIG_MULTISIG_POSTURE.md` as the fixed note for the current
    `feature_pqsig_multisig.py` contract.
-35. Use `FEATURE_LOADBLOCK_POSTURE.md` as the fixed note for the current
+36. Use `FEATURE_LOADBLOCK_POSTURE.md` as the fixed note for the current
    `feature_loadblock.py` contract.
-36. Use `WALLET_MINISCRIPT_POSTURE.md` as the fixed note for the current
+37. Use `WALLET_MINISCRIPT_POSTURE.md` as the fixed note for the current
    `wallet_miniscript.py` contract.
-37. Use `FEATURE_UTXO_SET_HASH_POSTURE.md` as the fixed note for the current
+38. Use `FEATURE_UTXO_SET_HASH_POSTURE.md` as the fixed note for the current
    `feature_utxo_set_hash.py` contract.
-38. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
+39. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
    `feature_coinstatsindex.py` contract.
-39. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
+40. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
    `feature_bip68_sequence.py` contract.
-40. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
+41. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
    `feature_cltv.py` contract.
-41. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
+42. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
    `feature_csv_activation.py` contract.
-42. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
+43. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
    `feature_pruning.py` contract.
-43. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
+44. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
    `feature_reindex.py` contract.
-44. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
+45. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
    `feature_reindex_init.py` contract.
-45. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
+46. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-46. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+47. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
    current `feature_versionbits_warning.py` contract.
-47. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+48. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-48. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+49. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-49. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+50. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1144,6 +1169,7 @@ Aineko must ask before:
 - `MEMPOOL_PQ_LIMITS_POSTURE.md`
 - `MEMPOOL_PQ_STRESS_POSTURE.md`
 - `MEMPOOL_ACCEPT_POSTURE.md`
+- `MEMPOOL_ACCEPT_WTXID_POSTURE.md`
 - `TEST_COST_POSTURE.md`
 - `POST_RC_EPICS.md`
 - `CI_COMPLETENESS.md`
@@ -1815,6 +1841,16 @@ Aineko must ask before:
   remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
   release assets exist; otherwise the adjacent local mempool candidate is
   `mempool_accept_wtxid.py` after a fresh targeted pass.
+- 2026-05-04: `mempool_accept_wtxid.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers same-`txid` / different-`wtxid` child
+  transactions, exact already-in-mempool and same-nonwitness-data reporting,
+  preservation of the canonical mempool transaction, and rebroadcast of the
+  canonical mempool `wtxid` to a newly connected peer. `mempool_compatibility.py`
+  remains previous-release blocked. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_datacarrier.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full
@@ -1860,6 +1896,8 @@ Aineko must ask before:
   PQBTC release assets are available to the compatibility harness.
 - `feature_unsupported_utxo_db.py` remains blocked locally until real prior
   PQBTC release assets are available to the previous-release harness.
+- `mempool_compatibility.py` remains blocked locally until real prior PQBTC
+  release assets are available to the previous-release harness.
 - There is no current blocker in the restored broad wallet
   funding/signing/finalization surface: `rpc_psbt.py`,
   `wallet_miniscript.py`,


### PR DESCRIPTION
## Summary

Promotes `mempool_accept_wtxid.py` from `pq_backlog` to `pq_required` as the adjacent inherited mempool acceptance gate after `mempool_accept.py`.

This is a metadata and handoff tranche only. It does not change mempool, policy, wallet, consensus, RPC, P2P, or test behavior.

## What Changed

- Moves `mempool_accept_wtxid.py` to `pq_required` in `ci/test/functional_suite_inventory.json`.
- Adds `mempool_accept_wtxid.py` to `ci/test/pq_functional_tests.txt` in exact inventory order, immediately after `mempool_accept.py`.
- Updates `docs/CI_COMPLETENESS.md` counts to `pq_required=98`, `pq_backlog=27`, `dual_profile=142`, `legacy_only=9` and adds the gate to the required list.
- Adds `docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md` to define the owned same-txid/different-wtxid mempool boundary.
- Updates `docs/TRACK_A_STATUS.md` to document the promotion, keep prior-release-dependent compatibility gates blocked, and point the local alternate at `mempool_datacarrier.py` after targeted validation.

## Validation

- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_accept_wtxid.py`
- `git diff --check`

## Notes

`mempool_compatibility.py` is not promoted in this tranche because it calls `skip_if_no_previous_releases()` and remains blocked until real prior PQBTC release assets are available locally.
