### PR TITLE
Promote mempool resurrect gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -679,10 +679,10 @@
   },
   {
     "name": "mempool_resurrect.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool resurrection gate: the suite mines parent and descendant transaction sets across two blocks, invalidates the first block to disconnect both blocks, verifies all disconnected transactions return to the mempool with zero confirmations, and confirms they are mined again under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_sigoplimit.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -41,6 +41,7 @@ mempool_persist.py
 mempool_pq_limits.py
 mempool_pq_stress.py
 mempool_reorg.py
+mempool_resurrect.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `109` |
-| `pq_backlog` | `16` |
+| `pq_required` | `110` |
+| `pq_backlog` | `15` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -67,91 +67,92 @@ Current required PQ-first gates:
 22. `mempool_packages.py`
 23. `mempool_persist.py`
 24. `mempool_reorg.py`
-25. `wallet_pq_active_ranged.py`
-26. `wallet_pq_backup_recovery.py`
-27. `wallet_pq_create_tx.py`
-28. `wallet_pq_descriptors.py`
-29. `wallet_pq_psbt.py`
-30. `wallet_pq_send.py`
-31. `wallet_pq_sendall.py`
-32. `wallet_pq_sendmany.py`
-33. `wallet_pq_signrawtransaction.py`
-34. `feature_assumeutxo.py`
-35. `feature_assumevalid.py`
-36. `feature_bip68_sequence.py`
-37. `feature_block.py`
-38. `feature_blocksdir.py`
-39. `feature_blocksxor.py`
-40. `feature_cltv.py`
-41. `feature_coinstatsindex.py`
-42. `feature_csv_activation.py`
-43. `feature_fastprune.py`
-44. `feature_index_prune.py`
-45. `feature_loadblock.py`
-46. `feature_pruning.py`
-47. `feature_reindex.py`
-48. `feature_reindex_init.py`
-49. `feature_reindex_readonly.py`
-50. `feature_remove_pruned_files_on_startup.py`
-51. `feature_utxo_set_hash.py`
-52. `feature_versionbits_warning.py`
-53. `rpc_psbt.py`
-54. `wallet_abandonconflict.py`
-55. `wallet_address_types.py`
-56. `wallet_assumeutxo.py`
-57. `wallet_avoid_mixing_output_types.py`
-58. `wallet_avoidreuse.py`
-59. `wallet_backup.py`
-60. `wallet_balance.py`
-61. `wallet_basic.py`
-62. `wallet_blank.py`
-63. `wallet_bumpfee.py`
-64. `wallet_change_address.py`
-65. `wallet_coinbase_category.py`
-66. `wallet_conflicts.py`
-67. `wallet_create_tx.py`
-68. `wallet_createwallet.py`
-69. `wallet_createwalletdescriptor.py`
-70. `wallet_crosschain.py`
-71. `wallet_descriptor.py`
-72. `wallet_disable.py`
-73. `wallet_encryption.py`
-74. `wallet_fallbackfee.py`
-75. `wallet_fast_rescan.py`
-76. `wallet_fundrawtransaction.py`
-77. `wallet_gethdkeys.py`
-78. `wallet_groups.py`
-79. `wallet_hd.py`
-80. `wallet_importdescriptors.py`
-81. `wallet_importprunedfunds.py`
-82. `wallet_keypool.py`
-83. `wallet_keypool_topup.py`
-84. `wallet_labels.py`
-85. `wallet_listdescriptors.py`
-86. `wallet_listreceivedby.py`
-87. `wallet_listsinceblock.py`
-88. `wallet_listtransactions.py`
-89. `wallet_miniscript.py`
-90. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-91. `wallet_multisig_descriptor_psbt.py`
-92. `wallet_multiwallet.py`
-93. `wallet_orphanedreward.py`
-94. `wallet_reindex.py`
-95. `wallet_reorgsrestore.py`
-96. `wallet_rescan_unconfirmed.py`
-97. `wallet_resendwallettransactions.py`
-98. `wallet_send.py`
-99. `wallet_sendall.py`
-100. `wallet_sendmany.py`
-101. `wallet_signrawtransactionwithwallet.py`
-102. `wallet_simulaterawtx.py`
-103. `wallet_spend_unconfirmed.py`
-104. `wallet_startup.py`
-105. `wallet_timelock.py`
-106. `wallet_transactiontime_rescan.py`
-107. `wallet_txn_clone.py`
-108. `wallet_txn_doublespend.py`
-109. `wallet_v3_txs.py`
+25. `mempool_resurrect.py`
+26. `wallet_pq_active_ranged.py`
+27. `wallet_pq_backup_recovery.py`
+28. `wallet_pq_create_tx.py`
+29. `wallet_pq_descriptors.py`
+30. `wallet_pq_psbt.py`
+31. `wallet_pq_send.py`
+32. `wallet_pq_sendall.py`
+33. `wallet_pq_sendmany.py`
+34. `wallet_pq_signrawtransaction.py`
+35. `feature_assumeutxo.py`
+36. `feature_assumevalid.py`
+37. `feature_bip68_sequence.py`
+38. `feature_block.py`
+39. `feature_blocksdir.py`
+40. `feature_blocksxor.py`
+41. `feature_cltv.py`
+42. `feature_coinstatsindex.py`
+43. `feature_csv_activation.py`
+44. `feature_fastprune.py`
+45. `feature_index_prune.py`
+46. `feature_loadblock.py`
+47. `feature_pruning.py`
+48. `feature_reindex.py`
+49. `feature_reindex_init.py`
+50. `feature_reindex_readonly.py`
+51. `feature_remove_pruned_files_on_startup.py`
+52. `feature_utxo_set_hash.py`
+53. `feature_versionbits_warning.py`
+54. `rpc_psbt.py`
+55. `wallet_abandonconflict.py`
+56. `wallet_address_types.py`
+57. `wallet_assumeutxo.py`
+58. `wallet_avoid_mixing_output_types.py`
+59. `wallet_avoidreuse.py`
+60. `wallet_backup.py`
+61. `wallet_balance.py`
+62. `wallet_basic.py`
+63. `wallet_blank.py`
+64. `wallet_bumpfee.py`
+65. `wallet_change_address.py`
+66. `wallet_coinbase_category.py`
+67. `wallet_conflicts.py`
+68. `wallet_create_tx.py`
+69. `wallet_createwallet.py`
+70. `wallet_createwalletdescriptor.py`
+71. `wallet_crosschain.py`
+72. `wallet_descriptor.py`
+73. `wallet_disable.py`
+74. `wallet_encryption.py`
+75. `wallet_fallbackfee.py`
+76. `wallet_fast_rescan.py`
+77. `wallet_fundrawtransaction.py`
+78. `wallet_gethdkeys.py`
+79. `wallet_groups.py`
+80. `wallet_hd.py`
+81. `wallet_importdescriptors.py`
+82. `wallet_importprunedfunds.py`
+83. `wallet_keypool.py`
+84. `wallet_keypool_topup.py`
+85. `wallet_labels.py`
+86. `wallet_listdescriptors.py`
+87. `wallet_listreceivedby.py`
+88. `wallet_listsinceblock.py`
+89. `wallet_listtransactions.py`
+90. `wallet_miniscript.py`
+91. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+92. `wallet_multisig_descriptor_psbt.py`
+93. `wallet_multiwallet.py`
+94. `wallet_orphanedreward.py`
+95. `wallet_reindex.py`
+96. `wallet_reorgsrestore.py`
+97. `wallet_rescan_unconfirmed.py`
+98. `wallet_resendwallettransactions.py`
+99. `wallet_send.py`
+100. `wallet_sendall.py`
+101. `wallet_sendmany.py`
+102. `wallet_signrawtransactionwithwallet.py`
+103. `wallet_simulaterawtx.py`
+104. `wallet_spend_unconfirmed.py`
+105. `wallet_startup.py`
+106. `wallet_timelock.py`
+107. `wallet_transactiontime_rescan.py`
+108. `wallet_txn_clone.py`
+109. `wallet_txn_doublespend.py`
+110. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -445,6 +446,11 @@ acceptance, disconnected block transactions returning to the mempool, invalid
 descendant removal after deeper invalidation, and relay/request behavior for
 transactions from recently disconnected blocks under the current
 legacy-compatible PQC profile.
+The inherited mempool resurrection confidence gap is now also part of the
+required gate: `mempool_resurrect.py` covers disconnected parent and
+descendant transactions returning to the mempool with zero confirmations after
+a two-block reorg, then being mined again under the current legacy-compatible
+PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -78,8 +78,9 @@ this worktree.
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -75,8 +75,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -70,8 +70,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -69,8 +69,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -80,8 +80,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -66,8 +66,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -76,8 +76,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -74,8 +74,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -76,8 +76,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -78,8 +78,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -77,8 +77,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PERSIST_POSTURE.md
+++ b/docs/MEMPOOL_PERSIST_POSTURE.md
@@ -76,8 +76,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_REORG_POSTURE.md
+++ b/docs/MEMPOOL_REORG_POSTURE.md
@@ -77,7 +77,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_RESURRECT_POSTURE.md
+++ b/docs/MEMPOOL_RESURRECT_POSTURE.md
@@ -1,0 +1,77 @@
+# PQBTC `mempool_resurrect.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-RESURRECT-POSTURE-v1
+## Updated: 2026-05-07
+## Frozen-By: track-a-phase1-20260507
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool transaction
+resurrection after a multi-block reorg under the current legacy-compatible PQC
+profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_resurrect.py](../test/functional/mempool_resurrect.py) suite owns a
+small one-node mempool resurrection boundary:
+
+- three first-level spends are accepted and mined into one block
+- three descendant spends are accepted and mined into the next block
+- while both blocks are active, the mempool is empty and all six spend
+  transactions are confirmed
+- invalidating the first mined block disconnects both blocks and returns all
+  six spend transactions to the mempool with zero confirmations
+- mining a replacement block confirms the resurrected transaction set again
+  and leaves the mempool empty
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- the broader mempool reorg, relay, TRUC, sigop-limit, spend-coinbase, or
+  mining-template suites are owned by this tranche
+- prior-release mempool compatibility behavior is covered without real prior
+  PQBTC release assets
+- PQ-native witness-size stress replaces this inherited resurrection surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-07:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_resurrect.py`
+  - result: passed
+  - current posture:
+    - disconnected parent and descendant transactions return to the mempool
+      after the reorg
+    - resurrected transactions are mined again in the replacement block
+    - the mempool is empty after both the original confirmation path and the
+      replacement confirmation path
+
+## Interpretation
+
+- `mempool_resurrect.py` is now a required inherited mempool resurrection gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -58,7 +58,8 @@ inherited one-more-descendant package carveout behavior in the same gate, keep
 `mempool_packages.py` inherited mempool ancestor/descendant tracking behavior
 in the same gate, keep `mempool_persist.py` inherited mempool persistence
 behavior in the same gate, keep `mempool_reorg.py` inherited mempool reorg
-behavior in the same gate,
+behavior in the same gate, keep `mempool_resurrect.py` inherited mempool
+resurrection behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -1252,8 +1253,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PERSIST_POSTURE.md`
    Still deferred inside this suite:
