### PR TITLE
promote mining prioritise transaction gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -742,10 +742,10 @@
   },
   {
     "name": "mining_prioritisetransaction.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Now promoted into pq_required as the inherited mining prioritise-transaction gate: the suite exercises prioritisetransaction and getprioritisedtransactions RPC argument validation, fee-delta persistence across replacement and restart boundaries, modified-fee accounting for diamond-shaped mempool packages, mining selection effects for prioritised and deprioritised transactions, relay-fee override admission for a free transaction, and getblocktemplate refresh after prioritisation changes under the current legacy-compatible PQC profile."
   },
   {
     "name": "mining_template_verification.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -50,6 +50,7 @@ mempool_updatefromblock.py
 mining_basic.py
 mining_getblocktemplate_longpoll.py
 mining_mainnet.py
+mining_prioritisetransaction.py
 rpc_psbt.py
 wallet_abandonconflict.py
 wallet_address_types.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,8 +36,8 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `118` |
-| `pq_backlog` | `7` |
+| `pq_required` | `119` |
+| `pq_backlog` | `6` |
 | `dual_profile` | `142` |
 | `legacy_only` | `9` |
 
@@ -76,91 +76,92 @@ Current required PQ-first gates:
 31. `mining_basic.py`
 32. `mining_getblocktemplate_longpoll.py`
 33. `mining_mainnet.py`
-34. `wallet_pq_active_ranged.py`
-35. `wallet_pq_backup_recovery.py`
-36. `wallet_pq_create_tx.py`
-37. `wallet_pq_descriptors.py`
-38. `wallet_pq_psbt.py`
-39. `wallet_pq_send.py`
-40. `wallet_pq_sendall.py`
-41. `wallet_pq_sendmany.py`
-42. `wallet_pq_signrawtransaction.py`
-43. `feature_assumeutxo.py`
-44. `feature_assumevalid.py`
-45. `feature_bip68_sequence.py`
-46. `feature_block.py`
-47. `feature_blocksdir.py`
-48. `feature_blocksxor.py`
-49. `feature_cltv.py`
-50. `feature_coinstatsindex.py`
-51. `feature_csv_activation.py`
-52. `feature_fastprune.py`
-53. `feature_index_prune.py`
-54. `feature_loadblock.py`
-55. `feature_pruning.py`
-56. `feature_reindex.py`
-57. `feature_reindex_init.py`
-58. `feature_reindex_readonly.py`
-59. `feature_remove_pruned_files_on_startup.py`
-60. `feature_utxo_set_hash.py`
-61. `feature_versionbits_warning.py`
-62. `rpc_psbt.py`
-63. `wallet_abandonconflict.py`
-64. `wallet_address_types.py`
-65. `wallet_assumeutxo.py`
-66. `wallet_avoid_mixing_output_types.py`
-67. `wallet_avoidreuse.py`
-68. `wallet_backup.py`
-69. `wallet_balance.py`
-70. `wallet_basic.py`
-71. `wallet_blank.py`
-72. `wallet_bumpfee.py`
-73. `wallet_change_address.py`
-74. `wallet_coinbase_category.py`
-75. `wallet_conflicts.py`
-76. `wallet_create_tx.py`
-77. `wallet_createwallet.py`
-78. `wallet_createwalletdescriptor.py`
-79. `wallet_crosschain.py`
-80. `wallet_descriptor.py`
-81. `wallet_disable.py`
-82. `wallet_encryption.py`
-83. `wallet_fallbackfee.py`
-84. `wallet_fast_rescan.py`
-85. `wallet_fundrawtransaction.py`
-86. `wallet_gethdkeys.py`
-87. `wallet_groups.py`
-88. `wallet_hd.py`
-89. `wallet_importdescriptors.py`
-90. `wallet_importprunedfunds.py`
-91. `wallet_keypool.py`
-92. `wallet_keypool_topup.py`
-93. `wallet_labels.py`
-94. `wallet_listdescriptors.py`
-95. `wallet_listreceivedby.py`
-96. `wallet_listsinceblock.py`
-97. `wallet_listtransactions.py`
-98. `wallet_miniscript.py`
-99. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-100. `wallet_multisig_descriptor_psbt.py`
-101. `wallet_multiwallet.py`
-102. `wallet_orphanedreward.py`
-103. `wallet_reindex.py`
-104. `wallet_reorgsrestore.py`
-105. `wallet_rescan_unconfirmed.py`
-106. `wallet_resendwallettransactions.py`
-107. `wallet_send.py`
-108. `wallet_sendall.py`
-109. `wallet_sendmany.py`
-110. `wallet_signrawtransactionwithwallet.py`
-111. `wallet_simulaterawtx.py`
-112. `wallet_spend_unconfirmed.py`
-113. `wallet_startup.py`
-114. `wallet_timelock.py`
-115. `wallet_transactiontime_rescan.py`
-116. `wallet_txn_clone.py`
-117. `wallet_txn_doublespend.py`
-118. `wallet_v3_txs.py`
+34. `mining_prioritisetransaction.py`
+35. `wallet_pq_active_ranged.py`
+36. `wallet_pq_backup_recovery.py`
+37. `wallet_pq_create_tx.py`
+38. `wallet_pq_descriptors.py`
+39. `wallet_pq_psbt.py`
+40. `wallet_pq_send.py`
+41. `wallet_pq_sendall.py`
+42. `wallet_pq_sendmany.py`
+43. `wallet_pq_signrawtransaction.py`
+44. `feature_assumeutxo.py`
+45. `feature_assumevalid.py`
+46. `feature_bip68_sequence.py`
+47. `feature_block.py`
+48. `feature_blocksdir.py`
+49. `feature_blocksxor.py`
+50. `feature_cltv.py`
+51. `feature_coinstatsindex.py`
+52. `feature_csv_activation.py`
+53. `feature_fastprune.py`
+54. `feature_index_prune.py`
+55. `feature_loadblock.py`
+56. `feature_pruning.py`
+57. `feature_reindex.py`
+58. `feature_reindex_init.py`
+59. `feature_reindex_readonly.py`
+60. `feature_remove_pruned_files_on_startup.py`
+61. `feature_utxo_set_hash.py`
+62. `feature_versionbits_warning.py`
+63. `rpc_psbt.py`
+64. `wallet_abandonconflict.py`
+65. `wallet_address_types.py`
+66. `wallet_assumeutxo.py`
+67. `wallet_avoid_mixing_output_types.py`
+68. `wallet_avoidreuse.py`
+69. `wallet_backup.py`
+70. `wallet_balance.py`
+71. `wallet_basic.py`
+72. `wallet_blank.py`
+73. `wallet_bumpfee.py`
+74. `wallet_change_address.py`
+75. `wallet_coinbase_category.py`
+76. `wallet_conflicts.py`
+77. `wallet_create_tx.py`
+78. `wallet_createwallet.py`
+79. `wallet_createwalletdescriptor.py`
+80. `wallet_crosschain.py`
+81. `wallet_descriptor.py`
+82. `wallet_disable.py`
+83. `wallet_encryption.py`
+84. `wallet_fallbackfee.py`
+85. `wallet_fast_rescan.py`
+86. `wallet_fundrawtransaction.py`
+87. `wallet_gethdkeys.py`
+88. `wallet_groups.py`
+89. `wallet_hd.py`
+90. `wallet_importdescriptors.py`
+91. `wallet_importprunedfunds.py`
+92. `wallet_keypool.py`
+93. `wallet_keypool_topup.py`
+94. `wallet_labels.py`
+95. `wallet_listdescriptors.py`
+96. `wallet_listreceivedby.py`
+97. `wallet_listsinceblock.py`
+98. `wallet_listtransactions.py`
+99. `wallet_miniscript.py`
+100. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+101. `wallet_multisig_descriptor_psbt.py`
+102. `wallet_multiwallet.py`
+103. `wallet_orphanedreward.py`
+104. `wallet_reindex.py`
+105. `wallet_reorgsrestore.py`
+106. `wallet_rescan_unconfirmed.py`
+107. `wallet_resendwallettransactions.py`
+108. `wallet_send.py`
+109. `wallet_sendall.py`
+110. `wallet_sendmany.py`
+111. `wallet_signrawtransactionwithwallet.py`
+112. `wallet_simulaterawtx.py`
+113. `wallet_spend_unconfirmed.py`
+114. `wallet_startup.py`
+115. `wallet_timelock.py`
+116. `wallet_transactiontime_rescan.py`
+117. `wallet_txn_clone.py`
+118. `wallet_txn_doublespend.py`
+119. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -511,6 +512,14 @@ alternate-mainnet block data, first-period block acceptance at difficulty 1,
 current and next retarget reporting in `getmininginfo`, acceptance of the first
 second-period block at difficulty 4, and historical difficulty, bits, and target
 reporting in `getblock` under the current legacy-compatible PQC profile.
+The inherited mining prioritise-transaction confidence gap is now also part of
+the required gate: `mining_prioritisetransaction.py` covers RPC argument
+validation for `prioritisetransaction` and `getprioritisedtransactions`,
+fee-delta accounting and persistence around replacement and restart boundaries,
+diamond-shaped package modified-fee accounting, prioritised and deprioritised
+mining selection, relay-fee override admission for a free transaction, and
+`getblocktemplate` refresh after prioritisation changes under the current
+legacy-compatible PQC profile.
 The remaining key backlog families are:
 
 1. remaining mempool and mining policy suites not yet given explicit PQ gating treatment

--- a/docs/MINING_BASIC_POSTURE.md
+++ b/docs/MINING_BASIC_POSTURE.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: MINING-BASIC-POSTURE-v1
-## Updated: 2026-05-08
+## Updated: 2026-06-11
 ## Frozen-By: track-a-phase1-20260508
 ## Consensus-Relevant: NO
 
@@ -75,5 +75,5 @@ Targeted confidence pass run on 2026-05-08:
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mining
   `pq_backlog` migration decision, with
-  `mining_prioritisetransaction.py` the adjacent candidate after a fresh
+  `mining_template_verification.py` the adjacent candidate after a fresh
   targeted pass

--- a/docs/MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md
+++ b/docs/MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: MINING-GETBLOCKTEMPLATE-LONGPOLL-POSTURE-v1
-## Updated: 2026-05-08
+## Updated: 2026-06-11
 ## Frozen-By: track-a-phase1-20260508
 ## Consensus-Relevant: NO
 
@@ -60,5 +60,5 @@ Targeted confidence pass run on 2026-05-08:
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mining
   `pq_backlog` migration decision, with
-  `mining_prioritisetransaction.py` the adjacent candidate after a fresh
+  `mining_template_verification.py` the adjacent candidate after a fresh
   targeted pass

--- a/docs/MINING_MAINNET_POSTURE.md
+++ b/docs/MINING_MAINNET_POSTURE.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: MINING-MAINNET-POSTURE-v1
-## Updated: 2026-06-10
+## Updated: 2026-06-11
 ## Frozen-By: track-a-phase3-20260610
 ## Consensus-Relevant: NO
 
@@ -67,5 +67,5 @@ Targeted confidence pass run on 2026-06-10:
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
 - without those assets, the local follow-on should be another bounded mining
   `pq_backlog` migration decision, with
-  `mining_prioritisetransaction.py` the adjacent candidate after a fresh
+  `mining_template_verification.py` the adjacent candidate after a fresh
   targeted pass

--- a/docs/MINING_PRIORITISETRANSACTION_POSTURE.md
+++ b/docs/MINING_PRIORITISETRANSACTION_POSTURE.md
@@ -1,0 +1,76 @@
+# PQBTC `mining_prioritisetransaction.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: MINING-PRIORITISETRANSACTION-POSTURE-v1
+## Updated: 2026-06-11
+## Frozen-By: track-a-phase3-20260611
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the owned Track A contract for inherited mining transaction
+prioritisation behavior under the current legacy-compatible PQC profile.
+
+## Current Owned Surface
+
+The current passing
+[mining_prioritisetransaction.py](../test/functional/mining_prioritisetransaction.py)
+suite owns the prioritisation and modified-fee mining boundary:
+
+- `prioritisetransaction` and `getprioritisedtransactions` reject missing,
+  malformed, and extra arguments with the expected RPC errors
+- fee deltas are additive, survive replacement of the prioritised transaction,
+  and are removed after mining
+- diamond-shaped package prioritisation updates modified, ancestor, and
+  descendant fee accounting while transactions are in and out of the mempool
+- persisted fee deltas are cleared where the suite requires deterministic
+  restart behavior
+- prioritised low-fee transactions can be mined ahead of otherwise comparable
+  low-fee transactions
+- deprioritised high-fee transactions can remain in the mempool while other
+  high-fee transactions are mined
+- zero-delta calls do not create prioritisation entries
+- a prioritised free transaction can satisfy relay-fee admission and enter the
+  mempool
+- `getblocktemplate` refreshes after a prioritisation change
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- package-template verification or orphan transaction suites are owned by this
+  tranche
+- prior-release mempool or mining compatibility behavior is covered without
+  real prior PQBTC release assets
+- PQ-native block-size stress replaces this inherited prioritisation surface
+- this tranche changes consensus, RPC, wallet, P2P, descriptor, or policy
+  behavior
+
+Those remain separate required gates or backlog decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-06-11:
+
+- `build/test/functional/test_runner.py --jobs=1 mining_prioritisetransaction.py`
+  - result: passed
+  - current posture:
+    - prioritisation RPC validation remains stable
+    - modified-fee accounting and mining selection effects remain green
+    - template refresh after prioritisation remains green under the current
+      legacy-compatible PQC profile
+
+## Interpretation
+
+- `mining_prioritisetransaction.py` is now a required inherited mining
+  prioritisation gate
+- it complements, but does not replace,
+  [mining_basic.py](MINING_BASIC_POSTURE.md),
+  [mining_getblocktemplate_longpoll.py](MINING_GETBLOCKTEMPLATE_LONGPOLL_POSTURE.md),
+  and [mining_mainnet.py](MINING_MAINNET_POSTURE.md)
+- the preferred asset-dependent follow-on remains
+  [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py)
+- without those assets, the local follow-on should be another bounded mining
+  `pq_backlog` migration decision, with
+  `mining_template_verification.py` the adjacent candidate after a fresh
+  targeted pass


### PR DESCRIPTION
## Summary
- Promote `mining_prioritisetransaction.py` from `pq_backlog` to `pq_required`.
- Add it to `ci/test/pq_functional_tests.txt` and update CI completeness counts to `pq_required: 119`, `pq_backlog: 6`.
- Add `docs/MINING_PRIORITISETRANSACTION_POSTURE.md` and advance adjacent mining posture docs to `mining_template_verification.py` as the next local backlog candidate.

## Validation
- `python3 ci/test/check_ci_inventory.py`
- `git diff --check`
- `git diff --cached --check`
- `build/test/functional/test_runner.py --jobs=1 mining_prioritisetransaction.py`