### PR TITLE
docs: record previous-release asset boundary

### DIFF
--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -532,7 +532,9 @@ The remaining key backlog families are:
 
 1. prior-release-dependent mempool, validation, chainstate, and wallet
    compatibility suites that require real PQBTC release assets before they can
-   receive a durable required-gate decision
+   receive a durable required-gate decision; see
+   [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md) for
+   the exact current asset layout and blocker
 2. broader dual-profile and legacy-only coverage that still needs durable
    ownership and migration boundaries
 

--- a/docs/FEATURE_COINSTATSINDEX_POSTURE.md
+++ b/docs/FEATURE_COINSTATSINDEX_POSTURE.md
@@ -66,3 +66,8 @@ Targeted confidence pass run on 2026-04-30:
 - the environment-dependent alternate is
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py),
   which stays relevant when previous-release test data is available
+- that compatibility alternate remains blocked by the explicit prior-release
+  asset boundary in
+  [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md):
+  the current harness needs PQBTC `v28.2` `pqbtcd` and `pqbtc-cli` binaries in
+  the previous-release layout before it can be promoted honestly

--- a/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
+++ b/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
@@ -1,0 +1,80 @@
+# PQBTC Previous-Release Asset Boundary
+
+## Status: ACTIVE
+## Spec-ID: PREVIOUS-RELEASE-ASSET-BOUNDARY-v1
+## Updated: 2026-06-11
+
+## Purpose
+
+Record the current blocker for previous-release functional suites so Track A
+does not promote skipped compatibility tests as required gates.
+
+## Required Harness Shape
+
+The immediate Track A candidate is
+[feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py).
+That suite calls `skip_if_no_previous_releases()` and starts two nodes with
+`versions=[None, 280200]`.
+
+Under the current functional-test framework, `280200` maps to `v28.2`, so the
+default local layout is:
+
+- `releases/v28.2/bin/pqbtcd`
+- `releases/v28.2/bin/pqbtc-cli`
+
+If `PREVIOUS_RELEASES_DIR` is set, the same `v28.2/bin/pqbtcd` and
+`v28.2/bin/pqbtc-cli` layout is expected below that directory instead.
+
+## Current Local State
+
+Current inspection found no usable previous-release PQBTC binary assets:
+
+- `PREVIOUS_RELEASES_DIR` is unset
+- the repo-local `releases/` directory is empty
+- the fork's GitHub releases currently expose no executable release assets:
+  - `v1.0.0` has no assets
+  - `v1.0.0-rc1` has only `RELEASE_V1_RC1.md` and `RUNBOOK_V1_RC1.md`
+- the checked `v28.2` tag is an inherited signed Bitcoin Core final tag, not a
+  PQBTC release-asset source
+- `test/get_previous_releases.py` downloads upstream Bitcoin Core
+  `bitcoin-28.2-*` archives and is therefore not enough to prove a prior-PQBTC
+  compatibility gate
+
+## Source Decision
+
+Do not promote `feature_coinstatsindex_compatibility.py` from `pq_backlog` until
+real PQBTC previous-release binaries are available outside the git-tracked
+tree.
+
+Acceptable sources are:
+
+1. an existing local PQBTC archive unpacked into the harness layout above
+2. a reproducible build of the intended prior PQBTC release, staged outside
+   git-tracked source and exposed through `PREVIOUS_RELEASES_DIR`
+3. downloaded PQBTC release artifacts with executable binaries and documented
+   checksums
+
+When assets exist, record their source and SHA256 checksums before promotion.
+Do not commit large generated binaries or downloaded release payloads.
+
+## Remaining Asset-Dependent Suites
+
+The current `pq_backlog` is entirely previous-release or prior-fixture
+dependent:
+
+1. `feature_coinstatsindex_compatibility.py`
+2. `feature_unsupported_utxo_db.py`
+3. `mempool_compatibility.py`
+4. `wallet_backwards_compatibility.py`
+5. `wallet_migration.py`
+
+## Validation Snapshot
+
+Current local validation without previous-release assets:
+
+- `python3 ci/test/check_ci_inventory.py`
+  - result: passed
+  - counts: `pq_required: 120`, `pq_backlog: 5`
+- `build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex_compatibility.py`
+  - result: skipped
+  - skip reason: previous releases not available or disabled

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -22,6 +22,14 @@ now the asset-dependent
 `feature_coinstatsindex_compatibility.py` promotion when real prior PQBTC
 release assets exist locally.
 
+The current asset boundary is recorded in
+[PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md). The
+compatibility harness maps `280200` to `v28.2` and expects PQBTC-named
+previous-release binaries at `releases/v28.2/bin/pqbtcd` and
+`releases/v28.2/bin/pqbtc-cli` unless `PREVIOUS_RELEASES_DIR` points at an
+equivalent layout. Current inspection found no such local assets, and the
+available GitHub release assets are not executable previous-release binaries.
+
 ## Current Working Thesis
 
 - `quantum-proof-bitcoin` stays on Track A: native post-quantum Bitcoin.
@@ -77,8 +85,10 @@ Alternate rebalance:
      `#156`
 2. When real prior PQBTC release assets exist locally, open the bounded
    `feature_coinstatsindex_compatibility.py` promotion slice.
-3. Until those assets exist, the remaining backlog stays deferred to the five
-   asset-dependent suites listed above.
+3. Until those assets exist, do not promote another `pq_backlog` suite. The
+   remaining backlog stays deferred to the five asset-dependent suites listed
+   above and in
+   [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md).
 
 
 ## Historical Queue Ledger
@@ -2483,6 +2493,11 @@ above as the controlling live next-PR handoff when these older notes disagree.
 - There is no current low-cost repo-local `pq_backlog` slice after the landed
   `mining_template_verification.py` promotion; the remaining backlog requires
   prior-release assets before another durable gate decision.
+- The exact prior-release asset precondition is documented in
+  [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md):
+  the immediate compatibility harness needs PQBTC `v28.2` binaries named
+  `pqbtcd` and `pqbtc-cli` in the previous-release layout, with source and
+  checksums recorded before any gate promotion.
 - `feature_coinstatsindex_compatibility.py` remains blocked until real prior
   PQBTC release assets are available to the compatibility harness.
 - `feature_unsupported_utxo_db.py` remains blocked until real prior PQBTC


### PR DESCRIPTION
## Summary
- add a previous-release asset boundary note for asset-dependent Track A backlog suites
- document the exact `feature_coinstatsindex_compatibility.py` harness layout: `v28.2/bin/pqbtcd` and `v28.2/bin/pqbtc-cli`
- link the blocker from Track A status, coinstats posture, and CI completeness docs

## Validation
- `git diff --check`
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex_compatibility.py` (skipped: previous releases not available or disabled)