### PR TITLE
Promote mempool TRUC gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -700,10 +700,10 @@
   },
   {
     "name": "mempool_truc.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited TRUC/v3 mempool policy gate: the suite exercises v3 transaction size and child-size limits, direct acceptance, replacement, and inheritance checks, reorg restoration that bypasses direct mempool TRUC topology enforcement, nondefault package-limit interactions, package ancestor checks, sibling eviction behavior, testmempoolaccept inheritance diagnostics, and minrelay package combinations under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_unbroadcast.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -44,6 +44,7 @@ mempool_reorg.py
 mempool_resurrect.py
 mempool_sigoplimit.py
 mempool_spend_coinbase.py
+mempool_truc.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `112` |
-| `pq_backlog` | `13` |
+| `pq_required` | `113` |
+| `pq_backlog` | `12` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -70,91 +70,92 @@ Current required PQ-first gates:
 25. `mempool_resurrect.py`
 26. `mempool_sigoplimit.py`
 27. `mempool_spend_coinbase.py`
-28. `wallet_pq_active_ranged.py`
-29. `wallet_pq_backup_recovery.py`
-30. `wallet_pq_create_tx.py`
-31. `wallet_pq_descriptors.py`
-32. `wallet_pq_psbt.py`
-33. `wallet_pq_send.py`
-34. `wallet_pq_sendall.py`
-35. `wallet_pq_sendmany.py`
-36. `wallet_pq_signrawtransaction.py`
-37. `feature_assumeutxo.py`
-38. `feature_assumevalid.py`
-39. `feature_bip68_sequence.py`
-40. `feature_block.py`
-41. `feature_blocksdir.py`
-42. `feature_blocksxor.py`
-43. `feature_cltv.py`
-44. `feature_coinstatsindex.py`
-45. `feature_csv_activation.py`
-46. `feature_fastprune.py`
-47. `feature_index_prune.py`
-48. `feature_loadblock.py`
-49. `feature_pruning.py`
-50. `feature_reindex.py`
-51. `feature_reindex_init.py`
-52. `feature_reindex_readonly.py`
-53. `feature_remove_pruned_files_on_startup.py`
-54. `feature_utxo_set_hash.py`
-55. `feature_versionbits_warning.py`
-56. `rpc_psbt.py`
-57. `wallet_abandonconflict.py`
-58. `wallet_address_types.py`
-59. `wallet_assumeutxo.py`
-60. `wallet_avoid_mixing_output_types.py`
-61. `wallet_avoidreuse.py`
-62. `wallet_backup.py`
-63. `wallet_balance.py`
-64. `wallet_basic.py`
-65. `wallet_blank.py`
-66. `wallet_bumpfee.py`
-67. `wallet_change_address.py`
-68. `wallet_coinbase_category.py`
-69. `wallet_conflicts.py`
-70. `wallet_create_tx.py`
-71. `wallet_createwallet.py`
-72. `wallet_createwalletdescriptor.py`
-73. `wallet_crosschain.py`
-74. `wallet_descriptor.py`
-75. `wallet_disable.py`
-76. `wallet_encryption.py`
-77. `wallet_fallbackfee.py`
-78. `wallet_fast_rescan.py`
-79. `wallet_fundrawtransaction.py`
-80. `wallet_gethdkeys.py`
-81. `wallet_groups.py`
-82. `wallet_hd.py`
-83. `wallet_importdescriptors.py`
-84. `wallet_importprunedfunds.py`
-85. `wallet_keypool.py`
-86. `wallet_keypool_topup.py`
-87. `wallet_labels.py`
-88. `wallet_listdescriptors.py`
-89. `wallet_listreceivedby.py`
-90. `wallet_listsinceblock.py`
-91. `wallet_listtransactions.py`
-92. `wallet_miniscript.py`
-93. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-94. `wallet_multisig_descriptor_psbt.py`
-95. `wallet_multiwallet.py`
-96. `wallet_orphanedreward.py`
-97. `wallet_reindex.py`
-98. `wallet_reorgsrestore.py`
-99. `wallet_rescan_unconfirmed.py`
-100. `wallet_resendwallettransactions.py`
-101. `wallet_send.py`
-102. `wallet_sendall.py`
-103. `wallet_sendmany.py`
-104. `wallet_signrawtransactionwithwallet.py`
-105. `wallet_simulaterawtx.py`
-106. `wallet_spend_unconfirmed.py`
-107. `wallet_startup.py`
-108. `wallet_timelock.py`
-109. `wallet_transactiontime_rescan.py`
-110. `wallet_txn_clone.py`
-111. `wallet_txn_doublespend.py`
-112. `wallet_v3_txs.py`
+28. `mempool_truc.py`
+29. `wallet_pq_active_ranged.py`
+30. `wallet_pq_backup_recovery.py`
+31. `wallet_pq_create_tx.py`
+32. `wallet_pq_descriptors.py`
+33. `wallet_pq_psbt.py`
+34. `wallet_pq_send.py`
+35. `wallet_pq_sendall.py`
+36. `wallet_pq_sendmany.py`
+37. `wallet_pq_signrawtransaction.py`
+38. `feature_assumeutxo.py`
+39. `feature_assumevalid.py`
+40. `feature_bip68_sequence.py`
+41. `feature_block.py`
+42. `feature_blocksdir.py`
+43. `feature_blocksxor.py`
+44. `feature_cltv.py`
+45. `feature_coinstatsindex.py`
+46. `feature_csv_activation.py`
+47. `feature_fastprune.py`
+48. `feature_index_prune.py`
+49. `feature_loadblock.py`
+50. `feature_pruning.py`
+51. `feature_reindex.py`
+52. `feature_reindex_init.py`
+53. `feature_reindex_readonly.py`
+54. `feature_remove_pruned_files_on_startup.py`
+55. `feature_utxo_set_hash.py`
+56. `feature_versionbits_warning.py`
+57. `rpc_psbt.py`
+58. `wallet_abandonconflict.py`
+59. `wallet_address_types.py`
+60. `wallet_assumeutxo.py`
+61. `wallet_avoid_mixing_output_types.py`
+62. `wallet_avoidreuse.py`
+63. `wallet_backup.py`
+64. `wallet_balance.py`
+65. `wallet_basic.py`
+66. `wallet_blank.py`
+67. `wallet_bumpfee.py`
+68. `wallet_change_address.py`
+69. `wallet_coinbase_category.py`
+70. `wallet_conflicts.py`
+71. `wallet_create_tx.py`
+72. `wallet_createwallet.py`
+73. `wallet_createwalletdescriptor.py`
+74. `wallet_crosschain.py`
+75. `wallet_descriptor.py`
+76. `wallet_disable.py`
+77. `wallet_encryption.py`
+78. `wallet_fallbackfee.py`
+79. `wallet_fast_rescan.py`
+80. `wallet_fundrawtransaction.py`
+81. `wallet_gethdkeys.py`
+82. `wallet_groups.py`
+83. `wallet_hd.py`
+84. `wallet_importdescriptors.py`
+85. `wallet_importprunedfunds.py`
+86. `wallet_keypool.py`
+87. `wallet_keypool_topup.py`
+88. `wallet_labels.py`
+89. `wallet_listdescriptors.py`
+90. `wallet_listreceivedby.py`
+91. `wallet_listsinceblock.py`
+92. `wallet_listtransactions.py`
+93. `wallet_miniscript.py`
+94. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+95. `wallet_multisig_descriptor_psbt.py`
+96. `wallet_multiwallet.py`
+97. `wallet_orphanedreward.py`
+98. `wallet_reindex.py`
+99. `wallet_reorgsrestore.py`
+100. `wallet_rescan_unconfirmed.py`
+101. `wallet_resendwallettransactions.py`
+102. `wallet_send.py`
+103. `wallet_sendall.py`
+104. `wallet_sendmany.py`
+105. `wallet_signrawtransactionwithwallet.py`
+106. `wallet_simulaterawtx.py`
+107. `wallet_spend_unconfirmed.py`
+108. `wallet_startup.py`
+109. `wallet_timelock.py`
+110. `wallet_transactiontime_rescan.py`
+111. `wallet_txn_clone.py`
+112. `wallet_txn_doublespend.py`
+113. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -465,6 +466,12 @@ spend admission, adjacent premature coinbase-spend rejection with
 `bad-txns-premature-spend-of-coinbase`, mined confirmation of the mature
 spend, and later admission of the formerly premature spend after height
 advances under the current legacy-compatible PQC profile.
+The inherited TRUC/v3 mempool policy confidence gap is now also part of the
+required gate: `mempool_truc.py` covers v3 transaction size and child-size
+limits, TRUC inheritance and replacement checks, reorg restoration behavior,
+sibling eviction, package ancestor handling, `testmempoolaccept` inheritance
+diagnostics, and minrelay package combinations under the current
+legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -38,7 +38,7 @@ single-node `testmempoolaccept` and raw transaction policy surface:
 This posture note does **not** mean:
 
 - every remaining mempool functional suite is owned by this tranche
-- package relay, package RBF, expiry, persistence, reorg, TRUC, or mining
+- package relay, package RBF, expiry, persistence, reorg, unbroadcast, or mining
   template behavior is covered here
 - PQ-native witness-size stress replaces this inherited policy surface
 - prior-release compatibility suites can run without real prior PQBTC release
@@ -81,8 +81,9 @@ this worktree.
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -36,7 +36,7 @@ owns the single-node wtxid/non-witness-data mempool boundary:
 
 This posture note does **not** mean:
 
-- the full mempool package, persistence, expiry, reorg, TRUC, or mining
+- the full mempool package, persistence, expiry, reorg, unbroadcast, or mining
   policy families are owned here
 - package relay or package RBF behavior is covered
 - broad P2P relay behavior beyond this single-node wtxid rebroadcast check is
@@ -78,8 +78,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -34,7 +34,8 @@ This posture note does **not** mean:
 
 - every remaining mempool policy suite is owned by this tranche
 - dust, ephemeral-dust, expiry, package relay, package RBF, persistence, reorg,
-  TRUC, mining-template, or prior-release compatibility behavior is covered
+  unbroadcast, mining-template, or prior-release compatibility behavior is
+  covered
   here
 - PQ-native witness-size stress replaces this inherited OP_RETURN policy
   surface
@@ -73,8 +74,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -34,7 +34,8 @@ This posture note does **not** mean:
 
 - every remaining mempool policy suite is owned by this tranche
 - ephemeral-dust package behavior, expiry, package relay, package RBF,
-  persistence, reorg, TRUC, mining-template, or prior-release compatibility
+  persistence, reorg, unbroadcast, mining-template, or prior-release
+  compatibility
   behavior is covered here
 - PQ-native witness-size stress replaces this inherited dust relay policy
   surface
@@ -72,8 +73,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -83,8 +83,9 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -69,8 +69,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -79,8 +79,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -39,7 +39,8 @@ two-node mempool package accounting boundary:
 This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
-- persistence, broad package relay, package RBF, TRUC policy, mining-template
+- persistence, broad package relay, package RBF, unbroadcast policy,
+  mining-template
   behavior, or prior-release compatibility behavior is covered here
 - PQ-native witness-size stress replaces this inherited accounting surface
 
@@ -77,8 +78,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -39,7 +39,7 @@ This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
 - one-more-descendant carveout, package RBF, package relay, persistence,
-  broad reorg behavior, TRUC policy, mining-template behavior, or
+  broad reorg behavior, unbroadcast policy, mining-template behavior, or
   prior-release compatibility behavior is covered here
 - PQ-native witness-size stress replaces this inherited package-limit surface
 
@@ -79,8 +79,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -40,7 +40,8 @@ suite owns the single-node one-more-descendant carveout boundary:
 This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
-- broad package RBF, package relay, persistence, broad reorg behavior, TRUC
+- broad package RBF, package relay, persistence, broad reorg behavior,
+  unbroadcast
   policy, mining-template behavior, or prior-release compatibility behavior is
   covered here
 - PQ-native witness-size stress replaces this inherited one-more-descendant
@@ -81,8 +82,9 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -80,8 +80,9 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PERSIST_POSTURE.md
+++ b/docs/MEMPOOL_PERSIST_POSTURE.md
@@ -39,7 +39,8 @@ three-node mempool persistence boundary:
 
 This posture note does **not** mean:
 
-- every remaining mempool reorg, resurrection, TRUC, or mining-template suite
+- every remaining mempool reorg, resurrection, unbroadcast, or
+  mining-template suite
   is owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -79,8 +80,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_REORG_POSTURE.md
+++ b/docs/MEMPOOL_REORG_POSTURE.md
@@ -39,7 +39,8 @@ two-node mempool reorg boundary:
 
 This posture note does **not** mean:
 
-- every remaining mempool resurrection, TRUC, sigop-limit, spend-coinbase, or
+- every remaining mempool resurrection, unbroadcast, sigop-limit,
+  spend-coinbase, or
   mining-template suite is owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -79,8 +80,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_RESURRECT_POSTURE.md
+++ b/docs/MEMPOOL_RESURRECT_POSTURE.md
@@ -31,7 +31,7 @@ small one-node mempool resurrection boundary:
 
 This posture note does **not** mean:
 
-- the broader mempool reorg, relay, TRUC, sigop-limit, spend-coinbase, or
+- the broader mempool reorg, relay, unbroadcast, sigop-limit, spend-coinbase, or
   mining-template suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -71,8 +71,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
-  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
+++ b/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
@@ -38,7 +38,7 @@ the mempool sigop adjusted-vsize boundary:
 
 This posture note does **not** mean:
 
-- the broader spend-coinbase, TRUC, unbroadcast, mining-template, or orphan
+- the broader spend-coinbase, unbroadcast, mining-template, or orphan
   transaction suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -80,8 +80,9 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
-  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md), and
-  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md)
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SPEND_COINBASE_POSTURE.md
+++ b/docs/MEMPOOL_SPEND_COINBASE_POSTURE.md
@@ -31,7 +31,7 @@ suite owns the mempool coinbase-spend maturity boundary:
 
 This posture note does **not** mean:
 
