### PR TITLE
ci: classify wallet backwards compatibility as legacy

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1494,10 +1494,10 @@
   },
   {
     "name": "wallet_backwards_compatibility.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "legacy_only",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Explicit inherited Bitcoin Core v0.20.1 through v25.0 wallet upgrade and downgrade coverage. The suite exercises legacy BDB and descriptor wallet loading, descriptor-version boundaries, transaction and keypool preservation, and legacy-to-descriptor migration behavior across releases PQBTC never shipped. Retained as legacy_only reference coverage rather than a supported PQBTC wallet migration path or required PQ gate."
   },
   {
     "name": "wallet_balance.py",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -37,9 +37,9 @@ The current functional corpus has `276` tracked test files, classified as:
 | Class | Count |
 |---|---|
 | `pq_required` | `120` |
-| `pq_backlog` | `2` |
+| `pq_backlog` | `1` |
 | `dual_profile` | `142` |
-| `legacy_only` | `12` |
+| `legacy_only` | `13` |
 
 Current required PQ-first gates:
 
@@ -546,15 +546,18 @@ current node to enforce an upstream serialization upgrade/downgrade contract.
 PQBTC has no v0.20.1 release lineage and does not support that cross-product
 migration path, so the mechanics remain reference coverage rather than a
 required PQBTC gate.
-The remaining key backlog families are:
-
-1. prior-release-dependent mempool, validation, chainstate, and wallet
-   compatibility suites that still require individual PQ relevance decisions;
-   see
-   [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md) for
-   the current provenance boundary
-2. broader dual-profile and legacy-only coverage that still needs durable
-   ownership and migration boundaries
+The inherited `wallet_backwards_compatibility.py` suite is now `legacy_only`.
+It loads wallets in both directions between the current node and Bitcoin Core
+v0.20.1 through v25.0, covering legacy BDB wallets, descriptor-version
+boundaries, transaction and keypool preservation, and legacy-to-descriptor
+migration behavior. PQBTC never shipped that release lineage and does not
+support those cross-product wallet upgrade and downgrade paths, so the suite
+remains inherited reference coverage rather than a required PQBTC gate.
+The final `pq_backlog` suite is `wallet_migration.py`; it requires a separate
+decision about its inherited Bitcoin Core v28.2 BDB-to-descriptor migration
+contract. See
+[PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md) for
+the current provenance boundary.
 
 Explicit legacy-only coverage in this tranche includes:
 
@@ -564,6 +567,7 @@ Explicit legacy-only coverage in this tranche includes:
 4. inherited Bitcoin Core v28.2 coinstats-index migration coverage
 5. inherited Bitcoin Core v0.14.3 chainstate-database migration coverage
 6. inherited Bitcoin Core v0.20.1 `mempool.dat` migration coverage
+7. inherited Bitcoin Core v0.20.1 through v25.0 wallet upgrade and downgrade coverage
 
 Inherited Taproot-specific suites remain `legacy_only` in the current CI contract,
 while `feature_taproot_replacement_deployment.py` and

--- a/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
+++ b/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: PREVIOUS-RELEASE-ASSET-BOUNDARY-v1
-## Updated: 2026-07-12
+## Updated: 2026-07-15
 
 ## Purpose
 
@@ -38,6 +38,14 @@ suite starts its legacy node with `version=200100`, which maps to:
 - `releases/v0.20.1/bin/pqbtcd`
 - `releases/v0.20.1/bin/pqbtc-cli`
 
+The wallet backwards-compatibility decision covers
+[wallet_backwards_compatibility.py](../test/functional/wallet_backwards_compatibility.py).
+That suite calls `skip_if_no_previous_releases()` and starts six historical
+nodes with versions `250000`, `240001`, `230000`, `220000`, `210000`, and
+`200100`. The framework maps them to `v25.0`, `v24.0.1`, `v23.0`, `v22.0`,
+`v0.21.0`, and `v0.20.1`, with `pqbtcd` and `pqbtc-cli` expected under each
+version's `releases/<tag>/bin/` directory.
+
 If `PREVIOUS_RELEASES_DIR` is set, the same versioned layouts are expected below
 that directory instead.
 
@@ -50,8 +58,9 @@ Current inspection found no usable previous-release PQBTC binary assets:
 - the fork's GitHub releases currently expose no executable release assets:
   - `v1.0.0` has no assets
   - `v1.0.0-rc1` has only `RELEASE_V1_RC1.md` and `RUNBOOK_V1_RC1.md`
-- the checked `v28.2`, `v0.14.3`, and `v0.20.1` tags are inherited signed
-  Bitcoin Core releases, not PQBTC release-asset sources
+- the checked `v28.2`, `v0.14.3`, `v0.20.1`, `v0.21.0`, `v22.0`, `v23.0`,
+  `v24.0.1`, and `v25.0` tags are inherited signed Bitcoin Core releases, not
+  PQBTC release-asset sources
 - `test/get_previous_releases.py` downloads upstream Bitcoin Core
   `bitcoin-28.2-*` archives and is therefore not enough to prove a prior-PQBTC
   compatibility gate
@@ -107,6 +116,34 @@ would not prove prior-PQBTC compatibility. `mempool_compatibility.py` is
 therefore classified as `legacy_only` reference coverage and remains outside
 `pq_required`.
 
+## Wallet Backwards-Compatibility Decision
+
+The 2026-07-15 repository audit confirms that the suite's six historical tags
+are inherited signed Bitcoin Core releases, while the fork's only PQBTC release
+tags are `v1.0.0-rc1` and `v1.0.0`. Both PQBTC tags identify as v30.2, neither
+provides the historical binaries required by this harness, and the published
+releases expose no executable PQBTC assets.
+
+The suite protects Bitcoin Core wallet transitions that PQBTC never shipped:
+
+- current descriptor wallets are copied to v0.21.0 through v25.0 and reopened
+  on the current node while preserving transaction and keypool state; v0.20.1
+  rejects those wallets, and v0.21.0 rejects wallets containing `tr()`
+  descriptors
+- descriptor wallets created by v0.21.0 through v25.0 are restored on the
+  current node and copied back to their source release without an automatic
+  incompatible upgrade
+- legacy BDB wallets created by v0.20.1 through v25.0 must be migrated rather
+  than loaded directly; the suite also checks v22 inactive-HD-chain keypool
+  cleanup during migration and current-node startup handling of legacy wallets
+
+These cross-version load, upgrade, downgrade, and migration contracts do not
+represent a supported prior-PQBTC wallet path. Building or renaming the
+inherited Bitcoin binaries could exercise the upstream wallet mechanics but
+would not prove PQBTC compatibility. `wallet_backwards_compatibility.py` is
+therefore classified as `legacy_only` reference coverage and remains outside
+`pq_required`.
+
 ## Reconsideration Boundaries
 
 Reopen these decisions only if an authentic PQBTC release matching the suite's
@@ -117,12 +154,11 @@ release payloads.
 
 ## Remaining Asset-Dependent Suites
 
-After the coinstats, unsupported-UTXO, and mempool decisions, two `pq_backlog`
-suites remain previous-release or prior-fixture dependent and require separate
-decisions:
+After the coinstats, unsupported-UTXO, mempool, and wallet-backwards decisions,
+one `pq_backlog` suite remains previous-release dependent and requires a
+separate decision:
 
-1. `wallet_backwards_compatibility.py`
-2. `wallet_migration.py`
+1. `wallet_migration.py`
 
 ## Validation Snapshot
 
@@ -130,8 +166,8 @@ Current local validation without previous-release assets:
 
 - `python3 ci/test/check_ci_inventory.py`
   - result: passed
-  - counts: `pq_required: 120`, `pq_backlog: 2`, `legacy_only: 12`
-- `build/test/functional/test_runner.py --jobs=1 mempool_compatibility.py`
+  - counts: `pq_required: 120`, `pq_backlog: 1`, `legacy_only: 13`
+- `build/test/functional/test_runner.py --jobs=1 wallet_backwards_compatibility.py`
   - result: skipped
   - skip reason: previous releases not available or disabled
   - interpretation: confirms that this run is not evidence for a required PQ

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-07-12
+## Updated: 2026-07-15
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -19,9 +19,11 @@ Keep the live `pq_required` gate aligned with the repo as it exists today.
 and PR `#156` has now landed the adjacent
 `mining_template_verification.py` promotion files. PR `#159` classified
 `feature_coinstatsindex_compatibility.py` as `legacy_only`, and PR `#160` did
-the same for `feature_unsupported_utxo_db.py`. The current bounded decision
-classifies `mempool_compatibility.py` as `legacy_only` because its bidirectional
-serialization contract uses Bitcoin Core v0.20.1, not a prior PQBTC release.
+the same for `feature_unsupported_utxo_db.py`. PR `#161` classified
+`mempool_compatibility.py` as `legacy_only`. The current bounded decision also
+classifies `wallet_backwards_compatibility.py` as `legacy_only` because its
+v0.20.1-through-v25.0 wallet transitions use Bitcoin Core releases, not a prior
+PQBTC release lineage.
 
 The current asset boundary is recorded in
 [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md). The
@@ -34,7 +36,9 @@ fixed coinstats-index path. The suite remains inherited reference coverage, not
 a skipped candidate for promotion. The unsupported-UTXO suite has the same
 provenance boundary: Track A does not support migrating a Bitcoin Core 0.14
 datadir into the new PQBTC chain. Nor does it support upgrading from or
-downgrading to Bitcoin Core v0.20.1 through a shared `mempool.dat` file.
+downgrading to Bitcoin Core v0.20.1 through a shared `mempool.dat` file. The
+same boundary applies to loading, upgrading, downgrading, or migrating wallet
+files across inherited Bitcoin Core v0.20.1 through v25.0 releases.
 
 ## Current Working Thesis
 
@@ -50,12 +54,11 @@ downgrading to Bitcoin Core v0.20.1 through a shared `mempool.dat` file.
 
 Preferred next owned tranche:
 
-1. `wallet_backwards_compatibility.py` one-suite PQ relevance decision
-   - Why next: after resolving the chainstate and mempool previous-release
-     boundaries, this is the next suite in the remaining `pq_backlog`. It spans
-     Bitcoin Core v0.20.1, v0.21.0, v22.0, v23.0, v24.0.1, and v25.0 and needs
-     an explicit decision about whether those wallet upgrade paths belong on
-     PQBTC's migration path.
+1. `wallet_migration.py` one-suite PQ relevance decision
+   - Why next: this is the final suite in `pq_backlog`. It uses Bitcoin Core
+     v28.2 to create legacy BDB wallets and checks their migration to current
+     descriptor wallets, so it needs an explicit decision about whether that
+     inherited migration contract belongs on PQBTC's supported path.
    - Exact files for the next PR:
      - `ci/test/functional_suite_inventory.json`
      - `docs/CI_COMPLETENESS.md`
@@ -63,34 +66,31 @@ Preferred next owned tranche:
      - `docs/TRACK_A_STATUS.md`
    - Minimum validation only:
      - `python3 ci/test/check_ci_inventory.py`
-     - `build/test/functional/test_runner.py --jobs=1 wallet_backwards_compatibility.py`
+     - `build/test/functional/test_runner.py --jobs=1 wallet_migration.py`
      - expected local result without authentic prior assets: skipped, which is
        boundary evidence rather than promotion evidence
    - Stays deferred:
-     - `wallet_migration.py`
-     - the final separate prior-release wallet migration decision
+     - no other `pq_backlog` suite; this is the final inventory disposition
 
 Alternate rebalance:
 
-2. Stop after the chainstate and mempool classifications until authentic prior-release
+2. Stop after the wallet-backwards classification until authentic prior-release
    evidence exists
-   - Why alternate: the two remaining `pq_backlog` suites both depend on
-     inherited previous-release formats and may resolve to explicit legacy
-     boundaries rather than required PQ gates.
+   - Why alternate: the final `pq_backlog` suite depends on an inherited
+     previous-release wallet format and may resolve to an explicit legacy
+     boundary rather than a required PQ gate.
 
 ## Current Queue
 
 1. Keep this handoff synced to the live inventory state:
    - `pq_required`: 120
-   - `pq_backlog`: 2
-   - `legacy_only`: 12
-   - latest landed bounded slice: `feature_unsupported_utxo_db.py`
-     legacy-boundary decision in PR `#160`
-2. Land the bounded `mempool_compatibility.py` legacy-boundary decision without
-   adding the skipped suite to `pq_required`.
-3. Then review `wallet_backwards_compatibility.py` as the next one-suite PQ
-   relevance decision. `wallet_migration.py` remains deferred as listed above
-   and in
+   - `pq_backlog`: 1
+   - `legacy_only`: 13
+   - latest bounded slice: `wallet_backwards_compatibility.py`
+     legacy-boundary decision
+2. Review `wallet_migration.py` as the final one-suite PQ relevance decision
+   without treating a skipped run as promotion evidence. Its provenance
+   boundary is listed above and in
    [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md).
 
 


### PR DESCRIPTION
## Summary

- classify `wallet_backwards_compatibility.py` as `legacy_only`
- record the inherited Bitcoin Core v0.20.1 through v25.0 wallet-loading, descriptor, BDB, keypool, and migration boundary
- update inventory counts to `pq_required: 120`, `pq_backlog: 1`, `dual_profile: 142`, and `legacy_only: 13`
- advance the Track A handoff to the final backlog suite, `wallet_migration.py`

## Audit

The suite requires six historical binaries corresponding to Bitcoin Core v0.20.1, v0.21.0, v22.0, v23.0, v24.0.1, and v25.0. It exercises cross-version descriptor-wallet loading, transaction and keypool preservation, legacy BDB rejection and migration, and the v22 inactive-HD-chain cleanup path.

Those tags are inherited Bitcoin Core releases. PQBTC shipped no matching release lineage or supported wallet upgrade/downgrade path; its published v1 release tags identify as v30.2 and expose no executable prior-release assets. The suite therefore remains useful upstream reference coverage but is not a PQBTC compatibility guarantee.

## Validation

- `git diff --check`
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 wallet_backwards_compatibility.py` (skipped: previous releases not available or disabled)

The skip is recorded as boundary evidence, not promotion evidence.
