### PR TITLE
ci: classify mempool compatibility as legacy

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -581,10 +581,10 @@
   },
   {
     "name": "mempool_compatibility.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "legacy_only",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Policy and resource-envelope coverage should gain an explicit PQ gating decision in later CI follow-up."
+    "notes": "Explicit inherited Bitcoin Core v0.20.1 bidirectional mempool.dat serialization coverage. This repository has no PQBTC v0.20.1 release lineage, and Track A does not support upgrading from or downgrading to an old Bitcoin Core node. Retained as legacy_only reference coverage rather than a PQBTC previous-release guarantee or required PQ gate."
   },
   {
     "name": "mempool_datacarrier.py",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -37,9 +37,9 @@ The current functional corpus has `276` tracked test files, classified as:
 | Class | Count |
 |---|---|
 | `pq_required` | `120` |
-| `pq_backlog` | `3` |
+| `pq_backlog` | `2` |
 | `dual_profile` | `142` |
-| `legacy_only` | `11` |
+| `legacy_only` | `12` |
 
 Current required PQ-first gates:
 
@@ -540,6 +540,12 @@ rejection and reindex behavior, but this repository has no PQBTC v0.14.3
 release lineage and Track A does not support migration from an old Bitcoin Core
 datadir. The mechanics remain useful reference coverage without becoming a
 required PQBTC previous-release gate.
+The inherited `mempool_compatibility.py` suite is now `legacy_only` as well. It
+moves `mempool.dat` in both directions between Bitcoin Core v0.20.1 and the
+current node to enforce an upstream serialization upgrade/downgrade contract.
+PQBTC has no v0.20.1 release lineage and does not support that cross-product
+migration path, so the mechanics remain reference coverage rather than a
+required PQBTC gate.
 The remaining key backlog families are:
 
 1. prior-release-dependent mempool, validation, chainstate, and wallet
@@ -557,6 +563,7 @@ Explicit legacy-only coverage in this tranche includes:
 3. legacy message-signing flows
 4. inherited Bitcoin Core v28.2 coinstats-index migration coverage
 5. inherited Bitcoin Core v0.14.3 chainstate-database migration coverage
+6. inherited Bitcoin Core v0.20.1 `mempool.dat` migration coverage
 
 Inherited Taproot-specific suites remain `legacy_only` in the current CI contract,
 while `feature_taproot_replacement_deployment.py` and

--- a/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
+++ b/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
@@ -31,6 +31,13 @@ node with `version=140300`. The framework maps that version to:
 - `releases/v0.14.3/bin/pqbtcd`
 - `releases/v0.14.3/bin/pqbtc-cli`
 
+The mempool serialization decision covers
+[mempool_compatibility.py](../test/functional/mempool_compatibility.py). That
+suite starts its legacy node with `version=200100`, which maps to:
+
+- `releases/v0.20.1/bin/pqbtcd`
+- `releases/v0.20.1/bin/pqbtc-cli`
+
 If `PREVIOUS_RELEASES_DIR` is set, the same versioned layouts are expected below
 that directory instead.
 
@@ -43,8 +50,8 @@ Current inspection found no usable previous-release PQBTC binary assets:
 - the fork's GitHub releases currently expose no executable release assets:
   - `v1.0.0` has no assets
   - `v1.0.0-rc1` has only `RELEASE_V1_RC1.md` and `RUNBOOK_V1_RC1.md`
-- the checked `v28.2` tag is an inherited signed Bitcoin Core final tag, not a
-  PQBTC release-asset source
+- the checked `v28.2`, `v0.14.3`, and `v0.20.1` tags are inherited signed
+  Bitcoin Core releases, not PQBTC release-asset sources
 - `test/get_previous_releases.py` downloads upstream Bitcoin Core
   `bitcoin-28.2-*` archives and is therefore not enough to prove a prior-PQBTC
   compatibility gate
@@ -84,9 +91,25 @@ prove a prior-PQBTC compatibility guarantee. `feature_unsupported_utxo_db.py`
 is therefore classified as `legacy_only` reference coverage and remains
 outside `pq_required`.
 
+## Mempool Compatibility Decision
+
+The 2026-07-12 repository audit confirms that `v0.20.1` is an inherited signed
+Bitcoin Core release whose source tree builds `bitcoind` and `bitcoin-cli` and
+contains no PQBTC or PQ signature implementation. The suite moves
+`mempool.dat` from the old node to the current node, adds current serialization
+state, then moves the file back to the old node and requires both transactions
+to load.
+
+That bidirectional contract protects a Bitcoin Core upgrade and downgrade path
+that PQBTC never shipped and does not support. Building or renaming the
+inherited Bitcoin binaries could exercise the file-format mechanics, but it
+would not prove prior-PQBTC compatibility. `mempool_compatibility.py` is
+therefore classified as `legacy_only` reference coverage and remains outside
+`pq_required`.
+
 ## Reconsideration Boundaries
 
-Reopen either decision only if an authentic PQBTC release matching the suite's
+Reopen these decisions only if an authentic PQBTC release matching the suite's
 historical format, version, and chain assumptions is found. Record the source
 tag or commit, build recipe, target platform, and SHA256 checksums before
 rerunning the suite. Do not commit large generated binaries or downloaded
@@ -94,13 +117,12 @@ release payloads.
 
 ## Remaining Asset-Dependent Suites
 
-After the coinstats and unsupported-UTXO decisions, three `pq_backlog` suites
-remain previous-release or prior-fixture dependent and require separate
+After the coinstats, unsupported-UTXO, and mempool decisions, two `pq_backlog`
+suites remain previous-release or prior-fixture dependent and require separate
 decisions:
 
-1. `mempool_compatibility.py`
-2. `wallet_backwards_compatibility.py`
-3. `wallet_migration.py`
+1. `wallet_backwards_compatibility.py`
+2. `wallet_migration.py`
 
 ## Validation Snapshot
 
@@ -108,8 +130,8 @@ Current local validation without previous-release assets:
 
 - `python3 ci/test/check_ci_inventory.py`
   - result: passed
-  - counts: `pq_required: 120`, `pq_backlog: 3`, `legacy_only: 11`
-- `build/test/functional/test_runner.py --jobs=1 feature_unsupported_utxo_db.py`
+  - counts: `pq_required: 120`, `pq_backlog: 2`, `legacy_only: 12`
+- `build/test/functional/test_runner.py --jobs=1 mempool_compatibility.py`
   - result: skipped
   - skip reason: previous releases not available or disabled
   - interpretation: confirms that this run is not evidence for a required PQ

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -18,9 +18,10 @@ Keep the live `pq_required` gate aligned with the repo as it exists today.
 `mining_prioritisetransaction.py` is already promoted in the live inventory,
 and PR `#156` has now landed the adjacent
 `mining_template_verification.py` promotion files. PR `#159` classified
-`feature_coinstatsindex_compatibility.py` as `legacy_only`. The current bounded
-decision does the same for `feature_unsupported_utxo_db.py` because its old
-database fixture comes from Bitcoin Core v0.14.3, not a prior PQBTC release.
+`feature_coinstatsindex_compatibility.py` as `legacy_only`, and PR `#160` did
+the same for `feature_unsupported_utxo_db.py`. The current bounded decision
+classifies `mempool_compatibility.py` as `legacy_only` because its bidirectional
+serialization contract uses Bitcoin Core v0.20.1, not a prior PQBTC release.
 
 The current asset boundary is recorded in
 [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md). The
@@ -32,7 +33,8 @@ that contract; the available v1 tags identify as v30.2 and already use the
 fixed coinstats-index path. The suite remains inherited reference coverage, not
 a skipped candidate for promotion. The unsupported-UTXO suite has the same
 provenance boundary: Track A does not support migrating a Bitcoin Core 0.14
-datadir into the new PQBTC chain.
+datadir into the new PQBTC chain. Nor does it support upgrading from or
+downgrading to Bitcoin Core v0.20.1 through a shared `mempool.dat` file.
 
 ## Current Working Thesis
 
@@ -48,12 +50,12 @@ datadir into the new PQBTC chain.
 
 Preferred next owned tranche:
 
-1. `mempool_compatibility.py` one-suite PQ relevance decision
-   - Why next: after resolving the two chainstate-facing previous-release
-     boundaries, this is the next suite in the remaining `pq_backlog`. It
-     hard-codes Bitcoin Core v0.20.1 and needs an explicit decision about
-     whether bidirectional `mempool.dat` compatibility belongs on PQBTC's
-     migration path.
+1. `wallet_backwards_compatibility.py` one-suite PQ relevance decision
+   - Why next: after resolving the chainstate and mempool previous-release
+     boundaries, this is the next suite in the remaining `pq_backlog`. It spans
+     Bitcoin Core v0.20.1, v0.21.0, v22.0, v23.0, v24.0.1, and v25.0 and needs
+     an explicit decision about whether those wallet upgrade paths belong on
+     PQBTC's migration path.
    - Exact files for the next PR:
      - `ci/test/functional_suite_inventory.json`
      - `docs/CI_COMPLETENESS.md`
@@ -61,19 +63,18 @@ Preferred next owned tranche:
      - `docs/TRACK_A_STATUS.md`
    - Minimum validation only:
      - `python3 ci/test/check_ci_inventory.py`
-     - `build/test/functional/test_runner.py --jobs=1 mempool_compatibility.py`
+     - `build/test/functional/test_runner.py --jobs=1 wallet_backwards_compatibility.py`
      - expected local result without authentic prior assets: skipped, which is
        boundary evidence rather than promotion evidence
    - Stays deferred:
-     - `wallet_backwards_compatibility.py`
      - `wallet_migration.py`
-     - broader prior-release wallet migration decisions
+     - the final separate prior-release wallet migration decision
 
 Alternate rebalance:
 
-2. Stop after the chainstate classifications until authentic prior-release
+2. Stop after the chainstate and mempool classifications until authentic prior-release
    evidence exists
-   - Why alternate: the three remaining `pq_backlog` suites all depend on
+   - Why alternate: the two remaining `pq_backlog` suites both depend on
      inherited previous-release formats and may resolve to explicit legacy
      boundaries rather than required PQ gates.
 
@@ -81,15 +82,15 @@ Alternate rebalance:
 
 1. Keep this handoff synced to the live inventory state:
    - `pq_required`: 120
-   - `pq_backlog`: 3
-   - `legacy_only`: 11
-   - latest landed bounded slice: `feature_coinstatsindex_compatibility.py`
-     legacy-boundary decision in PR `#159`
-2. Land the bounded `feature_unsupported_utxo_db.py` legacy-boundary decision
-   without adding the skipped suite to `pq_required`.
-3. Then review `mempool_compatibility.py` as the next one-suite PQ relevance
-   decision. The two wallet previous-release suites remain deferred as listed
-   above and in
+   - `pq_backlog`: 2
+   - `legacy_only`: 12
+   - latest landed bounded slice: `feature_unsupported_utxo_db.py`
+     legacy-boundary decision in PR `#160`
+2. Land the bounded `mempool_compatibility.py` legacy-boundary decision without
+   adding the skipped suite to `pq_required`.
+3. Then review `wallet_backwards_compatibility.py` as the next one-suite PQ
+   relevance decision. `wallet_migration.py` remains deferred as listed above
+   and in
    [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md).
 
 


### PR DESCRIPTION
## Summary

- classify `mempool_compatibility.py` as inherited `legacy_only` coverage
- record why Bitcoin Core v0.20.1 bidirectional `mempool.dat` compatibility is not a supported PQBTC migration contract
- advance the Track A handoff to a separate `wallet_backwards_compatibility.py` relevance decision

## Validation

- `git diff --check`
- `python3 ci/test/check_ci_inventory.py` (`pq_required: 120`, `pq_backlog: 2`, `legacy_only: 12`)
- `build/test/functional/test_runner.py --jobs=1 mempool_compatibility.py` (skipped: previous releases unavailable; explicitly non-gating evidence)