### PR TITLE
ci: classify unsupported utxo db as legacy

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -469,10 +469,10 @@
   },
   {
     "name": "feature_unsupported_utxo_db.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "legacy_only",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Previous-release-dependent chainstate coverage; skipped locally until real prior PQBTC release assets are available to the compatibility harness."
+    "notes": "Explicit inherited Bitcoin Core v0.14.3 chainstate-database migration coverage. This repository has no PQBTC v0.14.3 release lineage, and Track A launches PQBTC as a new chain rather than supporting migration from a Bitcoin Core 0.14 datadir. Retained as legacy_only reference coverage rather than a PQBTC previous-release guarantee or required PQ gate."
   },
   {
     "name": "feature_utxo_set_hash.py",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -37,9 +37,9 @@ The current functional corpus has `276` tracked test files, classified as:
 | Class | Count |
 |---|---|
 | `pq_required` | `120` |
-| `pq_backlog` | `4` |
+| `pq_backlog` | `3` |
 | `dual_profile` | `142` |
-| `legacy_only` | `10` |
+| `legacy_only` | `11` |
 
 Current required PQ-first gates:
 
@@ -534,6 +534,12 @@ repository has no PQBTC v28.2 release lineage or authentic compatible binaries.
 The available PQBTC v1 tags identify as v30.2 and cannot supply the old index
 format the suite is intended to exercise. This classification records the
 boundary without promoting a skipped test or fabricating release provenance.
+The inherited `feature_unsupported_utxo_db.py` suite is also now `legacy_only`:
+it creates a Bitcoin Core v0.14.3 chainstate database and checks current-node
+rejection and reindex behavior, but this repository has no PQBTC v0.14.3
+release lineage and Track A does not support migration from an old Bitcoin Core
+datadir. The mechanics remain useful reference coverage without becoming a
+required PQBTC previous-release gate.
 The remaining key backlog families are:
 
 1. prior-release-dependent mempool, validation, chainstate, and wallet
@@ -550,6 +556,7 @@ Explicit legacy-only coverage in this tranche includes:
 2. SegWit/pre-SegWit transition tests
 3. legacy message-signing flows
 4. inherited Bitcoin Core v28.2 coinstats-index migration coverage
+5. inherited Bitcoin Core v0.14.3 chainstate-database migration coverage
 
 Inherited Taproot-specific suites remain `legacy_only` in the current CI contract,
 while `feature_taproot_replacement_deployment.py` and

--- a/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
+++ b/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
@@ -10,9 +10,9 @@ Record the provenance boundary and suite-level decisions for previous-release
 functional coverage so Track A does not promote skipped compatibility tests as
 required gates.
 
-## Required Harness Shape
+## Observed Harness Shapes
 
-The immediate Track A candidate is
+The resolved coinstats decision covers
 [feature_coinstatsindex_compatibility.py](../test/functional/feature_coinstatsindex_compatibility.py).
 That suite calls `skip_if_no_previous_releases()` and starts two nodes with
 `versions=[None, 280200]`.
@@ -23,8 +23,16 @@ default local layout is:
 - `releases/v28.2/bin/pqbtcd`
 - `releases/v28.2/bin/pqbtc-cli`
 
-If `PREVIOUS_RELEASES_DIR` is set, the same `v28.2/bin/pqbtcd` and
-`v28.2/bin/pqbtc-cli` layout is expected below that directory instead.
+The unsupported-UTXO decision covers
+[feature_unsupported_utxo_db.py](../test/functional/feature_unsupported_utxo_db.py).
+That suite also calls `skip_if_no_previous_releases()` and starts its legacy
+node with `version=140300`. The framework maps that version to:
+
+- `releases/v0.14.3/bin/pqbtcd`
+- `releases/v0.14.3/bin/pqbtc-cli`
+
+If `PREVIOUS_RELEASES_DIR` is set, the same versioned layouts are expected below
+that directory instead.
 
 ## Current Local State
 
@@ -61,23 +69,38 @@ suite's intended PQBTC compatibility claim:
 but it is not a PQBTC previous-release guarantee and must not enter
 `pq_required` by placing unrelated binaries under a `v28.2` directory name.
 
-## Reconsideration Boundary
+## Unsupported UTXO DB Decision
 
-Reopen this decision only if an authentic PQBTC release predating the fixed
-coinstats-index path is found and its version and chain parameters match the
-test's compatibility assumptions. Record the source tag or commit, build
-recipe, target platform, and SHA256 checksums before rerunning the suite. Do not
-commit large generated binaries or downloaded release payloads.
+The 2026-07-12 repository audit confirms that `v0.14.3` is an inherited signed
+Bitcoin Core release. Its source tree builds `bitcoind` and `bitcoin-cli` and
+contains no PQBTC or PQ signature implementation. The functional suite uses it
+to create an old Bitcoin chainstate database before checking current-node
+rejection and `-reindex-chainstate` recovery.
+
+Track A launches PQBTC as a new chain at block 0 and does not support migrating
+a Bitcoin Core 0.14 datadir into PQBTC. Building or renaming the inherited
+Bitcoin binaries could exercise the old database mechanics, but it would not
+prove a prior-PQBTC compatibility guarantee. `feature_unsupported_utxo_db.py`
+is therefore classified as `legacy_only` reference coverage and remains
+outside `pq_required`.
+
+## Reconsideration Boundaries
+
+Reopen either decision only if an authentic PQBTC release matching the suite's
+historical format, version, and chain assumptions is found. Record the source
+tag or commit, build recipe, target platform, and SHA256 checksums before
+rerunning the suite. Do not commit large generated binaries or downloaded
+release payloads.
 
 ## Remaining Asset-Dependent Suites
 
-After the coinstats compatibility decision, four `pq_backlog` suites remain
-previous-release or prior-fixture dependent and require separate decisions:
+After the coinstats and unsupported-UTXO decisions, three `pq_backlog` suites
+remain previous-release or prior-fixture dependent and require separate
+decisions:
 
-1. `feature_unsupported_utxo_db.py`
-2. `mempool_compatibility.py`
-3. `wallet_backwards_compatibility.py`
-4. `wallet_migration.py`
+1. `mempool_compatibility.py`
+2. `wallet_backwards_compatibility.py`
+3. `wallet_migration.py`
 
 ## Validation Snapshot
 
@@ -85,8 +108,8 @@ Current local validation without previous-release assets:
 
 - `python3 ci/test/check_ci_inventory.py`
   - result: passed
-  - counts: `pq_required: 120`, `pq_backlog: 4`, `legacy_only: 10`
-- `build/test/functional/test_runner.py --jobs=1 feature_coinstatsindex_compatibility.py`
+  - counts: `pq_required: 120`, `pq_backlog: 3`, `legacy_only: 11`
+- `build/test/functional/test_runner.py --jobs=1 feature_unsupported_utxo_db.py`
   - result: skipped
   - skip reason: previous releases not available or disabled
   - interpretation: confirms that this run is not evidence for a required PQ

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -17,9 +17,10 @@ active, use this file to choose the next safe step for `quantum-proof-bitcoin`.
 Keep the live `pq_required` gate aligned with the repo as it exists today.
 `mining_prioritisetransaction.py` is already promoted in the live inventory,
 and PR `#156` has now landed the adjacent
-`mining_template_verification.py` promotion files. The current bounded decision
-classifies `feature_coinstatsindex_compatibility.py` as `legacy_only` because no
-PQBTC v28.2 release lineage or compatible prior-release artifact exists.
+`mining_template_verification.py` promotion files. PR `#159` classified
+`feature_coinstatsindex_compatibility.py` as `legacy_only`. The current bounded
+decision does the same for `feature_unsupported_utxo_db.py` because its old
+database fixture comes from Bitcoin Core v0.14.3, not a prior PQBTC release.
 
 The current asset boundary is recorded in
 [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md). The
@@ -29,7 +30,9 @@ previous-release binaries at `releases/v28.2/bin/pqbtcd` and
 equivalent layout. The source audit found no authentic PQBTC artifact matching
 that contract; the available v1 tags identify as v30.2 and already use the
 fixed coinstats-index path. The suite remains inherited reference coverage, not
-a skipped candidate for promotion.
+a skipped candidate for promotion. The unsupported-UTXO suite has the same
+provenance boundary: Track A does not support migrating a Bitcoin Core 0.14
+datadir into the new PQBTC chain.
 
 ## Current Working Thesis
 
@@ -45,11 +48,12 @@ a skipped candidate for promotion.
 
 Preferred next owned tranche:
 
-1. `feature_unsupported_utxo_db.py` one-suite PQ relevance decision
-   - Why next: after resolving the coinstats compatibility boundary, this is
-     the next chainstate-facing previous-release suite in the remaining
-     `pq_backlog`. It hard-codes v0.14.3 and needs an explicit decision about
-     whether that inherited database format belongs on PQBTC's migration path.
+1. `mempool_compatibility.py` one-suite PQ relevance decision
+   - Why next: after resolving the two chainstate-facing previous-release
+     boundaries, this is the next suite in the remaining `pq_backlog`. It
+     hard-codes Bitcoin Core v0.20.1 and needs an explicit decision about
+     whether bidirectional `mempool.dat` compatibility belongs on PQBTC's
+     migration path.
    - Exact files for the next PR:
      - `ci/test/functional_suite_inventory.json`
      - `docs/CI_COMPLETENESS.md`
@@ -57,20 +61,19 @@ Preferred next owned tranche:
      - `docs/TRACK_A_STATUS.md`
    - Minimum validation only:
      - `python3 ci/test/check_ci_inventory.py`
-     - `build/test/functional/test_runner.py --jobs=1 feature_unsupported_utxo_db.py`
+     - `build/test/functional/test_runner.py --jobs=1 mempool_compatibility.py`
      - expected local result without authentic prior assets: skipped, which is
        boundary evidence rather than promotion evidence
    - Stays deferred:
-     - `mempool_compatibility.py`
      - `wallet_backwards_compatibility.py`
      - `wallet_migration.py`
-     - broader prior-release wallet and mempool migration decisions
+     - broader prior-release wallet migration decisions
 
 Alternate rebalance:
 
-2. Stop after the coinstats classification until authentic prior-release
+2. Stop after the chainstate classifications until authentic prior-release
    evidence exists
-   - Why alternate: the four remaining `pq_backlog` suites all depend on
+   - Why alternate: the three remaining `pq_backlog` suites all depend on
      inherited previous-release formats and may resolve to explicit legacy
      boundaries rather than required PQ gates.
 
@@ -78,15 +81,15 @@ Alternate rebalance:
 
 1. Keep this handoff synced to the live inventory state:
    - `pq_required`: 120
-   - `pq_backlog`: 4
-   - `legacy_only`: 10
-   - latest landed bounded slice: `mining_template_verification.py` in PR
-     `#156`
-2. Land the bounded `feature_coinstatsindex_compatibility.py` legacy-boundary
-   decision without adding the skipped suite to `pq_required`.
-3. Then review `feature_unsupported_utxo_db.py` as the next one-suite PQ
-   relevance decision. The other three prior-release suites remain deferred as
-   listed above and in
+   - `pq_backlog`: 3
+   - `legacy_only`: 11
+   - latest landed bounded slice: `feature_coinstatsindex_compatibility.py`
+     legacy-boundary decision in PR `#159`
+2. Land the bounded `feature_unsupported_utxo_db.py` legacy-boundary decision
+   without adding the skipped suite to `pq_required`.
+3. Then review `mempool_compatibility.py` as the next one-suite PQ relevance
+   decision. The two wallet previous-release suites remain deferred as listed
+   above and in
    [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md).
 
 


### PR DESCRIPTION
## Summary

- classify `feature_unsupported_utxo_db.py` as inherited `legacy_only` coverage
- record why Bitcoin Core v0.14.3 database mechanics do not establish a supported PQBTC migration path
- advance the Track A handoff to a separate `mempool_compatibility.py` relevance decision

## Validation

- `git diff --check`
- `python3 ci/test/check_ci_inventory.py` (`pq_required: 120`, `pq_backlog: 3`, `legacy_only: 11`)
- `build/test/functional/test_runner.py --jobs=1 feature_unsupported_utxo_db.py` (skipped: previous releases unavailable; explicitly non-gating evidence)