-- the broader TRUC, unbroadcast, update-from-block, mining-template, or orphan
+- the broader unbroadcast, update-from-block, mining-template, or orphan
   transaction suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -71,6 +71,7 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_TRUC_POSTURE.md
+++ b/docs/MEMPOOL_TRUC_POSTURE.md
@@ -1,0 +1,88 @@
+# PQBTC `mempool_truc.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-TRUC-POSTURE-v1
+## Updated: 2026-05-08
+## Frozen-By: track-a-phase1-20260508
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited TRUC/v3 mempool policy under
+the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_truc.py](../test/functional/mempool_truc.py) suite owns the TRUC/v3
+mempool policy boundary:
+
+- v3 transactions over the TRUC maximum vsize are rejected while equivalent v2
+  transactions remain accepted
+- children of v3 transactions enforce the TRUC child-size limit
+- v3 and v2 replacements preserve direct TRUC policy and inheritance checks
+- reorg restoration can re-enter disconnected transactions even when the
+  resulting mempool shape would violate direct TRUC admission topology
+- nondefault ancestor and descendant package limits still override TRUC package
+  admission where appropriate
+- package ancestor checks reject multiparent, oversized-child, and
+  three-generation TRUC package shapes
+- sibling eviction works only under the expected individual and package
+  submission rules and keeps RBF fee and feerate constraints intact
+- `testmempoolaccept` reports TRUC inheritance violations consistently for
+  independent, in-package, and in-mempool parent cases
+- minrelay combinations keep the expected distinction between zero-fee TRUC
+  parents paid by children and non-TRUC equivalents
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- the unbroadcast, update-from-block, mining-template, or orphan transaction
+  suites are owned by this tranche
+- prior-release mempool compatibility behavior is covered without real prior
+  PQBTC release assets
+- PQ-native witness-size stress replaces this inherited TRUC policy surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-08:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_truc.py`
+  - result: passed
+  - current posture:
+    - TRUC size, inheritance, and replacement policy remains stable
+    - reorg restoration and sibling eviction boundaries keep their expected
+      outcomes
+    - package ancestor and minrelay combinations remain green under the current
+      legacy-compatible PQC profile
+
+## Interpretation
+
+- `mempool_truc.py` is now a required inherited TRUC/v3 mempool policy gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision, with `mempool_unbroadcast.py` the
+  adjacent candidate after a fresh targeted pass

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -62,7 +62,8 @@ behavior in the same gate, keep `mempool_resurrect.py` inherited mempool
 resurrection behavior in the same gate, keep `mempool_sigoplimit.py`
 inherited mempool sigop resource-envelope behavior in the same gate, keep
 `mempool_spend_coinbase.py` inherited mempool coinbase-spend maturity behavior
-in the same gate,
+in the same gate, keep `mempool_truc.py` inherited TRUC/v3 mempool policy
+behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -163,7 +164,9 @@ Alternate rebalance:
      sequence-lock, CLTV, CSV-activation, raw mempool-acceptance,
      wtxid-aware mempool-acceptance, datacarrier, dust, ephemeral-dust,
      expiry, mempool-limit, package-limit, and one-more-descendant carveout
-     tranches, plus package RBF.
+     tranches, plus package RBF, package accounting, persistence, reorg,
+     resurrection, sigop resource-envelope, coinbase-spend maturity, and TRUC
+     policy.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1005,8 +1008,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, reorg, TRUC, and mining
-     policy suites
+   - remaining mempool unbroadcast and mining policy suites
    - `feature_unsupported_utxo_db.py` and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1027,8 +1029,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_WTXID_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, reorg, TRUC, and mining
-     policy suites
+   - remaining mempool unbroadcast and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1048,8 +1049,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_DATACARRIER_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, reorg, TRUC, and mining
-     policy suites
+   - remaining mempool unbroadcast and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1071,8 +1071,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_DUST_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, reorg, TRUC, and mining
-     policy suites
+   - remaining mempool unbroadcast and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1096,8 +1095,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_EPHEMERAL_DUST_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, reorg, TRUC, and mining policy
-     suites
+   - remaining mempool unbroadcast and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1115,8 +1113,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_EXPIRY_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool package, persistence, reorg, TRUC, and mining policy
-     suites
+   - remaining mempool unbroadcast and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1136,8 +1133,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_LIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining package relay, persistence, reorg, TRUC, and mining policy
-     suites
+   - remaining mempool unbroadcast and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1160,7 +1156,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_LIMITS_POSTURE.md`
    Still deferred inside this suite:
-   - package relay, persistence, reorg, TRUC, and mining policy suites
+   - remaining mempool unbroadcast and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1183,7 +1179,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_ONEMORE_POSTURE.md`
    Still deferred inside this suite:
-   - package relay, persistence, reorg, TRUC, and mining policy suites
+   - remaining mempool unbroadcast and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1230,8 +1226,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGES_POSTURE.md`
    Still deferred inside this suite:
-   - persistence, broader package relay, TRUC, mining policy, and
-     prior-release compatibility suites
+   - unbroadcast, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1256,7 +1251,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PERSIST_POSTURE.md`
    Still deferred inside this suite:
-   - TRUC, mining policy, and prior-release compatibility suites
+   - unbroadcast, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1279,7 +1274,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_REORG_POSTURE.md`
    Still deferred inside this suite:
-   - TRUC, mining policy, and prior-release compatibility suites
+   - unbroadcast, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1299,7 +1294,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_RESURRECT_POSTURE.md`
    Still deferred inside this suite:
-   - TRUC, mining policy, and prior-release compatibility suites
+   - unbroadcast, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1321,7 +1316,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_SIGOPLIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - TRUC, mining policy, and prior-release compatibility suites
+   - unbroadcast, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1342,13 +1337,40 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_SPEND_COINBASE_POSTURE.md`
    Still deferred inside this suite:
-   - TRUC, mining policy, and prior-release compatibility suites
+   - unbroadcast, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-63. Recommended next PR after this tranche:
+63. `mempool_truc.py` now owns:
+   - inherited TRUC/v3 mempool policy under the current legacy-compatible PQC
+     profile
+   - v3 maximum-vsize and child-size rejection while equivalent v2
+     transactions remain accepted
+   - direct TRUC acceptance, replacement, and inheritance policy checks
+   - reorg restoration of disconnected transactions without enforcing direct
+     mempool TRUC topology at re-entry time
+   - nondefault ancestor and descendant package-limit interactions
+   - package ancestor rejection for multiparent, oversized-child, and
+     three-generation TRUC package shapes
+   - sibling eviction behavior across individual submission,
+     `testmempoolaccept`, CPFP package submission, and RBF constraints
+   - `testmempoolaccept` inheritance diagnostics for independent, in-package,
+     and in-mempool parent cases
+   - minrelay package combinations for zero-fee TRUC parents paid by children
+     versus non-TRUC equivalents
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_truc.py`
+   Fixed posture note:
+   - `MEMPOOL_TRUC_POSTURE.md`
+   Still deferred inside this suite:
+   - unbroadcast, update-from-block, mining policy, orphan transaction, and
+     prior-release compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+64. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_truc.py` as the next local mempool TRUC policy
+   - alternate: `mempool_unbroadcast.py` as the next local mempool policy
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1363,10 +1385,9 @@ Still deferred:
      ephemeral-dust, expiry, limit, package-limit, and one-more-descendant
      carveout policy are now frozen, and package RBF plus package accounting
      are now frozen, and mempool persistence, reorg, and resurrection behavior
