### PR TITLE
Promote mempool expiry gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -609,10 +609,10 @@
   },
   {
     "name": "mempool_expiry.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool expiry policy gate: the suite exercises default and custom -mempoolexpiry timeouts, parent and child eviction after expiry, independent transaction survival, and prioritisation persistence after expiry under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_limit.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -31,6 +31,7 @@ mempool_accept_wtxid.py
 mempool_datacarrier.py
 mempool_dust.py
 mempool_ephemeral_dust.py
+mempool_expiry.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `101` |
-| `pq_backlog` | `24` |
+| `pq_required` | `102` |
+| `pq_backlog` | `23` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -59,91 +59,92 @@ Current required PQ-first gates:
 14. `mempool_datacarrier.py`
 15. `mempool_dust.py`
 16. `mempool_ephemeral_dust.py`
-17. `wallet_pq_active_ranged.py`
-18. `wallet_pq_backup_recovery.py`
-19. `wallet_pq_create_tx.py`
-20. `wallet_pq_descriptors.py`
-21. `wallet_pq_psbt.py`
-22. `wallet_pq_send.py`
-23. `wallet_pq_sendall.py`
-24. `wallet_pq_sendmany.py`
-25. `wallet_pq_signrawtransaction.py`
-26. `feature_assumeutxo.py`
-27. `feature_assumevalid.py`
-28. `feature_bip68_sequence.py`
-29. `feature_block.py`
-30. `feature_blocksdir.py`
-31. `feature_blocksxor.py`
-32. `feature_cltv.py`
-33. `feature_coinstatsindex.py`
-34. `feature_csv_activation.py`
-35. `feature_fastprune.py`
-36. `feature_index_prune.py`
-37. `feature_loadblock.py`
-38. `feature_pruning.py`
-39. `feature_reindex.py`
-40. `feature_reindex_init.py`
-41. `feature_reindex_readonly.py`
-42. `feature_remove_pruned_files_on_startup.py`
-43. `feature_utxo_set_hash.py`
-44. `feature_versionbits_warning.py`
-45. `rpc_psbt.py`
-46. `wallet_abandonconflict.py`
-47. `wallet_address_types.py`
-48. `wallet_assumeutxo.py`
-49. `wallet_avoid_mixing_output_types.py`
-50. `wallet_avoidreuse.py`
-51. `wallet_backup.py`
-52. `wallet_balance.py`
-53. `wallet_basic.py`
-54. `wallet_blank.py`
-55. `wallet_bumpfee.py`
-56. `wallet_change_address.py`
-57. `wallet_coinbase_category.py`
-58. `wallet_conflicts.py`
-59. `wallet_create_tx.py`
-60. `wallet_createwallet.py`
-61. `wallet_createwalletdescriptor.py`
-62. `wallet_crosschain.py`
-63. `wallet_descriptor.py`
-64. `wallet_disable.py`
-65. `wallet_encryption.py`
-66. `wallet_fallbackfee.py`
-67. `wallet_fast_rescan.py`
-68. `wallet_fundrawtransaction.py`
-69. `wallet_gethdkeys.py`
-70. `wallet_groups.py`
-71. `wallet_hd.py`
-72. `wallet_importdescriptors.py`
-73. `wallet_importprunedfunds.py`
-74. `wallet_keypool.py`
-75. `wallet_keypool_topup.py`
-76. `wallet_labels.py`
-77. `wallet_listdescriptors.py`
-78. `wallet_listreceivedby.py`
-79. `wallet_listsinceblock.py`
-80. `wallet_listtransactions.py`
-81. `wallet_miniscript.py`
-82. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-83. `wallet_multisig_descriptor_psbt.py`
-84. `wallet_multiwallet.py`
-85. `wallet_orphanedreward.py`
-86. `wallet_reindex.py`
-87. `wallet_reorgsrestore.py`
-88. `wallet_rescan_unconfirmed.py`
-89. `wallet_resendwallettransactions.py`
-90. `wallet_send.py`
-91. `wallet_sendall.py`
-92. `wallet_sendmany.py`
-93. `wallet_signrawtransactionwithwallet.py`
-94. `wallet_simulaterawtx.py`
-95. `wallet_spend_unconfirmed.py`
-96. `wallet_startup.py`
-97. `wallet_timelock.py`
-98. `wallet_transactiontime_rescan.py`
-99. `wallet_txn_clone.py`
-100. `wallet_txn_doublespend.py`
-101. `wallet_v3_txs.py`
+17. `mempool_expiry.py`
+18. `wallet_pq_active_ranged.py`
+19. `wallet_pq_backup_recovery.py`
+20. `wallet_pq_create_tx.py`
+21. `wallet_pq_descriptors.py`
+22. `wallet_pq_psbt.py`
+23. `wallet_pq_send.py`
+24. `wallet_pq_sendall.py`
+25. `wallet_pq_sendmany.py`
+26. `wallet_pq_signrawtransaction.py`
+27. `feature_assumeutxo.py`
+28. `feature_assumevalid.py`
+29. `feature_bip68_sequence.py`
+30. `feature_block.py`
+31. `feature_blocksdir.py`
+32. `feature_blocksxor.py`
+33. `feature_cltv.py`
+34. `feature_coinstatsindex.py`
+35. `feature_csv_activation.py`
+36. `feature_fastprune.py`
+37. `feature_index_prune.py`
+38. `feature_loadblock.py`
+39. `feature_pruning.py`
+40. `feature_reindex.py`
+41. `feature_reindex_init.py`
+42. `feature_reindex_readonly.py`
+43. `feature_remove_pruned_files_on_startup.py`
+44. `feature_utxo_set_hash.py`
+45. `feature_versionbits_warning.py`
+46. `rpc_psbt.py`
+47. `wallet_abandonconflict.py`
+48. `wallet_address_types.py`
+49. `wallet_assumeutxo.py`
+50. `wallet_avoid_mixing_output_types.py`
+51. `wallet_avoidreuse.py`
+52. `wallet_backup.py`
+53. `wallet_balance.py`
+54. `wallet_basic.py`
+55. `wallet_blank.py`
+56. `wallet_bumpfee.py`
+57. `wallet_change_address.py`
+58. `wallet_coinbase_category.py`
+59. `wallet_conflicts.py`
+60. `wallet_create_tx.py`
+61. `wallet_createwallet.py`
+62. `wallet_createwalletdescriptor.py`
+63. `wallet_crosschain.py`
+64. `wallet_descriptor.py`
+65. `wallet_disable.py`
+66. `wallet_encryption.py`
+67. `wallet_fallbackfee.py`
+68. `wallet_fast_rescan.py`
+69. `wallet_fundrawtransaction.py`
+70. `wallet_gethdkeys.py`
+71. `wallet_groups.py`
+72. `wallet_hd.py`
+73. `wallet_importdescriptors.py`
+74. `wallet_importprunedfunds.py`
+75. `wallet_keypool.py`
+76. `wallet_keypool_topup.py`
+77. `wallet_labels.py`
+78. `wallet_listdescriptors.py`
+79. `wallet_listreceivedby.py`
+80. `wallet_listsinceblock.py`
+81. `wallet_listtransactions.py`
+82. `wallet_miniscript.py`
+83. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+84. `wallet_multisig_descriptor_psbt.py`
+85. `wallet_multiwallet.py`
+86. `wallet_orphanedreward.py`
+87. `wallet_reindex.py`
+88. `wallet_reorgsrestore.py`
+89. `wallet_rescan_unconfirmed.py`
+90. `wallet_resendwallettransactions.py`
+91. `wallet_send.py`
+92. `wallet_sendall.py`
+93. `wallet_sendmany.py`
+94. `wallet_signrawtransactionwithwallet.py`
+95. `wallet_simulaterawtx.py`
+96. `wallet_spend_unconfirmed.py`
+97. `wallet_startup.py`
+98. `wallet_timelock.py`
+99. `wallet_transactiontime_rescan.py`
+100. `wallet_txn_clone.py`
+101. `wallet_txn_doublespend.py`
+102. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -386,6 +387,11 @@ ephemeral-dust package acceptance, zero-fee dust parent rules, sponsor
 cycling, restart behavior, fee-having and multidust rejection, missing
 ephemeral spends, reorg restoration, and disabled-minrelay batched sweep
 behavior under the current legacy-compatible PQC profile.
+The inherited mempool expiry policy confidence gap is now also part of the
+required gate: `mempool_expiry.py` covers default and custom mempool expiry
+windows, parent and child eviction, independent transaction survival,
+prioritisation persistence after expiry, and mocktime-driven expiry checks
+under the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -70,6 +70,7 @@ this worktree.
   [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -67,6 +67,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -62,6 +62,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -61,6 +61,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
   [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -72,6 +72,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
   [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -1,0 +1,67 @@
+# PQBTC `mempool_expiry.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-EXPIRY-POSTURE-v1
+## Updated: 2026-05-05
+## Frozen-By: track-a-phase1-20260505
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool transaction expiry
+policy under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing [mempool_expiry.py](../test/functional/mempool_expiry.py)
+suite owns the single-node mempool expiry boundary:
+
+- the default `DEFAULT_MEMPOOL_EXPIRY_HOURS` timeout keeps parent transactions
+  in mempool until the configured expiry point
+- `-mempoolexpiry=<n>` custom timeout behavior matches the same boundary
+- a child transaction spending the expiring parent is evicted with its parent
+- an independent transaction received later remains in mempool after the
+  parent and child expire
+- transaction prioritisation survives expiry and flips from `in_mempool=true`
+  to `in_mempool=false`
+- expiry is triggered through normal mempool admission after mocktime advances
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool policy suite is owned by this tranche
+- package relay, package RBF, persistence, broad reorg behavior,
+  mining-template behavior, or prior-release compatibility behavior is covered
+  here
+- PQ-native witness-size stress replaces this inherited expiry policy surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-05:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_expiry.py`
+  - result: passed
+  - current posture:
+    - default and custom mempool expiry windows remain stable
+    - expired parent and child transactions are evicted together
+    - independent transactions and prioritisation state preserve their expected
+      behavior
+
+## Interpretation
+
+- `mempool_expiry.py` is now a required inherited mempool expiry policy gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -48,7 +48,8 @@ mempool-acceptance behavior in the same gate, keep `mempool_datacarrier.py`
 inherited datacarrier policy behavior in the same gate, keep
 `mempool_dust.py` inherited dust relay policy behavior in the same gate,
 keep `mempool_ephemeral_dust.py` inherited ephemeral-dust package policy
-behavior in the same gate,
+behavior in the same gate, keep `mempool_expiry.py` inherited mempool expiry
+policy behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -989,7 +990,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, expiry, reorg, TRUC, and mining
+   - remaining mempool package, persistence, reorg, TRUC, and mining
      policy suites
    - `feature_unsupported_utxo_db.py` and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
@@ -1011,7 +1012,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_WTXID_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, expiry, reorg, TRUC, and mining
+   - remaining mempool package, persistence, reorg, TRUC, and mining
      policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
@@ -1032,7 +1033,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_DATACARRIER_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, expiry, reorg, TRUC, and mining
+   - remaining mempool package, persistence, reorg, TRUC, and mining
      policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
@@ -1055,7 +1056,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_DUST_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, expiry, reorg, TRUC, and mining
+   - remaining mempool package, persistence, reorg, TRUC, and mining
      policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
@@ -1080,14 +1081,33 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_EPHEMERAL_DUST_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, expiry, reorg, TRUC, and mining
-     policy suites
+   - remaining mempool package, persistence, reorg, TRUC, and mining policy
+     suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-52. Recommended next PR after this tranche:
+52. `mempool_expiry.py` now owns:
+   - inherited mempool transaction expiry under the current legacy-compatible
+     PQC profile
+   - default `DEFAULT_MEMPOOL_EXPIRY_HOURS` behavior
+   - custom `-mempoolexpiry=<n>` behavior
+   - parent transaction expiry with child transaction eviction
+   - independent transaction survival across parent and child expiry
+   - prioritisation persistence after expiry with `in_mempool=false`
+   - expiry triggering through normal mempool admission after mocktime advance
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_expiry.py`
+   Fixed posture note:
+   - `MEMPOOL_EXPIRY_POSTURE.md`
+   Still deferred inside this suite:
+   - remaining mempool package, persistence, reorg, TRUC, and mining policy
+     suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+53. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_expiry.py` as the next local mempool policy candidate
+   - alternate: `mempool_limit.py` as the next local mempool policy candidate
      after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1099,9 +1119,9 @@ Still deferred:
      required gate, so any local alternate should be a fresh bounded migration
      decision outside those surfaces
    - the first two inherited mempool acceptance gates plus datacarrier, dust,
-     and ephemeral-dust policy are now frozen, so the adjacent local mempool
-     follow-on should be another bounded policy gate only after a fresh
-     targeted pass
+     ephemeral-dust, and expiry policy are now frozen, so the adjacent local
+     mempool follow-on should be another bounded policy gate only after a
+     fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -1147,39 +1167,41 @@ Still deferred:
    `mempool_dust.py` contract.
 36. Use `MEMPOOL_EPHEMERAL_DUST_POSTURE.md` as the fixed note for the current
    `mempool_ephemeral_dust.py` contract.
-37. Use `FEATURE_PQSIG_BASIC_POSTURE.md` as the fixed note for the current
+37. Use `MEMPOOL_EXPIRY_POSTURE.md` as the fixed note for the current
+   `mempool_expiry.py` contract.
+38. Use `FEATURE_PQSIG_BASIC_POSTURE.md` as the fixed note for the current
    `feature_pqsig_basic.py` contract.
-38. Use `FEATURE_PQSIG_MULTISIG_POSTURE.md` as the fixed note for the current
+39. Use `FEATURE_PQSIG_MULTISIG_POSTURE.md` as the fixed note for the current
    `feature_pqsig_multisig.py` contract.
-39. Use `FEATURE_LOADBLOCK_POSTURE.md` as the fixed note for the current
+40. Use `FEATURE_LOADBLOCK_POSTURE.md` as the fixed note for the current
    `feature_loadblock.py` contract.
-40. Use `WALLET_MINISCRIPT_POSTURE.md` as the fixed note for the current
+41. Use `WALLET_MINISCRIPT_POSTURE.md` as the fixed note for the current
    `wallet_miniscript.py` contract.
-41. Use `FEATURE_UTXO_SET_HASH_POSTURE.md` as the fixed note for the current
+42. Use `FEATURE_UTXO_SET_HASH_POSTURE.md` as the fixed note for the current
    `feature_utxo_set_hash.py` contract.
-42. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
+43. Use `FEATURE_COINSTATSINDEX_POSTURE.md` as the fixed note for the current
    `feature_coinstatsindex.py` contract.
-43. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
+44. Use `FEATURE_BIP68_SEQUENCE_POSTURE.md` as the fixed note for the current
    `feature_bip68_sequence.py` contract.
-44. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
+45. Use `FEATURE_CLTV_POSTURE.md` as the fixed note for the current
    `feature_cltv.py` contract.
-45. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
+46. Use `FEATURE_CSV_ACTIVATION_POSTURE.md` as the fixed note for the current
    `feature_csv_activation.py` contract.
-46. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
+47. Use `FEATURE_PRUNING_POSTURE.md` as the fixed note for the current
    `feature_pruning.py` contract.
-47. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
+48. Use `FEATURE_REINDEX_POSTURE.md` as the fixed note for the current
    `feature_reindex.py` contract.
-48. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
+49. Use `FEATURE_REINDEX_INIT_POSTURE.md` as the fixed note for the current
    `feature_reindex_init.py` contract.
-49. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
+50. Use `FEATURE_REINDEX_READONLY_POSTURE.md` as the fixed note for the current
    `feature_reindex_readonly.py` contract.
-50. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
+51. Use `FEATURE_VERSIONBITS_WARNING_POSTURE.md` as the fixed note for the
    current `feature_versionbits_warning.py` contract.
-51. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
+52. Use `FEATURE_ASSUMEVALID_POSTURE.md` as the fixed note for the current
    `feature_assumevalid.py` contract.
-52. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+53. Use `FEATURE_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `feature_assumeutxo.py` contract.
-53. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
+54. Use `WALLET_ASSUMEUTXO_POSTURE.md` as the fixed note for the current
    `wallet_assumeutxo.py` contract.
 29. Treat inherited `getnewaddress` / `getrawchangeaddress` as unsupported on
    PQ-only active-manager wallets; the owned PQ address UX remains
@@ -1962,6 +1984,15 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mempool candidate is
   `mempool_expiry.py` after a fresh targeted pass.
+- 2026-05-05: `mempool_expiry.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers default and custom mempool expiry windows,
+  parent and child eviction, independent transaction survival, prioritisation
+  persistence after expiry, and mocktime-driven expiry checks under the
+  current legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_limit.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_expiry.py` from `pq_backlog` to `pq_required`
- add the gate to `ci/test/pq_functional_tests.txt` and update CI completeness counts to `pq_required=102`, `pq_backlog=23`
- add `MEMPOOL_EXPIRY_POSTURE.md` and refresh Track A handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_expiry.py`

## Notes
- no source or functional test behavior changes
- `feature_coinstatsindex_compatibility.py` remains blocked until real prior PQBTC release assets exist
