### PR TITLE
Promote mempool sigoplimit gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -686,10 +686,10 @@
   },
   {
     "name": "mempool_sigoplimit.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool sigop resource-envelope gate: the suite exercises -bytespersigop-adjusted vsize across default and custom values, testmempoolaccept sizing above and below the sigop-equivalent threshold, ancestor/descendant size accounting using adjusted vsize, package-limit rejection for bare multisig sigop-heavy packages, and legacy sigops standardness boundaries under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_spend_coinbase.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -42,6 +42,7 @@ mempool_pq_limits.py
 mempool_pq_stress.py
 mempool_reorg.py
 mempool_resurrect.py
+mempool_sigoplimit.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `110` |
-| `pq_backlog` | `15` |
+| `pq_required` | `111` |
+| `pq_backlog` | `14` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -68,91 +68,92 @@ Current required PQ-first gates:
 23. `mempool_persist.py`
 24. `mempool_reorg.py`
 25. `mempool_resurrect.py`
-26. `wallet_pq_active_ranged.py`
-27. `wallet_pq_backup_recovery.py`
-28. `wallet_pq_create_tx.py`
-29. `wallet_pq_descriptors.py`
-30. `wallet_pq_psbt.py`
-31. `wallet_pq_send.py`
-32. `wallet_pq_sendall.py`
-33. `wallet_pq_sendmany.py`
-34. `wallet_pq_signrawtransaction.py`
-35. `feature_assumeutxo.py`
-36. `feature_assumevalid.py`
-37. `feature_bip68_sequence.py`
-38. `feature_block.py`
-39. `feature_blocksdir.py`
-40. `feature_blocksxor.py`
-41. `feature_cltv.py`
-42. `feature_coinstatsindex.py`
-43. `feature_csv_activation.py`
-44. `feature_fastprune.py`
-45. `feature_index_prune.py`
-46. `feature_loadblock.py`
-47. `feature_pruning.py`
-48. `feature_reindex.py`
-49. `feature_reindex_init.py`
-50. `feature_reindex_readonly.py`
-51. `feature_remove_pruned_files_on_startup.py`
-52. `feature_utxo_set_hash.py`
-53. `feature_versionbits_warning.py`
-54. `rpc_psbt.py`
-55. `wallet_abandonconflict.py`
-56. `wallet_address_types.py`
-57. `wallet_assumeutxo.py`
-58. `wallet_avoid_mixing_output_types.py`
-59. `wallet_avoidreuse.py`
-60. `wallet_backup.py`
-61. `wallet_balance.py`
-62. `wallet_basic.py`
-63. `wallet_blank.py`
-64. `wallet_bumpfee.py`
-65. `wallet_change_address.py`
-66. `wallet_coinbase_category.py`
-67. `wallet_conflicts.py`
-68. `wallet_create_tx.py`
-69. `wallet_createwallet.py`
-70. `wallet_createwalletdescriptor.py`
-71. `wallet_crosschain.py`
-72. `wallet_descriptor.py`
-73. `wallet_disable.py`
-74. `wallet_encryption.py`
-75. `wallet_fallbackfee.py`
-76. `wallet_fast_rescan.py`
-77. `wallet_fundrawtransaction.py`
-78. `wallet_gethdkeys.py`
-79. `wallet_groups.py`
-80. `wallet_hd.py`
-81. `wallet_importdescriptors.py`
-82. `wallet_importprunedfunds.py`
-83. `wallet_keypool.py`
-84. `wallet_keypool_topup.py`
-85. `wallet_labels.py`
-86. `wallet_listdescriptors.py`
-87. `wallet_listreceivedby.py`
-88. `wallet_listsinceblock.py`
-89. `wallet_listtransactions.py`
-90. `wallet_miniscript.py`
-91. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-92. `wallet_multisig_descriptor_psbt.py`
-93. `wallet_multiwallet.py`
-94. `wallet_orphanedreward.py`
-95. `wallet_reindex.py`
-96. `wallet_reorgsrestore.py`
-97. `wallet_rescan_unconfirmed.py`
-98. `wallet_resendwallettransactions.py`
-99. `wallet_send.py`
-100. `wallet_sendall.py`
-101. `wallet_sendmany.py`
-102. `wallet_signrawtransactionwithwallet.py`
-103. `wallet_simulaterawtx.py`
-104. `wallet_spend_unconfirmed.py`
-105. `wallet_startup.py`
-106. `wallet_timelock.py`
-107. `wallet_transactiontime_rescan.py`
-108. `wallet_txn_clone.py`
-109. `wallet_txn_doublespend.py`
-110. `wallet_v3_txs.py`
+26. `mempool_sigoplimit.py`
+27. `wallet_pq_active_ranged.py`
+28. `wallet_pq_backup_recovery.py`
+29. `wallet_pq_create_tx.py`
+30. `wallet_pq_descriptors.py`
+31. `wallet_pq_psbt.py`
+32. `wallet_pq_send.py`
+33. `wallet_pq_sendall.py`
+34. `wallet_pq_sendmany.py`
+35. `wallet_pq_signrawtransaction.py`
+36. `feature_assumeutxo.py`
+37. `feature_assumevalid.py`
+38. `feature_bip68_sequence.py`
+39. `feature_block.py`
+40. `feature_blocksdir.py`
+41. `feature_blocksxor.py`
+42. `feature_cltv.py`
+43. `feature_coinstatsindex.py`
+44. `feature_csv_activation.py`
+45. `feature_fastprune.py`
+46. `feature_index_prune.py`
+47. `feature_loadblock.py`
+48. `feature_pruning.py`
+49. `feature_reindex.py`
+50. `feature_reindex_init.py`
+51. `feature_reindex_readonly.py`
+52. `feature_remove_pruned_files_on_startup.py`
+53. `feature_utxo_set_hash.py`
+54. `feature_versionbits_warning.py`
+55. `rpc_psbt.py`
+56. `wallet_abandonconflict.py`
+57. `wallet_address_types.py`
+58. `wallet_assumeutxo.py`
+59. `wallet_avoid_mixing_output_types.py`
+60. `wallet_avoidreuse.py`
+61. `wallet_backup.py`
+62. `wallet_balance.py`
+63. `wallet_basic.py`
+64. `wallet_blank.py`
+65. `wallet_bumpfee.py`
+66. `wallet_change_address.py`
+67. `wallet_coinbase_category.py`
+68. `wallet_conflicts.py`
+69. `wallet_create_tx.py`
+70. `wallet_createwallet.py`
+71. `wallet_createwalletdescriptor.py`
+72. `wallet_crosschain.py`
+73. `wallet_descriptor.py`
+74. `wallet_disable.py`
+75. `wallet_encryption.py`
+76. `wallet_fallbackfee.py`
+77. `wallet_fast_rescan.py`
+78. `wallet_fundrawtransaction.py`
+79. `wallet_gethdkeys.py`
+80. `wallet_groups.py`
+81. `wallet_hd.py`
+82. `wallet_importdescriptors.py`
+83. `wallet_importprunedfunds.py`
+84. `wallet_keypool.py`
+85. `wallet_keypool_topup.py`
+86. `wallet_labels.py`
+87. `wallet_listdescriptors.py`
+88. `wallet_listreceivedby.py`
+89. `wallet_listsinceblock.py`
+90. `wallet_listtransactions.py`
+91. `wallet_miniscript.py`
+92. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+93. `wallet_multisig_descriptor_psbt.py`
+94. `wallet_multiwallet.py`
+95. `wallet_orphanedreward.py`
+96. `wallet_reindex.py`
+97. `wallet_reorgsrestore.py`
+98. `wallet_rescan_unconfirmed.py`
+99. `wallet_resendwallettransactions.py`
+100. `wallet_send.py`
+101. `wallet_sendall.py`
+102. `wallet_sendmany.py`
+103. `wallet_signrawtransactionwithwallet.py`
+104. `wallet_simulaterawtx.py`
+105. `wallet_spend_unconfirmed.py`
+106. `wallet_startup.py`
+107. `wallet_timelock.py`
+108. `wallet_transactiontime_rescan.py`
+109. `wallet_txn_clone.py`
+110. `wallet_txn_doublespend.py`
+111. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -451,6 +452,12 @@ required gate: `mempool_resurrect.py` covers disconnected parent and
 descendant transactions returning to the mempool with zero confirmations after
 a two-block reorg, then being mined again under the current legacy-compatible
 PQC profile.
+The inherited mempool sigop resource-envelope confidence gap is now also part
+of the required gate: `mempool_sigoplimit.py` covers `-bytespersigop` adjusted
+vsize accounting, ancestor and descendant size accounting with adjusted vsize,
+package-limit rejection for sigop-heavy bare multisig packages, and legacy
+sigops standardness boundaries under the current legacy-compatible PQC
+profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -79,8 +79,9 @@ this worktree.
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -76,8 +76,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -71,8 +71,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -70,8 +70,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -81,8 +81,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -67,8 +67,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -77,8 +77,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -75,8 +75,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -77,8 +77,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -79,8 +79,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -78,8 +78,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PERSIST_POSTURE.md
+++ b/docs/MEMPOOL_PERSIST_POSTURE.md
@@ -77,8 +77,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_REORG_POSTURE.md
+++ b/docs/MEMPOOL_REORG_POSTURE.md
@@ -77,8 +77,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_RESURRECT_POSTURE.md
+++ b/docs/MEMPOOL_RESURRECT_POSTURE.md
@@ -69,8 +69,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
+++ b/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
@@ -1,0 +1,87 @@
+# PQBTC `mempool_sigoplimit.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-SIGOPLIMIT-POSTURE-v1
+## Updated: 2026-05-07
+## Frozen-By: track-a-phase1-20260507
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool bytes-per-sigop
+resource-envelope policy under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_sigoplimit.py](../test/functional/mempool_sigoplimit.py) suite owns
+the mempool sigop adjusted-vsize boundary:
+
+- default and custom `-bytespersigop` settings are exercised across a fixed
+  range of sigop counts
+- `testmempoolaccept` reports the sigop-equivalent vsize when it is larger
+  than serialized vsize
+- vsize reporting grows when serialized vsize is above the sigop-equivalent
+  threshold
+- ancestor and descendant size accounting use adjusted vsize for sigop-heavy
+  transactions
+- sigop-heavy bare multisig packages hit the expected package-size limit in
+  package validation
+- direct package submission admits the parent while rejecting the child at the
+  ancestor-size boundary
+- legacy P2SH sigops standardness rejects the too-large input set while the
+  one-input-smaller transaction is accepted
+- the non-standard high-sigop transaction remains mineable when explicitly
+  included in a block
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- the broader spend-coinbase, TRUC, unbroadcast, mining-template, or orphan
+  transaction suites are owned by this tranche
+- prior-release mempool compatibility behavior is covered without real prior
+  PQBTC release assets
+- PQ-native witness-size stress replaces this inherited sigop accounting
+  surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-07:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_sigoplimit.py`
+  - result: passed
+  - current posture:
+    - bytes-per-sigop adjusted vsize remains stable across tested settings
+    - package-limit rejection still uses adjusted vsize for sigop-heavy
+      packages
+    - legacy sigops standardness and explicit block mining boundaries remain
+      green
+
+## Interpretation
+
+- `mempool_sigoplimit.py` is now a required inherited mempool sigop
+  resource-envelope gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -59,7 +59,8 @@ inherited one-more-descendant package carveout behavior in the same gate, keep
 in the same gate, keep `mempool_persist.py` inherited mempool persistence
 behavior in the same gate, keep `mempool_reorg.py` inherited mempool reorg
 behavior in the same gate, keep `mempool_resurrect.py` inherited mempool
-resurrection behavior in the same gate,
+resurrection behavior in the same gate, keep `mempool_sigoplimit.py`
+inherited mempool sigop resource-envelope behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -1276,8 +1277,8 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_REORG_POSTURE.md`
    Still deferred inside this suite:
