### PR TITLE
Promote mempool update-from-block gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -714,10 +714,10 @@
   },
   {
     "name": "mempool_updatefromblock.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mempool update-from-block reorg accounting gate: the suite exercises descendant and ancestor count/size reconstruction for a 100-transaction tournament graph re-added from disconnected blocks, disconnect-pool trimming at the MAX_DISCONNECTED_TX_POOL_BYTES boundary with child removal coupled to parent trimming, and too-long-chain handling when non-standardly mined chains are returned to the mempool under normal chain limits in the current legacy-compatible PQC profile."
   },
   {
     "name": "mining_basic.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -46,6 +46,7 @@ mempool_sigoplimit.py
 mempool_spend_coinbase.py
 mempool_truc.py
 mempool_unbroadcast.py
+mempool_updatefromblock.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `114` |
-| `pq_backlog` | `11` |
+| `pq_required` | `115` |
+| `pq_backlog` | `10` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -72,91 +72,92 @@ Current required PQ-first gates:
 27. `mempool_spend_coinbase.py`
 28. `mempool_truc.py`
 29. `mempool_unbroadcast.py`
-30. `wallet_pq_active_ranged.py`
-31. `wallet_pq_backup_recovery.py`
-32. `wallet_pq_create_tx.py`
-33. `wallet_pq_descriptors.py`
-34. `wallet_pq_psbt.py`
-35. `wallet_pq_send.py`
-36. `wallet_pq_sendall.py`
-37. `wallet_pq_sendmany.py`
-38. `wallet_pq_signrawtransaction.py`
-39. `feature_assumeutxo.py`
-40. `feature_assumevalid.py`
-41. `feature_bip68_sequence.py`
-42. `feature_block.py`
-43. `feature_blocksdir.py`
-44. `feature_blocksxor.py`
-45. `feature_cltv.py`
-46. `feature_coinstatsindex.py`
-47. `feature_csv_activation.py`
-48. `feature_fastprune.py`
-49. `feature_index_prune.py`
-50. `feature_loadblock.py`
-51. `feature_pruning.py`
-52. `feature_reindex.py`
-53. `feature_reindex_init.py`
-54. `feature_reindex_readonly.py`
-55. `feature_remove_pruned_files_on_startup.py`
-56. `feature_utxo_set_hash.py`
-57. `feature_versionbits_warning.py`
-58. `rpc_psbt.py`
-59. `wallet_abandonconflict.py`
-60. `wallet_address_types.py`
-61. `wallet_assumeutxo.py`
-62. `wallet_avoid_mixing_output_types.py`
-63. `wallet_avoidreuse.py`
-64. `wallet_backup.py`
-65. `wallet_balance.py`
-66. `wallet_basic.py`
-67. `wallet_blank.py`
-68. `wallet_bumpfee.py`
-69. `wallet_change_address.py`
-70. `wallet_coinbase_category.py`
-71. `wallet_conflicts.py`
-72. `wallet_create_tx.py`
-73. `wallet_createwallet.py`
-74. `wallet_createwalletdescriptor.py`
-75. `wallet_crosschain.py`
-76. `wallet_descriptor.py`
-77. `wallet_disable.py`
-78. `wallet_encryption.py`
-79. `wallet_fallbackfee.py`
-80. `wallet_fast_rescan.py`
-81. `wallet_fundrawtransaction.py`
-82. `wallet_gethdkeys.py`
-83. `wallet_groups.py`
-84. `wallet_hd.py`
-85. `wallet_importdescriptors.py`
-86. `wallet_importprunedfunds.py`
-87. `wallet_keypool.py`
-88. `wallet_keypool_topup.py`
-89. `wallet_labels.py`
-90. `wallet_listdescriptors.py`
-91. `wallet_listreceivedby.py`
-92. `wallet_listsinceblock.py`
-93. `wallet_listtransactions.py`
-94. `wallet_miniscript.py`
-95. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-96. `wallet_multisig_descriptor_psbt.py`
-97. `wallet_multiwallet.py`
-98. `wallet_orphanedreward.py`
-99. `wallet_reindex.py`
-100. `wallet_reorgsrestore.py`
-101. `wallet_rescan_unconfirmed.py`
-102. `wallet_resendwallettransactions.py`
-103. `wallet_send.py`
-104. `wallet_sendall.py`
-105. `wallet_sendmany.py`
-106. `wallet_signrawtransactionwithwallet.py`
-107. `wallet_simulaterawtx.py`
-108. `wallet_spend_unconfirmed.py`
-109. `wallet_startup.py`
-110. `wallet_timelock.py`
-111. `wallet_transactiontime_rescan.py`
-112. `wallet_txn_clone.py`
-113. `wallet_txn_doublespend.py`
-114. `wallet_v3_txs.py`
+30. `mempool_updatefromblock.py`
+31. `wallet_pq_active_ranged.py`
+32. `wallet_pq_backup_recovery.py`
+33. `wallet_pq_create_tx.py`
+34. `wallet_pq_descriptors.py`
+35. `wallet_pq_psbt.py`
+36. `wallet_pq_send.py`
+37. `wallet_pq_sendall.py`
+38. `wallet_pq_sendmany.py`
+39. `wallet_pq_signrawtransaction.py`
+40. `feature_assumeutxo.py`
+41. `feature_assumevalid.py`
+42. `feature_bip68_sequence.py`
+43. `feature_block.py`
+44. `feature_blocksdir.py`
+45. `feature_blocksxor.py`
+46. `feature_cltv.py`
+47. `feature_coinstatsindex.py`
+48. `feature_csv_activation.py`
+49. `feature_fastprune.py`
+50. `feature_index_prune.py`
+51. `feature_loadblock.py`
+52. `feature_pruning.py`
+53. `feature_reindex.py`
+54. `feature_reindex_init.py`
+55. `feature_reindex_readonly.py`
+56. `feature_remove_pruned_files_on_startup.py`
+57. `feature_utxo_set_hash.py`
+58. `feature_versionbits_warning.py`
+59. `rpc_psbt.py`
+60. `wallet_abandonconflict.py`
+61. `wallet_address_types.py`
+62. `wallet_assumeutxo.py`
+63. `wallet_avoid_mixing_output_types.py`
+64. `wallet_avoidreuse.py`
+65. `wallet_backup.py`
+66. `wallet_balance.py`
+67. `wallet_basic.py`
+68. `wallet_blank.py`
+69. `wallet_bumpfee.py`
+70. `wallet_change_address.py`
+71. `wallet_coinbase_category.py`
+72. `wallet_conflicts.py`
+73. `wallet_create_tx.py`
+74. `wallet_createwallet.py`
+75. `wallet_createwalletdescriptor.py`
+76. `wallet_crosschain.py`
+77. `wallet_descriptor.py`
+78. `wallet_disable.py`
+79. `wallet_encryption.py`
+80. `wallet_fallbackfee.py`
+81. `wallet_fast_rescan.py`
+82. `wallet_fundrawtransaction.py`
+83. `wallet_gethdkeys.py`
+84. `wallet_groups.py`
+85. `wallet_hd.py`
+86. `wallet_importdescriptors.py`
+87. `wallet_importprunedfunds.py`
+88. `wallet_keypool.py`
+89. `wallet_keypool_topup.py`
+90. `wallet_labels.py`
+91. `wallet_listdescriptors.py`
+92. `wallet_listreceivedby.py`
+93. `wallet_listsinceblock.py`
+94. `wallet_listtransactions.py`
+95. `wallet_miniscript.py`
+96. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+97. `wallet_multisig_descriptor_psbt.py`
+98. `wallet_multiwallet.py`
+99. `wallet_orphanedreward.py`
+100. `wallet_reindex.py`
+101. `wallet_reorgsrestore.py`
+102. `wallet_rescan_unconfirmed.py`
+103. `wallet_resendwallettransactions.py`
+104. `wallet_send.py`
+105. `wallet_sendall.py`
+106. `wallet_sendmany.py`
+107. `wallet_signrawtransactionwithwallet.py`
+108. `wallet_simulaterawtx.py`
+109. `wallet_spend_unconfirmed.py`
+110. `wallet_startup.py`
+111. `wallet_timelock.py`
+112. `wallet_transactiontime_rescan.py`
+113. `wallet_txn_clone.py`
+114. `wallet_txn_doublespend.py`
+115. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -480,6 +481,13 @@ reconnect and scheduler advance, removal from the unbroadcast set after peer
 delivery, suppression of repeat broadcast to later peers, no re-addition for
 already-known transactions, and cleanup before confirmation under the current
 legacy-compatible PQC profile.
+The inherited mempool update-from-block reorg-accounting confidence gap is now
+also part of the required gate: `mempool_updatefromblock.py` covers descendant
+and ancestor count/size reconstruction for a 100-transaction tournament graph
+re-added from disconnected blocks, disconnect-pool trimming at the
+`MAX_DISCONNECTED_TX_POOL_BYTES` boundary with coupled child removal, and
+too-long-chain handling when non-standardly mined chains return to the mempool
+under normal chain limits in the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MEMPOOL_ACCEPT_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_POSTURE.md
@@ -38,7 +38,7 @@ single-node `testmempoolaccept` and raw transaction policy surface:
 This posture note does **not** mean:
 
 - every remaining mempool functional suite is owned by this tranche
-- package relay, package RBF, expiry, persistence, reorg, update-from-block, or
+- package relay, package RBF, expiry, persistence, reorg, or
   mining-template behavior is covered here
 - PQ-native witness-size stress replaces this inherited policy surface
 - prior-release compatibility suites can run without real prior PQBTC release
@@ -84,7 +84,8 @@ this worktree.
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
+++ b/docs/MEMPOOL_ACCEPT_WTXID_POSTURE.md
@@ -36,7 +36,7 @@ owns the single-node wtxid/non-witness-data mempool boundary:
 
 This posture note does **not** mean:
 
-- the full mempool package, persistence, expiry, reorg, update-from-block, or mining
+- the full mempool package, persistence, expiry, reorg, or mining
   policy families are owned here
 - package relay or package RBF behavior is covered
 - broad P2P relay behavior beyond this single-node wtxid rebroadcast check is
@@ -81,7 +81,8 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DATACARRIER_POSTURE.md
+++ b/docs/MEMPOOL_DATACARRIER_POSTURE.md
@@ -34,7 +34,7 @@ This posture note does **not** mean:
 
 - every remaining mempool policy suite is owned by this tranche
 - dust, ephemeral-dust, expiry, package relay, package RBF, persistence, reorg,
-  update-from-block, mining-template, or prior-release compatibility behavior is
+  mining-template or prior-release compatibility behavior is
   covered
   here
 - PQ-native witness-size stress replaces this inherited OP_RETURN policy
@@ -77,7 +77,8 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_DUST_POSTURE.md
@@ -34,7 +34,7 @@ This posture note does **not** mean:
 
 - every remaining mempool policy suite is owned by this tranche
 - ephemeral-dust package behavior, expiry, package relay, package RBF,
-  persistence, reorg, update-from-block, mining-template, or prior-release
+  persistence, reorg, mining-template or prior-release
   compatibility
   behavior is covered here
 - PQ-native witness-size stress replaces this inherited dust relay policy
@@ -76,7 +76,8 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
+++ b/docs/MEMPOOL_EPHEMERAL_DUST_POSTURE.md
@@ -86,7 +86,8 @@ Targeted confidence pass run on 2026-05-04:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_EXPIRY_POSTURE.md
+++ b/docs/MEMPOOL_EXPIRY_POSTURE.md
@@ -72,7 +72,8 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_LIMIT_POSTURE.md
+++ b/docs/MEMPOOL_LIMIT_POSTURE.md
@@ -82,7 +82,8 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGES_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGES_POSTURE.md
@@ -39,9 +39,8 @@ two-node mempool package accounting boundary:
 This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
-- persistence, broad package relay, package RBF, update-from-block policy,
-  mining-template
-  behavior, or prior-release compatibility behavior is covered here
+- persistence, broad package relay, package RBF, mining-template behavior, or
+  prior-release compatibility behavior is covered here
 - PQ-native witness-size stress replaces this inherited accounting surface
 
 Those remain separate required gates or backlog decisions.
@@ -81,7 +80,8 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_LIMITS_POSTURE.md
@@ -39,7 +39,7 @@ This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
 - one-more-descendant carveout, package RBF, package relay, persistence,
-  broad reorg behavior, update-from-block policy, mining-template behavior, or
+  broad reorg behavior, mining-template behavior, or
   prior-release compatibility behavior is covered here
 - PQ-native witness-size stress replaces this inherited package-limit surface
 
@@ -82,7 +82,8 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_ONEMORE_POSTURE.md
@@ -41,7 +41,7 @@ This posture note does **not** mean:
 
 - every remaining mempool package suite is owned by this tranche
 - broad package RBF, package relay, persistence, broad reorg behavior,
-  update-from-block
+  mining-template behavior
   policy, mining-template behavior, or prior-release compatibility behavior is
   covered here
 - PQ-native witness-size stress replaces this inherited one-more-descendant
@@ -85,7 +85,8 @@ Targeted confidence pass run on 2026-05-05:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
+++ b/docs/MEMPOOL_PACKAGE_RBF_POSTURE.md
@@ -83,7 +83,8 @@ Targeted confidence pass run on 2026-05-06:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_PERSIST_POSTURE.md
+++ b/docs/MEMPOOL_PERSIST_POSTURE.md
@@ -39,9 +39,8 @@ three-node mempool persistence boundary:
 
 This posture note does **not** mean:
 
-- every remaining mempool reorg, resurrection, update-from-block, or
-  mining-template suite
-  is owned by this tranche
+- every remaining mempool reorg, resurrection, or mining-template suite is
+  owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
 - PQ-native witness-size stress replaces this inherited persistence surface
@@ -83,7 +82,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_REORG_POSTURE.md
+++ b/docs/MEMPOOL_REORG_POSTURE.md
@@ -39,7 +39,7 @@ two-node mempool reorg boundary:
 
 This posture note does **not** mean:
 
-- every remaining mempool resurrection, update-from-block, sigop-limit,
+- every remaining mempool resurrection, sigop-limit,
   spend-coinbase, or
   mining-template suite is owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
@@ -83,7 +83,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_RESURRECT_POSTURE.md
+++ b/docs/MEMPOOL_RESURRECT_POSTURE.md
@@ -31,7 +31,7 @@ small one-node mempool resurrection boundary:
 
 This posture note does **not** mean:
 
-- the broader mempool reorg, relay, update-from-block, sigop-limit,
+- the broader mempool reorg, relay, sigop-limit,
   spend-coinbase, or
   mining-template suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
@@ -75,7 +75,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
+++ b/docs/MEMPOOL_SIGOPLIMIT_POSTURE.md
@@ -38,7 +38,7 @@ the mempool sigop adjusted-vsize boundary:
 
 This posture note does **not** mean:
 
-- the broader spend-coinbase, update-from-block, mining-template, or orphan
+- the broader spend-coinbase, mining-template or orphan
   transaction suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -83,7 +83,8 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md), and
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md), and
-  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md)
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md), and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool

--- a/docs/MEMPOOL_SPEND_COINBASE_POSTURE.md
+++ b/docs/MEMPOOL_SPEND_COINBASE_POSTURE.md
@@ -31,7 +31,7 @@ suite owns the mempool coinbase-spend maturity boundary:
 
 This posture note does **not** mean:
 
-- the broader update-from-block, mining-template, or orphan
+- the broader mining-template or orphan
   transaction suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -73,6 +73,7 @@ Targeted confidence pass run on 2026-05-07:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md),
   [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md),
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains

--- a/docs/MEMPOOL_TRUC_POSTURE.md
+++ b/docs/MEMPOOL_TRUC_POSTURE.md
@@ -38,7 +38,7 @@ mempool policy boundary:
 
 This posture note does **not** mean:
 
-- the update-from-block, mining-template, or orphan transaction
+- the mining-template or orphan transaction
   suites are owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -80,11 +80,11 @@ Targeted confidence pass run on 2026-05-08:
   [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
   [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md),
   [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md),
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md),
   [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
   [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool
   or mining `pq_backlog` migration decision, with
-  `mempool_updatefromblock.py` the adjacent candidate after a fresh targeted
-  pass
+  `mining_basic.py` the adjacent candidate after a fresh targeted pass

--- a/docs/MEMPOOL_UNBROADCAST_POSTURE.md
+++ b/docs/MEMPOOL_UNBROADCAST_POSTURE.md
@@ -37,7 +37,7 @@ the local unbroadcast delivery boundary:
 
 This posture note does **not** mean:
 
-- the update-from-block, mining-template, or orphan transaction suites are
+- the mining-template or orphan transaction suites are
   owned by this tranche
 - prior-release mempool compatibility behavior is covered without real prior
   PQBTC release assets
@@ -87,5 +87,4 @@ Targeted confidence pass run on 2026-05-08:
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool
   or mining `pq_backlog` migration decision, with
-  `mempool_updatefromblock.py` the adjacent candidate after a fresh targeted
-  pass
+  `mining_basic.py` the adjacent candidate after a fresh targeted pass

--- a/docs/MEMPOOL_UPDATEFROMBLOCK_POSTURE.md
+++ b/docs/MEMPOOL_UPDATEFROMBLOCK_POSTURE.md
@@ -1,0 +1,90 @@
+# PQBTC `mempool_updatefromblock.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MEMPOOL-UPDATEFROMBLOCK-POSTURE-v1
+## Updated: 2026-05-08
+## Frozen-By: track-a-phase1-20260508
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mempool update-from-block reorg
+accounting under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mempool_updatefromblock.py](../test/functional/mempool_updatefromblock.py)
+suite owns the reorg-time mempool accounting boundary:
+
+- a 100-transaction tournament graph is mined in batches and re-added from
+  disconnected blocks after an empty-fork reorg
+- every re-added transaction preserves expected descendant count, descendant
+  size, ancestor count, and ancestor size
+- after mining the re-added graph, the mempool returns to empty and the
+  MiniWallet UTXO view is rescanned
+- large independent parent transactions exercise the
+  `MAX_DISCONNECTED_TX_POOL_BYTES` disconnect-pool trimming boundary
+- child transactions are recursively removed whenever their trimmed parent is
+  dropped during reorg handling
+- trimming removes the most recently confirmed parents and their children while
+  preserving the earlier parent/child pairs
+- a non-standardly mined chain that exceeds normal ancestor limits is returned
+  to the mempool only up to the standard chain-limit boundary
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- the mining-template, mining basic, mining prioritisation, or orphan
+  transaction suites are owned by this tranche
+- prior-release mempool compatibility behavior is covered without real prior
+  PQBTC release assets
+- PQ-native witness-size stress replaces this inherited reorg accounting
+  surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-08:
+
+- `build/test/functional/test_runner.py --jobs=1 mempool_updatefromblock.py`
+  - result: passed
+  - current posture:
+    - descendant and ancestor accounting survives disconnected-block re-entry
+    - disconnect-pool trimming preserves coupled parent/child removal behavior
+    - long-chain reorg handling keeps the expected standard chain-limit
+      boundary under the current legacy-compatible PQC profile
+
+## Interpretation
+
+- `mempool_updatefromblock.py` is now a required inherited mempool
+  mining-template behavior reorg-accounting gate
+- it complements, but does not replace,
+  [mempool_accept.py](MEMPOOL_ACCEPT_POSTURE.md),
+  [mempool_accept_wtxid.py](MEMPOOL_ACCEPT_WTXID_POSTURE.md),
+  [mempool_datacarrier.py](MEMPOOL_DATACARRIER_POSTURE.md),
+  [mempool_dust.py](MEMPOOL_DUST_POSTURE.md),
+  [mempool_ephemeral_dust.py](MEMPOOL_EPHEMERAL_DUST_POSTURE.md),
+  [mempool_expiry.py](MEMPOOL_EXPIRY_POSTURE.md),
+  [mempool_limit.py](MEMPOOL_LIMIT_POSTURE.md),
+  [mempool_package_limits.py](MEMPOOL_PACKAGE_LIMITS_POSTURE.md),
+  [mempool_package_onemore.py](MEMPOOL_PACKAGE_ONEMORE_POSTURE.md),
+  [mempool_package_rbf.py](MEMPOOL_PACKAGE_RBF_POSTURE.md),
+  [mempool_packages.py](MEMPOOL_PACKAGES_POSTURE.md),
+  [mempool_persist.py](MEMPOOL_PERSIST_POSTURE.md),
+  [mempool_reorg.py](MEMPOOL_REORG_POSTURE.md),
+  [mempool_resurrect.py](MEMPOOL_RESURRECT_POSTURE.md),
+  [mempool_sigoplimit.py](MEMPOOL_SIGOPLIMIT_POSTURE.md),
+  [mempool_spend_coinbase.py](MEMPOOL_SPEND_COINBASE_POSTURE.md),
+  [mempool_truc.py](MEMPOOL_TRUC_POSTURE.md),
+  [mempool_unbroadcast.py](MEMPOOL_UNBROADCAST_POSTURE.md),
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md),
+  [mempool_pq_limits.py](MEMPOOL_PQ_LIMITS_POSTURE.md), and
+  [mempool_pq_stress.py](MEMPOOL_PQ_STRESS_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mempool
+  or mining `pq_backlog` migration decision, with `mining_basic.py` the
+  adjacent candidate after a fresh targeted pass

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -64,7 +64,9 @@ inherited mempool sigop resource-envelope behavior in the same gate, keep
 `mempool_spend_coinbase.py` inherited mempool coinbase-spend maturity behavior
 in the same gate, keep `mempool_truc.py` inherited TRUC/v3 mempool policy
 behavior in the same gate, keep `mempool_unbroadcast.py` inherited mempool
-unbroadcast delivery behavior in the same gate,
+unbroadcast delivery behavior in the same gate, keep
+`mempool_updatefromblock.py` inherited mempool update-from-block reorg
+accounting behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -167,7 +169,7 @@ Alternate rebalance:
      expiry, mempool-limit, package-limit, and one-more-descendant carveout
      tranches, plus package RBF, package accounting, persistence, reorg,
      resurrection, sigop resource-envelope, coinbase-spend maturity, and TRUC
-     policy, plus unbroadcast delivery.
+     policy, plus unbroadcast delivery and update-from-block reorg accounting.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1009,7 +1011,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `feature_unsupported_utxo_db.py` and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1030,7 +1032,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_ACCEPT_WTXID_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1050,7 +1052,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_DATACARRIER_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1072,7 +1074,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_DUST_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1096,7 +1098,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_EPHEMERAL_DUST_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1114,7 +1116,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_EXPIRY_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1134,7 +1136,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_LIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1157,7 +1159,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_LIMITS_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1180,7 +1182,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGE_ONEMORE_POSTURE.md`
    Still deferred inside this suite:
-   - remaining mempool update-from-block and mining policy suites
+   - remaining mempool mining policy suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1227,7 +1229,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PACKAGES_POSTURE.md`
    Still deferred inside this suite:
-   - update-from-block, mining policy, and prior-release compatibility suites
+   - mining policy and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1252,7 +1254,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_PERSIST_POSTURE.md`
    Still deferred inside this suite:
-   - update-from-block, mining policy, and prior-release compatibility suites
+   - mining policy and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1275,7 +1277,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_REORG_POSTURE.md`
    Still deferred inside this suite:
-   - update-from-block, mining policy, and prior-release compatibility suites
+   - mining policy and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1295,7 +1297,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_RESURRECT_POSTURE.md`
    Still deferred inside this suite:
-   - update-from-block, mining policy, and prior-release compatibility suites
+   - mining policy and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1317,7 +1319,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_SIGOPLIMIT_POSTURE.md`
    Still deferred inside this suite:
-   - update-from-block, mining policy, and prior-release compatibility suites
+   - mining policy and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1338,7 +1340,7 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_SPEND_COINBASE_POSTURE.md`
    Still deferred inside this suite:
-   - update-from-block, mining policy, and prior-release compatibility suites
+   - mining policy and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1364,8 +1366,8 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_TRUC_POSTURE.md`
    Still deferred inside this suite:
-   - update-from-block, mining policy, orphan transaction, and
-     prior-release compatibility suites
+   - mining policy, orphan transaction, and prior-release
+     compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
@@ -1390,14 +1392,39 @@ Still deferred:
    Fixed posture note:
    - `MEMPOOL_UNBROADCAST_POSTURE.md`
    Still deferred inside this suite:
-   - update-from-block, mining policy, orphan transaction, and prior-release
-     compatibility suites
+   - mining policy, orphan transaction, and prior-release compatibility suites
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-65. Recommended next PR after this tranche:
+65. `mempool_updatefromblock.py` now owns:
+   - inherited mempool update-from-block reorg accounting under the current
+     legacy-compatible PQC profile
+   - 100-transaction tournament-graph re-entry from disconnected blocks after
+     an empty-fork reorg
+   - descendant count, descendant size, ancestor count, and ancestor size
+     reconstruction for every re-added transaction
+   - mempool cleanup after mining the re-added graph and MiniWallet UTXO
+     rescan
+   - `MAX_DISCONNECTED_TX_POOL_BYTES` disconnect-pool trimming across large
+     independent parent transactions
+   - recursive child removal whenever the trimmed parent is dropped during
+     reorg handling
+   - FIFO trimming of the most recently confirmed parents and children while
+     preserving earlier parent/child pairs
+   - standard chain-limit enforcement when a non-standardly mined too-long
+     chain is returned to the mempool
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mempool_updatefromblock.py`
+   Fixed posture note:
+   - `MEMPOOL_UPDATEFROMBLOCK_POSTURE.md`
+   Still deferred inside this suite:
+   - mining policy, orphan transaction, and prior-release compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+66. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mempool_updatefromblock.py` as the next local mempool policy
+   - alternate: `mining_basic.py` as the next local mining policy
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1414,8 +1441,9 @@ Still deferred:
      are now frozen, and mempool persistence, reorg, and resurrection behavior
      are now frozen, and sigop resource-envelope, coinbase-spend maturity, and
      TRUC policy are now frozen, and unbroadcast delivery is now frozen, so the
-     adjacent local mempool follow-on should be another bounded policy gate
-     only after a fresh targeted pass
+     adjacent update-from-block reorg-accounting gate is now frozen, so the
+     local follow-on can move to a bounded mining policy gate only after a
+     fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2410,6 +2438,16 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mempool candidate is
   `mempool_updatefromblock.py` after a fresh targeted pass.
+- 2026-05-08: `mempool_updatefromblock.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers descendant and ancestor accounting after
+  disconnected-block re-entry, disconnect-pool trimming at the
+  `MAX_DISCONNECTED_TX_POOL_BYTES` boundary with coupled child removal, and
+  standard chain-limit handling for non-standardly mined too-long chains under
+  the current legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mining candidate is
+  `mining_basic.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
Promotes mempool_updatefromblock.py from pq_backlog to pq_required as a metadata/docs-only Track A tranche.

Local validation before pushing:
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 mempool_updatefromblock.py
- git diff --check
- git diff --cached --check

No source, RPC, consensus, wallet, descriptor, P2P, or policy behavior changes.