### PR TITLE
Promote mempool reorg gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -672,10 +672,10 @@
   },
   {
     "name": "mempool_reorg.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool reorg gate: the suite exercises coinbase-spend mempool removal when reorgs make coinbase spends immature, timelock non-final rejection and later acceptance, reorg return of disconnected block transactions to the mempool, removal of invalid descendants after deeper invalidation, and relay/request behavior for transactions from recently disconnected blocks under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_resurrect.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -40,6 +40,7 @@ mempool_packages.py
 mempool_persist.py
 mempool_pq_limits.py
 mempool_pq_stress.py
+mempool_reorg.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `108` |
-| `pq_backlog` | `17` |
+| `pq_required` | `109` |
+| `pq_backlog` | `16` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -66,91 +66,92 @@ Current required PQ-first gates:
 21. `mempool_package_rbf.py`
 22. `mempool_packages.py`
 23. `mempool_persist.py`
-24. `wallet_pq_active_ranged.py`
-25. `wallet_pq_backup_recovery.py`
-26. `wallet_pq_create_tx.py`
-27. `wallet_pq_descriptors.py`
-28. `wallet_pq_psbt.py`
-29. `wallet_pq_send.py`
-30. `wallet_pq_sendall.py`
-31. `wallet_pq_sendmany.py`
-32. `wallet_pq_signrawtransaction.py`
-33. `feature_assumeutxo.py`
-34. `feature_assumevalid.py`
-35. `feature_bip68_sequence.py`
-36. `feature_block.py`
-37. `feature_blocksdir.py`
-38. `feature_blocksxor.py`
-39. `feature_cltv.py`
-40. `feature_coinstatsindex.py`
-41. `feature_csv_activation.py`
-42. `feature_fastprune.py`
-43. `feature_index_prune.py`
-44. `feature_loadblock.py`
-45. `feature_pruning.py`
-46. `feature_reindex.py`
-47. `feature_reindex_init.py`
-48. `feature_reindex_readonly.py`
-49. `feature_remove_pruned_files_on_startup.py`
-50. `feature_utxo_set_hash.py`
-51. `feature_versionbits_warning.py`
-52. `rpc_psbt.py`
-53. `wallet_abandonconflict.py`
-54. `wallet_address_types.py`
-55. `wallet_assumeutxo.py`
-56. `wallet_avoid_mixing_output_types.py`
-57. `wallet_avoidreuse.py`
-58. `wallet_backup.py`
-59. `wallet_balance.py`
-60. `wallet_basic.py`
-61. `wallet_blank.py`
-62. `wallet_bumpfee.py`
-63. `wallet_change_address.py`
-64. `wallet_coinbase_category.py`
-65. `wallet_conflicts.py`
-66. `wallet_create_tx.py`
-67. `wallet_createwallet.py`
-68. `wallet_createwalletdescriptor.py`
-69. `wallet_crosschain.py`
-70. `wallet_descriptor.py`
-71. `wallet_disable.py`
-72. `wallet_encryption.py`
-73. `wallet_fallbackfee.py`
-74. `wallet_fast_rescan.py`
-75. `wallet_fundrawtransaction.py`
-76. `wallet_gethdkeys.py`
-77. `wallet_groups.py`
-78. `wallet_hd.py`
-79. `wallet_importdescriptors.py`
-80. `wallet_importprunedfunds.py`
-81. `wallet_keypool.py`
-82. `wallet_keypool_topup.py`
-83. `wallet_labels.py`
-84. `wallet_listdescriptors.py`
-85. `wallet_listreceivedby.py`
-86. `wallet_listsinceblock.py`
-87. `wallet_listtransactions.py`
-88. `wallet_miniscript.py`
-89. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-90. `wallet_multisig_descriptor_psbt.py`
-91. `wallet_multiwallet.py`
-92. `wallet_orphanedreward.py`
-93. `wallet_reindex.py`
-94. `wallet_reorgsrestore.py`
-95. `wallet_rescan_unconfirmed.py`
-96. `wallet_resendwallettransactions.py`
-97. `wallet_send.py`
-98. `wallet_sendall.py`
-99. `wallet_sendmany.py`
-100. `wallet_signrawtransactionwithwallet.py`
-101. `wallet_simulaterawtx.py`
-102. `wallet_spend_unconfirmed.py`
-103. `wallet_startup.py`
-104. `wallet_timelock.py`
-105. `wallet_transactiontime_rescan.py`
-106. `wallet_txn_clone.py`
-107. `wallet_txn_doublespend.py`
-108. `wallet_v3_txs.py`
+24. `mempool_reorg.py`
+25. `wallet_pq_active_ranged.py`
+26. `wallet_pq_backup_recovery.py`
+27. `wallet_pq_create_tx.py`
+28. `wallet_pq_descriptors.py`
+29. `wallet_pq_psbt.py`
+30. `wallet_pq_send.py`
+31. `wallet_pq_sendall.py`
+32. `wallet_pq_sendmany.py`
+33. `wallet_pq_signrawtransaction.py`
+34. `feature_assumeutxo.py`
+35. `feature_assumevalid.py`
+36. `feature_bip68_sequence.py`
+37. `feature_block.py`
+38. `feature_blocksdir.py`
+39. `feature_blocksxor.py`
+40. `feature_cltv.py`
+41. `feature_coinstatsindex.py`
+42. `feature_csv_activation.py`
+43. `feature_fastprune.py`
+44. `feature_index_prune.py`
+45. `feature_loadblock.py`
+46. `feature_pruning.py`
+47. `feature_reindex.py`
+48. `feature_reindex_init.py`
+49. `feature_reindex_readonly.py`
+50. `feature_remove_pruned_files_on_startup.py`
+51. `feature_utxo_set_hash.py`
+52. `feature_versionbits_warning.py`
+53. `rpc_psbt.py`
+54. `wallet_abandonconflict.py`
+55. `wallet_address_types.py`
+56. `wallet_assumeutxo.py`
+57. `wallet_avoid_mixing_output_types.py`
+58. `wallet_avoidreuse.py`
+59. `wallet_backup.py`
+60. `wallet_balance.py`
+61. `wallet_basic.py`
+62. `wallet_blank.py`
+63. `wallet_bumpfee.py`
+64. `wallet_change_address.py`
+65. `wallet_coinbase_category.py`
+66. `wallet_conflicts.py`
+67. `wallet_create_tx.py`
+68. `wallet_createwallet.py`
+69. `wallet_createwalletdescriptor.py`
+70. `wallet_crosschain.py`
+71. `wallet_descriptor.py`
+72. `wallet_disable.py`
+73. `wallet_encryption.py`
+74. `wallet_fallbackfee.py`
+75. `wallet_fast_rescan.py`
+76. `wallet_fundrawtransaction.py`
+77. `wallet_gethdkeys.py`
+78. `wallet_groups.py`
+79. `wallet_hd.py`
+80. `wallet_importdescriptors.py`
+81. `wallet_importprunedfunds.py`
+82. `wallet_keypool.py`
+83. `wallet_keypool_topup.py`
+84. `wallet_labels.py`
+85. `wallet_listdescriptors.py`
+86. `wallet_listreceivedby.py`
+87. `wallet_listsinceblock.py`
+88. `wallet_listtransactions.py`
+89. `wallet_miniscript.py`
+90. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+91. `wallet_multisig_descriptor_psbt.py`
+92. `wallet_multiwallet.py`
+93. `wallet_orphanedreward.py`
+94. `wallet_reindex.py`
+95. `wallet_reorgsrestore.py`
+96. `wallet_rescan_unconfirmed.py`
+97. `wallet_resendwallettransactions.py`
+98. `wallet_send.py`
+99. `wallet_sendall.py`
+100. `wallet_sendmany.py`
+101. `wallet_signrawtransactionwithwallet.py`
+102. `wallet_simulaterawtx.py`
+103. `wallet_spend_unconfirmed.py`
+104. `wallet_startup.py`
+105. `wallet_timelock.py`
+106. `wallet_transactiontime_rescan.py`
+107. `wallet_txn_clone.py`
+108. `wallet_txn_doublespend.py`
+109. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -437,6 +438,13 @@ RPC behavior, priority-delta and unbroadcast-set persistence, wallet
 watch-only accounting after reload where wallet support is compiled,
 cross-node `mempool.dat` import, import union behavior, and disk-write failure
 handling under the current legacy-compatible PQC profile.
+The inherited mempool reorg confidence gap is now also part of the required
+gate: `mempool_reorg.py` covers coinbase-spend mempool removal when reorgs
+make coinbase spends immature, timelock non-final rejection and later
+acceptance, disconnected block transactions returning to the mempool, invalid
+descendant removal after deeper invalidation, and relay/request behavior for
+transactions from recently disconnected blocks under the current
+legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -77,8 +77,9 @@ this worktree.
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md) and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -74,8 +74,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -69,8 +69,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -68,8 +68,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -79,8 +79,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -65,8 +65,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -75,8 +75,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -73,8 +73,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -75,8 +75,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -77,8 +77,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -76,8 +76,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PERSIST_POSTURE.md
+++ b/docs/MEMPOOL_PERSIST_POSTURE.md
@@ -75,8 +75,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_REORG_POSTURE.md
+++ b/docs/MEMPOOL_REORG_POSTURE.md
@@ -1,0 +1,84 @@
+# PQBTC `mempool_reorg.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-REORG-POSTURE-v1
+## Updated: 2026-05-07
+## Frozen-By: track-a-phase1-20260507
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool behavior across
+coinbase-spend reorgs and recently disconnected block transaction relay under
+the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_reorg.py](../test/functional/mempool_reorg.py) suite owns the
+two-node mempool reorg boundary:
+
+- timelocked coinbase-spend transactions are rejected while non-final and later
+  accepted when the chain height makes them final
+- direct and indirect coinbase spends enter the mempool or chain in the three
+  tested shapes: direct coinbase spend, coinbase spend in-chain with a child in
+  mempool, and coinbase plus child both in-chain
+- invalidating the most recent block returns the disconnected child
+  transaction to the mempool while removing the no-longer-final timelocked
+  transaction
+- deeper invalidation makes the relevant coinbase spends immature and clears
+  the mempool
+- transactions from disconnected blocks are immediately available for explicit
+  `getdata` relay even before normal announcement delay elapses
+- very recent unannounced mempool transactions remain unavailable for early
+  explicit requests until mock time advances
+- after mock time advances, disconnected-block and mempool transactions are
+  announced to the peer with the expected inventory behavior
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- every remaining mempool resurrection, TRUC, sigop-limit, spend-coinbase, or
+  mining-template suite is owned by this tranche
+- prior-release mempool compatibility behavior is covered without real prior
+  PQBTC release assets
+- PQ-native witness-size stress replaces this inherited reorg surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-07:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_reorg.py`
+  - result: passed
+  - current posture:
+    - immature coinbase-spend removal and disconnected-block return remain
+      stable
+    - timelock rejection/acceptance across the reorg path remains stable
+    - explicit relay of recently disconnected block transactions remains green
+      under the current legacy-compatible PQC profile
+
+## Interpretation
+
+- `mempool_reorg.py` is now a required inherited mempool reorg gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -57,6 +57,7 @@ inherited one-more-descendant package carveout behavior in the same gate, keep
 `mempool_package_rbf.py` inherited package RBF behavior in the same gate, keep
 `mempool_packages.py` inherited mempool ancestor/descendant tracking behavior
 in the same gate, keep `mempool_persist.py` inherited mempool persistence
+behavior in the same gate, keep `mempool_reorg.py` inherited mempool reorg
 behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
@@ -1256,9 +1257,33 @@ Still deferred:
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-59. Recommended next PR after this tranche:
+59. `mempool_reorg.py` now owns:
+   - inherited mempool reorg behavior under the current legacy-compatible PQC
+     profile
+   - timelock non-final rejection and later acceptance after the chain advances
+   - direct and indirect coinbase-spend scenarios across mempool and chain
+   - disconnected-block child transaction return to the mempool after shallow
+     invalidation
+   - no-longer-final timelocked transaction removal after reorg
+   - immature coinbase-spend cleanup after deeper invalidation
+   - immediate explicit relay availability for transactions from recently
+     disconnected blocks
+   - early explicit request rejection for very recent unannounced mempool
+     transactions until mock time advances
+   - expected inventory announcement after mock time advances
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_reorg.py`
+   Fixed posture note:
+   - `MEMPOOL_REORG_POSTURE.md`
+   Still deferred inside this suite:
+   - resurrection, sigop-limit, spend-coinbase, TRUC, mining policy, and
+     prior-release compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+60. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_reorg.py` as the next local mempool reorg-policy
+   - alternate: `mempool_resurrect.py` as the next local mempool resurrection
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1274,7 +1299,7 @@ Still deferred:
      carveout policy are now frozen, and package RBF plus package accounting
      are now frozen, and mempool persistence is now frozen, so the adjacent
      local mempool follow-on should be another bounded policy gate only after a
-     fresh targeted pass
+     fresh targeted pass, with mempool reorg behavior now represented too
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2209,6 +2234,17 @@ Aineko must ask before:
   owned follow-on remains `feature_coinstatsindex_compatibility.py` when real
   prior PQBTC release assets exist; otherwise the adjacent local mempool
   candidate is `mempool_reorg.py` after a fresh targeted pass.
+- 2026-05-07: `mempool_reorg.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers coinbase-spend mempool removal when reorgs
+  make coinbase spends immature, timelock non-final rejection and later
+  acceptance, disconnected block transactions returning to the mempool, invalid
+  descendant removal after deeper invalidation, and relay/request behavior for
+  transactions from recently disconnected blocks under the current
+  legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_resurrect.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_reorg.py` from `pq_backlog` to `pq_required`
- add it to the PQ functional runner list and update CI completeness counts to `pq_required=109`, `pq_backlog=16`
- add `MEMPOOL_REORG_POSTURE.md` and refresh Track A/mempool posture handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_reorg.py`
- `git diff --check`
- `git diff --cached --check`

## Notes
- no source or test behavior edits
- `feature_coinstatsindex_compatibility.py` remains preferred once real prior PQBTC release assets exist; local alternate moves to `mempool_resurrect.py`