### PR TITLE
Promote mempool persist gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -651,10 +651,10 @@
   },
   {
     "name": "mempool_persist.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool persistence gate: the suite exercises default mempool.dat reload, -persistmempool=0 dump/load suppression, savemempool and importmempool RPC behavior, priority-delta and unbroadcast-set persistence, wallet watch-only accounting after reload where wallet support is compiled, cross-node mempool.dat import, import union behavior, and disk-write failure handling under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_pq_limits.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -37,6 +37,7 @@ mempool_package_limits.py
 mempool_package_onemore.py
 mempool_package_rbf.py
 mempool_packages.py
+mempool_persist.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 rpc_psbt.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `107` |
-| `pq_backlog` | `18` |
+| `pq_required` | `108` |
+| `pq_backlog` | `17` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -65,91 +65,92 @@ Current required PQ-first gates:
 20. `mempool_package_onemore.py`
 21. `mempool_package_rbf.py`
 22. `mempool_packages.py`
-23. `wallet_pq_active_ranged.py`
-24. `wallet_pq_backup_recovery.py`
-25. `wallet_pq_create_tx.py`
-26. `wallet_pq_descriptors.py`
-27. `wallet_pq_psbt.py`
-28. `wallet_pq_send.py`
-29. `wallet_pq_sendall.py`
-30. `wallet_pq_sendmany.py`
-31. `wallet_pq_signrawtransaction.py`
-32. `feature_assumeutxo.py`
-33. `feature_assumevalid.py`
-34. `feature_bip68_sequence.py`
-35. `feature_block.py`
-36. `feature_blocksdir.py`
-37. `feature_blocksxor.py`
-38. `feature_cltv.py`
-39. `feature_coinstatsindex.py`
-40. `feature_csv_activation.py`
-41. `feature_fastprune.py`
-42. `feature_index_prune.py`
-43. `feature_loadblock.py`
-44. `feature_pruning.py`
-45. `feature_reindex.py`
-46. `feature_reindex_init.py`
-47. `feature_reindex_readonly.py`
-48. `feature_remove_pruned_files_on_startup.py`
-49. `feature_utxo_set_hash.py`
-50. `feature_versionbits_warning.py`
-51. `rpc_psbt.py`
-52. `wallet_abandonconflict.py`
-53. `wallet_address_types.py`
-54. `wallet_assumeutxo.py`
-55. `wallet_avoid_mixing_output_types.py`
-56. `wallet_avoidreuse.py`
-57. `wallet_backup.py`
-58. `wallet_balance.py`
-59. `wallet_basic.py`
-60. `wallet_blank.py`
-61. `wallet_bumpfee.py`
-62. `wallet_change_address.py`
-63. `wallet_coinbase_category.py`
-64. `wallet_conflicts.py`
-65. `wallet_create_tx.py`
-66. `wallet_createwallet.py`
-67. `wallet_createwalletdescriptor.py`
-68. `wallet_crosschain.py`
-69. `wallet_descriptor.py`
-70. `wallet_disable.py`
-71. `wallet_encryption.py`
-72. `wallet_fallbackfee.py`
-73. `wallet_fast_rescan.py`
-74. `wallet_fundrawtransaction.py`
-75. `wallet_gethdkeys.py`
-76. `wallet_groups.py`
-77. `wallet_hd.py`
-78. `wallet_importdescriptors.py`
-79. `wallet_importprunedfunds.py`
-80. `wallet_keypool.py`
-81. `wallet_keypool_topup.py`
-82. `wallet_labels.py`
-83. `wallet_listdescriptors.py`
-84. `wallet_listreceivedby.py`
-85. `wallet_listsinceblock.py`
-86. `wallet_listtransactions.py`
-87. `wallet_miniscript.py`
-88. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-89. `wallet_multisig_descriptor_psbt.py`
-90. `wallet_multiwallet.py`
-91. `wallet_orphanedreward.py`
-92. `wallet_reindex.py`
-93. `wallet_reorgsrestore.py`
-94. `wallet_rescan_unconfirmed.py`
-95. `wallet_resendwallettransactions.py`
-96. `wallet_send.py`
-97. `wallet_sendall.py`
-98. `wallet_sendmany.py`
-99. `wallet_signrawtransactionwithwallet.py`
-100. `wallet_simulaterawtx.py`
-101. `wallet_spend_unconfirmed.py`
-102. `wallet_startup.py`
-103. `wallet_timelock.py`
-104. `wallet_transactiontime_rescan.py`
-105. `wallet_txn_clone.py`
-106. `wallet_txn_doublespend.py`
-107. `wallet_v3_txs.py`
+23. `mempool_persist.py`
+24. `wallet_pq_active_ranged.py`
+25. `wallet_pq_backup_recovery.py`
+26. `wallet_pq_create_tx.py`
+27. `wallet_pq_descriptors.py`
+28. `wallet_pq_psbt.py`
+29. `wallet_pq_send.py`
+30. `wallet_pq_sendall.py`
+31. `wallet_pq_sendmany.py`
+32. `wallet_pq_signrawtransaction.py`
+33. `feature_assumeutxo.py`
+34. `feature_assumevalid.py`
+35. `feature_bip68_sequence.py`
+36. `feature_block.py`
+37. `feature_blocksdir.py`
+38. `feature_blocksxor.py`
+39. `feature_cltv.py`
+40. `feature_coinstatsindex.py`
+41. `feature_csv_activation.py`
+42. `feature_fastprune.py`
+43. `feature_index_prune.py`
+44. `feature_loadblock.py`
+45. `feature_pruning.py`
+46. `feature_reindex.py`
+47. `feature_reindex_init.py`
+48. `feature_reindex_readonly.py`
+49. `feature_remove_pruned_files_on_startup.py`
+50. `feature_utxo_set_hash.py`
+51. `feature_versionbits_warning.py`
+52. `rpc_psbt.py`
+53. `wallet_abandonconflict.py`
+54. `wallet_address_types.py`
+55. `wallet_assumeutxo.py`
+56. `wallet_avoid_mixing_output_types.py`
+57. `wallet_avoidreuse.py`
+58. `wallet_backup.py`
+59. `wallet_balance.py`
+60. `wallet_basic.py`
+61. `wallet_blank.py`
+62. `wallet_bumpfee.py`
+63. `wallet_change_address.py`
+64. `wallet_coinbase_category.py`
+65. `wallet_conflicts.py`
+66. `wallet_create_tx.py`
+67. `wallet_createwallet.py`
+68. `wallet_createwalletdescriptor.py`
+69. `wallet_crosschain.py`
+70. `wallet_descriptor.py`
+71. `wallet_disable.py`
+72. `wallet_encryption.py`
+73. `wallet_fallbackfee.py`
+74. `wallet_fast_rescan.py`
+75. `wallet_fundrawtransaction.py`
+76. `wallet_gethdkeys.py`
+77. `wallet_groups.py`
+78. `wallet_hd.py`
+79. `wallet_importdescriptors.py`
+80. `wallet_importprunedfunds.py`
+81. `wallet_keypool.py`
+82. `wallet_keypool_topup.py`
+83. `wallet_labels.py`
+84. `wallet_listdescriptors.py`
+85. `wallet_listreceivedby.py`
+86. `wallet_listsinceblock.py`
+87. `wallet_listtransactions.py`
+88. `wallet_miniscript.py`
+89. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+90. `wallet_multisig_descriptor_psbt.py`
+91. `wallet_multiwallet.py`
+92. `wallet_orphanedreward.py`
+93. `wallet_reindex.py`
+94. `wallet_reorgsrestore.py`
+95. `wallet_rescan_unconfirmed.py`
+96. `wallet_resendwallettransactions.py`
+97. `wallet_send.py`
+98. `wallet_sendall.py`
+99. `wallet_sendmany.py`
+100. `wallet_signrawtransactionwithwallet.py`
+101. `wallet_simulaterawtx.py`
+102. `wallet_spend_unconfirmed.py`
+103. `wallet_startup.py`
+104. `wallet_timelock.py`
+105. `wallet_transactiontime_rescan.py`
+106. `wallet_txn_clone.py`
+107. `wallet_txn_doublespend.py`
+108. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -429,6 +430,13 @@ ancestor/descendant chain limits, verbose ancestor and descendant accounting,
 `gettxspendingprevout` consistency, `prioritisetransaction` fee-delta
 accounting, cross-node custom limit propagation, and reorg disconnect handling
 under the current legacy-compatible PQC profile.
+The inherited mempool persistence confidence gap is now also part of the
+required gate: `mempool_persist.py` covers default `mempool.dat` reload,
+`-persistmempool=0` dump/load suppression, `savemempool` and `importmempool`
+RPC behavior, priority-delta and unbroadcast-set persistence, wallet
+watch-only accounting after reload where wallet support is compiled,
+cross-node `mempool.dat` import, import union behavior, and disk-write failure
+handling under the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -76,6 +76,7 @@ this worktree.
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -73,6 +73,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -68,6 +68,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -67,6 +67,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -78,6 +78,7 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -64,6 +64,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -74,6 +74,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -72,6 +72,7 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -74,6 +74,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -76,6 +76,7 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -75,6 +75,7 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_PERSIST_POSTURE.md
+++ b/docs/MEMPOOL_PERSIST_POSTURE.md
@@ -1,0 +1,83 @@
+# PQBTC `mempool_persist.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-PERSIST-POSTURE-v1
+## Updated: 2026-05-07
+## Frozen-By: track-a-phase1-20260507
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool persistence and
+runtime mempool import behavior under the current legacy-compatible PQC
+profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_persist.py](../test/functional/mempool_persist.py) suite owns the
+three-node mempool persistence boundary:
+
+- default shutdown/startup persistence reloads `mempool.dat`
+- `-persistmempool=0` suppresses both mempool dump and startup load without
+  overwriting a previously valid on-disk mempool
+- `savemempool` recreates `mempool.dat` on demand and returns the expected
+  filename
+- `importmempool` can load a saved mempool at runtime, with optional
+  priority-delta and unbroadcast-set restoration
+- `prioritisetransaction` fee deltas persist for in-mempool transactions and
+  for transactions prioritised before submission
+- watch-only wallet accounting remains stable across mempool reload when wallet
+  support is compiled
+- a saved mempool can be moved between nodes and loaded successfully
+- disk-write failure during `savemempool` returns the expected RPC error
+- importing a saved mempool unions transactions into the existing mempool
+  without replacing it and stacks fee deltas as expected
+- the unbroadcast set persists and later announces to a peer after restart
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool reorg, resurrection, TRUC, or mining-template suite
+  is owned by this tranche
+- prior-release mempool compatibility behavior is covered without real prior
+  PQBTC release assets
+- PQ-native witness-size stress replaces this inherited persistence surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-07:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_persist.py`
+  - result: passed
+  - current posture:
+    - default persistence and `-persistmempool=0` behavior remain stable
+    - runtime `savemempool` / `importmempool` behavior remains stable
+    - priority-delta, unbroadcast-set, cross-node import, and disk-write
+      failure handling remain green under the current legacy-compatible PQC
+      profile
+
+## Interpretation
+
+- `mempool_persist.py` is now a required inherited mempool persistence gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -56,7 +56,8 @@ policy behavior in the same gate, keep `mempool_package_onemore.py`
 inherited one-more-descendant package carveout behavior in the same gate, keep
 `mempool_package_rbf.py` inherited package RBF behavior in the same gate, keep
 `mempool_packages.py` inherited mempool ancestor/descendant tracking behavior
-in the same gate,
+in the same gate, keep `mempool_persist.py` inherited mempool persistence
+behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -1229,9 +1230,35 @@ Still deferred:
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-58. Recommended next PR after this tranche:
+58. `mempool_persist.py` now owns:
+   - inherited mempool persistence and runtime import behavior under the
+     current legacy-compatible PQC profile
+   - default `mempool.dat` reload across shutdown/startup
+   - `-persistmempool=0` dump and load suppression without overwriting a valid
+     saved mempool
+   - `savemempool` file recreation and filename reporting
+   - runtime `importmempool` with optional priority-delta and unbroadcast-set
+     restoration
+   - `prioritisetransaction` fee-delta persistence for in-mempool transactions
+     and not-yet-submitted transactions
+   - watch-only wallet accounting after reload when wallet support is compiled
+   - cross-node `mempool.dat` import
+   - import union behavior without replacing the current mempool
+   - disk-write failure handling for `savemempool`
+   - unbroadcast-set persistence and later peer announcement after restart
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_persist.py`
+   Fixed posture note:
+   - `MEMPOOL_PERSIST_POSTURE.md`
+   Still deferred inside this suite:
+   - reorg, resurrection, TRUC, mining policy, and prior-release compatibility
+     suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+59. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_persist.py` as the next local mempool persistence
+   - alternate: `mempool_reorg.py` as the next local mempool reorg-policy
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1245,8 +1272,9 @@ Still deferred:
    - the first two inherited mempool acceptance gates plus datacarrier, dust,
      ephemeral-dust, expiry, limit, package-limit, and one-more-descendant
      carveout policy are now frozen, and package RBF plus package accounting
-     are now frozen, so the adjacent local mempool follow-on should be another
-     bounded policy gate only after a fresh targeted pass
+     are now frozen, and mempool persistence is now frozen, so the adjacent
+     local mempool follow-on should be another bounded policy gate only after a
+     fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2170,6 +2198,17 @@ Aineko must ask before:
   follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
   PQBTC release assets exist; otherwise the adjacent local mempool candidate is
   `mempool_persist.py` after a fresh targeted pass.
+- 2026-05-07: `mempool_persist.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers default `mempool.dat` reload,
+  `-persistmempool=0` dump/load suppression, `savemempool` and
+  `importmempool` RPC behavior, priority-delta and unbroadcast-set
+  persistence, wallet watch-only accounting after reload where wallet support
+  is compiled, cross-node mempool import, import union behavior, and disk-write
+  failure handling under the current legacy-compatible PQC profile. The next
+  owned follow-on remains `feature_coinstatsindex_compatibility.py` when real
+  prior PQBTC release assets exist; otherwise the adjacent local mempool
+  candidate is `mempool_reorg.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_persist.py` from `pq_backlog` to `pq_required`
- add the suite to the PQ functional runner list and update CI completeness counts to `pq_required=108`, `pq_backlog=17`
- add `MEMPOOL_PERSIST_POSTURE.md` and refresh Track A/mempool posture handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_persist.py`
- `git diff --check`
- `git diff --cached --check`

## Notes
- no source or test behavior edits
- `feature_coinstatsindex_compatibility.py` remains preferred once real prior PQBTC release assets exist; local alternate moves to `mempool_reorg.py`