### PR TITLE
Promote mempool unbroadcast gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -707,10 +707,10 @@
   },
   {
     "name": "mempool_unbroadcast.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool unbroadcast delivery gate: the suite exercises local wallet and raw transaction entry into the unbroadcast set, unbroadcast count and per-entry reporting, mempool.dat persistence across restart, rebroadcast after reconnect and scheduler advance, removal from the unbroadcast set after peer delivery, no repeat broadcast to later peers, no re-addition for already-known transactions, and cleanup before confirmation under the current legacy-compatible PQC profile."
   },
   {
     "name": "mempool_updatefromblock.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -45,6 +45,7 @@ mempool_resurrect.py
 mempool_sigoplimit.py
 mempool_spend_coinbase.py
 mempool_truc.py
+mempool_unbroadcast.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `113` |
-| `pq_backlog` | `12` |
+| `pq_required` | `114` |
+| `pq_backlog` | `11` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -71,91 +71,92 @@ Current required PQ-first gates:
 26. `mempool_sigoplimit.py`
 27. `mempool_spend_coinbase.py`
 28. `mempool_truc.py`
-29. `wallet_pq_active_ranged.py`
-30. `wallet_pq_backup_recovery.py`
-31. `wallet_pq_create_tx.py`
-32. `wallet_pq_descriptors.py`
-33. `wallet_pq_psbt.py`
-34. `wallet_pq_send.py`
-35. `wallet_pq_sendall.py`
-36. `wallet_pq_sendmany.py`
-37. `wallet_pq_signrawtransaction.py`
-38. `feature_assumeutxo.py`
-39. `feature_assumevalid.py`
-40. `feature_bip68_sequence.py`
-41. `feature_block.py`
-42. `feature_blocksdir.py`
-43. `feature_blocksxor.py`
-44. `feature_cltv.py`
-45. `feature_coinstatsindex.py`
-46. `feature_csv_activation.py`
-47. `feature_fastprune.py`
-48. `feature_index_prune.py`
-49. `feature_loadblock.py`
-50. `feature_pruning.py`
-51. `feature_reindex.py`
-52. `feature_reindex_init.py`
-53. `feature_reindex_readonly.py`
-54. `feature_remove_pruned_files_on_startup.py`
-55. `feature_utxo_set_hash.py`
-56. `feature_versionbits_warning.py`
-57. `rpc_psbt.py`
-58. `wallet_abandonconflict.py`
-59. `wallet_address_types.py`
-60. `wallet_assumeutxo.py`
-61. `wallet_avoid_mixing_output_types.py`
-62. `wallet_avoidreuse.py`
-63. `wallet_backup.py`
-64. `wallet_balance.py`
-65. `wallet_basic.py`
-66. `wallet_blank.py`
-67. `wallet_bumpfee.py`
-68. `wallet_change_address.py`
-69. `wallet_coinbase_category.py`
-70. `wallet_conflicts.py`
-71. `wallet_create_tx.py`
-72. `wallet_createwallet.py`
-73. `wallet_createwalletdescriptor.py`
-74. `wallet_crosschain.py`
-75. `wallet_descriptor.py`
-76. `wallet_disable.py`
-77. `wallet_encryption.py`
-78. `wallet_fallbackfee.py`
-79. `wallet_fast_rescan.py`
-80. `wallet_fundrawtransaction.py`
-81. `wallet_gethdkeys.py`
-82. `wallet_groups.py`
-83. `wallet_hd.py`
-84. `wallet_importdescriptors.py`
-85. `wallet_importprunedfunds.py`
-86. `wallet_keypool.py`
-87. `wallet_keypool_topup.py`
-88. `wallet_labels.py`
-89. `wallet_listdescriptors.py`
-90. `wallet_listreceivedby.py`
-91. `wallet_listsinceblock.py`
-92. `wallet_listtransactions.py`
-93. `wallet_miniscript.py`
-94. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-95. `wallet_multisig_descriptor_psbt.py`
-96. `wallet_multiwallet.py`
-97. `wallet_orphanedreward.py`
-98. `wallet_reindex.py`
-99. `wallet_reorgsrestore.py`
-100. `wallet_rescan_unconfirmed.py`
-101. `wallet_resendwallettransactions.py`
-102. `wallet_send.py`
-103. `wallet_sendall.py`
-104. `wallet_sendmany.py`
-105. `wallet_signrawtransactionwithwallet.py`
-106. `wallet_simulaterawtx.py`
-107. `wallet_spend_unconfirmed.py`
-108. `wallet_startup.py`
-109. `wallet_timelock.py`
-110. `wallet_transactiontime_rescan.py`
-111. `wallet_txn_clone.py`
-112. `wallet_txn_doublespend.py`
-113. `wallet_v3_txs.py`
+29. `mempool_unbroadcast.py`
+30. `wallet_pq_active_ranged.py`
+31. `wallet_pq_backup_recovery.py`
+32. `wallet_pq_create_tx.py`
+33. `wallet_pq_descriptors.py`
+34. `wallet_pq_psbt.py`
+35. `wallet_pq_send.py`
+36. `wallet_pq_sendall.py`
+37. `wallet_pq_sendmany.py`
+38. `wallet_pq_signrawtransaction.py`
+39. `feature_assumeutxo.py`
+40. `feature_assumevalid.py`
+41. `feature_bip68_sequence.py`
+42. `feature_block.py`
+43. `feature_blocksdir.py`
+44. `feature_blocksxor.py`
+45. `feature_cltv.py`
+46. `feature_coinstatsindex.py`
+47. `feature_csv_activation.py`
+48. `feature_fastprune.py`
+49. `feature_index_prune.py`
+50. `feature_loadblock.py`
+51. `feature_pruning.py`
+52. `feature_reindex.py`
+53. `feature_reindex_init.py`
+54. `feature_reindex_readonly.py`
+55. `feature_remove_pruned_files_on_startup.py`
+56. `feature_utxo_set_hash.py`
+57. `feature_versionbits_warning.py`
+58. `rpc_psbt.py`
+59. `wallet_abandonconflict.py`
+60. `wallet_address_types.py`
+61. `wallet_assumeutxo.py`
+62. `wallet_avoid_mixing_output_types.py`
+63. `wallet_avoidreuse.py`
+64. `wallet_backup.py`
+65. `wallet_balance.py`
+66. `wallet_basic.py`
+67. `wallet_blank.py`
+68. `wallet_bumpfee.py`
+69. `wallet_change_address.py`
+70. `wallet_coinbase_category.py`
+71. `wallet_conflicts.py`
+72. `wallet_create_tx.py`
+73. `wallet_createwallet.py`
+74. `wallet_createwalletdescriptor.py`
+75. `wallet_crosschain.py`
+76. `wallet_descriptor.py`
+77. `wallet_disable.py`
+78. `wallet_encryption.py`
+79. `wallet_fallbackfee.py`
+80. `wallet_fast_rescan.py`
+81. `wallet_fundrawtransaction.py`
+82. `wallet_gethdkeys.py`
+83. `wallet_groups.py`
+84. `wallet_hd.py`
+85. `wallet_importdescriptors.py`
+86. `wallet_importprunedfunds.py`
+87. `wallet_keypool.py`
+88. `wallet_keypool_topup.py`
+89. `wallet_labels.py`
+90. `wallet_listdescriptors.py`
+91. `wallet_listreceivedby.py`
+92. `wallet_listsinceblock.py`
+93. `wallet_listtransactions.py`
+94. `wallet_miniscript.py`
+95. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+96. `wallet_multisig_descriptor_psbt.py`
+97. `wallet_multiwallet.py`
+98. `wallet_orphanedreward.py`
+99. `wallet_reindex.py`
+100. `wallet_reorgsrestore.py`
+101. `wallet_rescan_unconfirmed.py`
+102. `wallet_resendwallettransactions.py`
+103. `wallet_send.py`
+104. `wallet_sendall.py`
+105. `wallet_sendmany.py`
+106. `wallet_signrawtransactionwithwallet.py`
+107. `wallet_simulaterawtx.py`
+108. `wallet_spend_unconfirmed.py`
+109. `wallet_startup.py`
+110. `wallet_timelock.py`
+111. `wallet_transactiontime_rescan.py`
+112. `wallet_txn_clone.py`
+113. `wallet_txn_doublespend.py`
+114. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -471,6 +472,13 @@ required gate: `mempool_truc.py` covers v3 transaction size and child-size
 limits, TRUC inheritance and replacement checks, reorg restoration behavior,
 sibling eviction, package ancestor handling, `testmempoolaccept` inheritance
 diagnostics, and minrelay package combinations under the current
+legacy-compatible PQC profile.
+The inherited mempool unbroadcast delivery confidence gap is now also part of
+the required gate: `mempool_unbroadcast.py` covers unbroadcast count and
+per-entry reporting, mempool.dat persistence across restart, rebroadcast after
+reconnect and scheduler advance, removal from the unbroadcast set after peer
+delivery, suppression of repeat broadcast to later peers, no re-addition for
+already-known transactions, and cleanup before confirmation under the current
 legacy-compatible PQC profile.
 The remaining key backlog families are:
 

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -38,8 +38,8 @@ single-node `testmempoolaccept` and raw transaction policy surface:
 This posture note does **not** mean:
 
 - every remaining mempool functional suite is owned by this tranche
-- package relay, package RBF, expiry, persistence, reorg, unbroadcast, or mining
-  template behavior is covered here
+- package relay, package RBF, expiry, persistence, reorg, update-from-block, or
+  mining-template behavior is covered here
 - PQ-native witness-size stress replaces this inherited policy surface
 - prior-release compatibility suites can run without real prior PQBTC release
   assets
@@ -83,7 +83,8 @@ this worktree.
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -36,7 +36,7 @@ owns the single-node wtxid/non-witness-data mempool boundary:
 
 This posture note does **not** mean:
 
-- the full mempool package, persistence, expiry, reorg, unbroadcast, or mining
+- the full mempool package, persistence, expiry, reorg, update-from-block, or mining
   policy families are owned here
 - package relay or package RBF behavior is covered
 - broad P2P relay behavior beyond this single-node wtxid rebroadcast check is
@@ -80,7 +80,8 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -34,7 +34,7 @@ This posture note does **not** mean:
 
 - every remaining mempool policy suite is owned by this tranche
 - dust, ephemeral-dust, expiry, package relay, package RBF, persistence, reorg,
-  unbroadcast, mining-template, or prior-release compatibility behavior is
+  update-from-block, mining-template, or prior-release compatibility behavior is
   covered
   here
 - PQ-native witness-size stress replaces this inherited OP_RETURN policy
@@ -76,7 +76,8 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -34,7 +34,7 @@ This posture note does **not** mean:
 
 - every remaining mempool policy suite is owned by this tranche
 - ephemeral-dust package behavior, expiry, package relay, package RBF,
-  persistence, reorg, unbroadcast, mining-template, or prior-release
+  persistence, reorg, update-from-block, mining-template, or prior-release
   compatibility
   behavior is covered here
 - PQ-native witness-size stress replaces this inherited dust relay policy
@@ -75,7 +75,8 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -85,7 +85,8 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -71,7 +71,8 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -81,7 +81,8 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -39,7 +39,7 @@ two-node mempool package accounting boundary:
 This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
-- persistence, broad package relay, package RBF, unbroadcast policy,
+- persistence, broad package relay, package RBF, update-from-block policy,
   mining-template
   behavior, or prior-release compatibility behavior is covered here
 - PQ-native witness-size stress replaces this inherited accounting surface
@@ -80,7 +80,8 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -39,7 +39,7 @@ This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
 - one-more-descendant carveout, package RBF, package relay, persistence,
-  broad reorg behavior, unbroadcast policy, mining-template behavior, or
+  broad reorg behavior, update-from-block policy, mining-template behavior, or
   prior-release compatibility behavior is covered here
 - PQ-native witness-size stress replaces this inherited package-limit surface
 
@@ -81,7 +81,8 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -41,7 +41,7 @@ This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
 - broad package RBF, package relay, persistence, broad reorg behavior,
-  unbroadcast
+  update-from-block
   policy, mining-template behavior, or prior-release compatibility behavior is
   covered here
 - PQ-native witness-size stress replaces this inherited one-more-descendant
@@ -84,7 +84,8 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -82,7 +82,8 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PERSIST_POSTURE.md
+++ b/docs/MEMPOOL_PERSIST_POSTURE.md
@@ -39,7 +39,7 @@ three-node mempool persistence boundary:
 
 This posture note does **not** mean:
 
-- every remaining mempool reorg, resurrection, unbroadcast, or
+- every remaining mempool reorg, resurrection, update-from-block, or
   mining-template suite
   is owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
@@ -82,7 +82,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_REORG_POSTURE.md
+++ b/docs/MEMPOOL_REORG_POSTURE.md
@@ -39,7 +39,7 @@ two-node mempool reorg boundary:
 
 This posture note does **not** mean:
 
-- every remaining mempool resurrection, unbroadcast, sigop-limit,
+- every remaining mempool resurrection, update-from-block, sigop-limit,
   spend-coinbase, or
   mining-template suite is owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
@@ -82,7 +82,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_RESURRECT_POSTURE.md
+++ b/docs/MEMPOOL_RESURRECT_POSTURE.md
@@ -31,7 +31,8 @@ small one-node mempool resurrection boundary:
 
 This posture note does **not** mean:
 
-- the broader mempool reorg, relay, unbroadcast, sigop-limit, spend-coinbase, or
+- the broader mempool reorg, relay, update-from-block, sigop-limit,
+  spend-coinbase, or
   mining-template suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -73,7 +74,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
+++ b/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
@@ -38,7 +38,7 @@ the mempool sigop adjusted-vsize boundary:
 
 This posture note does **not** mean:
 
-- the broader spend-coinbase, unbroadcast, mining-template, or orphan
+- the broader spend-coinbase, update-from-block, mining-template, or orphan
   transaction suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -82,7 +82,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md),
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
-  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md)
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SPEND_COINBASE_POSTURE.md
+++ b/docs/MEMPOOL_SPEND_COINBASE_POSTURE.md
@@ -31,7 +31,7 @@ suite owns the mempool coinbase-spend maturity boundary:
 
 This posture note does **not** mean:
 