-   - sigop-limit, spend-coinbase, TRUC, mining policy, and prior-release
-     compatibility suites
+   - spend-coinbase, TRUC, mining policy, and prior-release compatibility
+     suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1297,15 +1298,38 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_RESURRECT_POSTURE.md`
    Still deferred inside this suite:
-   - sigop-limit, spend-coinbase, TRUC, mining policy, and prior-release
-     compatibility suites
+   - spend-coinbase, TRUC, mining policy, and prior-release compatibility
+     suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-61. Recommended next PR after this tranche:
+61. `mempool_sigoplimit.py` now owns:
+   - inherited bytes-per-sigop mempool resource-envelope policy under the
+     current legacy-compatible PQC profile
+   - default and custom `-bytespersigop` settings across fixed sigop counts
+   - `testmempoolaccept` vsize reporting at, above, and below the
+     sigop-equivalent threshold
+   - ancestor and descendant size accounting with adjusted vsize
+   - package-size rejection for sigop-heavy bare multisig packages
+   - direct package submission where the parent enters mempool and the child
+     fails ancestor-size policy
+   - legacy P2SH sigops standardness rejection and one-input-smaller
+     acceptance
+   - explicit block mining of the non-standard high-sigop transaction
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_sigoplimit.py`
+   Fixed posture note:
+   - `MEMPOOL_SIGOPLIMIT_POSTURE.md`
+   Still deferred inside this suite:
+   - spend-coinbase, TRUC, mining policy, and prior-release compatibility
+     suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+62. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_sigoplimit.py` as the next local mempool resource
-     envelope candidate after a fresh targeted pass, while
+   - alternate: `mempool_spend_coinbase.py` as the next local mempool
+     coinbase-spend policy candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
@@ -1319,8 +1343,9 @@ Still deferred:
      ephemeral-dust, expiry, limit, package-limit, and one-more-descendant
      carveout policy are now frozen, and package RBF plus package accounting
      are now frozen, and mempool persistence, reorg, and resurrection behavior
-     are now frozen, so the adjacent local mempool follow-on should be another
-     bounded policy/resource-envelope gate only after a fresh targeted pass
+     are now frozen, and sigop resource-envelope policy is now frozen, so the
+     adjacent local mempool follow-on should be another bounded policy gate
+     only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2276,6 +2301,16 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mempool candidate is
   `mempool_sigoplimit.py` after a fresh targeted pass.
+- 2026-05-07: `mempool_sigoplimit.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers bytes-per-sigop adjusted vsize accounting,
+  ancestor and descendant size accounting with adjusted vsize, package-limit
+  rejection for sigop-heavy bare multisig packages, direct package submission
+  at the ancestor-size boundary, and legacy sigops standardness boundaries
+  under the current legacy-compatible PQC profile. The next owned follow-on
+  remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
+  release assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_spend_coinbase.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_sigoplimit.py` from `pq_backlog` to `pq_required`
- add it to the PQ functional runner list and update CI completeness counts to `pq_required=111`, `pq_backlog=14`
- add `MEMPOOL_SIGOPLIMIT_POSTURE.md` and refresh Track A/mempool posture handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_sigoplimit.py`
- `git diff --check`
- `git diff --cached --check`

## Notes
- no source or test behavior edits
- `feature_coinstatsindex_compatibility.py` remains preferred once real prior PQBTC release assets exist; local alternate moves to `mempool_spend_coinbase.py`