### PR TITLE
Promote mempool package onemore gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -630,10 +630,10 @@
   },
   {
     "name": "mempool_package_onemore.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited one-more-descendant package carveout gate: the suite exercises full ancestor-chain construction, ancestor and descendant limit rejection, oversized descendant rejection, package rejection diagnostics, direct-child carveout acceptance, independent chain admission, and single-conflict RBF replacement of the carveout chain under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_package_rbf.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -34,6 +34,7 @@ mempool_ephemeral_dust.py
 mempool_expiry.py
 mempool_limit.py
 mempool_package_limits.py
+mempool_package_onemore.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `104` |
-| `pq_backlog` | `21` |
+| `pq_required` | `105` |
+| `pq_backlog` | `20` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -62,91 +62,92 @@ Current required PQ-first gates:
 17. `mempool_expiry.py`
 18. `mempool_limit.py`
 19. `mempool_package_limits.py`
-20. `wallet_pq_active_ranged.py`
-21. `wallet_pq_backup_recovery.py`
-22. `wallet_pq_create_tx.py`
-23. `wallet_pq_descriptors.py`
-24. `wallet_pq_psbt.py`
-25. `wallet_pq_send.py`
-26. `wallet_pq_sendall.py`
-27. `wallet_pq_sendmany.py`
-28. `wallet_pq_signrawtransaction.py`
-29. `feature_assumeutxo.py`
-30. `feature_assumevalid.py`
-31. `feature_bip68_sequence.py`
-32. `feature_block.py`
-33. `feature_blocksdir.py`
-34. `feature_blocksxor.py`
-35. `feature_cltv.py`
-36. `feature_coinstatsindex.py`
-37. `feature_csv_activation.py`
-38. `feature_fastprune.py`
-39. `feature_index_prune.py`
-40. `feature_loadblock.py`
-41. `feature_pruning.py`
-42. `feature_reindex.py`
-43. `feature_reindex_init.py`
-44. `feature_reindex_readonly.py`
-45. `feature_remove_pruned_files_on_startup.py`
-46. `feature_utxo_set_hash.py`
-47. `feature_versionbits_warning.py`
-48. `rpc_psbt.py`
-49. `wallet_abandonconflict.py`
-50. `wallet_address_types.py`
-51. `wallet_assumeutxo.py`
-52. `wallet_avoid_mixing_output_types.py`
-53. `wallet_avoidreuse.py`
-54. `wallet_backup.py`
-55. `wallet_balance.py`
-56. `wallet_basic.py`
-57. `wallet_blank.py`
-58. `wallet_bumpfee.py`
-59. `wallet_change_address.py`
-60. `wallet_coinbase_category.py`
-61. `wallet_conflicts.py`
-62. `wallet_create_tx.py`
-63. `wallet_createwallet.py`
-64. `wallet_createwalletdescriptor.py`
-65. `wallet_crosschain.py`
-66. `wallet_descriptor.py`
-67. `wallet_disable.py`
-68. `wallet_encryption.py`
-69. `wallet_fallbackfee.py`
-70. `wallet_fast_rescan.py`
-71. `wallet_fundrawtransaction.py`
-72. `wallet_gethdkeys.py`
-73. `wallet_groups.py`
-74. `wallet_hd.py`
-75. `wallet_importdescriptors.py`
-76. `wallet_importprunedfunds.py`
-77. `wallet_keypool.py`
-78. `wallet_keypool_topup.py`
-79. `wallet_labels.py`
-80. `wallet_listdescriptors.py`
-81. `wallet_listreceivedby.py`
-82. `wallet_listsinceblock.py`
-83. `wallet_listtransactions.py`
-84. `wallet_miniscript.py`
-85. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-86. `wallet_multisig_descriptor_psbt.py`
-87. `wallet_multiwallet.py`
-88. `wallet_orphanedreward.py`
-89. `wallet_reindex.py`
-90. `wallet_reorgsrestore.py`
-91. `wallet_rescan_unconfirmed.py`
-92. `wallet_resendwallettransactions.py`
-93. `wallet_send.py`
-94. `wallet_sendall.py`
-95. `wallet_sendmany.py`
-96. `wallet_signrawtransactionwithwallet.py`
-97. `wallet_simulaterawtx.py`
-98. `wallet_spend_unconfirmed.py`
-99. `wallet_startup.py`
-100. `wallet_timelock.py`
-101. `wallet_transactiontime_rescan.py`
-102. `wallet_txn_clone.py`
-103. `wallet_txn_doublespend.py`
-104. `wallet_v3_txs.py`
+20. `mempool_package_onemore.py`
+21. `wallet_pq_active_ranged.py`
+22. `wallet_pq_backup_recovery.py`
+23. `wallet_pq_create_tx.py`
+24. `wallet_pq_descriptors.py`
+25. `wallet_pq_psbt.py`
+26. `wallet_pq_send.py`
+27. `wallet_pq_sendall.py`
+28. `wallet_pq_sendmany.py`
+29. `wallet_pq_signrawtransaction.py`
+30. `feature_assumeutxo.py`
+31. `feature_assumevalid.py`
+32. `feature_bip68_sequence.py`
+33. `feature_block.py`
+34. `feature_blocksdir.py`
+35. `feature_blocksxor.py`
+36. `feature_cltv.py`
+37. `feature_coinstatsindex.py`
+38. `feature_csv_activation.py`
+39. `feature_fastprune.py`
+40. `feature_index_prune.py`
+41. `feature_loadblock.py`
+42. `feature_pruning.py`
+43. `feature_reindex.py`
+44. `feature_reindex_init.py`
+45. `feature_reindex_readonly.py`
+46. `feature_remove_pruned_files_on_startup.py`
+47. `feature_utxo_set_hash.py`
+48. `feature_versionbits_warning.py`
+49. `rpc_psbt.py`
+50. `wallet_abandonconflict.py`
+51. `wallet_address_types.py`
+52. `wallet_assumeutxo.py`
+53. `wallet_avoid_mixing_output_types.py`
+54. `wallet_avoidreuse.py`
+55. `wallet_backup.py`
+56. `wallet_balance.py`
+57. `wallet_basic.py`
+58. `wallet_blank.py`
+59. `wallet_bumpfee.py`
+60. `wallet_change_address.py`
+61. `wallet_coinbase_category.py`
+62. `wallet_conflicts.py`
+63. `wallet_create_tx.py`
+64. `wallet_createwallet.py`
+65. `wallet_createwalletdescriptor.py`
+66. `wallet_crosschain.py`
+67. `wallet_descriptor.py`
+68. `wallet_disable.py`
+69. `wallet_encryption.py`
+70. `wallet_fallbackfee.py`
+71. `wallet_fast_rescan.py`
+72. `wallet_fundrawtransaction.py`
+73. `wallet_gethdkeys.py`
+74. `wallet_groups.py`
+75. `wallet_hd.py`
+76. `wallet_importdescriptors.py`
+77. `wallet_importprunedfunds.py`
+78. `wallet_keypool.py`
+79. `wallet_keypool_topup.py`
+80. `wallet_labels.py`
+81. `wallet_listdescriptors.py`
+82. `wallet_listreceivedby.py`
+83. `wallet_listsinceblock.py`
+84. `wallet_listtransactions.py`
+85. `wallet_miniscript.py`
+86. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+87. `wallet_multisig_descriptor_psbt.py`
+88. `wallet_multiwallet.py`
+89. `wallet_orphanedreward.py`
+90. `wallet_reindex.py`
+91. `wallet_reorgsrestore.py`
+92. `wallet_rescan_unconfirmed.py`
+93. `wallet_resendwallettransactions.py`
+94. `wallet_send.py`
+95. `wallet_sendall.py`
+96. `wallet_sendmany.py`
+97. `wallet_signrawtransactionwithwallet.py`
+98. `wallet_simulaterawtx.py`
+99. `wallet_spend_unconfirmed.py`
+100. `wallet_startup.py`
+101. `wallet_timelock.py`
+102. `wallet_transactiontime_rescan.py`
+103. `wallet_txn_clone.py`
+104. `wallet_txn_doublespend.py`
+105. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -407,6 +408,12 @@ in-mempool and in-package chain limits, ancestor and descendant count limits,
 bushy package ancestor accounting, ancestor-size and descendant-size limits,
 stable `package-mempool-limits` rejection, and acceptance after clearing the
 conflicting mempool state under the current legacy-compatible PQC profile.
+The inherited one-more-descendant carveout confidence gap is now also part of
+the required gate: `mempool_package_onemore.py` covers full ancestor-chain
+construction, ancestor and descendant limit rejection, oversized descendant
+rejection, package rejection diagnostics, direct-child carveout acceptance,
+independent chain admission, and single-conflict RBF replacement of the
+carveout chain under the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -73,6 +73,7 @@ this worktree.
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -70,6 +70,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -65,6 +65,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -64,6 +64,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -75,6 +75,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -61,6 +61,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -71,6 +71,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -38,9 +38,9 @@ suite owns the single-node package-limit boundary:
 This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
-- one-more-package admission, package RBF, package relay, persistence, broad
-  reorg behavior, TRUC policy, mining-template behavior, or prior-release
-  compatibility behavior is covered here
+- one-more-descendant carveout, package RBF, package relay, persistence,
+  broad reorg behavior, TRUC policy, mining-template behavior, or
+  prior-release compatibility behavior is covered here
 - PQ-native witness-size stress replaces this inherited package-limit surface
 
 Those remain separate required gates or backlog decisions.
@@ -71,6 +71,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -1,0 +1,82 @@
+# PQBTC `mempool_package_onemore.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-PACKAGE-ONEMORE-POSTURE-v1
+## Updated: 2026-05-05
+## Frozen-By: track-a-phase1-20260505
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited one-more-descendant package
+carveout behavior under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_package_onemore.py](../test/functional/mempool_package_onemore.py)
+suite owns the single-node one-more-descendant carveout boundary:
+
+- a chain of `DEFAULT_ANCESTOR_LIMIT` transactions can be built from a
+  confirmed wallet UTXO while a second independent unconfirmed chain remains
+  available
+- adding one more transaction to the chain tip is rejected with the expected
+  `too-long-mempool-chain` ancestor-limit error
+- adding a descendant from the middle of the chain is rejected with stable
+  descendant-limit errors
+- adding a descendant that spends both the chain and an independent mempool
+  parent is still rejected by descendant limits
+- oversized descendants that would exceed the carveout size remain rejected
+- two-transaction package submission reports the first transaction's
+  `too-long-mempool-chain` error and the child's missing-input result
+- the direct child of the first chain transaction is accepted through the
+  one-more-descendant carveout
+- the independent second chain remains admissible after the carveout path
+- a single direct-conflict replacement can RBF the chain that used the carveout
+  rule
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool package suite is owned by this tranche
+- broad package RBF, package relay, persistence, broad reorg behavior, TRUC
+  policy, mining-template behavior, or prior-release compatibility behavior is
+  covered here
+- PQ-native witness-size stress replaces this inherited one-more-descendant
+  carveout surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-05:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_package_onemore.py`
+  - result: passed
+  - current posture:
+    - one-more-descendant carveout admission remains stable
+    - ancestor, descendant, oversized-child, and package rejection diagnostics
+      keep their expected outcomes
+    - direct-conflict RBF replacement of the carveout chain remains green under
+      the current legacy-compatible PQC profile
+
+## Interpretation
+
+- `mempool_package_onemore.py` is now a required inherited
+  one-more-descendant carveout policy gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -52,7 +52,8 @@ behavior in the same gate, keep `mempool_expiry.py` inherited mempool expiry
 policy behavior in the same gate, keep `mempool_limit.py` inherited mempool
 size, eviction, and package-limit policy behavior in the same gate, keep
 `mempool_package_limits.py` inherited package ancestor/descendant limit
-policy behavior in the same gate,
+policy behavior in the same gate, keep `mempool_package_onemore.py`
+inherited one-more-descendant package carveout behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -152,7 +153,8 @@ Alternate rebalance:
      init-recovery, read-only blockstore, versionbits-warning, and
      sequence-lock, CLTV, CSV-activation, raw mempool-acceptance,
      wtxid-aware mempool-acceptance, datacarrier, dust, ephemeral-dust,
-     expiry, mempool-limit, and package-limit tranches.
+     expiry, mempool-limit, package-limit, and one-more-descendant carveout
+     tranches.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1125,8 +1127,8 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_LIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining package-limit, package relay, package RBF, persistence, reorg,
-     TRUC, and mining policy suites
+   - remaining package relay, package RBF, persistence, reorg, TRUC, and
+     mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1149,14 +1151,38 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_LIMITS_POSTURE.md`
    Still deferred inside this suite:
-   - one-more-package admission, package RBF, package relay, persistence,
-     reorg, TRUC, and mining policy suites
+   - package RBF, package relay, persistence, reorg, TRUC, and mining policy
+     suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-55. Recommended next PR after this tranche:
+55. `mempool_package_onemore.py` now owns:
+   - inherited one-more-descendant package carveout policy under the current
+     legacy-compatible PQC profile
+   - full `DEFAULT_ANCESTOR_LIMIT` chain construction from a confirmed UTXO
+   - ancestor-limit rejection for adding one more transaction to the chain tip
+   - descendant-limit rejection for middle-of-chain descendants and
+     two-parent descendants
+   - oversized descendant rejection outside the carveout size boundary
+   - package rejection diagnostics for a rejected parent plus missing-input
+     child
+   - direct-child carveout acceptance from the first transaction in the chain
+   - independent second-chain admission after the carveout path
+   - single direct-conflict RBF replacement of the chain using the carveout
+     rule
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_package_onemore.py`
+   Fixed posture note:
+   - `MEMPOOL_PACKAGE_ONEMORE_POSTURE.md`
+   Still deferred inside this suite:
+   - broad package RBF, package relay, persistence, reorg, TRUC, and mining
+     policy suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+56. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_package_onemore.py` as the next local mempool policy
+   - alternate: `mempool_package_rbf.py` as the next local mempool policy
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1168,9 +1194,9 @@ Still deferred:
      required gate, so any local alternate should be a fresh bounded migration
      decision outside those surfaces
    - the first two inherited mempool acceptance gates plus datacarrier, dust,