-- the broader unbroadcast, update-from-block, mining-template, or orphan
+- the broader update-from-block, mining-template, or orphan
   transaction suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -72,6 +72,7 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md),
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_UNBROADCAST_POSTURE.md
+++ b/docs/MEMPOOL_UNBROADCAST_POSTURE.md
@@ -1,48 +1,48 @@
-# PQBTC `mempool_truc.py` Posture
+# PQBTC `mempool_unbroadcast.py` Posture
 
 ## Status: ACTIVE
-## Spec-ID: MEMPOOL-TRUC-POSTURE-v1
+## Spec-ID: MEMPOOL-UNBROADCAST-POSTURE-v1
 ## Updated: 2026-05-08
 ## Frozen-By: track-a-phase1-20260508
 ## Consensus-Relevant: NO
 
 ## Purpose
 
-Define the owned Track A contract for inherited TRUC/v3 mempool policy under
-the current legacy-compatible PQC profile.
+Define the owned Track A contract for inherited mempool unbroadcast delivery
+policy under the current legacy-compatible PQC profile.
 
 ## Current Owned Surface
 
 The current passing
-[mempool_truc.py](../test/functional/mempool_truc.py) suite owns the TRUC/v3
-mempool policy boundary:
+[mempool_unbroadcast.py](../test/functional/mempool_unbroadcast.py) suite owns
+the local unbroadcast delivery boundary:
 
