### PR TITLE
ci: classify coinstats compatibility as legacy

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -113,10 +113,10 @@
   },
   {
     "name": "feature_coinstatsindex_compatibility.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "legacy_only",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Consensus or chainstate-facing coverage should receive an explicit PQ migration decision in later CI follow-up."
+    "notes": "Explicit inherited Bitcoin Core v28.2 coinstats-index migration coverage. This repository has no PQBTC v28.2 release lineage or compatible prior-release binaries, while the available PQBTC v1 tags identify as v30.2 and already use the fixed index path. Retained as legacy_only reference coverage rather than a PQBTC previous-release guarantee or required PQ gate."
   },
   {
     "name": "feature_config_args.py",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -37,9 +37,9 @@ The current functional corpus has `276` tracked test files, classified as:
 | Class | Count |
 |---|---|
 | `pq_required` | `120` |
-| `pq_backlog` | `5` |
+| `pq_backlog` | `4` |
 | `dual_profile` | `142` |
-| `legacy_only` | `9` |
+| `legacy_only` | `10` |
 
 Current required PQ-first gates:
 
@@ -528,13 +528,19 @@ reject reasons, difficulty, merkle-root, timestamp, and best-prevblk
 boundaries, transaction-bearing proposal checks without UTXO mutation,
 overspend and double-spend rejection, and concurrent proposal validation under
 the current legacy-compatible PQC profile.
+The inherited `feature_coinstatsindex_compatibility.py` suite is now
+`legacy_only`: it hard-codes Bitcoin Core v28.2 migration behavior, but this
+repository has no PQBTC v28.2 release lineage or authentic compatible binaries.
+The available PQBTC v1 tags identify as v30.2 and cannot supply the old index
+format the suite is intended to exercise. This classification records the
+boundary without promoting a skipped test or fabricating release provenance.
 The remaining key backlog families are:
 
 1. prior-release-dependent mempool, validation, chainstate, and wallet
-   compatibility suites that require real PQBTC release assets before they can
-   receive a durable required-gate decision; see
+   compatibility suites that still require individual PQ relevance decisions;
+   see
    [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md) for
-   the exact current asset layout and blocker
+   the current provenance boundary
 2. broader dual-profile and legacy-only coverage that still needs durable
    ownership and migration boundaries
 
@@ -543,6 +549,7 @@ Explicit legacy-only coverage in this tranche includes:
 1. Taproot-specific tests
 2. SegWit/pre-SegWit transition tests
 3. legacy message-signing flows
+4. inherited Bitcoin Core v28.2 coinstats-index migration coverage
 
 Inherited Taproot-specific suites remain `legacy_only` in the current CI contract,
 while `feature_taproot_replacement_deployment.py` and

--- a/docs/FEATURE_COINSTATSINDEX_POSTURE.md
+++ b/docs/FEATURE_COINSTATSINDEX_POSTURE.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: FEATURE-COINSTATSINDEX-POSTURE-v1
-## Updated: 2026-04-30
+## Updated: 2026-07-12
 ## Frozen-By: track-a-phase1-20260413
 ## Consensus-Relevant: YES
 
@@ -36,9 +36,11 @@ owns a narrow txoutset/index slice:
 This posture note does **not** mean:
 
 - the inherited default MiniWallet mempool/send path is owned
-- previous-release coinstats index compatibility is owned in this local harness
+- inherited Bitcoin Core v28.2 coinstats-index migration is on the PQBTC
+  migration path
 
-Those remain separate follow-on surfaces.
+The first remains a separate follow-on surface. The second is retained as
+explicit `legacy_only` reference coverage.
 
 ## Confidence Snapshot
 
@@ -63,11 +65,13 @@ Targeted confidence pass run on 2026-04-30:
 - the adjacent restart/index follow-on,
   [feature_reindex.py](../test/functional/feature_reindex.py), is now covered
   by the required gate
-- the environment-dependent alternate is
+- the inherited alternate,
   [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py),
-  which stays relevant when previous-release test data is available
-- that compatibility alternate remains blocked by the explicit prior-release
-  asset boundary in
-  [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md):
-  the current harness needs PQBTC `v28.2` `pqbtcd` and `pqbtc-cli` binaries in
-  the previous-release layout before it can be promoted honestly
+  is now `legacy_only`
+- the compatibility suite hard-codes `versions=[None, 280200]`, but the
+  inherited `v28.2` tag is Bitcoin Core rather than PQBTC, and the available
+  PQBTC v1 tags identify as v30.2 and already use the fixed index path
+- the provenance audit and reconsideration boundary are recorded in
+  [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md)
+- this decision does not claim a passing PQBTC previous-release compatibility
+  test; it prevents a skipped inherited suite from being promoted as one

--- a/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
+++ b/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
@@ -2,12 +2,13 @@
 
 ## Status: ACTIVE
 ## Spec-ID: PREVIOUS-RELEASE-ASSET-BOUNDARY-v1
-## Updated: 2026-06-11
+## Updated: 2026-07-12
 
 ## Purpose
 
-Record the current blocker for previous-release functional suites so Track A
-does not promote skipped compatibility tests as required gates.
+Record the provenance boundary and suite-level decisions for previous-release
+functional coverage so Track A does not promote skipped compatibility tests as
+required gates.
 
 ## Required Harness Shape
 
@@ -40,33 +41,43 @@ Current inspection found no usable previous-release PQBTC binary assets:
   `bitcoin-28.2-*` archives and is therefore not enough to prove a prior-PQBTC
   compatibility gate
 
-## Source Decision
+## Coinstats Compatibility Decision
 
-Do not promote `feature_coinstatsindex_compatibility.py` from `pq_backlog` until
-real PQBTC previous-release binaries are available outside the git-tracked
-tree.
+The 2026-07-12 source audit found no authentic artifact that can satisfy this
+suite's intended PQBTC compatibility claim:
 
-Acceptable sources are:
+- the fork releases still expose no executable PQBTC assets
+- the exact `v1.0.0` workflow run retained only an expired Windows executable
+  bundle, while the `v1.0.0-rc1` run produced no executable artifact
+- both PQBTC v1 tags identify as v30.2 and already contain the fixed
+  `indexes/coinstatsindex` path, so they cannot supply the old v28.2
+  `indexes/coinstats` format under test
+- public artifact search found no separate archived PQBTC binaries
+- the repository's `v28.2` tag remains inherited Bitcoin Core source, not a
+  PQBTC release
 
-1. an existing local PQBTC archive unpacked into the harness layout above
-2. a reproducible build of the intended prior PQBTC release, staged outside
-   git-tracked source and exposed through `PREVIOUS_RELEASES_DIR`
-3. downloaded PQBTC release artifacts with executable binaries and documented
-   checksums
+`feature_coinstatsindex_compatibility.py` is therefore classified as
+`legacy_only`. It remains useful as inherited Bitcoin Core reference coverage,
+but it is not a PQBTC previous-release guarantee and must not enter
+`pq_required` by placing unrelated binaries under a `v28.2` directory name.
 
-When assets exist, record their source and SHA256 checksums before promotion.
-Do not commit large generated binaries or downloaded release payloads.
+## Reconsideration Boundary
+
+Reopen this decision only if an authentic PQBTC release predating the fixed
+coinstats-index path is found and its version and chain parameters match the
+test's compatibility assumptions. Record the source tag or commit, build
+recipe, target platform, and SHA256 checksums before rerunning the suite. Do not
+commit large generated binaries or downloaded release payloads.
 
 ## Remaining Asset-Dependent Suites
 
-The current `pq_backlog` is entirely previous-release or prior-fixture
-dependent:
+After the coinstats compatibility decision, four `pq_backlog` suites remain
+previous-release or prior-fixture dependent and require separate decisions:
 
-1. `feature_coinstatsindex_compatibility.py`
-2. `feature_unsupported_utxo_db.py`
-3. `mempool_compatibility.py`
-4. `wallet_backwards_compatibility.py`
-5. `wallet_migration.py`
+1. `feature_unsupported_utxo_db.py`
+2. `mempool_compatibility.py`
+3. `wallet_backwards_compatibility.py`
+4. `wallet_migration.py`
 
 ## Validation Snapshot
 
@@ -74,7 +85,9 @@ Current local validation without previous-release assets:
 
 - `python3 ci/test/check_ci_inventory.py`
   - result: passed
-  - counts: `pq_required: 120`, `pq_backlog: 5`
+  - counts: `pq_required: 120`, `pq_backlog: 4`, `legacy_only: 10`
 - `build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex_compatibility.py`
   - result: skipped
   - skip reason: previous releases not available or disabled
+  - interpretation: confirms that this run is not evidence for a required PQ
+    gate

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-06-11
+## Updated: 2026-07-12
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -17,18 +17,19 @@ active, use this file to choose the next safe step for `quantum-proof-bitcoin`.
 Keep the live `pq_required` gate aligned with the repo as it exists today.
 `mining_prioritisetransaction.py` is already promoted in the live inventory,
 and PR `#156` has now landed the adjacent
-`mining_template_verification.py` promotion files. The next owned follow-on is
-now the asset-dependent
-`feature_coinstatsindex_compatibility.py` promotion when real prior PQBTC
-release assets exist locally.
+`mining_template_verification.py` promotion files. The current bounded decision
+classifies `feature_coinstatsindex_compatibility.py` as `legacy_only` because no
+PQBTC v28.2 release lineage or compatible prior-release artifact exists.
 
 The current asset boundary is recorded in
 [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md). The
 compatibility harness maps `280200` to `v28.2` and expects PQBTC-named
 previous-release binaries at `releases/v28.2/bin/pqbtcd` and
 `releases/v28.2/bin/pqbtc-cli` unless `PREVIOUS_RELEASES_DIR` points at an
-equivalent layout. Current inspection found no such local assets, and the
-available GitHub release assets are not executable previous-release binaries.
+equivalent layout. The source audit found no authentic PQBTC artifact matching
+that contract; the available v1 tags identify as v30.2 and already use the
+fixed coinstats-index path. The suite remains inherited reference coverage, not
+a skipped candidate for promotion.
 
 ## Current Working Thesis
 
@@ -44,50 +45,48 @@ available GitHub release assets are not executable previous-release binaries.
 
 Preferred next owned tranche:
 
-1. `feature_coinstatsindex_compatibility.py` promotion slice after real prior
-   PQBTC release assets exist locally
-   - Why next: now that `mining_template_verification.py` has landed, the
-     remaining `pq_backlog` is five asset-dependent suites, and
-     `feature_coinstatsindex_compatibility.py` is the nearest
-     chainstate/index compatibility follow-on already named by the adjacent
-     required posture notes.
+1. `feature_unsupported_utxo_db.py` one-suite PQ relevance decision
+   - Why next: after resolving the coinstats compatibility boundary, this is
+     the next chainstate-facing previous-release suite in the remaining
+     `pq_backlog`. It hard-codes v0.14.3 and needs an explicit decision about
+     whether that inherited database format belongs on PQBTC's migration path.
    - Exact files for the next PR:
-     - `ci/test/pq_functional_tests.txt`
      - `ci/test/functional_suite_inventory.json`
      - `docs/CI_COMPLETENESS.md`
-     - `docs/FEATURE_COINSTATSINDEX_POSTURE.md`
+     - `docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md`
+     - `docs/TRACK_A_STATUS.md`
    - Minimum validation only:
-     - `build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex_compatibility.py`
-     - expected local precondition: real prior PQBTC release assets must exist
-       locally or the suite remains skipped
+     - `python3 ci/test/check_ci_inventory.py`
+     - `build/test/functional/test_runner.py --jobs=1 feature_unsupported_utxo_db.py`
+     - expected local result without authentic prior assets: skipped, which is
+       boundary evidence rather than promotion evidence
    - Stays deferred:
-     - `feature_unsupported_utxo_db.py`
      - `mempool_compatibility.py`
      - `wallet_backwards_compatibility.py`
      - `wallet_migration.py`
-     - broader prior-release wallet and mempool migration decisions beyond the
-       bounded coinstats compatibility gate
+     - broader prior-release wallet and mempool migration decisions
 
 Alternate rebalance:
 
-2. No new local `pq_backlog` promotion until prior-release assets exist
-   - Why alternate: PR `#156` already landed the
-     `mining_template_verification.py` bookkeeping files, and every remaining
-     `pq_backlog` suite is blocked on prior-release assets rather than another
-     cheap local mining or mempool pass.
+2. Stop after the coinstats classification until authentic prior-release
+   evidence exists
+   - Why alternate: the four remaining `pq_backlog` suites all depend on
+     inherited previous-release formats and may resolve to explicit legacy
+     boundaries rather than required PQ gates.
 
 ## Current Queue
 
 1. Keep this handoff synced to the live inventory state:
    - `pq_required`: 120
-   - `pq_backlog`: 5
+   - `pq_backlog`: 4
+   - `legacy_only`: 10
    - latest landed bounded slice: `mining_template_verification.py` in PR
      `#156`
-2. When real prior PQBTC release assets exist locally, open the bounded
-   `feature_coinstatsindex_compatibility.py` promotion slice.
-3. Until those assets exist, do not promote another `pq_backlog` suite. The
-   remaining backlog stays deferred to the five asset-dependent suites listed
-   above and in
+2. Land the bounded `feature_coinstatsindex_compatibility.py` legacy-boundary
+   decision without adding the skipped suite to `pq_required`.
+3. Then review `feature_unsupported_utxo_db.py` as the next one-suite PQ
+   relevance decision. The other three prior-release suites remain deferred as
+   listed above and in
    [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md).
 
 


### PR DESCRIPTION
## Summary

- classify `feature_coinstatsindex_compatibility.py` as inherited `legacy_only` coverage
- record the release and artifact provenance audit and why PQBTC v1 cannot supply the v28.2 index format
- advance the Track A handoff to a separate `feature_unsupported_utxo_db.py` relevance decision

## Validation

- `git diff --check`
- `python3 ci/test/check_ci_inventory.py` (`pq_required: 120`, `pq_backlog: 4`, `legacy_only: 10`)
- `build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex_compatibility.py` (skipped: previous releases unavailable; explicitly non-gating evidence)