-     are now frozen, and sigop resource-envelope policy is now frozen, so the
-     adjacent local mempool follow-on should be another bounded policy gate
-     only after a fresh targeted pass, with coinbase-spend maturity behavior
-     now represented too
+     are now frozen, and sigop resource-envelope, coinbase-spend maturity, and
+     TRUC policy are now frozen, so the adjacent local mempool follow-on should
+     be another bounded policy gate only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2342,6 +2363,15 @@ Aineko must ask before:
   follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
   PQBTC release assets exist; otherwise the adjacent local mempool candidate
   is `mempool_truc.py` after a fresh targeted pass.
+- 2026-05-08: `mempool_truc.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers v3/TRUC size limits, inheritance,
+  replacement, reorg restoration, package ancestor checks, sibling eviction,
+  `testmempoolaccept` diagnostics, and minrelay package combinations under the
+  current legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_unbroadcast.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_truc.py` from `pq_backlog` to `pq_required`
- add it to the PQ functional runner list and update CI completeness counts to `pq_required=113`, `pq_backlog=12`
- add `MEMPOOL_TRUC_POSTURE.md` and refresh Track A/mempool posture handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_truc.py`
- `git diff --check`
- `git diff --cached --check`

## Notes
- no source or test behavior edits
- work-ahead PR opened while post-merge checks for #146 continue
- `feature_coinstatsindex_compatibility.py` remains preferred once real prior PQBTC release assets exist; local alternate moves to `mempool_unbroadcast.py`
