### PR TITLE
Promote mempool datacarrier gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -588,10 +588,10 @@
   },
   {
     "name": "mempool_datacarrier.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited OP_RETURN/datacarrier mempool policy gate: the suite exercises default uncapped datacarrier relay, disabled datacarrier relay, custom datacarriersize boundaries, no-data and zero-byte OP_RETURN handling, and getmempoolinfo reporting under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_dust.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -28,6 +28,7 @@ feature_utxo_set_hash.py
 feature_versionbits_warning.py
 mempool_accept.py
 mempool_accept_wtxid.py
+mempool_datacarrier.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `98` |
-| `pq_backlog` | `27` |
+| `pq_required` | `99` |
+| `pq_backlog` | `26` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -56,91 +56,92 @@ Current required PQ-first gates:
 11. `mempool_pq_stress.py`
 12. `mempool_accept.py`
 13. `mempool_accept_wtxid.py`
-14. `wallet_pq_active_ranged.py`
-15. `wallet_pq_backup_recovery.py`
-16. `wallet_pq_create_tx.py`
-17. `wallet_pq_descriptors.py`
-18. `wallet_pq_psbt.py`
-19. `wallet_pq_send.py`
-20. `wallet_pq_sendall.py`
-21. `wallet_pq_sendmany.py`
-22. `wallet_pq_signrawtransaction.py`
-23. `feature_assumeutxo.py`
-24. `feature_assumevalid.py`
-25. `feature_bip68_sequence.py`
-26. `feature_block.py`
-27. `feature_blocksdir.py`
-28. `feature_blocksxor.py`
-29. `feature_cltv.py`
-30. `feature_coinstatsindex.py`
-31. `feature_csv_activation.py`
-32. `feature_fastprune.py`
-33. `feature_index_prune.py`
-34. `feature_loadblock.py`
-35. `feature_pruning.py`
-36. `feature_reindex.py`
-37. `feature_reindex_init.py`
-38. `feature_reindex_readonly.py`
-39. `feature_remove_pruned_files_on_startup.py`
-40. `feature_utxo_set_hash.py`
-41. `feature_versionbits_warning.py`
-42. `rpc_psbt.py`
-43. `wallet_abandonconflict.py`
-44. `wallet_address_types.py`
-45. `wallet_assumeutxo.py`
-46. `wallet_avoid_mixing_output_types.py`
-47. `wallet_avoidreuse.py`
-48. `wallet_backup.py`
-49. `wallet_balance.py`
-50. `wallet_basic.py`
-51. `wallet_blank.py`
-52. `wallet_bumpfee.py`
-53. `wallet_change_address.py`
-54. `wallet_coinbase_category.py`
-55. `wallet_conflicts.py`
-56. `wallet_create_tx.py`
-57. `wallet_createwallet.py`
-58. `wallet_createwalletdescriptor.py`
-59. `wallet_crosschain.py`
-60. `wallet_descriptor.py`
-61. `wallet_disable.py`
-62. `wallet_encryption.py`
-63. `wallet_fallbackfee.py`
-64. `wallet_fast_rescan.py`
-65. `wallet_fundrawtransaction.py`
-66. `wallet_gethdkeys.py`
-67. `wallet_groups.py`
-68. `wallet_hd.py`
-69. `wallet_importdescriptors.py`
-70. `wallet_importprunedfunds.py`
-71. `wallet_keypool.py`
-72. `wallet_keypool_topup.py`
-73. `wallet_labels.py`
-74. `wallet_listdescriptors.py`
-75. `wallet_listreceivedby.py`
-76. `wallet_listsinceblock.py`
-77. `wallet_listtransactions.py`
-78. `wallet_miniscript.py`
-79. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-80. `wallet_multisig_descriptor_psbt.py`
-81. `wallet_multiwallet.py`
-82. `wallet_orphanedreward.py`
-83. `wallet_reindex.py`
-84. `wallet_reorgsrestore.py`
-85. `wallet_rescan_unconfirmed.py`
-86. `wallet_resendwallettransactions.py`
-87. `wallet_send.py`
-88. `wallet_sendall.py`
-89. `wallet_sendmany.py`
-90. `wallet_signrawtransactionwithwallet.py`
-91. `wallet_simulaterawtx.py`
-92. `wallet_spend_unconfirmed.py`
-93. `wallet_startup.py`
-94. `wallet_timelock.py`
-95. `wallet_transactiontime_rescan.py`
-96. `wallet_txn_clone.py`
-97. `wallet_txn_doublespend.py`
-98. `wallet_v3_txs.py`
+14. `mempool_datacarrier.py`
+15. `wallet_pq_active_ranged.py`
+16. `wallet_pq_backup_recovery.py`
+17. `wallet_pq_create_tx.py`
+18. `wallet_pq_descriptors.py`
+19. `wallet_pq_psbt.py`
+20. `wallet_pq_send.py`
+21. `wallet_pq_sendall.py`
+22. `wallet_pq_sendmany.py`
+23. `wallet_pq_signrawtransaction.py`
+24. `feature_assumeutxo.py`
+25. `feature_assumevalid.py`
+26. `feature_bip68_sequence.py`
+27. `feature_block.py`
+28. `feature_blocksdir.py`
+29. `feature_blocksxor.py`
+30. `feature_cltv.py`
+31. `feature_coinstatsindex.py`
+32. `feature_csv_activation.py`
+33. `feature_fastprune.py`
+34. `feature_index_prune.py`
+35. `feature_loadblock.py`
+36. `feature_pruning.py`
+37. `feature_reindex.py`
+38. `feature_reindex_init.py`
+39. `feature_reindex_readonly.py`
+40. `feature_remove_pruned_files_on_startup.py`
+41. `feature_utxo_set_hash.py`
+42. `feature_versionbits_warning.py`
+43. `rpc_psbt.py`
+44. `wallet_abandonconflict.py`
+45. `wallet_address_types.py`
+46. `wallet_assumeutxo.py`
+47. `wallet_avoid_mixing_output_types.py`
+48. `wallet_avoidreuse.py`
+49. `wallet_backup.py`
+50. `wallet_balance.py`
+51. `wallet_basic.py`
+52. `wallet_blank.py`
+53. `wallet_bumpfee.py`
+54. `wallet_change_address.py`
+55. `wallet_coinbase_category.py`
+56. `wallet_conflicts.py`
+57. `wallet_create_tx.py`
+58. `wallet_createwallet.py`
+59. `wallet_createwalletdescriptor.py`
+60. `wallet_crosschain.py`
+61. `wallet_descriptor.py`
+62. `wallet_disable.py`
+63. `wallet_encryption.py`
+64. `wallet_fallbackfee.py`
+65. `wallet_fast_rescan.py`
+66. `wallet_fundrawtransaction.py`
+67. `wallet_gethdkeys.py`
+68. `wallet_groups.py`
+69. `wallet_hd.py`
+70. `wallet_importdescriptors.py`
+71. `wallet_importprunedfunds.py`
+72. `wallet_keypool.py`
+73. `wallet_keypool_topup.py`
+74. `wallet_labels.py`
+75. `wallet_listdescriptors.py`
+76. `wallet_listreceivedby.py`
+77. `wallet_listsinceblock.py`
+78. `wallet_listtransactions.py`
+79. `wallet_miniscript.py`
+80. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+81. `wallet_multisig_descriptor_psbt.py`
+82. `wallet_multiwallet.py`
+83. `wallet_orphanedreward.py`
+84. `wallet_reindex.py`
+85. `wallet_reorgsrestore.py`
+86. `wallet_rescan_unconfirmed.py`
+87. `wallet_resendwallettransactions.py`
+88. `wallet_send.py`
+89. `wallet_sendall.py`
+90. `wallet_sendmany.py`
+91. `wallet_signrawtransactionwithwallet.py`
+92. `wallet_simulaterawtx.py`
+93. `wallet_spend_unconfirmed.py`
+94. `wallet_startup.py`
+95. `wallet_timelock.py`
+96. `wallet_transactiontime_rescan.py`
+97. `wallet_txn_clone.py`
+98. `wallet_txn_doublespend.py`
+99. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -366,6 +367,12 @@ different-`wtxid` child transactions, exact already-in-mempool reporting,
 same-nonwitness-data rejection, no replacement by an alternate witness, and
 canonical mempool `wtxid` rebroadcast under the current legacy-compatible PQC
 profile.
+The inherited datacarrier policy confidence gap is now also part of the
+required gate: `mempool_datacarrier.py` covers default uncapped OP_RETURN
+relay, disabled datacarrier relay, custom `-datacarriersize` acceptance and
+rejection boundaries, empty and zero-byte OP_RETURN payload handling, and
+`getmempoolinfo` datacarrier-size reporting under the current
+legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -67,6 +67,7 @@ this worktree.
 
 - `mempool_accept.py` is now a required inherited mempool acceptance gate
 - it complements, but does not replace,
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -64,6 +64,7 @@ Targeted confidence pass run on 2026-05-04:
   acceptance gate
 - it complements, but does not replace,
   [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -1,0 +1,68 @@
+# PQBTC `mempool_datacarrier.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-DATACARRIER-POSTURE-v1
+## Updated: 2026-05-04
+## Frozen-By: track-a-phase1-20260504
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited OP_RETURN/datacarrier mempool
+policy under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_datacarrier.py](../test/functional/mempool_datacarrier.py) suite owns
+the single-node datacarrier policy boundary:
+
+- default datacarrier relay remains uncapped by the historical 83-byte limit
+- `-datacarrier=0` rejects OP_RETURN outputs with the expected policy reason
+- custom `-datacarriersize=83` accepts the historical payload size and rejects
+  payloads that exceed that configured boundary
+- `-datacarriersize=2` accepts empty and zero-byte OP_RETURN payloads while
+  rejecting one-byte data payloads
+- `getmempoolinfo()["maxdatacarriersize"]` reports the expected default,
+  disabled, custom, and small-limit values
+- confirmed bare-multisig policy remains allowed by default as the suite-local
+  inherited policy smoke check
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool policy suite is owned by this tranche
+- dust, ephemeral-dust, expiry, package relay, package RBF, persistence, reorg,
+  TRUC, mining-template, or prior-release compatibility behavior is covered
+  here
+- PQ-native witness-size stress replaces this inherited OP_RETURN policy
+  surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-04:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_datacarrier.py`
+  - result: passed
+  - current posture:
+    - OP_RETURN/datacarrier policy boundaries remain stable under the current
+      legacy-compatible PQC profile
+    - configured size limits and disabled relay behavior preserve expected
+      mempool rejection semantics
+    - `getmempoolinfo` reports the configured datacarrier limits
+
+## Interpretation
+
+- `mempool_datacarrier.py` is now a required inherited datacarrier policy gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -44,7 +44,8 @@ keep
 `mempool_pq_limits.py`, and `mempool_pq_stress.py` boundaries, keep
 `mempool_accept.py` inherited raw transaction mempool-acceptance behavior in
 the same gate, keep `mempool_accept_wtxid.py` inherited wtxid-aware
-mempool-acceptance behavior in the same gate, freeze the new
+mempool-acceptance behavior in the same gate, keep `mempool_datacarrier.py`
+inherited datacarrier policy behavior in the same gate, freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
 `feature_assumevalid.py` boundaries, keep
@@ -1006,15 +1007,36 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_WTXID_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, expiry, reorg, TRUC, datacarrier,
-     and mining policy suites
+   - remaining mempool package, persistence, expiry, reorg, TRUC, and mining
+     policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-49. Recommended next PR after this tranche:
+49. `mempool_datacarrier.py` now owns:
+   - inherited OP_RETURN/datacarrier mempool policy under the current
+     legacy-compatible PQC profile
+   - default uncapped datacarrier relay behavior
+   - disabled datacarrier relay rejection behavior
+   - custom `-datacarriersize=83` acceptance and rejection boundaries
+   - empty, zero-byte, and one-byte OP_RETURN payload policy under a small
+     `-datacarriersize=2` limit
+   - `getmempoolinfo()["maxdatacarriersize"]` reporting for default,
+     disabled, historical custom, and small custom limits
+   - the suite-local confirmed bare-multisig policy smoke check
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_datacarrier.py`
+   Fixed posture note:
+   - `MEMPOOL_DATACARRIER_POSTURE.md`
+   Still deferred inside this suite:
+   - remaining mempool dust, ephemeral-dust, package, persistence, expiry,
+     reorg, TRUC, and mining policy suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+50. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_datacarrier.py` as the next local mempool policy
-     candidate if it passes targeted validation, while
+   - alternate: `mempool_dust.py` as the next local mempool policy candidate
+     after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
@@ -1024,9 +1046,9 @@ Still deferred:
      CSV activation, and broad pruning surfaces are now represented in the
      required gate, so any local alternate should be a fresh bounded migration
      decision outside those surfaces
-   - the first two inherited mempool acceptance gates are now frozen, so the
-     adjacent local mempool follow-on is datacarrier policy only after a fresh
-     targeted pass
+   - the first two inherited mempool acceptance gates and the datacarrier
+     policy gate are now frozen, so the adjacent local mempool follow-on should
+     be another bounded policy gate only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1066,39 +1088,41 @@ Still deferred:
    `mempool_accept.py` contract.
 33. Use `MEMPOOL_ACCEPT_WTXID_POSTURE.md` as the fixed note for the current
    `mempool_accept_wtxid.py` contract.
-34. Use `FEATURE_PQSIG_BASIC_POSTURE.md` as the fixed note for the current
+34. Use `MEMPOOL_DATACARRIER_POSTURE.md` as the fixed note for the current
+   `mempool_datacarrier.py` contract.
+35. Use `FEATURE_PQSIG_BASIC_POSTURE.md` as the fixed note for the current
    `feature_pqsig_basic.py` contract.
-35. Use `FEATURE_PQSIG_MULTISIG_POSTURE.md` as the fixed note for the current
+36. Use `FEATURE_PQSIG_MULTISIG_POSTURE.md` as the fixed note for the current
    `feature_pqsig_multisig.py` contract.
-36. Use `FEATURE_LOADBLOCK_POSTURE.md` as the fixed note for the current
+37. Use `FEATURE_LOADBLOCK_POSTURE.md` as the fixed note for the current
    `feature_loadblock.py` contract.
-37. Use `WALLET_MINISCRIPT_POSTURE.md` as the fixed note for the current
+38. Use `WALLET_MINISCRIPT_POSTURE.md` as the fixed note for the current
    `wallet_miniscript.py` contract.
-38. Use `FEATURE_UTXO_SET_HASH_POSTURE.md` as the fixed note for the current
+39. Use `FEATURE_UTXO_SET_HASH_POSTURE.md` as the fixed note for the current
    `feature_utxo_set_hash.py` contract.
-39. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
+40. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
    `feature_coinstatsindex.py` contract.
-40. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
+41. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
    `feature_bip68_sequence.py` contract.
-41. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
+42. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
    `feature_cltv.py` contract.
-42. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
+43. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
    `feature_csv_activation.py` contract.
-43. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
+44. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
    `feature_pruning.py` contract.
-44. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
+45. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
    `feature_reindex.py` contract.
-45. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
+46. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
    `feature_reindex_init.py` contract.
-46. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
+47. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-47. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+48. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
    current `feature_versionbits_warning.py` contract.
-48. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+49. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-49. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+50. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-50. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+51. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1851,6 +1875,16 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mempool candidate is
   `mempool_datacarrier.py` after a fresh targeted pass.
+- 2026-05-04: `mempool_datacarrier.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers default uncapped OP_RETURN relay, disabled
+  datacarrier relay, custom `-datacarriersize` acceptance and rejection
+  boundaries, empty and zero-byte OP_RETURN payload handling, and
+  `getmempoolinfo` datacarrier-size reporting under the current
+  legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_dust.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_datacarrier.py` from `pq_backlog` to `pq_required`
- add the gate to `ci/test/pq_functional_tests.txt` and update CI completeness counts to `pq_required=99`, `pq_backlog=26`
- add `MEMPOOL_DATACARRIER_POSTURE.md` and refresh Track A handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_datacarrier.py`

## Notes
- no source or functional test behavior changes
- `feature_coinstatsindex_compatibility.py` remains blocked until real prior PQBTC release assets exist
