### PR TITLE
Promote mining longpoll gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -728,10 +728,10 @@
   },
   {
     "name": "mining_getblocktemplate_longpoll.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited getblocktemplate longpoll gate: the suite exercises stable longpollid values when no chain or mempool event occurs, longpoll wait behavior on a separate RPC connection, wakeup after another node generates a block, wakeup after the local node generates a block, and wakeup after a new mempool transaction enters under the current legacy-compatible PQC profile."
   },
   {
     "name": "mining_mainnet.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -48,6 +48,7 @@ mempool_truc.py
 mempool_unbroadcast.py
 mempool_updatefromblock.py
 mining_basic.py
+mining_getblocktemplate_longpoll.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `116` |
-| `pq_backlog` | `9` |
+| `pq_required` | `117` |
+| `pq_backlog` | `8` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -74,91 +74,92 @@ Current required PQ-first gates:
 29. `mempool_unbroadcast.py`
 30. `mempool_updatefromblock.py`
 31. `mining_basic.py`
-32. `wallet_pq_active_ranged.py`
-33. `wallet_pq_backup_recovery.py`
-34. `wallet_pq_create_tx.py`
-35. `wallet_pq_descriptors.py`
-36. `wallet_pq_psbt.py`
-37. `wallet_pq_send.py`
-38. `wallet_pq_sendall.py`
-39. `wallet_pq_sendmany.py`
-40. `wallet_pq_signrawtransaction.py`
-41. `feature_assumeutxo.py`
-42. `feature_assumevalid.py`
-43. `feature_bip68_sequence.py`
-44. `feature_block.py`
-45. `feature_blocksdir.py`
-46. `feature_blocksxor.py`
-47. `feature_cltv.py`
-48. `feature_coinstatsindex.py`
-49. `feature_csv_activation.py`
-50. `feature_fastprune.py`
-51. `feature_index_prune.py`
-52. `feature_loadblock.py`
-53. `feature_pruning.py`
-54. `feature_reindex.py`
-55. `feature_reindex_init.py`
-56. `feature_reindex_readonly.py`
-57. `feature_remove_pruned_files_on_startup.py`
-58. `feature_utxo_set_hash.py`
-59. `feature_versionbits_warning.py`
-60. `rpc_psbt.py`
-61. `wallet_abandonconflict.py`
-62. `wallet_address_types.py`
-63. `wallet_assumeutxo.py`
-64. `wallet_avoid_mixing_output_types.py`
-65. `wallet_avoidreuse.py`
-66. `wallet_backup.py`
-67. `wallet_balance.py`
-68. `wallet_basic.py`
-69. `wallet_blank.py`
-70. `wallet_bumpfee.py`
-71. `wallet_change_address.py`
-72. `wallet_coinbase_category.py`
-73. `wallet_conflicts.py`
-74. `wallet_create_tx.py`
-75. `wallet_createwallet.py`
-76. `wallet_createwalletdescriptor.py`
-77. `wallet_crosschain.py`
-78. `wallet_descriptor.py`
-79. `wallet_disable.py`
-80. `wallet_encryption.py`
-81. `wallet_fallbackfee.py`
-82. `wallet_fast_rescan.py`
-83. `wallet_fundrawtransaction.py`
-84. `wallet_gethdkeys.py`
-85. `wallet_groups.py`
-86. `wallet_hd.py`
-87. `wallet_importdescriptors.py`
-88. `wallet_importprunedfunds.py`
-89. `wallet_keypool.py`
-90. `wallet_keypool_topup.py`
-91. `wallet_labels.py`
-92. `wallet_listdescriptors.py`
-93. `wallet_listreceivedby.py`
-94. `wallet_listsinceblock.py`
-95. `wallet_listtransactions.py`
-96. `wallet_miniscript.py`
-97. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-98. `wallet_multisig_descriptor_psbt.py`
-99. `wallet_multiwallet.py`
-100. `wallet_orphanedreward.py`
-101. `wallet_reindex.py`
-102. `wallet_reorgsrestore.py`
-103. `wallet_rescan_unconfirmed.py`
-104. `wallet_resendwallettransactions.py`
-105. `wallet_send.py`
-106. `wallet_sendall.py`
-107. `wallet_sendmany.py`
-108. `wallet_signrawtransactionwithwallet.py`
-109. `wallet_simulaterawtx.py`
-110. `wallet_spend_unconfirmed.py`
-111. `wallet_startup.py`
-112. `wallet_timelock.py`
-113. `wallet_transactiontime_rescan.py`
-114. `wallet_txn_clone.py`
-115. `wallet_txn_doublespend.py`
-116. `wallet_v3_txs.py`
+32. `mining_getblocktemplate_longpoll.py`
+33. `wallet_pq_active_ranged.py`
+34. `wallet_pq_backup_recovery.py`
+35. `wallet_pq_create_tx.py`
+36. `wallet_pq_descriptors.py`
+37. `wallet_pq_psbt.py`
+38. `wallet_pq_send.py`
+39. `wallet_pq_sendall.py`
+40. `wallet_pq_sendmany.py`
+41. `wallet_pq_signrawtransaction.py`
+42. `feature_assumeutxo.py`
+43. `feature_assumevalid.py`
+44. `feature_bip68_sequence.py`
+45. `feature_block.py`
+46. `feature_blocksdir.py`
+47. `feature_blocksxor.py`
+48. `feature_cltv.py`
+49. `feature_coinstatsindex.py`
+50. `feature_csv_activation.py`
+51. `feature_fastprune.py`
+52. `feature_index_prune.py`
+53. `feature_loadblock.py`
+54. `feature_pruning.py`
+55. `feature_reindex.py`
+56. `feature_reindex_init.py`
+57. `feature_reindex_readonly.py`
+58. `feature_remove_pruned_files_on_startup.py`
+59. `feature_utxo_set_hash.py`
+60. `feature_versionbits_warning.py`
+61. `rpc_psbt.py`
+62. `wallet_abandonconflict.py`
+63. `wallet_address_types.py`
+64. `wallet_assumeutxo.py`
+65. `wallet_avoid_mixing_output_types.py`
+66. `wallet_avoidreuse.py`
+67. `wallet_backup.py`
+68. `wallet_balance.py`
+69. `wallet_basic.py`
+70. `wallet_blank.py`
+71. `wallet_bumpfee.py`
+72. `wallet_change_address.py`
+73. `wallet_coinbase_category.py`
+74. `wallet_conflicts.py`
+75. `wallet_create_tx.py`
+76. `wallet_createwallet.py`
+77. `wallet_createwalletdescriptor.py`
+78. `wallet_crosschain.py`
+79. `wallet_descriptor.py`
+80. `wallet_disable.py`
+81. `wallet_encryption.py`
+82. `wallet_fallbackfee.py`
+83. `wallet_fast_rescan.py`
+84. `wallet_fundrawtransaction.py`
+85. `wallet_gethdkeys.py`
+86. `wallet_groups.py`
+87. `wallet_hd.py`
+88. `wallet_importdescriptors.py`
+89. `wallet_importprunedfunds.py`
+90. `wallet_keypool.py`
+91. `wallet_keypool_topup.py`
+92. `wallet_labels.py`
+93. `wallet_listdescriptors.py`
+94. `wallet_listreceivedby.py`
+95. `wallet_listsinceblock.py`
+96. `wallet_listtransactions.py`
+97. `wallet_miniscript.py`
+98. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+99. `wallet_multisig_descriptor_psbt.py`
+100. `wallet_multiwallet.py`
+101. `wallet_orphanedreward.py`
+102. `wallet_reindex.py`
+103. `wallet_reorgsrestore.py`
+104. `wallet_rescan_unconfirmed.py`
+105. `wallet_resendwallettransactions.py`
+106. `wallet_send.py`
+107. `wallet_sendall.py`
+108. `wallet_sendmany.py`
+109. `wallet_signrawtransactionwithwallet.py`
+110. `wallet_simulaterawtx.py`
+111. `wallet_spend_unconfirmed.py`
+112. `wallet_startup.py`
+113. `wallet_timelock.py`
+114. `wallet_transactiontime_rescan.py`
+115. `wallet_txn_clone.py`
+116. `wallet_txn_doublespend.py`
+117. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -497,6 +498,12 @@ commitment construction, versionbits and `-blockversion`, `submitblock` and
 `submitblock`, `-blockmaxweight` and `-blockreservedweight` boundaries, and
 generated coinbase height-locktime behavior under the current
 legacy-compatible PQC profile.
+The inherited getblocktemplate longpoll confidence gap is now also part of the
+required gate: `mining_getblocktemplate_longpoll.py` covers stable longpollid
+values when nothing changes, longpoll wait behavior on a separate RPC
+connection, wakeup after another node generates a block, wakeup after the local
+node generates a block, and wakeup after a new mempool transaction enters under
+the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MINING_BASIC_POSTURE.md
+++ b/docs/MINING_BASIC_POSTURE.md
@@ -75,5 +75,4 @@ Targeted confidence pass run on 2026-05-08:
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mining
   `pq_backlog` migration decision, with
-  `mining_getblocktemplate_longpoll.py` the adjacent candidate after a fresh
-  targeted pass
+  `mining_mainnet.py` the adjacent candidate after a fresh targeted pass

--- a/docs/MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md
+++ b/docs/MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md
@@ -1,0 +1,63 @@
+# PQBTC `mining_getblocktemplate_longpoll.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MINING-GETBLOCKTEMPLATE-LONGPOLL-POSTURE-v1
+## Updated: 2026-05-08
+## Frozen-By: track-a-phase1-20260508
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited `getblocktemplate` longpoll
+behavior under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mining_getblocktemplate_longpoll.py](../test/functional/mining_getblocktemplate_longpoll.py)
+suite owns the longpoll wakeup boundary:
+
+- repeated `getblocktemplate` calls keep the same `longpollid` when no chain or
+  mempool event occurs
+- a longpoll request on a separate RPC connection waits when there is no
+  wakeup event
+- generating a block on another connected node wakes the longpoll request
+- generating a block on the local node wakes the longpoll request
+- submitting a new mempool transaction wakes the longpoll request within the
+  expected polling window
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- mainnet mining, package-template selection, prioritisation, or orphan
+  transaction suites are owned by this tranche
+- prior-release mempool or mining compatibility behavior is covered without
+  real prior PQBTC release assets
+- PQ-native block-size stress replaces this inherited longpoll surface
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-05-08:
+
+- `build/test/functional/test_runner.py --jobs=1 mining_getblocktemplate_longpoll.py`
+  - result: passed
+  - current posture:
+    - stable longpoll IDs remain stable when nothing changes
+    - chain updates from a peer node and the local node wake longpolls
+    - mempool updates wake longpolls under the current legacy-compatible PQC
+      profile
+
+## Interpretation
+
+- `mining_getblocktemplate_longpoll.py` is now a required inherited
+  `getblocktemplate` longpoll gate
+- it complements, but does not replace,
+  [mining_basic.py](MINING_BASIC_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mining
+  `pq_backlog` migration decision, with `mining_mainnet.py` the adjacent
+  candidate after a fresh targeted pass

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -67,7 +67,9 @@ behavior in the same gate, keep `mempool_unbroadcast.py` inherited mempool
 unbroadcast delivery behavior in the same gate, keep
 `mempool_updatefromblock.py` inherited mempool update-from-block reorg
 accounting behavior in the same gate, keep `mining_basic.py` inherited mining
-RPC and block-template behavior in the same gate,
+RPC and block-template behavior in the same gate, keep
+`mining_getblocktemplate_longpoll.py` inherited getblocktemplate longpoll
+behavior in the same gate,
 freeze the new
 `feature_pqsig_basic.py`, `feature_pqsig_multisig.py`,
 `wallet_miniscript.py`, and
@@ -172,7 +174,8 @@ Alternate rebalance:
      resurrection, sigop resource-envelope, coinbase-spend maturity, and TRUC
      policy, plus unbroadcast delivery and update-from-block reorg accounting.
      The broad inherited mining RPC and block-template gate is now represented
-     too.
+     too, and getblocktemplate longpoll wakeup behavior is now represented as
+     the adjacent mining RPC slice.
      `wallet_backwards_compatibility.py`, `wallet_migration.py`, and
      `feature_coinstatsindex_compatibility.py` stay blocked until
      prior-release assets are available; `feature_unsupported_utxo_db.py` is
@@ -1455,10 +1458,28 @@ Still deferred:
    - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
      `feature_coinstatsindex_compatibility.py`, which remain blocked until
      real prior PQBTC release assets exist
-67. Recommended next PR after this tranche:
+67. `mining_getblocktemplate_longpoll.py` now owns:
+   - inherited `getblocktemplate` longpoll behavior under the current
+     legacy-compatible PQC profile
+   - stable `longpollid` reporting across successive `getblocktemplate` calls
+     when no chain or mempool event occurs
+   - longpoll wait behavior on a separate RPC connection
+   - longpoll wakeup after another connected node generates a block
+   - longpoll wakeup after the local node generates a block
+   - longpoll wakeup after a new transaction enters the mempool
+   Minimum validation target:
+   - `build/test/functional/test_runner.py --jobs=1 mining_getblocktemplate_longpoll.py`
+   Fixed posture note:
+   - `MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md`
+   Still deferred inside this suite:
+   - mainnet mining, package-template selection, prioritisation, orphan
+     transaction, and prior-release compatibility suites
+   - `mempool_compatibility.py`, `feature_unsupported_utxo_db.py`, and
+     `feature_coinstatsindex_compatibility.py`, which remain blocked until
+     real prior PQBTC release assets exist
+68. Recommended next PR after this tranche:
    - preferred: `feature_coinstatsindex_compatibility.py`
-   - alternate: `mining_getblocktemplate_longpoll.py` as the next local mining
-     policy
+   - alternate: `mining_mainnet.py` as the next local mining policy
      candidate after a fresh targeted pass, while
      `mempool_compatibility.py` stays previous-release blocked
    Why next:
@@ -1477,8 +1498,9 @@ Still deferred:
      TRUC policy are now frozen, and unbroadcast delivery is now frozen, so the
      adjacent update-from-block reorg-accounting gate is now frozen, so the
      broad inherited mining RPC and block-template gate is now frozen, so the
-     local follow-on can move to another bounded mining policy gate only after
-     a fresh targeted pass
+     getblocktemplate longpoll gate is now frozen, so the local follow-on can
+     move to another bounded mining policy gate only after a fresh targeted
+     pass
    - `wallet_backwards_compatibility.py` and `wallet_migration.py` remain
      useful, but both stay asset-dependent after the current
      startup, blank-wallet, createwallet, multiwallet, descriptor, encryption,
@@ -2494,6 +2516,16 @@ Aineko must ask before:
   follow-on remains `feature_coinstatsindex_compatibility.py` when real prior
   PQBTC release assets exist; otherwise the adjacent local mining candidate is
   `mining_getblocktemplate_longpoll.py` after a fresh targeted pass.
+- 2026-05-08: `mining_getblocktemplate_longpoll.py` is now promoted into the
+  canonical `pq_required` gate and locally revalidated with the build-tree
+  functional runner. The owned boundary covers stable `longpollid` reporting,
+  longpoll wait behavior on a separate RPC connection, wakeup after another
+  node generates a block, wakeup after the local node generates a block, and
+  wakeup after a new mempool transaction enters under the current
+  legacy-compatible PQC profile. The next owned follow-on remains
+  `feature_coinstatsindex_compatibility.py` when real prior PQBTC release
+  assets exist; otherwise the adjacent local mining candidate is
+  `mining_mainnet.py` after a fresh targeted pass.
 - 2026-04-06: Full `OPS_SLO` evidence bundle refreshed at
   `docs/artifacts/ops-slo/2026-04-06` and validated at signoff.
 - 2026-04-06: Targeted `OPS_SLO` sanity check completed without running the full


### PR DESCRIPTION
Promotes mining_getblocktemplate_longpoll.py from pq_backlog to pq_required as the next metadata/docs-only Track A tranche, stacked on #150.

Local validation before pushing:
- python3 ci/test/check_ci_inventory.py
- build/test/functional/test_runner.py --jobs=1 mining_getblocktemplate_longpoll.py
- git diff HEAD~1..HEAD --check

No source, RPC, consensus, wallet, descriptor, P2P, or policy behavior changes.