-- v3 transactions over the TRUC maximum vsize are rejected while equivalent v2
-  transactions remain accepted
-- children of v3 transactions enforce the TRUC child-size limit
-- v3 and v2 replacements preserve direct TRUC policy and inheritance checks
-- reorg restoration can re-enter disconnected transactions even when the
-  resulting mempool shape would violate direct TRUC admission topology
-- nondefault ancestor and descendant package limits still override TRUC package
-  admission where appropriate
-- package ancestor checks reject multiparent, oversized-child, and
-  three-generation TRUC package shapes
-- sibling eviction works only under the expected individual and package
-  submission rules and keeps RBF fee and feerate constraints intact
-- `testmempoolaccept` reports TRUC inheritance violations consistently for
-  independent, in-package, and in-mempool parent cases
-- minrelay combinations keep the expected distinction between zero-fee TRUC
-  parents paid by children and non-TRUC equivalents
+- locally submitted raw transactions enter the unbroadcast set
+- wallet-originated transactions enter the unbroadcast set when wallet support
+  is compiled
+- `getmempoolinfo()["unbroadcastcount"]` and verbose `getrawmempool`
+  `unbroadcast` flags report the expected pending-delivery state
+- unbroadcast transactions persist through `mempool.dat` after node restart
+- after peers reconnect and the scheduler advances, the unbroadcast
+  transactions are delivered to the peer mempool
+- delivered transactions leave the first node's unbroadcast set
+- a later peer connection does not receive repeat announcements for already
+  delivered transactions
+- rebroadcasting an already-known transaction does not re-add it to the
+  unbroadcast set
+- transactions removed by block confirmation are removed from the unbroadcast
+  set before delivery confirmation
 
 ## What This Does Not Mean
 
 This posture note does **not** mean:
 
