### PR TITLE
Promote mempool limit gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -616,10 +616,10 @@
   },
   {
     "name": "mempool_limit.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool size, eviction, and package-limit policy gate: the suite exercises full-mempool min-fee rejection, CPFP package admission below mempool minimum, peer broadcast fee-filter behavior, immediate low-feerate package eviction, -maxmempool floor init rejection, mid-package eviction, mid-package replacement, and RBF carveout limit rejection under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_package_limits.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -32,6 +32,7 @@ mempool_datacarrier.py
 mempool_dust.py
 mempool_ephemeral_dust.py
 mempool_expiry.py
+mempool_limit.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `102` |
-| `pq_backlog` | `23` |
+| `pq_required` | `103` |
+| `pq_backlog` | `22` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -60,91 +60,92 @@ Current required PQ-first gates:
 15. `mempool_dust.py`
 16. `mempool_ephemeral_dust.py`
 17. `mempool_expiry.py`
-18. `wallet_pq_active_ranged.py`
-19. `wallet_pq_backup_recovery.py`
-20. `wallet_pq_create_tx.py`
-21. `wallet_pq_descriptors.py`
-22. `wallet_pq_psbt.py`
-23. `wallet_pq_send.py`
-24. `wallet_pq_sendall.py`
-25. `wallet_pq_sendmany.py`
-26. `wallet_pq_signrawtransaction.py`
-27. `feature_assumeutxo.py`
-28. `feature_assumevalid.py`
-29. `feature_bip68_sequence.py`
-30. `feature_block.py`
-31. `feature_blocksdir.py`
-32. `feature_blocksxor.py`
-33. `feature_cltv.py`
-34. `feature_coinstatsindex.py`
-35. `feature_csv_activation.py`
-36. `feature_fastprune.py`
-37. `feature_index_prune.py`
-38. `feature_loadblock.py`
-39. `feature_pruning.py`
-40. `feature_reindex.py`
-41. `feature_reindex_init.py`
-42. `feature_reindex_readonly.py`
-43. `feature_remove_pruned_files_on_startup.py`
-44. `feature_utxo_set_hash.py`
-45. `feature_versionbits_warning.py`
-46. `rpc_psbt.py`
-47. `wallet_abandonconflict.py`
-48. `wallet_address_types.py`
-49. `wallet_assumeutxo.py`
-50. `wallet_avoid_mixing_output_types.py`
-51. `wallet_avoidreuse.py`
-52. `wallet_backup.py`
-53. `wallet_balance.py`
-54. `wallet_basic.py`
-55. `wallet_blank.py`
-56. `wallet_bumpfee.py`
-57. `wallet_change_address.py`
-58. `wallet_coinbase_category.py`
-59. `wallet_conflicts.py`
-60. `wallet_create_tx.py`
-61. `wallet_createwallet.py`
-62. `wallet_createwalletdescriptor.py`
-63. `wallet_crosschain.py`
-64. `wallet_descriptor.py`
-65. `wallet_disable.py`
-66. `wallet_encryption.py`
-67. `wallet_fallbackfee.py`
-68. `wallet_fast_rescan.py`
-69. `wallet_fundrawtransaction.py`
-70. `wallet_gethdkeys.py`
-71. `wallet_groups.py`
-72. `wallet_hd.py`
-73. `wallet_importdescriptors.py`
-74. `wallet_importprunedfunds.py`
-75. `wallet_keypool.py`
-76. `wallet_keypool_topup.py`
-77. `wallet_labels.py`
-78. `wallet_listdescriptors.py`
-79. `wallet_listreceivedby.py`
-80. `wallet_listsinceblock.py`
-81. `wallet_listtransactions.py`
-82. `wallet_miniscript.py`
-83. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-84. `wallet_multisig_descriptor_psbt.py`
-85. `wallet_multiwallet.py`
-86. `wallet_orphanedreward.py`
-87. `wallet_reindex.py`
-88. `wallet_reorgsrestore.py`
-89. `wallet_rescan_unconfirmed.py`
-90. `wallet_resendwallettransactions.py`
-91. `wallet_send.py`
-92. `wallet_sendall.py`
-93. `wallet_sendmany.py`
-94. `wallet_signrawtransactionwithwallet.py`
-95. `wallet_simulaterawtx.py`
-96. `wallet_spend_unconfirmed.py`
-97. `wallet_startup.py`
-98. `wallet_timelock.py`
-99. `wallet_transactiontime_rescan.py`
-100. `wallet_txn_clone.py`
-101. `wallet_txn_doublespend.py`
-102. `wallet_v3_txs.py`
+18. `mempool_limit.py`
+19. `wallet_pq_active_ranged.py`
+20. `wallet_pq_backup_recovery.py`
+21. `wallet_pq_create_tx.py`
+22. `wallet_pq_descriptors.py`
+23. `wallet_pq_psbt.py`
+24. `wallet_pq_send.py`
+25. `wallet_pq_sendall.py`
+26. `wallet_pq_sendmany.py`
+27. `wallet_pq_signrawtransaction.py`
+28. `feature_assumeutxo.py`
+29. `feature_assumevalid.py`
+30. `feature_bip68_sequence.py`
+31. `feature_block.py`
+32. `feature_blocksdir.py`
+33. `feature_blocksxor.py`
+34. `feature_cltv.py`
+35. `feature_coinstatsindex.py`
+36. `feature_csv_activation.py`
+37. `feature_fastprune.py`
+38. `feature_index_prune.py`
+39. `feature_loadblock.py`
+40. `feature_pruning.py`
+41. `feature_reindex.py`
+42. `feature_reindex_init.py`
+43. `feature_reindex_readonly.py`
+44. `feature_remove_pruned_files_on_startup.py`
+45. `feature_utxo_set_hash.py`
+46. `feature_versionbits_warning.py`
+47. `rpc_psbt.py`
+48. `wallet_abandonconflict.py`
+49. `wallet_address_types.py`
+50. `wallet_assumeutxo.py`
+51. `wallet_avoid_mixing_output_types.py`
+52. `wallet_avoidreuse.py`
+53. `wallet_backup.py`
+54. `wallet_balance.py`
+55. `wallet_basic.py`
+56. `wallet_blank.py`
+57. `wallet_bumpfee.py`
+58. `wallet_change_address.py`
+59. `wallet_coinbase_category.py`
+60. `wallet_conflicts.py`
+61. `wallet_create_tx.py`
+62. `wallet_createwallet.py`
+63. `wallet_createwalletdescriptor.py`
+64. `wallet_crosschain.py`
+65. `wallet_descriptor.py`
+66. `wallet_disable.py`
+67. `wallet_encryption.py`
+68. `wallet_fallbackfee.py`
+69. `wallet_fast_rescan.py`
+70. `wallet_fundrawtransaction.py`
+71. `wallet_gethdkeys.py`
+72. `wallet_groups.py`
+73. `wallet_hd.py`
+74. `wallet_importdescriptors.py`
+75. `wallet_importprunedfunds.py`
+76. `wallet_keypool.py`
+77. `wallet_keypool_topup.py`
+78. `wallet_labels.py`
+79. `wallet_listdescriptors.py`
+80. `wallet_listreceivedby.py`
+81. `wallet_listsinceblock.py`
+82. `wallet_listtransactions.py`
+83. `wallet_miniscript.py`
+84. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+85. `wallet_multisig_descriptor_psbt.py`
+86. `wallet_multiwallet.py`
+87. `wallet_orphanedreward.py`
+88. `wallet_reindex.py`
+89. `wallet_reorgsrestore.py`
+90. `wallet_rescan_unconfirmed.py`
+91. `wallet_resendwallettransactions.py`
+92. `wallet_send.py`
+93. `wallet_sendall.py`
+94. `wallet_sendmany.py`
+95. `wallet_signrawtransactionwithwallet.py`
+96. `wallet_simulaterawtx.py`
+97. `wallet_spend_unconfirmed.py`
+98. `wallet_startup.py`
+99. `wallet_timelock.py`
+100. `wallet_transactiontime_rescan.py`
+101. `wallet_txn_clone.py`
+102. `wallet_txn_doublespend.py`
+103. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -392,6 +393,13 @@ required gate: `mempool_expiry.py` covers default and custom mempool expiry
 windows, parent and child eviction, independent transaction survival,
 prioritisation persistence after expiry, and mocktime-driven expiry checks
 under the current legacy-compatible PQC profile.
+The inherited mempool size, eviction, and package-limit policy confidence gap
+is now also part of the required gate: `mempool_limit.py` covers full-mempool
+minimum-fee rejection, CPFP package admission below the mempool minimum, peer
+broadcast fee-filter behavior, immediate low-feerate package eviction,
+`-maxmempool` floor init rejection, mid-package eviction, mid-package
+replacement, and RBF carveout limit rejection under the current
+legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -71,6 +71,7 @@ this worktree.
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -68,6 +68,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -63,6 +63,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -62,6 +62,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -73,6 +73,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -59,6 +59,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -1,0 +1,78 @@
+# PQBTC `mempool_limit.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-LIMIT-POSTURE-v1
+## Updated: 2026-05-05
+## Frozen-By: track-a-phase1-20260505
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool size, eviction, and
+package-limit policy under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing [mempool_limit.py](../test/functional/mempool_limit.py)
+suite owns the single-node mempool limit boundary:
+
+- `-maxmempool=5` full-mempool behavior bumps `mempoolminfee` above the relay
+  fee after filling the mempool
+- transactions below the rolling mempool minimum are rejected with stable
+  `mempool min fee not met` policy errors
+- CPFP package submission can admit a parent below the mempool minimum when the
+  child raises the package effective feerate
+- accepted package transactions are rebroadcast while still respecting the
+  peer fee filter
+- packages that clear the rolling minimum but rank below existing descendant
+  packages are rejected as `mempool full`
+- `-maxmempool` values below the 5 MB floor fail init with the expected error
+- mid-package eviction keeps all accepted package parents and the child in
+  mempool while evicting lower-ranked existing transactions
+- mid-package replacement does not leave stale descendants behind after a
+  replacement transaction spends the original input
+- individually evaluated package replacements do not expand descendant limits
+  for other package members, preserving the RBF carveout rejection
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool policy suite is owned by this tranche
+- broad package relay, package RBF, persistence, reorg behavior,
+  mining-template behavior, or prior-release compatibility behavior is covered
+  here
+- PQ-native witness-size stress replaces this inherited mempool limit surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-05:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_limit.py`
+  - result: passed
+  - current posture:
+    - full-mempool minimum-fee and eviction behavior remains stable
+    - CPFP package admission, immediate package eviction, and peer broadcast
+      filtering keep their expected outcomes
+    - mid-package eviction, mid-package replacement, and RBF carveout rejection
+      remain green under the current legacy-compatible PQC profile
+
+## Interpretation
+
+- `mempool_limit.py` is now a required inherited mempool size, eviction, and
+  package-limit policy gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-05-04
+## Updated: 2026-05-05
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -49,7 +49,8 @@ inherited datacarrier policy behavior in the same gate, keep
 `mempool_dust.py` inherited dust relay policy behavior in the same gate,
 keep `mempool_ephemeral_dust.py` inherited ephemeral-dust package policy
 behavior in the same gate, keep `mempool_expiry.py` inherited mempool expiry
-policy behavior in the same gate,
+policy behavior in the same gate, keep `mempool_limit.py` inherited mempool
+size, eviction, and package-limit policy behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -147,8 +148,9 @@ Alternate rebalance:
      tranches, or the current block storage, prune-lifecycle, broad pruning,
      bootstrap/import, txoutset-hash, txoutset/index, restart/reindex,
      init-recovery, read-only blockstore, versionbits-warning, and
-     sequence-lock, CLTV, CSV-activation, raw mempool-acceptance, and
-     wtxid-aware mempool-acceptance tranches.
+     sequence-lock, CLTV, CSV-activation, raw mempool-acceptance,
+     wtxid-aware mempool-acceptance, datacarrier, dust, ephemeral-dust,
+     expiry, and mempool-limit tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1105,9 +1107,30 @@ Still deferred:
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-53. Recommended next PR after this tranche:
+53. `mempool_limit.py` now owns:
+   - inherited mempool size, eviction, and package-limit policy under the
+     current legacy-compatible PQC profile
+   - full-mempool `mempoolminfee` behavior and minimum-fee rejection
+   - CPFP package admission with a parent below the mempool minimum
+   - package broadcast behavior that still respects peer fee filters
+   - immediate rejection for a low-ranked package after full-mempool eviction
+   - `-maxmempool` floor init rejection
+   - mid-package eviction without evicting the newly accepted package
+   - mid-package replacement without stale descendants
+   - RBF carveout limit rejection for package members
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_limit.py`
+   Fixed posture note:
+   - `MEMPOOL_LIMIT_POSTURE.md`
+   Still deferred inside this suite:
+   - remaining package-limit, package relay, package RBF, persistence, reorg,
+     TRUC, and mining policy suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+54. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_limit.py` as the next local mempool policy candidate
+   - alternate: `mempool_package_limits.py` as the next local mempool policy candidate
      after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1119,7 +1142,7 @@ Still deferred:
      required gate, so any local alternate should be a fresh bounded migration
      decision outside those surfaces
    - the first two inherited mempool acceptance gates plus datacarrier, dust,
-     ephemeral-dust, and expiry policy are now frozen, so the adjacent local
+     ephemeral-dust, expiry, and limit policy are now frozen, so the adjacent local
      mempool follow-on should be another bounded policy gate only after a
      fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
@@ -1993,6 +2016,16 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mempool candidate is
   `mempool_limit.py` after a fresh targeted pass.
+- 2026-05-05: `mempool_limit.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers full-mempool minimum-fee rejection, CPFP
+  package admission below the mempool minimum, peer broadcast fee-filter
+  behavior, immediate low-feerate package eviction, `-maxmempool` floor init
+  rejection, mid-package eviction, mid-package replacement, and RBF carveout
+  limit rejection under the current legacy-compatible PQC profile. The next
+  owned follow-on remains `feature_coinstatsindex_compatibility.py` when real
+  prior PQBTC release assets exist; otherwise the adjacent local mempool
+  candidate is `mempool_package_limits.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote mempool_limit.py from pq_backlog to pq_required
- add the suite to the PQ functional gate list and update CI counts to pq_required=103 / pq_backlog=22
- add MEMPOOL_LIMIT_POSTURE.md and update Track A handoff to point the next local alternate at mempool_package_limits.py

## Validation
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 mempool_limit.py
- git diff --cached --check