### PR TITLE
promote mining mainnet gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -735,10 +735,10 @@
   },
   {
     "name": "mining_mainnet.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited alternate-mainnet difficulty-adjustment mining gate: the suite loads deterministic alternate mainnet block data, mines the first 2015 blocks at difficulty 1, verifies getmininginfo current and next retarget fields at the first retarget boundary, accepts the first block of the second retarget period at difficulty 4, and confirms getblock still reports historical difficulty, bits, and target values for earlier blocks under the current legacy-compatible PQC profile."
   },
   {
     "name": "mining_prioritisetransaction.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -49,6 +49,7 @@ mempool_unbroadcast.py
 mempool_updatefromblock.py
 mining_basic.py
 mining_getblocktemplate_longpoll.py
+mining_mainnet.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `117` |
-| `pq_backlog` | `8` |
+| `pq_required` | `118` |
+| `pq_backlog` | `7` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -75,91 +75,92 @@ Current required PQ-first gates:
 30. `mempool_updatefromblock.py`
 31. `mining_basic.py`
 32. `mining_getblocktemplate_longpoll.py`
-33. `wallet_pq_active_ranged.py`
-34. `wallet_pq_backup_recovery.py`
-35. `wallet_pq_create_tx.py`
-36. `wallet_pq_descriptors.py`
-37. `wallet_pq_psbt.py`
-38. `wallet_pq_send.py`
-39. `wallet_pq_sendall.py`
-40. `wallet_pq_sendmany.py`
-41. `wallet_pq_signrawtransaction.py`
-42. `feature_assumeutxo.py`
-43. `feature_assumevalid.py`
-44. `feature_bip68_sequence.py`
-45. `feature_block.py`
-46. `feature_blocksdir.py`
-47. `feature_blocksxor.py`
-48. `feature_cltv.py`
-49. `feature_coinstatsindex.py`
-50. `feature_csv_activation.py`
-51. `feature_fastprune.py`
-52. `feature_index_prune.py`
-53. `feature_loadblock.py`
-54. `feature_pruning.py`
-55. `feature_reindex.py`
-56. `feature_reindex_init.py`
-57. `feature_reindex_readonly.py`
-58. `feature_remove_pruned_files_on_startup.py`
-59. `feature_utxo_set_hash.py`
-60. `feature_versionbits_warning.py`
-61. `rpc_psbt.py`
-62. `wallet_abandonconflict.py`
-63. `wallet_address_types.py`
-64. `wallet_assumeutxo.py`
-65. `wallet_avoid_mixing_output_types.py`
-66. `wallet_avoidreuse.py`
-67. `wallet_backup.py`
-68. `wallet_balance.py`
-69. `wallet_basic.py`
-70. `wallet_blank.py`
-71. `wallet_bumpfee.py`
-72. `wallet_change_address.py`
-73. `wallet_coinbase_category.py`
-74. `wallet_conflicts.py`
-75. `wallet_create_tx.py`
-76. `wallet_createwallet.py`
-77. `wallet_createwalletdescriptor.py`
-78. `wallet_crosschain.py`
-79. `wallet_descriptor.py`
-80. `wallet_disable.py`
-81. `wallet_encryption.py`
-82. `wallet_fallbackfee.py`
-83. `wallet_fast_rescan.py`
-84. `wallet_fundrawtransaction.py`
-85. `wallet_gethdkeys.py`
-86. `wallet_groups.py`
-87. `wallet_hd.py`
-88. `wallet_importdescriptors.py`
-89. `wallet_importprunedfunds.py`
-90. `wallet_keypool.py`
-91. `wallet_keypool_topup.py`
-92. `wallet_labels.py`
-93. `wallet_listdescriptors.py`
-94. `wallet_listreceivedby.py`
-95. `wallet_listsinceblock.py`
-96. `wallet_listtransactions.py`
-97. `wallet_miniscript.py`
-98. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-99. `wallet_multisig_descriptor_psbt.py`
-100. `wallet_multiwallet.py`
-101. `wallet_orphanedreward.py`
-102. `wallet_reindex.py`
-103. `wallet_reorgsrestore.py`
-104. `wallet_rescan_unconfirmed.py`
-105. `wallet_resendwallettransactions.py`
-106. `wallet_send.py`
-107. `wallet_sendall.py`
-108. `wallet_sendmany.py`
-109. `wallet_signrawtransactionwithwallet.py`
-110. `wallet_simulaterawtx.py`
-111. `wallet_spend_unconfirmed.py`
-112. `wallet_startup.py`
-113. `wallet_timelock.py`
-114. `wallet_transactiontime_rescan.py`
-115. `wallet_txn_clone.py`
-116. `wallet_txn_doublespend.py`
-117. `wallet_v3_txs.py`
+33. `mining_mainnet.py`
+34. `wallet_pq_active_ranged.py`
+35. `wallet_pq_backup_recovery.py`
+36. `wallet_pq_create_tx.py`
+37. `wallet_pq_descriptors.py`
+38. `wallet_pq_psbt.py`
+39. `wallet_pq_send.py`
+40. `wallet_pq_sendall.py`
+41. `wallet_pq_sendmany.py`
+42. `wallet_pq_signrawtransaction.py`
+43. `feature_assumeutxo.py`
+44. `feature_assumevalid.py`
+45. `feature_bip68_sequence.py`
+46. `feature_block.py`
+47. `feature_blocksdir.py`
+48. `feature_blocksxor.py`
+49. `feature_cltv.py`
+50. `feature_coinstatsindex.py`
+51. `feature_csv_activation.py`
+52. `feature_fastprune.py`
+53. `feature_index_prune.py`
+54. `feature_loadblock.py`
+55. `feature_pruning.py`
+56. `feature_reindex.py`
+57. `feature_reindex_init.py`
+58. `feature_reindex_readonly.py`
+59. `feature_remove_pruned_files_on_startup.py`
+60. `feature_utxo_set_hash.py`
+61. `feature_versionbits_warning.py`
+62. `rpc_psbt.py`
+63. `wallet_abandonconflict.py`
+64. `wallet_address_types.py`
+65. `wallet_assumeutxo.py`
+66. `wallet_avoid_mixing_output_types.py`
+67. `wallet_avoidreuse.py`
+68. `wallet_backup.py`
+69. `wallet_balance.py`
+70. `wallet_basic.py`
+71. `wallet_blank.py`
+72. `wallet_bumpfee.py`
+73. `wallet_change_address.py`
+74. `wallet_coinbase_category.py`
+75. `wallet_conflicts.py`
+76. `wallet_create_tx.py`
+77. `wallet_createwallet.py`
+78. `wallet_createwalletdescriptor.py`
+79. `wallet_crosschain.py`
+80. `wallet_descriptor.py`
+81. `wallet_disable.py`
+82. `wallet_encryption.py`
+83. `wallet_fallbackfee.py`
+84. `wallet_fast_rescan.py`
+85. `wallet_fundrawtransaction.py`
+86. `wallet_gethdkeys.py`
+87. `wallet_groups.py`
+88. `wallet_hd.py`
+89. `wallet_importdescriptors.py`
+90. `wallet_importprunedfunds.py`
+91. `wallet_keypool.py`
+92. `wallet_keypool_topup.py`
+93. `wallet_labels.py`
+94. `wallet_listdescriptors.py`
+95. `wallet_listreceivedby.py`
+96. `wallet_listsinceblock.py`
+97. `wallet_listtransactions.py`
+98. `wallet_miniscript.py`
+99. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+100. `wallet_multisig_descriptor_psbt.py`
+101. `wallet_multiwallet.py`
+102. `wallet_orphanedreward.py`
+103. `wallet_reindex.py`
+104. `wallet_reorgsrestore.py`
+105. `wallet_rescan_unconfirmed.py`
+106. `wallet_resendwallettransactions.py`
+107. `wallet_send.py`
+108. `wallet_sendall.py`
+109. `wallet_sendmany.py`
+110. `wallet_signrawtransactionwithwallet.py`
+111. `wallet_simulaterawtx.py`
+112. `wallet_spend_unconfirmed.py`
+113. `wallet_startup.py`
+114. `wallet_timelock.py`
+115. `wallet_transactiontime_rescan.py`
+116. `wallet_txn_clone.py`
+117. `wallet_txn_doublespend.py`
+118. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -504,6 +505,12 @@ values when nothing changes, longpoll wait behavior on a separate RPC
 connection, wakeup after another node generates a block, wakeup after the local
 node generates a block, and wakeup after a new mempool transaction enters under
 the current legacy-compatible PQC profile.
+The inherited alternate-mainnet difficulty-adjustment mining confidence gap is
+now also part of the required gate: `mining_mainnet.py` covers deterministic
+alternate-mainnet block data, first-period block acceptance at difficulty 1,
+current and next retarget reporting in `getmininginfo`, acceptance of the first
+second-period block at difficulty 4, and historical difficulty, bits, and target
+reporting in `getblock` under the current legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment
@@ -539,4 +546,4 @@ Until a separate ownership model or `CODEOWNERS` file exists, all current workfl
 Still deferred after this tranche:
 
 1. converting additional `pq_backlog` suites into required PQ gates or documenting permanent dual-profile boundaries for them
-2. promoting high-value chainstate and validation suites from `pq_backlog` once the current wallet-confidence tranche is stable
+2. promoting high-value suites from `pq_backlog` once each bounded confidence pass is stable

--- a/docs/MINING_BASIC_POSTURE.md
+++ b/docs/MINING_BASIC_POSTURE.md
@@ -75,4 +75,5 @@ Targeted confidence pass run on 2026-05-08:
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mining
   `pq_backlog` migration decision, with
-  `mining_mainnet.py` the adjacent candidate after a fresh targeted pass
+  `mining_prioritisetransaction.py` the adjacent candidate after a fresh
+  targeted pass

--- a/docs/MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md
+++ b/docs/MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md
@@ -59,5 +59,6 @@ Targeted confidence pass run on 2026-05-08:
 - the preferred asset-dependent follow-on remains
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mining
-  `pq_backlog` migration decision, with `mining_mainnet.py` the adjacent
-  candidate after a fresh targeted pass
+  `pq_backlog` migration decision, with
+  `mining_prioritisetransaction.py` the adjacent candidate after a fresh
+  targeted pass

--- a/docs/MINING_MAINNET_POSTURE.md
+++ b/docs/MINING_MAINNET_POSTURE.md
@@ -1,0 +1,71 @@
+# PQBTC `mining_mainnet.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MINING-MAINNET-POSTURE-v1
+## Updated: 2026-06-10
+## Frozen-By: track-a-phase3-20260610
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited alternate-mainnet
+difficulty-adjustment mining behavior under the current legacy-compatible PQC
+profile.
+
+## Current Owned Surface
+
+The current passing [mining_mainnet.py](../test/functional/mining_mainnet.py)
+suite owns the deterministic alternate-mainnet retarget boundary:
+
+- deterministic `data/mainnet_alt.json` block timestamp and nonce data is
+  loaded for the first 2016 blocks
+- the first 2015 blocks are accepted at difficulty 1 on the alternate mainnet
+  chain
+- `getmininginfo` reports current difficulty, bits, and target values for the
+  first retarget period
+- `getmininginfo` reports the next height, difficulty, bits, and target values
+  for the first retarget boundary
+- the first block of the second retarget period is accepted at difficulty 4
+- historical `getblock` reporting for an earlier block keeps the original
+  difficulty 1 bits and target values
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- mining prioritisation, package-template selection, or orphan transaction
+  suites are owned by this tranche
+- prior-release mempool or mining compatibility behavior is covered without
+  real prior PQBTC release assets
+- PQ-native block-size stress replaces this inherited alternate-mainnet
+  retarget surface
+- this tranche changes consensus, RPC, wallet, P2P, descriptor, or policy
+  behavior
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-06-10:
+
+- `build/test/functional/test_runner.py --jobs=1 mining_mainnet.py`
+  - result: passed
+  - current posture:
+    - deterministic alternate-mainnet block construction remains green
+    - first-period and second-period difficulty reporting remains stable
+    - historical block difficulty reporting remains stable under the current
+      legacy-compatible PQC profile
+
+## Interpretation
+
+- `mining_mainnet.py` is now a required inherited alternate-mainnet
+  difficulty-adjustment mining gate
+- it complements, but does not replace,
+  [mining_basic.py](MINING_BASIC_POSTURE.md) and
+  [mining_getblocktemplate_longpoll.py](MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mining
+  `pq_backlog` migration decision, with
+  `mining_prioritisetransaction.py` the adjacent candidate after a fresh
+  targeted pass


### PR DESCRIPTION
## Summary
- Promote `mining_mainnet.py` from `pq_backlog` to `pq_required`.
- Add it to `ci/test/pq_functional_tests.txt` and update CI completeness counts to `pq_required: 118`, `pq_backlog: 7`.
- Add `docs/MINING_MAINNET_POSTURE.md` and advance adjacent mining posture docs to `mining_prioritisetransaction.py` as the next local backlog candidate.

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `git diff --cached --check`
- `build/test/functional/test_runner.py --jobs=1 mining_mainnet.py`

Note: the targeted functional test required normal local process/RPC permissions; the sandboxed run failed before test execution when `bitcoind` could not start its local HTTP RPC server.