### PR TITLE
Promote mempool package RBF gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -637,10 +637,10 @@
   },
   {
     "name": "mempool_package_rbf.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited package RBF policy gate: the suite exercises 1-parent-1-child package replacement, singleton conflict replacement, additional-fee and incremental-relay-fee requirements, max-replacement-candidate caps, package and conflict-cluster shape rejection, feerate diagram rejection, TRUC zero-fee-parent package RBF, and mempool-ancestor conflict rejection under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_packages.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -35,6 +35,7 @@ mempool_expiry.py
 mempool_limit.py
 mempool_package_limits.py
 mempool_package_onemore.py
+mempool_package_rbf.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `105` |
-| `pq_backlog` | `20` |
+| `pq_required` | `106` |
+| `pq_backlog` | `19` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -63,91 +63,92 @@ Current required PQ-first gates:
 18. `mempool_limit.py`
 19. `mempool_package_limits.py`
 20. `mempool_package_onemore.py`
-21. `wallet_pq_active_ranged.py`
-22. `wallet_pq_backup_recovery.py`
-23. `wallet_pq_create_tx.py`
-24. `wallet_pq_descriptors.py`
-25. `wallet_pq_psbt.py`
-26. `wallet_pq_send.py`
-27. `wallet_pq_sendall.py`
-28. `wallet_pq_sendmany.py`
-29. `wallet_pq_signrawtransaction.py`
-30. `feature_assumeutxo.py`
-31. `feature_assumevalid.py`
-32. `feature_bip68_sequence.py`
-33. `feature_block.py`
-34. `feature_blocksdir.py`
-35. `feature_blocksxor.py`
-36. `feature_cltv.py`
-37. `feature_coinstatsindex.py`
-38. `feature_csv_activation.py`
-39. `feature_fastprune.py`
-40. `feature_index_prune.py`
-41. `feature_loadblock.py`
-42. `feature_pruning.py`
-43. `feature_reindex.py`
-44. `feature_reindex_init.py`
-45. `feature_reindex_readonly.py`
-46. `feature_remove_pruned_files_on_startup.py`
-47. `feature_utxo_set_hash.py`
-48. `feature_versionbits_warning.py`
-49. `rpc_psbt.py`
-50. `wallet_abandonconflict.py`
-51. `wallet_address_types.py`
-52. `wallet_assumeutxo.py`
-53. `wallet_avoid_mixing_output_types.py`
-54. `wallet_avoidreuse.py`
-55. `wallet_backup.py`
-56. `wallet_balance.py`
-57. `wallet_basic.py`
-58. `wallet_blank.py`
-59. `wallet_bumpfee.py`
-60. `wallet_change_address.py`
-61. `wallet_coinbase_category.py`
-62. `wallet_conflicts.py`
-63. `wallet_create_tx.py`
-64. `wallet_createwallet.py`
-65. `wallet_createwalletdescriptor.py`
-66. `wallet_crosschain.py`
-67. `wallet_descriptor.py`
-68. `wallet_disable.py`
-69. `wallet_encryption.py`
-70. `wallet_fallbackfee.py`
-71. `wallet_fast_rescan.py`
-72. `wallet_fundrawtransaction.py`
-73. `wallet_gethdkeys.py`
-74. `wallet_groups.py`
-75. `wallet_hd.py`
-76. `wallet_importdescriptors.py`
-77. `wallet_importprunedfunds.py`
-78. `wallet_keypool.py`
-79. `wallet_keypool_topup.py`
-80. `wallet_labels.py`
-81. `wallet_listdescriptors.py`
-82. `wallet_listreceivedby.py`
-83. `wallet_listsinceblock.py`
-84. `wallet_listtransactions.py`
-85. `wallet_miniscript.py`
-86. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-87. `wallet_multisig_descriptor_psbt.py`
-88. `wallet_multiwallet.py`
-89. `wallet_orphanedreward.py`
-90. `wallet_reindex.py`
-91. `wallet_reorgsrestore.py`
-92. `wallet_rescan_unconfirmed.py`
-93. `wallet_resendwallettransactions.py`
-94. `wallet_send.py`
-95. `wallet_sendall.py`
-96. `wallet_sendmany.py`
-97. `wallet_signrawtransactionwithwallet.py`
-98. `wallet_simulaterawtx.py`
-99. `wallet_spend_unconfirmed.py`
-100. `wallet_startup.py`
-101. `wallet_timelock.py`
-102. `wallet_transactiontime_rescan.py`
-103. `wallet_txn_clone.py`
-104. `wallet_txn_doublespend.py`
-105. `wallet_v3_txs.py`
+21. `mempool_package_rbf.py`
+22. `wallet_pq_active_ranged.py`
+23. `wallet_pq_backup_recovery.py`
+24. `wallet_pq_create_tx.py`
+25. `wallet_pq_descriptors.py`
+26. `wallet_pq_psbt.py`
+27. `wallet_pq_send.py`
+28. `wallet_pq_sendall.py`
+29. `wallet_pq_sendmany.py`
+30. `wallet_pq_signrawtransaction.py`
+31. `feature_assumeutxo.py`
+32. `feature_assumevalid.py`
+33. `feature_bip68_sequence.py`
+34. `feature_block.py`
+35. `feature_blocksdir.py`
+36. `feature_blocksxor.py`
+37. `feature_cltv.py`
+38. `feature_coinstatsindex.py`
+39. `feature_csv_activation.py`
+40. `feature_fastprune.py`
+41. `feature_index_prune.py`
+42. `feature_loadblock.py`
+43. `feature_pruning.py`
+44. `feature_reindex.py`
+45. `feature_reindex_init.py`
+46. `feature_reindex_readonly.py`
+47. `feature_remove_pruned_files_on_startup.py`
+48. `feature_utxo_set_hash.py`
+49. `feature_versionbits_warning.py`
+50. `rpc_psbt.py`
+51. `wallet_abandonconflict.py`
+52. `wallet_address_types.py`
+53. `wallet_assumeutxo.py`
+54. `wallet_avoid_mixing_output_types.py`
+55. `wallet_avoidreuse.py`
+56. `wallet_backup.py`
+57. `wallet_balance.py`
+58. `wallet_basic.py`
+59. `wallet_blank.py`
+60. `wallet_bumpfee.py`
+61. `wallet_change_address.py`
+62. `wallet_coinbase_category.py`
+63. `wallet_conflicts.py`
+64. `wallet_create_tx.py`
+65. `wallet_createwallet.py`
+66. `wallet_createwalletdescriptor.py`
+67. `wallet_crosschain.py`
+68. `wallet_descriptor.py`
+69. `wallet_disable.py`
+70. `wallet_encryption.py`
+71. `wallet_fallbackfee.py`
+72. `wallet_fast_rescan.py`
+73. `wallet_fundrawtransaction.py`
+74. `wallet_gethdkeys.py`
+75. `wallet_groups.py`
+76. `wallet_hd.py`
+77. `wallet_importdescriptors.py`
+78. `wallet_importprunedfunds.py`
+79. `wallet_keypool.py`
+80. `wallet_keypool_topup.py`
+81. `wallet_labels.py`
+82. `wallet_listdescriptors.py`
+83. `wallet_listreceivedby.py`
+84. `wallet_listsinceblock.py`
+85. `wallet_listtransactions.py`
+86. `wallet_miniscript.py`
+87. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+88. `wallet_multisig_descriptor_psbt.py`
+89. `wallet_multiwallet.py`
+90. `wallet_orphanedreward.py`
+91. `wallet_reindex.py`
+92. `wallet_reorgsrestore.py`
+93. `wallet_rescan_unconfirmed.py`
+94. `wallet_resendwallettransactions.py`
+95. `wallet_send.py`
+96. `wallet_sendall.py`
+97. `wallet_sendmany.py`
+98. `wallet_signrawtransactionwithwallet.py`
+99. `wallet_simulaterawtx.py`
+100. `wallet_spend_unconfirmed.py`
+101. `wallet_startup.py`
+102. `wallet_timelock.py`
+103. `wallet_transactiontime_rescan.py`
+104. `wallet_txn_clone.py`
+105. `wallet_txn_doublespend.py`
+106. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -414,6 +415,13 @@ construction, ancestor and descendant limit rejection, oversized descendant
 rejection, package rejection diagnostics, direct-child carveout acceptance,
 independent chain admission, and single-conflict RBF replacement of the
 carveout chain under the current legacy-compatible PQC profile.
+The inherited package RBF confidence gap is now also part of the required
+gate: `mempool_package_rbf.py` covers 1-parent-1-child package replacement,
+singleton conflict replacement, additional-fee and incremental-relay-fee
+requirements, replacement-candidate caps, package and conflict-cluster shape
+rejection, feerate diagram rejection, TRUC zero-fee-parent package RBF, and
+mempool-ancestor conflict rejection under the current legacy-compatible PQC
+profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -74,6 +74,7 @@ this worktree.
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -71,6 +71,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -66,6 +66,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -65,6 +65,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -76,6 +76,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -62,6 +62,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -72,6 +72,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -72,6 +72,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -74,6 +74,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -1,0 +1,82 @@
+# PQBTC `mempool_package_rbf.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-PACKAGE-RBF-POSTURE-v1
+## Updated: 2026-05-06
+## Frozen-By: track-a-phase1-20260506
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited package replace-by-fee policy
+under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_package_rbf.py](../test/functional/mempool_package_rbf.py) suite owns
+the two-node package RBF boundary:
+
+- a 1-parent-1-child package can replace its conflicting parent/child package
+  when the child pays enough fee
+- `testmempoolaccept` still rejects conflicts during subpackage evaluation with
+  `bip125-replacement-disallowed`
+- package RBF propagates across the second node through normal sync
+- a child can pay to replace a parent's singleton conflict
+- replacements must increase absolute fee, pay incremental relay cost, and
+  preserve the required CPFP package shape
+- replacements that would evict more than `MAX_REPLACEMENT_CANDIDATES` stay
+  rejected, while the maximum allowed candidate count succeeds
+- packages larger than 1-parent-1-child and packages with mempool ancestors are
+  rejected for package RBF
+- conflicting clusters with linear, multiple-parent, or multiple-child shapes
+  are rejected with stable diagnostics
+- replacement packages must improve the feerate diagram
+- TRUC zero-fee-parent plus high-fee-child package RBF replaces the prior
+  default-fee package
+- package members that conflict with a parent mempool ancestor are rejected
+  without evicting the ancestor
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool package suite is owned by this tranche
+- broad package relay, persistence, broad reorg behavior, mining-template
+  behavior, or prior-release compatibility behavior is covered here
+- PQ-native witness-size stress replaces this inherited package RBF surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-06:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_package_rbf.py`
+  - result: passed
+  - current posture:
+    - package RBF admission and rejection diagnostics remain stable
+    - absolute-fee, incremental-relay-fee, candidate-count, cluster-shape, and
+      feerate-diagram constraints keep their expected outcomes
+    - TRUC zero-fee-parent package RBF and mempool-ancestor conflict rejection
+      remain green under the current legacy-compatible PQC profile
+
+## Interpretation
+
+- `mempool_package_rbf.py` is now a required inherited package RBF policy gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-05-05
+## Updated: 2026-05-06
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -53,7 +53,8 @@ policy behavior in the same gate, keep `mempool_limit.py` inherited mempool
 size, eviction, and package-limit policy behavior in the same gate, keep
 `mempool_package_limits.py` inherited package ancestor/descendant limit
 policy behavior in the same gate, keep `mempool_package_onemore.py`
-inherited one-more-descendant package carveout behavior in the same gate,
+inherited one-more-descendant package carveout behavior in the same gate, keep
+`mempool_package_rbf.py` inherited package RBF behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -154,7 +155,7 @@ Alternate rebalance:
      sequence-lock, CLTV, CSV-activation, raw mempool-acceptance,
      wtxid-aware mempool-acceptance, datacarrier, dust, ephemeral-dust,
      expiry, mempool-limit, package-limit, and one-more-descendant carveout
-     tranches.
+     tranches, plus package RBF.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1127,8 +1128,8 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_LIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining package relay, package RBF, persistence, reorg, TRUC, and
-     mining policy suites
+   - remaining package relay, persistence, reorg, TRUC, and mining policy
+     suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1151,8 +1152,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_LIMITS_POSTURE.md`
    Still deferred inside this suite:
-   - package RBF, package relay, persistence, reorg, TRUC, and mining policy
-     suites
+   - package relay, persistence, reorg, TRUC, and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1175,14 +1175,36 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_ONEMORE_POSTURE.md`
    Still deferred inside this suite:
-   - broad package RBF, package relay, persistence, reorg, TRUC, and mining
-     policy suites
+   - package relay, persistence, reorg, TRUC, and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-56. Recommended next PR after this tranche:
+56. `mempool_package_rbf.py` now owns:
+   - inherited package RBF policy under the current legacy-compatible PQC
+     profile
+   - 1-parent-1-child package replacement with child-paid conflicts
+   - `testmempoolaccept` conflict rejection during subpackage evaluation
+   - p2p propagation of a basic package RBF replacement to the second node
+   - singleton conflict replacement
+   - absolute-fee and incremental-relay-fee replacement requirements
+   - maximum replacement-candidate limits
+   - package-size, mempool-ancestor, and conflict-cluster shape rejection
+   - package feerate diagram rejection
+   - TRUC zero-fee-parent plus high-fee-child package RBF
+   - filled-mempool ancestor-conflict rejection without evicting the ancestor
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_package_rbf.py`
+   Fixed posture note:
+   - `MEMPOOL_PACKAGE_RBF_POSTURE.md`
+   Still deferred inside this suite:
+   - broader package relay, persistence, reorg, mining policy, and
+     prior-release compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+57. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_package_rbf.py` as the next local mempool policy
+   - alternate: `mempool_packages.py` as the next local mempool policy
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1195,8 +1217,9 @@ Still deferred:
      decision outside those surfaces
    - the first two inherited mempool acceptance gates plus datacarrier, dust,
      ephemeral-dust, expiry, limit, package-limit, and one-more-descendant
-     carveout policy are now frozen, so the adjacent local mempool follow-on
-     should be another bounded policy gate only after a fresh targeted pass
+     carveout policy are now frozen, and package RBF is now frozen, so the
+     adjacent local mempool follow-on should be another bounded policy gate
+     only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2099,6 +2122,17 @@ Aineko must ask before:
   remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
   release assets exist; otherwise the adjacent local mempool candidate is
   `mempool_package_rbf.py` after a fresh targeted pass.
+- 2026-05-06: `mempool_package_rbf.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers 1-parent-1-child package replacement,
+  singleton conflict replacement, additional-fee and incremental-relay-fee
+  requirements, replacement-candidate caps, package and conflict-cluster shape
+  rejection, feerate diagram rejection, TRUC zero-fee-parent package RBF, and
+  mempool-ancestor conflict rejection under the current legacy-compatible PQC
+  profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_packages.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote mempool_package_rbf.py from pq_backlog to pq_required
- add the suite to the PQ functional gate list and update CI counts to pq_required=106 / pq_backlog=19
- add MEMPOOL_PACKAGE_RBF_POSTURE.md and update Track A handoff to point the next local alternate at mempool_packages.py

## Validation
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 mempool_package_rbf.py
- git diff --cached --check