-     ephemeral-dust, expiry, limit, and package-limit policy are now frozen,
-     so the adjacent local mempool follow-on should be another bounded policy
-     gate only after a fresh targeted pass
+     ephemeral-dust, expiry, limit, package-limit, and one-more-descendant
+     carveout policy are now frozen, so the adjacent local mempool follow-on
+     should be another bounded policy gate only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2063,6 +2089,16 @@ Aineko must ask before:
   when real prior PQBTC release assets exist; otherwise the adjacent local
   mempool candidate is `mempool_package_onemore.py` after a fresh targeted
   pass.
+- 2026-05-05: `mempool_package_onemore.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers full ancestor-chain construction,
+  ancestor and descendant limit rejection, oversized descendant rejection,
+  package rejection diagnostics, direct-child carveout acceptance, independent
+  chain admission, and single-conflict RBF replacement of the carveout chain
+  under the current legacy-compatible PQC profile. The next owned follow-on
+  remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
+  release assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_package_rbf.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote mempool_package_onemore.py from pq_backlog to pq_required
- add the suite to the PQ functional gate list and update CI counts to pq_required=105 / pq_backlog=20
- add MEMPOOL_PACKAGE_ONEMORE_POSTURE.md and update Track A handoff to point the next local alternate at mempool_package_rbf.py

## Validation
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 mempool_package_onemore.py
- git diff --cached --check