### PR TITLE
Promote mempool spend coinbase gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -693,10 +693,10 @@
   },
   {
     "name": "mempool_spend_coinbase.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool coinbase-spend maturity gate: the suite invalidates back to a height where one coinbase spend is mature for the next block and the adjacent coinbase is premature, verifies mature admission and premature rejection with bad-txns-premature-spend-of-coinbase, confirms the mature spend when mined, and then accepts the formerly premature spend after height advances under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_truc.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -43,6 +43,7 @@ mempool_pq_stress.py
 mempool_reorg.py
 mempool_resurrect.py
 mempool_sigoplimit.py
+mempool_spend_coinbase.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `111` |
-| `pq_backlog` | `14` |
+| `pq_required` | `112` |
+| `pq_backlog` | `13` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -69,91 +69,92 @@ Current required PQ-first gates:
 24. `mempool_reorg.py`
 25. `mempool_resurrect.py`
 26. `mempool_sigoplimit.py`
-27. `wallet_pq_active_ranged.py`
-28. `wallet_pq_backup_recovery.py`
-29. `wallet_pq_create_tx.py`
-30. `wallet_pq_descriptors.py`
-31. `wallet_pq_psbt.py`
-32. `wallet_pq_send.py`
-33. `wallet_pq_sendall.py`
-34. `wallet_pq_sendmany.py`
-35. `wallet_pq_signrawtransaction.py`
-36. `feature_assumeutxo.py`
-37. `feature_assumevalid.py`
-38. `feature_bip68_sequence.py`
-39. `feature_block.py`
-40. `feature_blocksdir.py`
-41. `feature_blocksxor.py`
-42. `feature_cltv.py`
-43. `feature_coinstatsindex.py`
-44. `feature_csv_activation.py`
-45. `feature_fastprune.py`
-46. `feature_index_prune.py`
-47. `feature_loadblock.py`
-48. `feature_pruning.py`
-49. `feature_reindex.py`
-50. `feature_reindex_init.py`
-51. `feature_reindex_readonly.py`
-52. `feature_remove_pruned_files_on_startup.py`
-53. `feature_utxo_set_hash.py`
-54. `feature_versionbits_warning.py`
-55. `rpc_psbt.py`
-56. `wallet_abandonconflict.py`
-57. `wallet_address_types.py`
-58. `wallet_assumeutxo.py`
-59. `wallet_avoid_mixing_output_types.py`
-60. `wallet_avoidreuse.py`
-61. `wallet_backup.py`
-62. `wallet_balance.py`
-63. `wallet_basic.py`
-64. `wallet_blank.py`
-65. `wallet_bumpfee.py`
-66. `wallet_change_address.py`
-67. `wallet_coinbase_category.py`
-68. `wallet_conflicts.py`
-69. `wallet_create_tx.py`
-70. `wallet_createwallet.py`
-71. `wallet_createwalletdescriptor.py`
-72. `wallet_crosschain.py`
-73. `wallet_descriptor.py`
-74. `wallet_disable.py`
-75. `wallet_encryption.py`
-76. `wallet_fallbackfee.py`
-77. `wallet_fast_rescan.py`
-78. `wallet_fundrawtransaction.py`
-79. `wallet_gethdkeys.py`
-80. `wallet_groups.py`
-81. `wallet_hd.py`
-82. `wallet_importdescriptors.py`
-83. `wallet_importprunedfunds.py`
-84. `wallet_keypool.py`
-85. `wallet_keypool_topup.py`
-86. `wallet_labels.py`
-87. `wallet_listdescriptors.py`
-88. `wallet_listreceivedby.py`
-89. `wallet_listsinceblock.py`
-90. `wallet_listtransactions.py`
-91. `wallet_miniscript.py`
-92. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-93. `wallet_multisig_descriptor_psbt.py`
-94. `wallet_multiwallet.py`
-95. `wallet_orphanedreward.py`
-96. `wallet_reindex.py`
-97. `wallet_reorgsrestore.py`
-98. `wallet_rescan_unconfirmed.py`
-99. `wallet_resendwallettransactions.py`
-100. `wallet_send.py`
-101. `wallet_sendall.py`
-102. `wallet_sendmany.py`
-103. `wallet_signrawtransactionwithwallet.py`
-104. `wallet_simulaterawtx.py`
-105. `wallet_spend_unconfirmed.py`
-106. `wallet_startup.py`
-107. `wallet_timelock.py`
-108. `wallet_transactiontime_rescan.py`
-109. `wallet_txn_clone.py`
-110. `wallet_txn_doublespend.py`
-111. `wallet_v3_txs.py`
+27. `mempool_spend_coinbase.py`
+28. `wallet_pq_active_ranged.py`
+29. `wallet_pq_backup_recovery.py`
+30. `wallet_pq_create_tx.py`
+31. `wallet_pq_descriptors.py`
+32. `wallet_pq_psbt.py`
+33. `wallet_pq_send.py`
+34. `wallet_pq_sendall.py`
+35. `wallet_pq_sendmany.py`
+36. `wallet_pq_signrawtransaction.py`
+37. `feature_assumeutxo.py`
+38. `feature_assumevalid.py`
+39. `feature_bip68_sequence.py`
+40. `feature_block.py`
+41. `feature_blocksdir.py`
+42. `feature_blocksxor.py`
+43. `feature_cltv.py`
+44. `feature_coinstatsindex.py`
+45. `feature_csv_activation.py`
+46. `feature_fastprune.py`
+47. `feature_index_prune.py`
+48. `feature_loadblock.py`
+49. `feature_pruning.py`
+50. `feature_reindex.py`
+51. `feature_reindex_init.py`
+52. `feature_reindex_readonly.py`
+53. `feature_remove_pruned_files_on_startup.py`
+54. `feature_utxo_set_hash.py`
+55. `feature_versionbits_warning.py`
+56. `rpc_psbt.py`
+57. `wallet_abandonconflict.py`
+58. `wallet_address_types.py`
+59. `wallet_assumeutxo.py`
+60. `wallet_avoid_mixing_output_types.py`
+61. `wallet_avoidreuse.py`
+62. `wallet_backup.py`
+63. `wallet_balance.py`
+64. `wallet_basic.py`
+65. `wallet_blank.py`
+66. `wallet_bumpfee.py`
+67. `wallet_change_address.py`
+68. `wallet_coinbase_category.py`
+69. `wallet_conflicts.py`
+70. `wallet_create_tx.py`
+71. `wallet_createwallet.py`
+72. `wallet_createwalletdescriptor.py`
+73. `wallet_crosschain.py`
+74. `wallet_descriptor.py`
+75. `wallet_disable.py`
+76. `wallet_encryption.py`
+77. `wallet_fallbackfee.py`
+78. `wallet_fast_rescan.py`
+79. `wallet_fundrawtransaction.py`
+80. `wallet_gethdkeys.py`
+81. `wallet_groups.py`
+82. `wallet_hd.py`
+83. `wallet_importdescriptors.py`
+84. `wallet_importprunedfunds.py`
+85. `wallet_keypool.py`
+86. `wallet_keypool_topup.py`
+87. `wallet_labels.py`
+88. `wallet_listdescriptors.py`
+89. `wallet_listreceivedby.py`
+90. `wallet_listsinceblock.py`
+91. `wallet_listtransactions.py`
+92. `wallet_miniscript.py`
+93. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+94. `wallet_multisig_descriptor_psbt.py`
+95. `wallet_multiwallet.py`
+96. `wallet_orphanedreward.py`
+97. `wallet_reindex.py`
+98. `wallet_reorgsrestore.py`
+99. `wallet_rescan_unconfirmed.py`
+100. `wallet_resendwallettransactions.py`
+101. `wallet_send.py`
+102. `wallet_sendall.py`
+103. `wallet_sendmany.py`
+104. `wallet_signrawtransactionwithwallet.py`
+105. `wallet_simulaterawtx.py`
+106. `wallet_spend_unconfirmed.py`
+107. `wallet_startup.py`
+108. `wallet_timelock.py`
+109. `wallet_transactiontime_rescan.py`
+110. `wallet_txn_clone.py`
+111. `wallet_txn_doublespend.py`
+112. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -458,6 +459,12 @@ vsize accounting, ancestor and descendant size accounting with adjusted vsize,
 package-limit rejection for sigop-heavy bare multisig packages, and legacy
 sigops standardness boundaries under the current legacy-compatible PQC
 profile.
+The inherited mempool coinbase-spend maturity confidence gap is now also part
+of the required gate: `mempool_spend_coinbase.py` covers near-mature coinbase
+spend admission, adjacent premature coinbase-spend rejection with
+`bad-txns-premature-spend-of-coinbase`, mined confirmation of the mature
+spend, and later admission of the formerly premature spend after height
+advances under the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -80,8 +80,9 @@ this worktree.
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -77,8 +77,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -72,8 +72,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -71,8 +71,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -82,8 +82,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -68,8 +68,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -78,8 +78,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -76,8 +76,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -78,8 +78,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -80,8 +80,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -79,8 +79,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PERSIST_POSTURE.md
+++ b/docs/MEMPOOL_PERSIST_POSTURE.md
@@ -78,8 +78,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_REORG_POSTURE.md
+++ b/docs/MEMPOOL_REORG_POSTURE.md
@@ -78,8 +78,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_RESURRECT_POSTURE.md
+++ b/docs/MEMPOOL_RESURRECT_POSTURE.md
@@ -70,8 +70,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
+++ b/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
@@ -79,8 +79,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SPEND_COINBASE_POSTURE.md
+++ b/docs/MEMPOOL_SPEND_COINBASE_POSTURE.md
@@ -1,0 +1,79 @@
+# PQBTC `mempool_spend_coinbase.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-SPEND-COINBASE-POSTURE-v1
+## Updated: 2026-05-07
+## Frozen-By: track-a-phase1-20260507
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool coinbase-spend maturity
+policy under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_spend_coinbase.py](../test/functional/mempool_spend_coinbase.py)
+suite owns the mempool coinbase-spend maturity boundary:
+
+- the chain is invalidated to a height where one coinbase spend is mature for
+  the next block while the adjacent coinbase spend is still premature
+- the near-mature coinbase spend enters the mempool
+- the premature coinbase spend is rejected with
+  `bad-txns-premature-spend-of-coinbase`
+- the mempool contains only the mature coinbase spend before mining
+- mining one block confirms the mature coinbase spend and clears the mempool
+- after height advances, the previously premature coinbase spend is accepted
+  into the mempool
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- the broader TRUC, unbroadcast, update-from-block, mining-template, or orphan
+  transaction suites are owned by this tranche
+- prior-release mempool compatibility behavior is covered without real prior
+  PQBTC release assets
+- PQ-native witness-size stress replaces this inherited coinbase maturity
+  surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-07:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_spend_coinbase.py`
+  - result: passed
+  - current posture:
+    - near-mature coinbase-spend admission remains stable
+    - premature coinbase-spend rejection keeps the expected policy reason
+    - the formerly premature spend is accepted after the chain height advances
+
+## Interpretation
+
+- `mempool_spend_coinbase.py` is now a required inherited mempool
+  coinbase-spend maturity gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -60,7 +60,9 @@ in the same gate, keep `mempool_persist.py` inherited mempool persistence
 behavior in the same gate, keep `mempool_reorg.py` inherited mempool reorg
 behavior in the same gate, keep `mempool_resurrect.py` inherited mempool
 resurrection behavior in the same gate, keep `mempool_sigoplimit.py`
-inherited mempool sigop resource-envelope behavior in the same gate,
+inherited mempool sigop resource-envelope behavior in the same gate, keep
+`mempool_spend_coinbase.py` inherited mempool coinbase-spend maturity behavior
+in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -1277,8 +1279,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_REORG_POSTURE.md`
    Still deferred inside this suite:
-   - spend-coinbase, TRUC, mining policy, and prior-release compatibility
-     suites
+   - TRUC, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1298,8 +1299,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_RESURRECT_POSTURE.md`
    Still deferred inside this suite:
-   - spend-coinbase, TRUC, mining policy, and prior-release compatibility
-     suites
+   - TRUC, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1321,15 +1321,35 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_SIGOPLIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - spend-coinbase, TRUC, mining policy, and prior-release compatibility
-     suites
+   - TRUC, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-62. Recommended next PR after this tranche:
+62. `mempool_spend_coinbase.py` now owns:
+   - inherited mempool coinbase-spend maturity policy under the current
+     legacy-compatible PQC profile
+   - chain invalidation to a height where one coinbase spend is mature for the
+     next block and the adjacent coinbase spend is premature
+   - near-mature coinbase-spend admission to the mempool
+   - premature coinbase-spend rejection with
+     `bad-txns-premature-spend-of-coinbase`
+   - mempool contents containing only the mature spend before mining
+   - mined confirmation of the mature coinbase spend and mempool cleanup
+   - later admission of the formerly premature coinbase spend after height
+     advances
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_spend_coinbase.py`
+   Fixed posture note:
+   - `MEMPOOL_SPEND_COINBASE_POSTURE.md`
+   Still deferred inside this suite:
+   - TRUC, mining policy, and prior-release compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+63. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_spend_coinbase.py` as the next local mempool
-     coinbase-spend policy candidate after a fresh targeted pass, while
+   - alternate: `mempool_truc.py` as the next local mempool TRUC policy
+     candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
    - `feature_coinstatsindex_compatibility.py` is the remaining nearby
@@ -1345,7 +1365,8 @@ Still deferred:
      are now frozen, and mempool persistence, reorg, and resurrection behavior
      are now frozen, and sigop resource-envelope policy is now frozen, so the
      adjacent local mempool follow-on should be another bounded policy gate
-     only after a fresh targeted pass
+     only after a fresh targeted pass, with coinbase-spend maturity behavior
+     now represented too
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2311,6 +2332,16 @@ Aineko must ask before:
   remains `feature_coinstatsindex_compatibility.py` when real prior PQBTC
   release assets exist; otherwise the adjacent local mempool candidate is
   `mempool_spend_coinbase.py` after a fresh targeted pass.
+- 2026-05-07: `mempool_spend_coinbase.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers near-mature coinbase-spend admission,
+  adjacent premature coinbase-spend rejection with
+  `bad-txns-premature-spend-of-coinbase`, mined confirmation of the mature
+  spend, and later admission of the formerly premature spend after height
+  advances under the current legacy-compatible PQC profile. The next owned
+  follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+  PQBTC release assets exist; otherwise the adjacent local mempool candidate
+  is `mempool_truc.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_spend_coinbase.py` from `pq_backlog` to `pq_required`
- add it to the PQ functional runner list and update CI completeness counts to `pq_required=112`, `pq_backlog=13`
- add `MEMPOOL_SPEND_COINBASE_POSTURE.md` and refresh Track A/mempool posture handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_spend_coinbase.py`
- `git diff --check`
- `git diff --cached --check`

## Notes
- no source or test behavior edits
- work-ahead PR opened while post-merge checks for #145 continue
- `feature_coinstatsindex_compatibility.py` remains preferred once real prior PQBTC release assets exist; local alternate moves to `mempool_truc.py`