### PR TITLE
Promote mining basic gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -721,10 +721,10 @@
   },
   {
     "name": "mining_basic.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mining RPC and block-template policy gate: the suite exercises getmininginfo fields, getblocktemplate witness commitment, versionbits and -blockversion behavior, submitblock and submitheader validation, block-template fee and sigop ordering, -blockmintxfee filtering, BIP94 timewarp protection, pruned-block submitblock storage, blockmaxweight and blockreservedweight boundaries, and generated coinbase height-locktime behavior under the current legacy-compatible PQC profile."
   },
   {
     "name": "mining_getblocktemplate_longpoll.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -47,6 +47,7 @@ mempool_spend_coinbase.py
 mempool_truc.py
 mempool_unbroadcast.py
 mempool_updatefromblock.py
+mining_basic.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `115` |
-| `pq_backlog` | `10` |
+| `pq_required` | `116` |
+| `pq_backlog` | `9` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -73,91 +73,92 @@ Current required PQ-first gates:
 28. `mempool_truc.py`
 29. `mempool_unbroadcast.py`
 30. `mempool_updatefromblock.py`
-31. `wallet_pq_active_ranged.py`
-32. `wallet_pq_backup_recovery.py`
-33. `wallet_pq_create_tx.py`
-34. `wallet_pq_descriptors.py`
-35. `wallet_pq_psbt.py`
-36. `wallet_pq_send.py`
-37. `wallet_pq_sendall.py`
-38. `wallet_pq_sendmany.py`
-39. `wallet_pq_signrawtransaction.py`
-40. `feature_assumeutxo.py`
-41. `feature_assumevalid.py`
-42. `feature_bip68_sequence.py`
-43. `feature_block.py`
-44. `feature_blocksdir.py`
-45. `feature_blocksxor.py`
-46. `feature_cltv.py`
-47. `feature_coinstatsindex.py`
-48. `feature_csv_activation.py`
-49. `feature_fastprune.py`
-50. `feature_index_prune.py`
-51. `feature_loadblock.py`
-52. `feature_pruning.py`
-53. `feature_reindex.py`
-54. `feature_reindex_init.py`
-55. `feature_reindex_readonly.py`
-56. `feature_remove_pruned_files_on_startup.py`
-57. `feature_utxo_set_hash.py`
-58. `feature_versionbits_warning.py`
-59. `rpc_psbt.py`
-60. `wallet_abandonconflict.py`
-61. `wallet_address_types.py`
-62. `wallet_assumeutxo.py`
-63. `wallet_avoid_mixing_output_types.py`
-64. `wallet_avoidreuse.py`
-65. `wallet_backup.py`
-66. `wallet_balance.py`
-67. `wallet_basic.py`
-68. `wallet_blank.py`
-69. `wallet_bumpfee.py`
-70. `wallet_change_address.py`
-71. `wallet_coinbase_category.py`
-72. `wallet_conflicts.py`
-73. `wallet_create_tx.py`
-74. `wallet_createwallet.py`
-75. `wallet_createwalletdescriptor.py`
-76. `wallet_crosschain.py`
-77. `wallet_descriptor.py`
-78. `wallet_disable.py`
-79. `wallet_encryption.py`
-80. `wallet_fallbackfee.py`
-81. `wallet_fast_rescan.py`
-82. `wallet_fundrawtransaction.py`
-83. `wallet_gethdkeys.py`
-84. `wallet_groups.py`
-85. `wallet_hd.py`
-86. `wallet_importdescriptors.py`
-87. `wallet_importprunedfunds.py`
-88. `wallet_keypool.py`
-89. `wallet_keypool_topup.py`
-90. `wallet_labels.py`
-91. `wallet_listdescriptors.py`
-92. `wallet_listreceivedby.py`
-93. `wallet_listsinceblock.py`
-94. `wallet_listtransactions.py`
-95. `wallet_miniscript.py`
-96. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-97. `wallet_multisig_descriptor_psbt.py`
-98. `wallet_multiwallet.py`
-99. `wallet_orphanedreward.py`
-100. `wallet_reindex.py`
-101. `wallet_reorgsrestore.py`
-102. `wallet_rescan_unconfirmed.py`
-103. `wallet_resendwallettransactions.py`
-104. `wallet_send.py`
-105. `wallet_sendall.py`
-106. `wallet_sendmany.py`
-107. `wallet_signrawtransactionwithwallet.py`
-108. `wallet_simulaterawtx.py`
-109. `wallet_spend_unconfirmed.py`
-110. `wallet_startup.py`
-111. `wallet_timelock.py`
-112. `wallet_transactiontime_rescan.py`
-113. `wallet_txn_clone.py`
-114. `wallet_txn_doublespend.py`
-115. `wallet_v3_txs.py`
+31. `mining_basic.py`
+32. `wallet_pq_active_ranged.py`
+33. `wallet_pq_backup_recovery.py`
+34. `wallet_pq_create_tx.py`
+35. `wallet_pq_descriptors.py`
+36. `wallet_pq_psbt.py`
+37. `wallet_pq_send.py`
+38. `wallet_pq_sendall.py`
+39. `wallet_pq_sendmany.py`
+40. `wallet_pq_signrawtransaction.py`
+41. `feature_assumeutxo.py`
+42. `feature_assumevalid.py`
+43. `feature_bip68_sequence.py`
+44. `feature_block.py`
+45. `feature_blocksdir.py`
+46. `feature_blocksxor.py`
+47. `feature_cltv.py`
+48. `feature_coinstatsindex.py`
+49. `feature_csv_activation.py`
+50. `feature_fastprune.py`
+51. `feature_index_prune.py`
+52. `feature_loadblock.py`
+53. `feature_pruning.py`
+54. `feature_reindex.py`
+55. `feature_reindex_init.py`
+56. `feature_reindex_readonly.py`
+57. `feature_remove_pruned_files_on_startup.py`
+58. `feature_utxo_set_hash.py`
+59. `feature_versionbits_warning.py`
+60. `rpc_psbt.py`
+61. `wallet_abandonconflict.py`
+62. `wallet_address_types.py`
+63. `wallet_assumeutxo.py`
+64. `wallet_avoid_mixing_output_types.py`
+65. `wallet_avoidreuse.py`
+66. `wallet_backup.py`
+67. `wallet_balance.py`
+68. `wallet_basic.py`
+69. `wallet_blank.py`
+70. `wallet_bumpfee.py`
+71. `wallet_change_address.py`
+72. `wallet_coinbase_category.py`
+73. `wallet_conflicts.py`
+74. `wallet_create_tx.py`
+75. `wallet_createwallet.py`
+76. `wallet_createwalletdescriptor.py`
+77. `wallet_crosschain.py`
+78. `wallet_descriptor.py`
+79. `wallet_disable.py`
+80. `wallet_encryption.py`
+81. `wallet_fallbackfee.py`
+82. `wallet_fast_rescan.py`
+83. `wallet_fundrawtransaction.py`
+84. `wallet_gethdkeys.py`
+85. `wallet_groups.py`
+86. `wallet_hd.py`
+87. `wallet_importdescriptors.py`
+88. `wallet_importprunedfunds.py`
+89. `wallet_keypool.py`
+90. `wallet_keypool_topup.py`
+91. `wallet_labels.py`
+92. `wallet_listdescriptors.py`
+93. `wallet_listreceivedby.py`
+94. `wallet_listsinceblock.py`
+95. `wallet_listtransactions.py`
+96. `wallet_miniscript.py`
+97. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+98. `wallet_multisig_descriptor_psbt.py`
+99. `wallet_multiwallet.py`
+100. `wallet_orphanedreward.py`
+101. `wallet_reindex.py`
+102. `wallet_reorgsrestore.py`
+103. `wallet_rescan_unconfirmed.py`
+104. `wallet_resendwallettransactions.py`
+105. `wallet_send.py`
+106. `wallet_sendall.py`
+107. `wallet_sendmany.py`
+108. `wallet_signrawtransactionwithwallet.py`
+109. `wallet_simulaterawtx.py`
+110. `wallet_spend_unconfirmed.py`
+111. `wallet_startup.py`
+112. `wallet_timelock.py`
+113. `wallet_transactiontime_rescan.py`
+114. `wallet_txn_clone.py`
+115. `wallet_txn_doublespend.py`
+116. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -488,6 +489,14 @@ re-added from disconnected blocks, disconnect-pool trimming at the
 `MAX_DISCONNECTED_TX_POOL_BYTES` boundary with coupled child removal, and
 too-long-chain handling when non-standardly mined chains return to the mempool
 under normal chain limits in the current legacy-compatible PQC profile.
+The inherited mining RPC and block-template confidence gap is now also part of
+the required gate: `mining_basic.py` covers `getmininginfo`, witness
+commitment construction, versionbits and `-blockversion`, `submitblock` and
+`submitheader` validation, fee and sigop ordering in block templates,
+`-blockmintxfee` filtering, BIP94 timewarp protection, pruned-block
+`submitblock`, `-blockmaxweight` and `-blockreservedweight` boundaries, and
+generated coinbase height-locktime behavior under the current
+legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/FEATURE_PQ_BLOCK_LIMITS_POSTURE.md
+++ b/docs/FEATURE_PQ_BLOCK_LIMITS_POSTURE.md
@@ -54,6 +54,8 @@ Targeted confidence pass run on 2026-04-12:
   restored legacy block ceiling under PQ-capable script validation
 - it is a very small contract, but it is directly tied to the launch block
   profile and already belongs in the required PQ gate
+- broader mining RPC and block-template behavior is now covered separately by
+  [mining_basic.py](MINING_BASIC_POSTURE.md)
 - the next clean follow-on is
   [feature_pq_reorg.py](../test/functional/feature_pq_reorg.py), which is the
   adjacent PQ-native reorg/mempool reconciliation surface and is already green

--- a/docs/MEMPOOL_UPDATEFROMBLOCK_POSTURE.md
+++ b/docs/MEMPOOL_UPDATEFROMBLOCK_POSTURE.md
@@ -86,5 +86,6 @@ Targeted confidence pass run on 2026-05-08:
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mempool
-  or mining `pq_backlog` migration decision, with `mining_basic.py` the
-  adjacent candidate after a fresh targeted pass
+  or mining `pq_backlog` migration decision, with
+  `mining_getblocktemplate_longpoll.py` the adjacent candidate after a fresh
+  targeted pass

--- a/docs/MINING_BASIC_POSTURE.md
+++ b/docs/MINING_BASIC_POSTURE.md
@@ -1,0 +1,79 @@
+# PQBTC `mining_basic.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MINING-BASIC-POSTURE-v1
+## Updated: 2026-05-08
+## Frozen-By: track-a-phase1-20260508
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mining RPC and block-template
+policy under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing [mining_basic.py](../test/functional/mining_basic.py) suite
+owns the broad mining RPC and template boundary:
+
+- `getmininginfo` reports the expected chain, height, bits, target,
+  difficulty, next-block, networkhashps, and pooled transaction fields
+- `getblocktemplate` builds the expected default witness commitment for the
+  current mempool transaction set
+- `-blockversion` overrides the advertised block template version and normal
+  versionbits behavior resumes after restart
+- `getblocktemplate` requires the segwit rule and advertises proposal
+  capability without `coinbasetxn`
+- `submitblock` and `submitheader` preserve decode, empty-block,
+  missing-ancestor, bad-merkle-root, nonfinal, bad-prevblk, old-time,
+  duplicate, and active-tip outcomes
+- block templates order transactions by the expected fee and sigop accounting
+  behavior
+- `-blockmintxfee` filters transactions at and below many configured fee-rate
+  boundaries
+- BIP94 timewarp protection enforces the first-block retarget-period timestamp
+  boundary
+- `submitblock` can restore a previously pruned block to a pruned node when
+  the host pruning run exposes that path
+- `-blockmaxweight` and `-blockreservedweight` affect block template packing
+  and reject invalid startup values
+- generated blocks keep coinbase locktime tied to block height
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- longpoll, mainnet mining, block-template package selection, prioritisation,
+  or orphan transaction suites are owned by this tranche
+- prior-release mempool or mining compatibility behavior is covered without
+  real prior PQBTC release assets
+- PQ-native block-size stress replaces this inherited mining RPC surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-08:
+
+- `build/test/functional/test_runner.py --jobs=1 mining_basic.py`
+  - result: passed
+  - current posture:
+    - mining RPC fields and block-template construction remain stable
+    - block submission, header submission, fee filtering, and weight-boundary
+      behavior keep their expected outcomes
+    - BIP94 timewarp, pruning replay, and generated coinbase locktime behavior
+      remain green under the current legacy-compatible PQC profile
+
+## Interpretation
+
+- `mining_basic.py` is now a required inherited mining RPC and block-template
+  policy gate
+- it complements, but does not replace,
+  [feature_pq_block_limits.py](FEATURE_PQ_BLOCK_LIMITS_POSTURE.md) and
+  [mempool_updatefromblock.py](MEMPOOL_UPDATEFROMBLOCK_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mining
+  `pq_backlog` migration decision, with
+  `mining_getblocktemplate_longpoll.py` the adjacent candidate after a fresh
+  targeted pass

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -66,7 +66,8 @@ in the same gate, keep `mempool_truc.py` inherited TRUC/v3 mempool policy
 behavior in the same gate, keep `mempool_unbroadcast.py` inherited mempool
 unbroadcast delivery behavior in the same gate, keep
 `mempool_updatefromblock.py` inherited mempool update-from-block reorg
-accounting behavior in the same gate,
+accounting behavior in the same gate, keep `mining_basic.py` inherited mining
+RPC and block-template behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -170,6 +171,8 @@ Alternate rebalance:
      tranches, plus package RBF, package accounting, persistence, reorg,
      resurrection, sigop resource-envelope, coinbase-spend maturity, and TRUC
      policy, plus unbroadcast delivery and update-from-block reorg accounting.
+     The broad inherited mining RPC and block-template gate is now represented
+     too.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1422,9 +1425,40 @@ Still deferred:
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-66. Recommended next PR after this tranche:
+66. `mining_basic.py` now owns:
+   - inherited mining RPC and block-template policy under the current
+     legacy-compatible PQC profile
+   - `getmininginfo` chain, height, bits, target, difficulty, next-block,
+     networkhashps, and pooled transaction fields
+   - `getblocktemplate` default witness commitment construction
+   - `-blockversion` override behavior and normal versionbits template behavior
+     after restart
+   - `getblocktemplate` segwit-rule enforcement and proposal capability
+   - `submitblock` and `submitheader` decode, missing-ancestor,
+     bad-merkle-root, nonfinal, bad-prevblk, old-time, duplicate, and active-tip
+     outcomes
+   - block-template transaction fee and sigop ordering
+   - `-blockmintxfee` filtering across many configured fee-rate boundaries
+   - BIP94 timewarp protection at the first-block retarget-period boundary
+   - pruned-block `submitblock` replay when the pruning run exposes a pruned
+     historical block
+   - `-blockmaxweight` and `-blockreservedweight` block-template packing and
+     invalid startup value rejection
+   - generated coinbase height-locktime behavior
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mining_basic.py`
+   Fixed posture note:
+   - `MINING_BASIC_POSTURE.md`
+   Still deferred inside this suite:
+   - longpoll, mainnet mining, package-template selection, prioritisation,
+     orphan transaction, and prior-release compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+67. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mining_basic.py` as the next local mining policy
+   - alternate: `mining_getblocktemplate_longpoll.py` as the next local mining
+     policy
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1442,8 +1476,9 @@ Still deferred:
      are now frozen, and sigop resource-envelope, coinbase-spend maturity, and
      TRUC policy are now frozen, and unbroadcast delivery is now frozen, so the
      adjacent update-from-block reorg-accounting gate is now frozen, so the
-     local follow-on can move to a bounded mining policy gate only after a
-     fresh targeted pass
+     broad inherited mining RPC and block-template gate is now frozen, so the
+     local follow-on can move to another bounded mining policy gate only after
+     a fresh targeted pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2448,6 +2483,17 @@ Aineko must ask before:
   `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
   assets exist; otherwise the adjacent local mining candidate is
   `mining_basic.py` after a fresh targeted pass.
+- 2026-05-08: `mining_basic.py` is now promoted into the canonical
+  `pq_required` gate and locally revalidated with the build-tree functional
+  runner. The owned boundary covers `getmininginfo`, `getblocktemplate`
+  witness commitment and version behavior, `submitblock` and `submitheader`
+  validation, block-template fee and sigop ordering, `-blockmintxfee`
+  filtering, BIP94 timewarp protection, pruned-block replay, block weight and
+  reserved-weight startup boundaries, and generated coinbase height-locktime
+  behavior under the current legacy-compatible PQC profile. The next owned
+  follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
+  PQBTC release assets exist; otherwise the adjacent local mining candidate is
+  `mining_getblocktemplate_longpoll.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
Promotes mining_basic.py from pq_backlog to pq_required as the next metadata/docs-only Track A tranche, stacked on #149.

Local validation before pushing:
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 mining_basic.py
- git diff --check
- git diff --cached --check

No source, RPC, consensus, wallet, descriptor, P2P, or policy behavior changes.