-   - reorg, resurrection, TRUC, mining policy, and prior-release compatibility
-     suites
+   - TRUC, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1276,15 +1276,36 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_REORG_POSTURE.md`
    Still deferred inside this suite:
-   - resurrection, sigop-limit, spend-coinbase, TRUC, mining policy, and
-     prior-release compatibility suites
+   - sigop-limit, spend-coinbase, TRUC, mining policy, and prior-release
+     compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-60. Recommended next PR after this tranche:
+60. `mempool_resurrect.py` now owns:
+   - inherited mempool resurrection behavior under the current
+     legacy-compatible PQC profile
+   - first-level spend admission and confirmation into one block
+   - descendant spend admission and confirmation into a second block
+   - empty mempool while the original two-block confirmation path is active
+   - two-block disconnect after invalidating the first mined block
+   - all disconnected parent and descendant transactions returning to the
+     mempool with zero confirmations
+   - replacement-block mining of the resurrected transaction set
+   - empty mempool after the replacement confirmation path
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_resurrect.py`
+   Fixed posture note:
+   - `MEMPOOL_RESURRECT_POSTURE.md`
+   Still deferred inside this suite:
+   - sigop-limit, spend-coinbase, TRUC, mining policy, and prior-release
+     compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+61. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_resurrect.py` as the next local mempool resurrection
-     candidate after a fresh targeted pass, while
+   - alternate: `mempool_sigoplimit.py` as the next local mempool resource
+     envelope candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
@@ -1297,9 +1318,9 @@ Still deferred:
    - the first two inherited mempool acceptance gates plus datacarrier, dust,
      ephemeral-dust, expiry, limit, package-limit, and one-more-descendant
      carveout policy are now frozen, and package RBF plus package accounting
-     are now frozen, and mempool persistence is now frozen, so the adjacent
-     local mempool follow-on should be another bounded policy gate only after a
-     fresh targeted pass, with mempool reorg behavior now represented too
+     are now frozen, and mempool persistence, reorg, and resurrection behavior
+     are now frozen, so the adjacent local mempool follow-on should be another
+     bounded policy/resource-envelope gate only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2245,6 +2266,16 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mempool candidate is
   `mempool_resurrect.py` after a fresh targeted pass.
+- 2026-05-07: `mempool_resurrect.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers parent and descendant transactions mined
+  across two blocks, full transaction resurrection into mempool after
+  invalidating the first block, zero-confirmation reporting for the
+  resurrected set, and replacement-block mining under the current
+  legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_sigoplimit.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_resurrect.py` from `pq_backlog` to `pq_required`
- add it to the PQ functional runner list and update CI completeness counts to `pq_required=110`, `pq_backlog=15`
- add `MEMPOOL_RESURRECT_POSTURE.md` and refresh Track A/mempool posture handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_resurrect.py`
- `git diff --check`
- `git diff --cached --check`

## Notes
- no source or test behavior edits
- `feature_coinstatsindex_compatibility.py` remains preferred once real prior PQBTC release assets exist; local alternate moves to `mempool_sigoplimit.py`