### PR TITLE
Promote mempool packages gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -644,10 +644,10 @@
   },
   {
     "name": "mempool_packages.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool ancestor/descendant tracking gate: the suite exercises default and custom ancestor/descendant chain limits, verbose ancestor and descendant accounting, gettxspendingprevout consistency, prioritisetransaction fee-delta accounting, cross-node custom limit propagation, and reorg disconnect handling under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_persist.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -36,6 +36,7 @@ mempool_limit.py
 mempool_package_limits.py
 mempool_package_onemore.py
 mempool_package_rbf.py
+mempool_packages.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `106` |
-| `pq_backlog` | `19` |
+| `pq_required` | `107` |
+| `pq_backlog` | `18` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -64,91 +64,92 @@ Current required PQ-first gates:
 19. `mempool_package_limits.py`
 20. `mempool_package_onemore.py`
 21. `mempool_package_rbf.py`
-22. `wallet_pq_active_ranged.py`
-23. `wallet_pq_backup_recovery.py`
-24. `wallet_pq_create_tx.py`
-25. `wallet_pq_descriptors.py`
-26. `wallet_pq_psbt.py`
-27. `wallet_pq_send.py`
-28. `wallet_pq_sendall.py`
-29. `wallet_pq_sendmany.py`
-30. `wallet_pq_signrawtransaction.py`
-31. `feature_assumeutxo.py`
-32. `feature_assumevalid.py`
-33. `feature_bip68_sequence.py`
-34. `feature_block.py`
-35. `feature_blocksdir.py`
-36. `feature_blocksxor.py`
-37. `feature_cltv.py`
-38. `feature_coinstatsindex.py`
-39. `feature_csv_activation.py`
-40. `feature_fastprune.py`
-41. `feature_index_prune.py`
-42. `feature_loadblock.py`
-43. `feature_pruning.py`
-44. `feature_reindex.py`
-45. `feature_reindex_init.py`
-46. `feature_reindex_readonly.py`
-47. `feature_remove_pruned_files_on_startup.py`
-48. `feature_utxo_set_hash.py`
-49. `feature_versionbits_warning.py`
-50. `rpc_psbt.py`
-51. `wallet_abandonconflict.py`
-52. `wallet_address_types.py`
-53. `wallet_assumeutxo.py`
-54. `wallet_avoid_mixing_output_types.py`
-55. `wallet_avoidreuse.py`
-56. `wallet_backup.py`
-57. `wallet_balance.py`
-58. `wallet_basic.py`
-59. `wallet_blank.py`
-60. `wallet_bumpfee.py`
-61. `wallet_change_address.py`
-62. `wallet_coinbase_category.py`
-63. `wallet_conflicts.py`
-64. `wallet_create_tx.py`
-65. `wallet_createwallet.py`
-66. `wallet_createwalletdescriptor.py`
-67. `wallet_crosschain.py`
-68. `wallet_descriptor.py`
-69. `wallet_disable.py`
-70. `wallet_encryption.py`
-71. `wallet_fallbackfee.py`
-72. `wallet_fast_rescan.py`
-73. `wallet_fundrawtransaction.py`
-74. `wallet_gethdkeys.py`
-75. `wallet_groups.py`
-76. `wallet_hd.py`
-77. `wallet_importdescriptors.py`
-78. `wallet_importprunedfunds.py`
-79. `wallet_keypool.py`
-80. `wallet_keypool_topup.py`
-81. `wallet_labels.py`
-82. `wallet_listdescriptors.py`
-83. `wallet_listreceivedby.py`
-84. `wallet_listsinceblock.py`
-85. `wallet_listtransactions.py`
-86. `wallet_miniscript.py`
-87. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-88. `wallet_multisig_descriptor_psbt.py`
-89. `wallet_multiwallet.py`
-90. `wallet_orphanedreward.py`
-91. `wallet_reindex.py`
-92. `wallet_reorgsrestore.py`
-93. `wallet_rescan_unconfirmed.py`
-94. `wallet_resendwallettransactions.py`
-95. `wallet_send.py`
-96. `wallet_sendall.py`
-97. `wallet_sendmany.py`
-98. `wallet_signrawtransactionwithwallet.py`
-99. `wallet_simulaterawtx.py`
-100. `wallet_spend_unconfirmed.py`
-101. `wallet_startup.py`
-102. `wallet_timelock.py`
-103. `wallet_transactiontime_rescan.py`
-104. `wallet_txn_clone.py`
-105. `wallet_txn_doublespend.py`
-106. `wallet_v3_txs.py`
+22. `mempool_packages.py`
+23. `wallet_pq_active_ranged.py`
+24. `wallet_pq_backup_recovery.py`
+25. `wallet_pq_create_tx.py`
+26. `wallet_pq_descriptors.py`
+27. `wallet_pq_psbt.py`
+28. `wallet_pq_send.py`
+29. `wallet_pq_sendall.py`
+30. `wallet_pq_sendmany.py`
+31. `wallet_pq_signrawtransaction.py`
+32. `feature_assumeutxo.py`
+33. `feature_assumevalid.py`
+34. `feature_bip68_sequence.py`
+35. `feature_block.py`
+36. `feature_blocksdir.py`
+37. `feature_blocksxor.py`
+38. `feature_cltv.py`
+39. `feature_coinstatsindex.py`
+40. `feature_csv_activation.py`
+41. `feature_fastprune.py`
+42. `feature_index_prune.py`
+43. `feature_loadblock.py`
+44. `feature_pruning.py`
+45. `feature_reindex.py`
+46. `feature_reindex_init.py`
+47. `feature_reindex_readonly.py`
+48. `feature_remove_pruned_files_on_startup.py`
+49. `feature_utxo_set_hash.py`
+50. `feature_versionbits_warning.py`
+51. `rpc_psbt.py`
+52. `wallet_abandonconflict.py`
+53. `wallet_address_types.py`
+54. `wallet_assumeutxo.py`
+55. `wallet_avoid_mixing_output_types.py`
+56. `wallet_avoidreuse.py`
+57. `wallet_backup.py`
+58. `wallet_balance.py`
+59. `wallet_basic.py`
+60. `wallet_blank.py`
+61. `wallet_bumpfee.py`
+62. `wallet_change_address.py`
+63. `wallet_coinbase_category.py`
+64. `wallet_conflicts.py`
+65. `wallet_create_tx.py`
+66. `wallet_createwallet.py`
+67. `wallet_createwalletdescriptor.py`
+68. `wallet_crosschain.py`
+69. `wallet_descriptor.py`
+70. `wallet_disable.py`
+71. `wallet_encryption.py`
+72. `wallet_fallbackfee.py`
+73. `wallet_fast_rescan.py`
+74. `wallet_fundrawtransaction.py`
+75. `wallet_gethdkeys.py`
+76. `wallet_groups.py`
+77. `wallet_hd.py`
+78. `wallet_importdescriptors.py`
+79. `wallet_importprunedfunds.py`
+80. `wallet_keypool.py`
+81. `wallet_keypool_topup.py`
+82. `wallet_labels.py`
+83. `wallet_listdescriptors.py`
+84. `wallet_listreceivedby.py`
+85. `wallet_listsinceblock.py`
+86. `wallet_listtransactions.py`
+87. `wallet_miniscript.py`
+88. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+89. `wallet_multisig_descriptor_psbt.py`
+90. `wallet_multiwallet.py`
+91. `wallet_orphanedreward.py`
+92. `wallet_reindex.py`
+93. `wallet_reorgsrestore.py`
+94. `wallet_rescan_unconfirmed.py`
+95. `wallet_resendwallettransactions.py`
+96. `wallet_send.py`
+97. `wallet_sendall.py`
+98. `wallet_sendmany.py`
+99. `wallet_signrawtransactionwithwallet.py`
+100. `wallet_simulaterawtx.py`
+101. `wallet_spend_unconfirmed.py`
+102. `wallet_startup.py`
+103. `wallet_timelock.py`
+104. `wallet_transactiontime_rescan.py`
+105. `wallet_txn_clone.py`
+106. `wallet_txn_doublespend.py`
+107. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -422,6 +423,12 @@ requirements, replacement-candidate caps, package and conflict-cluster shape
 rejection, feerate diagram rejection, TRUC zero-fee-parent package RBF, and
 mempool-ancestor conflict rejection under the current legacy-compatible PQC
 profile.
+The inherited mempool package tracking confidence gap is now also part of the
+required gate: `mempool_packages.py` covers default and custom
+ancestor/descendant chain limits, verbose ancestor and descendant accounting,
+`gettxspendingprevout` consistency, `prioritisetransaction` fee-delta
+accounting, cross-node custom limit propagation, and reorg disconnect handling
+under the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -75,6 +75,7 @@ this worktree.
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -72,6 +72,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -67,6 +67,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -66,6 +66,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -77,6 +77,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -63,6 +63,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -73,6 +73,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -1,0 +1,80 @@
+# PQBTC `mempool_packages.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-PACKAGES-POSTURE-v1
+## Updated: 2026-05-06
+## Frozen-By: track-a-phase1-20260506
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool ancestor/descendant
+package tracking under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_packages.py](../test/functional/mempool_packages.py) suite owns the
+two-node mempool package accounting boundary:
+
+- default ancestor-chain admission succeeds up to the configured limit and the
+  next chained transaction is rejected with `too-long-mempool-chain`
+- `getmempoolentry`, `getrawmempool`, `getmempoolancestors`, and
+  `getmempooldescendants` report consistent ancestor/descendant counts, sizes,
+  fees, dependencies, and spent-by relationships
+- `gettxspendingprevout` stays consistent with each mempool spend in the
+  ancestor chain
+- `prioritisetransaction` fee deltas are reflected in ancestor and descendant
+  modified-fee accounting before and after a mined-block invalidation
+- a second node with custom ancestor and descendant limits accepts only the
+  expected prefix of the relayed chains
+- descendant chain limits reject the next chained transaction after the
+  configured descendant ceiling
+- block disconnect/reconnect handling preserves mempool consistency when a
+  transaction depends on mined parents and one parent is not accepted back due
+  to the custom ancestor limit
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool package suite is owned by this tranche
+- persistence, broad package relay, package RBF, TRUC policy, mining-template
+  behavior, or prior-release compatibility behavior is covered here
+- PQ-native witness-size stress replaces this inherited accounting surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-06:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_packages.py`
+  - result: passed
+  - current posture:
+    - default and custom ancestor/descendant limits remain stable
+    - verbose mempool package accounting remains internally consistent
+    - fee-delta, cross-node propagation, and reorg disconnect handling remain
+      green under the current legacy-compatible PQC profile
+
+## Interpretation
+
+- `mempool_packages.py` is now a required inherited mempool
+  ancestor/descendant tracking gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -73,6 +73,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -75,6 +75,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -74,6 +74,7 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -54,7 +54,9 @@ size, eviction, and package-limit policy behavior in the same gate, keep
 `mempool_package_limits.py` inherited package ancestor/descendant limit
 policy behavior in the same gate, keep `mempool_package_onemore.py`
 inherited one-more-descendant package carveout behavior in the same gate, keep
-`mempool_package_rbf.py` inherited package RBF behavior in the same gate,
+`mempool_package_rbf.py` inherited package RBF behavior in the same gate, keep
+`mempool_packages.py` inherited mempool ancestor/descendant tracking behavior
+in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -1202,9 +1204,34 @@ Still deferred:
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-57. Recommended next PR after this tranche:
+57. `mempool_packages.py` now owns:
+   - inherited mempool ancestor/descendant tracking under the current
+     legacy-compatible PQC profile
+   - default ancestor-chain admission through the configured ceiling and
+     `too-long-mempool-chain` rejection for the next hop
+   - verbose `getmempoolentry`, `getrawmempool`, `getmempoolancestors`, and
+     `getmempooldescendants` accounting
+   - `gettxspendingprevout` consistency for in-mempool spends
+   - `prioritisetransaction` ancestor and descendant fee-delta accounting
+   - cross-node propagation into a peer with custom ancestor and descendant
+     limits
+   - descendant-chain limit rejection at the configured ceiling
+   - block disconnect/reconnect handling when a transaction depends on mined
+     parents and one parent is not accepted back due to the custom ancestor
+     limit
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_packages.py`
+   Fixed posture note:
+   - `MEMPOOL_PACKAGES_POSTURE.md`
+   Still deferred inside this suite:
+   - persistence, broader package relay, TRUC, mining policy, and
+     prior-release compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+58. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_packages.py` as the next local mempool policy
+   - alternate: `mempool_persist.py` as the next local mempool persistence
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1217,9 +1244,9 @@ Still deferred:
      decision outside those surfaces
    - the first two inherited mempool acceptance gates plus datacarrier, dust,
      ephemeral-dust, expiry, limit, package-limit, and one-more-descendant
-     carveout policy are now frozen, and package RBF is now frozen, so the
-     adjacent local mempool follow-on should be another bounded policy gate
-     only after a fresh targeted pass
+     carveout policy are now frozen, and package RBF plus package accounting
+     are now frozen, so the adjacent local mempool follow-on should be another
+     bounded policy gate only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2133,6 +2160,16 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mempool candidate is
   `mempool_packages.py` after a fresh targeted pass.
+- 2026-05-06: `mempool_packages.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers default and custom ancestor/descendant
+  chain limits, verbose ancestor and descendant accounting,
+  `gettxspendingprevout` consistency, `prioritisetransaction` fee-delta
+  accounting, cross-node custom limit propagation, and reorg disconnect
+  handling under the current legacy-compatible PQC profile. The next owned
+  follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+  PQBTC release assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_persist.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_packages.py` from `pq_backlog` to `pq_required`
- add the suite to the PQ functional runner list and update CI completeness counts to `pq_required=107`, `pq_backlog=18`
- add `MEMPOOL_PACKAGES_POSTURE.md` and refresh Track A/mempool posture handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_packages.py`
- `git diff --check`

## Notes
- no source or test behavior edits
- `feature_coinstatsindex_compatibility.py` remains preferred once real prior PQBTC release assets exist; local alternate moves to `mempool_persist.py`