### PR TITLE
Promote mempool package limits gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -623,10 +623,10 @@
   },
   {
     "name": "mempool_package_limits.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited package ancestor/descendant limit gate: the suite exercises combined in-mempool and in-package chain limits, ancestor and descendant count limits, bushy package ancestor accounting, ancestor-size limits, descendant-size limits, stable package-mempool-limits rejection, and acceptance after clearing the conflicting mempool state under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_package_onemore.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -33,6 +33,7 @@ mempool_dust.py
 mempool_ephemeral_dust.py
 mempool_expiry.py
 mempool_limit.py
+mempool_package_limits.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `103` |
-| `pq_backlog` | `22` |
+| `pq_required` | `104` |
+| `pq_backlog` | `21` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -61,91 +61,92 @@ Current required PQ-first gates:
 16. `mempool_ephemeral_dust.py`
 17. `mempool_expiry.py`
 18. `mempool_limit.py`
-19. `wallet_pq_active_ranged.py`
-20. `wallet_pq_backup_recovery.py`
-21. `wallet_pq_create_tx.py`
-22. `wallet_pq_descriptors.py`
-23. `wallet_pq_psbt.py`
-24. `wallet_pq_send.py`
-25. `wallet_pq_sendall.py`
-26. `wallet_pq_sendmany.py`
-27. `wallet_pq_signrawtransaction.py`
-28. `feature_assumeutxo.py`
-29. `feature_assumevalid.py`
-30. `feature_bip68_sequence.py`
-31. `feature_block.py`
-32. `feature_blocksdir.py`
-33. `feature_blocksxor.py`
-34. `feature_cltv.py`
-35. `feature_coinstatsindex.py`
-36. `feature_csv_activation.py`
-37. `feature_fastprune.py`
-38. `feature_index_prune.py`
-39. `feature_loadblock.py`
-40. `feature_pruning.py`
-41. `feature_reindex.py`
-42. `feature_reindex_init.py`
-43. `feature_reindex_readonly.py`
-44. `feature_remove_pruned_files_on_startup.py`
-45. `feature_utxo_set_hash.py`
-46. `feature_versionbits_warning.py`
-47. `rpc_psbt.py`
-48. `wallet_abandonconflict.py`
-49. `wallet_address_types.py`
-50. `wallet_assumeutxo.py`
-51. `wallet_avoid_mixing_output_types.py`
-52. `wallet_avoidreuse.py`
-53. `wallet_backup.py`
-54. `wallet_balance.py`
-55. `wallet_basic.py`
-56. `wallet_blank.py`
-57. `wallet_bumpfee.py`
-58. `wallet_change_address.py`
-59. `wallet_coinbase_category.py`
-60. `wallet_conflicts.py`
-61. `wallet_create_tx.py`
-62. `wallet_createwallet.py`
-63. `wallet_createwalletdescriptor.py`
-64. `wallet_crosschain.py`
-65. `wallet_descriptor.py`
-66. `wallet_disable.py`
-67. `wallet_encryption.py`
-68. `wallet_fallbackfee.py`
-69. `wallet_fast_rescan.py`
-70. `wallet_fundrawtransaction.py`
-71. `wallet_gethdkeys.py`
-72. `wallet_groups.py`
-73. `wallet_hd.py`
-74. `wallet_importdescriptors.py`
-75. `wallet_importprunedfunds.py`
-76. `wallet_keypool.py`
-77. `wallet_keypool_topup.py`
-78. `wallet_labels.py`
-79. `wallet_listdescriptors.py`
-80. `wallet_listreceivedby.py`
-81. `wallet_listsinceblock.py`
-82. `wallet_listtransactions.py`
-83. `wallet_miniscript.py`
-84. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-85. `wallet_multisig_descriptor_psbt.py`
-86. `wallet_multiwallet.py`
-87. `wallet_orphanedreward.py`
-88. `wallet_reindex.py`
-89. `wallet_reorgsrestore.py`
-90. `wallet_rescan_unconfirmed.py`
-91. `wallet_resendwallettransactions.py`
-92. `wallet_send.py`
-93. `wallet_sendall.py`
-94. `wallet_sendmany.py`
-95. `wallet_signrawtransactionwithwallet.py`
-96. `wallet_simulaterawtx.py`
-97. `wallet_spend_unconfirmed.py`
-98. `wallet_startup.py`
-99. `wallet_timelock.py`
-100. `wallet_transactiontime_rescan.py`
-101. `wallet_txn_clone.py`
-102. `wallet_txn_doublespend.py`
-103. `wallet_v3_txs.py`
+19. `mempool_package_limits.py`
+20. `wallet_pq_active_ranged.py`
+21. `wallet_pq_backup_recovery.py`
+22. `wallet_pq_create_tx.py`
+23. `wallet_pq_descriptors.py`
+24. `wallet_pq_psbt.py`
+25. `wallet_pq_send.py`
+26. `wallet_pq_sendall.py`
+27. `wallet_pq_sendmany.py`
+28. `wallet_pq_signrawtransaction.py`
+29. `feature_assumeutxo.py`
+30. `feature_assumevalid.py`
+31. `feature_bip68_sequence.py`
+32. `feature_block.py`
+33. `feature_blocksdir.py`
+34. `feature_blocksxor.py`
+35. `feature_cltv.py`
+36. `feature_coinstatsindex.py`
+37. `feature_csv_activation.py`
+38. `feature_fastprune.py`
+39. `feature_index_prune.py`
+40. `feature_loadblock.py`
+41. `feature_pruning.py`
+42. `feature_reindex.py`
+43. `feature_reindex_init.py`
+44. `feature_reindex_readonly.py`
+45. `feature_remove_pruned_files_on_startup.py`
+46. `feature_utxo_set_hash.py`
+47. `feature_versionbits_warning.py`
+48. `rpc_psbt.py`
+49. `wallet_abandonconflict.py`
+50. `wallet_address_types.py`
+51. `wallet_assumeutxo.py`
+52. `wallet_avoid_mixing_output_types.py`
+53. `wallet_avoidreuse.py`
+54. `wallet_backup.py`
+55. `wallet_balance.py`
+56. `wallet_basic.py`
+57. `wallet_blank.py`
+58. `wallet_bumpfee.py`
+59. `wallet_change_address.py`
+60. `wallet_coinbase_category.py`
+61. `wallet_conflicts.py`
+62. `wallet_create_tx.py`
+63. `wallet_createwallet.py`
+64. `wallet_createwalletdescriptor.py`
+65. `wallet_crosschain.py`
+66. `wallet_descriptor.py`
+67. `wallet_disable.py`
+68. `wallet_encryption.py`
+69. `wallet_fallbackfee.py`
+70. `wallet_fast_rescan.py`
+71. `wallet_fundrawtransaction.py`
+72. `wallet_gethdkeys.py`
+73. `wallet_groups.py`
+74. `wallet_hd.py`
+75. `wallet_importdescriptors.py`
+76. `wallet_importprunedfunds.py`
+77. `wallet_keypool.py`
+78. `wallet_keypool_topup.py`
+79. `wallet_labels.py`
+80. `wallet_listdescriptors.py`
+81. `wallet_listreceivedby.py`
+82. `wallet_listsinceblock.py`
+83. `wallet_listtransactions.py`
+84. `wallet_miniscript.py`
+85. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+86. `wallet_multisig_descriptor_psbt.py`
+87. `wallet_multiwallet.py`
+88. `wallet_orphanedreward.py`
+89. `wallet_reindex.py`
+90. `wallet_reorgsrestore.py`
+91. `wallet_rescan_unconfirmed.py`
+92. `wallet_resendwallettransactions.py`
+93. `wallet_send.py`
+94. `wallet_sendall.py`
+95. `wallet_sendmany.py`
+96. `wallet_signrawtransactionwithwallet.py`
+97. `wallet_simulaterawtx.py`
+98. `wallet_spend_unconfirmed.py`
+99. `wallet_startup.py`
+100. `wallet_timelock.py`
+101. `wallet_transactiontime_rescan.py`
+102. `wallet_txn_clone.py`
+103. `wallet_txn_doublespend.py`
+104. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -400,6 +401,12 @@ broadcast fee-filter behavior, immediate low-feerate package eviction,
 `-maxmempool` floor init rejection, mid-package eviction, mid-package
 replacement, and RBF carveout limit rejection under the current
 legacy-compatible PQC profile.
+The inherited package ancestor/descendant limit confidence gap is now also
+part of the required gate: `mempool_package_limits.py` covers combined
+in-mempool and in-package chain limits, ancestor and descendant count limits,
+bushy package ancestor accounting, ancestor-size and descendant-size limits,
+stable `package-mempool-limits` rejection, and acceptance after clearing the
+conflicting mempool state under the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -72,6 +72,7 @@ this worktree.
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -69,6 +69,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -64,6 +64,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -63,6 +63,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -74,6 +74,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -60,6 +60,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -70,6 +70,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -1,0 +1,79 @@
+# PQBTC `mempool_package_limits.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-PACKAGE-LIMITS-POSTURE-v1
+## Updated: 2026-05-05
+## Frozen-By: track-a-phase1-20260505
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited package ancestor and descendant
+limit policy under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_package_limits.py](../test/functional/mempool_package_limits.py)
+suite owns the single-node package-limit boundary:
+
+- packages that only exceed chain limits when in-mempool and in-package
+  transactions are counted together fail with stable `package-mempool-limits`
+  errors
+- chain-limit accounting covers `24+2`, `2+24`, and `13+13`
+  mempool/package transaction splits
+- descendant-count accounting covers A-shaped and two-leg package topologies
+  where a shared mempool ancestor would exceed descendant limits
+- ancestor-count accounting covers V-shaped, Y-shaped, and bushy package
+  topologies where the lowest in-package descendant exceeds ancestor limits
+- ancestor-size accounting covers two large independent mempool parents plus
+  an in-package parent/child pair
+- descendant-size accounting covers a top mempool ancestor with two large
+  descendant legs that continue into the package
+- the same package transactions are accepted after mining a block clears the
+  pre-submitted mempool transactions
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool package suite is owned by this tranche
+- one-more-package admission, package RBF, package relay, persistence, broad
+  reorg behavior, TRUC policy, mining-template behavior, or prior-release
+  compatibility behavior is covered here
+- PQ-native witness-size stress replaces this inherited package-limit surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-05:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_package_limits.py`
+  - result: passed
+  - current posture:
+    - combined in-mempool and in-package ancestor/descendant counting remains
+      stable
+    - package count and size limits reject with the expected
+      `package-mempool-limits` boundary
+    - the packages become acceptable once the conflicting mempool state is
+      cleared by mining
+
+## Interpretation
+
+- `mempool_package_limits.py` is now a required inherited package
+  ancestor/descendant limit policy gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -50,7 +50,9 @@ inherited datacarrier policy behavior in the same gate, keep
 keep `mempool_ephemeral_dust.py` inherited ephemeral-dust package policy
 behavior in the same gate, keep `mempool_expiry.py` inherited mempool expiry
 policy behavior in the same gate, keep `mempool_limit.py` inherited mempool
-size, eviction, and package-limit policy behavior in the same gate,
+size, eviction, and package-limit policy behavior in the same gate, keep
+`mempool_package_limits.py` inherited package ancestor/descendant limit
+policy behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -150,7 +152,7 @@ Alternate rebalance:
      init-recovery, read-only blockstore, versionbits-warning, and
      sequence-lock, CLTV, CSV-activation, raw mempool-acceptance,
      wtxid-aware mempool-acceptance, datacarrier, dust, ephemeral-dust,
-     expiry, and mempool-limit tranches.
+     expiry, mempool-limit, and package-limit tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1128,10 +1130,34 @@ Still deferred:
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-54. Recommended next PR after this tranche:
+54. `mempool_package_limits.py` now owns:
+   - inherited package ancestor/descendant limit policy under the current
+     legacy-compatible PQC profile
+   - combined in-mempool and in-package chain-limit accounting
+   - descendant-count accounting across shared-ancestor package topologies
+   - ancestor-count accounting across V-shaped, Y-shaped, and bushy package
+     topologies
+   - ancestor-size accounting for large independent mempool parents plus
+     in-package descendants
+   - descendant-size accounting for large mempool descendants that continue
+     into the package
+   - stable `package-mempool-limits` rejection before clearing mempool state
+   - package acceptance after mining clears the pre-submitted mempool
+     transactions
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_package_limits.py`
+   Fixed posture note:
+   - `MEMPOOL_PACKAGE_LIMITS_POSTURE.md`
+   Still deferred inside this suite:
+   - one-more-package admission, package RBF, package relay, persistence,
+     reorg, TRUC, and mining policy suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+55. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_package_limits.py` as the next local mempool policy candidate
-     after a fresh targeted pass, while
+   - alternate: `mempool_package_onemore.py` as the next local mempool policy
+     candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
@@ -1142,9 +1168,9 @@ Still deferred:
      required gate, so any local alternate should be a fresh bounded migration
      decision outside those surfaces
    - the first two inherited mempool acceptance gates plus datacarrier, dust,
-     ephemeral-dust, expiry, and limit policy are now frozen, so the adjacent local
-     mempool follow-on should be another bounded policy gate only after a
-     fresh targeted pass
+     ephemeral-dust, expiry, limit, and package-limit policy are now frozen,
+     so the adjacent local mempool follow-on should be another bounded policy
+     gate only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2026,6 +2052,17 @@ Aineko must ask before:
   owned follow-on remains `feature_coinstatsindex_compatibility.py` when real
   prior PQBTC release assets exist; otherwise the adjacent local mempool
   candidate is `mempool_package_limits.py` after a fresh targeted pass.
+- 2026-05-05: `mempool_package_limits.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers combined in-mempool and in-package chain
+  limits, ancestor and descendant count limits, bushy package ancestor
+  accounting, ancestor-size limits, descendant-size limits, stable
+  `package-mempool-limits` rejection, and acceptance after clearing the
+  conflicting mempool state under the current legacy-compatible PQC profile.
+  The next owned follow-on remains `feature_coinstatsindex_compatibility.py`
+  when real prior PQBTC release assets exist; otherwise the adjacent local
+  mempool candidate is `mempool_package_onemore.py` after a fresh targeted
+  pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote mempool_package_limits.py from pq_backlog to pq_required
- add the suite to the PQ functional gate list and update CI counts to pq_required=104 / pq_backlog=21
- add MEMPOOL_PACKAGE_LIMITS_POSTURE.md and update Track A handoff to point the next local alternate at mempool_package_onemore.py

## Validation
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 mempool_package_limits.py
- git diff --cached --check