-- the update-from-block, mining-template, or orphan transaction
-  suites are owned by this tranche
+- the update-from-block, mining-template, or orphan transaction suites are
+  owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
-- PQ-native witness-size stress replaces this inherited TRUC policy surface
+- PQ-native witness-size stress replaces this inherited unbroadcast delivery
+  surface
 
 Those remain separate required gates or backlog decisions.
 
@@ -50,18 +50,19 @@ Those remain separate required gates or backlog decisions.
 
 Targeted confidence pass run on 2026-05-08:
 
-- `build/test/functional/test_runner.py --jobs=1 mempool_truc.py`
+- `build/test/functional/test_runner.py --jobs=1 mempool_unbroadcast.py`
   - result: passed
   - current posture:
-    - TRUC size, inheritance, and replacement policy remains stable
-    - reorg restoration and sibling eviction boundaries keep their expected
-      outcomes
-    - package ancestor and minrelay combinations remain green under the current
-      legacy-compatible PQC profile
+    - unbroadcast accounting and per-entry reporting remain stable
+    - restart persistence and peer delivery clear the unbroadcast state as
+      expected
+    - confirmation cleanup removes transactions from the unbroadcast set under
+      the current legacy-compatible PQC profile
 
 ## Interpretation
 
-- `mempool_truc.py` is now a required inherited TRUC/v3 mempool policy gate
+- `mempool_unbroadcast.py` is now a required inherited mempool unbroadcast
+  delivery gate
 - it complements, but does not replace,
   [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
   [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
@@ -79,7 +80,7 @@ Targeted confidence pass run on 2026-05-08:
   [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md),
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md),
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -63,7 +63,8 @@ resurrection behavior in the same gate, keep `mempool_sigoplimit.py`
 inherited mempool sigop resource-envelope behavior in the same gate, keep
 `mempool_spend_coinbase.py` inherited mempool coinbase-spend maturity behavior
 in the same gate, keep `mempool_truc.py` inherited TRUC/v3 mempool policy
-behavior in the same gate,
+behavior in the same gate, keep `mempool_unbroadcast.py` inherited mempool
+unbroadcast delivery behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -166,7 +167,7 @@ Alternate rebalance:
      expiry, mempool-limit, package-limit, and one-more-descendant carveout
      tranches, plus package RBF, package accounting, persistence, reorg,
      resurrection, sigop resource-envelope, coinbase-spend maturity, and TRUC
-     policy.
+     policy, plus unbroadcast delivery.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1008,7 +1009,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `feature_unsupported_utxo_db.py` and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1029,7 +1030,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_WTXID_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1049,7 +1050,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_DATACARRIER_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1071,7 +1072,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_DUST_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1095,7 +1096,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_EPHEMERAL_DUST_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1113,7 +1114,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_EXPIRY_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1133,7 +1134,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_LIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1156,7 +1157,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_LIMITS_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1179,7 +1180,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_ONEMORE_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool unbroadcast and mining policy suites
+   - remaining mempool update-from-block and mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1226,7 +1227,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGES_POSTURE.md`
    Still deferred inside this suite:
-   - unbroadcast, mining policy, and prior-release compatibility suites
+   - update-from-block, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1251,7 +1252,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PERSIST_POSTURE.md`
    Still deferred inside this suite:
-   - unbroadcast, mining policy, and prior-release compatibility suites
+   - update-from-block, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1274,7 +1275,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_REORG_POSTURE.md`
    Still deferred inside this suite:
-   - unbroadcast, mining policy, and prior-release compatibility suites
+   - update-from-block, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1294,7 +1295,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_RESURRECT_POSTURE.md`
    Still deferred inside this suite:
-   - unbroadcast, mining policy, and prior-release compatibility suites
+   - update-from-block, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1316,7 +1317,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_SIGOPLIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - unbroadcast, mining policy, and prior-release compatibility suites
+   - update-from-block, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1337,7 +1338,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_SPEND_COINBASE_POSTURE.md`
    Still deferred inside this suite:
-   - unbroadcast, mining policy, and prior-release compatibility suites
+   - update-from-block, mining policy, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1363,14 +1364,40 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_TRUC_POSTURE.md`
    Still deferred inside this suite:
-   - unbroadcast, update-from-block, mining policy, orphan transaction, and
+   - update-from-block, mining policy, orphan transaction, and
      prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-64. Recommended next PR after this tranche:
+64. `mempool_unbroadcast.py` now owns:
+   - inherited mempool unbroadcast delivery policy under the current
+     legacy-compatible PQC profile
+   - local raw transaction entry into the unbroadcast set
+   - wallet-originated transaction entry into the unbroadcast set when wallet
+     support is compiled
+   - `getmempoolinfo()["unbroadcastcount"]` and verbose `getrawmempool`
+     unbroadcast flag reporting
+   - `mempool.dat` persistence of unbroadcast state across restart
+   - delivery to a peer after reconnect and scheduler advance
+   - removal from the first node's unbroadcast set after peer delivery
+   - no repeat broadcast to later peer connections after delivery
+   - no re-addition to the unbroadcast set when an already-known transaction is
+     rebroadcast
+   - removal from the unbroadcast set before block confirmation when the
+     transaction leaves the mempool
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_unbroadcast.py`
+   Fixed posture note:
+   - `MEMPOOL_UNBROADCAST_POSTURE.md`
+   Still deferred inside this suite:
+   - update-from-block, mining policy, orphan transaction, and prior-release
+     compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+65. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_unbroadcast.py` as the next local mempool policy
+   - alternate: `mempool_updatefromblock.py` as the next local mempool policy
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1386,8 +1413,9 @@ Still deferred:
      carveout policy are now frozen, and package RBF plus package accounting
      are now frozen, and mempool persistence, reorg, and resurrection behavior
      are now frozen, and sigop resource-envelope, coinbase-spend maturity, and
-     TRUC policy are now frozen, so the adjacent local mempool follow-on should
-     be another bounded policy gate only after a fresh targeted pass
+     TRUC policy are now frozen, and unbroadcast delivery is now frozen, so the
+     adjacent local mempool follow-on should be another bounded policy gate
+     only after a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2372,6 +2400,16 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mempool candidate is
   `mempool_unbroadcast.py` after a fresh targeted pass.
+- 2026-05-08: `mempool_unbroadcast.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers unbroadcast accounting, mempool.dat
+  persistence across restart, peer delivery after reconnect and scheduler
+  advance, suppression of repeat announcements to later peers, no re-addition
+  for already-known transactions, and confirmation cleanup under the current
+  legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mempool candidate is
+  `mempool_updatefromblock.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
## Summary
- promote `mempool_unbroadcast.py` from `pq_backlog` to `pq_required`
- add it to the PQ functional runner list and update CI completeness counts to `pq_required=114`, `pq_backlog=11`
- add `MEMPOOL_UNBROADCAST_POSTURE.md` and refresh Track A/mempool posture handoff docs

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 mempool_unbroadcast.py`
- `git diff --check`
- `git diff --cached --check`

## Notes
- stacked on #147 / `codex/promote-mempool-truc-gate`
- no source or test behavior edits
- `feature_coinstatsindex_compatibility.py` remains preferred once real prior PQBTC release assets exist; local alternate moves to `mempool_updatefromblock.py`
