### PR TITLE
ci: classify wallet migration as legacy

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -1705,10 +1705,10 @@
   },
   {
     "name": "wallet_migration.py",
-    "policy_class": "pq_backlog",
+    "policy_class": "legacy_only",
     "owner": "@scottdhughes",
     "tracking_issue": "#15",
-    "notes": "Wallet behavior still needs an explicit PQ-vs-dual-profile disposition in later CI follow-up."
+    "notes": "Explicit inherited Bitcoin Core v28.2 legacy BDB-to-descriptor migration coverage. The suite creates BDB wallets with an upstream v28.2 node and verifies current-node SQLite descriptor conversion, watch-only and solvables partitioning, data preservation, backups, and failure rollback across wallet and script shapes. PQBTC has no v28.2 release lineage or supported Bitcoin Core wallet migration path. Retained as legacy_only reference coverage rather than a PQBTC migration guarantee or required PQ gate."
   },
   {
     "name": "wallet_miniscript.py",

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -37,9 +37,9 @@ The current functional corpus has `276` tracked test files, classified as:
 | Class | Count |
 |---|---|
 | `pq_required` | `120` |
-| `pq_backlog` | `1` |
+| `pq_backlog` | `0` |
 | `dual_profile` | `142` |
-| `legacy_only` | `13` |
+| `legacy_only` | `14` |
 
 Current required PQ-first gates:
 
@@ -553,11 +553,15 @@ boundaries, transaction and keypool preservation, and legacy-to-descriptor
 migration behavior. PQBTC never shipped that release lineage and does not
 support those cross-product wallet upgrade and downgrade paths, so the suite
 remains inherited reference coverage rather than a required PQBTC gate.
-The final `pq_backlog` suite is `wallet_migration.py`; it requires a separate
-decision about its inherited Bitcoin Core v28.2 BDB-to-descriptor migration
-contract. See
+The inherited `wallet_migration.py` suite is now `legacy_only`. It creates
+legacy BDB wallets with Bitcoin Core v28.2 and verifies current-node conversion
+to SQLite descriptor wallets, including watch-only and solvables partitioning,
+wallet-data preservation, backup creation, and failure rollback. PQBTC has no
+v28.2 release lineage and does not support migration from an upstream Bitcoin
+Core wallet, so this remains reference coverage rather than a required PQBTC
+gate. No suites remain in `pq_backlog`; see
 [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md) for
-the current provenance boundary.
+the completed provenance boundary.
 
 Explicit legacy-only coverage in this tranche includes:
 
@@ -568,6 +572,7 @@ Explicit legacy-only coverage in this tranche includes:
 5. inherited Bitcoin Core v0.14.3 chainstate-database migration coverage
 6. inherited Bitcoin Core v0.20.1 `mempool.dat` migration coverage
 7. inherited Bitcoin Core v0.20.1 through v25.0 wallet upgrade and downgrade coverage
+8. inherited Bitcoin Core v28.2 legacy BDB-to-descriptor wallet migration coverage
 
 Inherited Taproot-specific suites remain `legacy_only` in the current CI contract,
 while `feature_taproot_replacement_deployment.py` and
@@ -591,5 +596,8 @@ Until a separate ownership model or `CODEOWNERS` file exists, all current workfl
 
 Still deferred after this tranche:
 
-1. converting additional `pq_backlog` suites into required PQ gates or documenting permanent dual-profile boundaries for them
-2. promoting high-value suites from `pq_backlog` once each bounded confidence pass is stable
+1. selecting any future promotion candidate from `dual_profile` through a
+   separate risk-based posture decision rather than extending this completed
+   backlog mechanically
+2. defining explicit entry criteria for any new `pq_backlog` suite so the
+   zero-backlog inventory remains a meaningful reviewed baseline

--- a/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
+++ b/docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: PREVIOUS-RELEASE-ASSET-BOUNDARY-v1
-## Updated: 2026-07-15
+## Updated: 2026-07-16
 
 ## Purpose
 
@@ -45,6 +45,15 @@ nodes with versions `250000`, `240001`, `230000`, `220000`, `210000`, and
 `200100`. The framework maps them to `v25.0`, `v24.0.1`, `v23.0`, `v22.0`,
 `v0.21.0`, and `v0.20.1`, with `pqbtcd` and `pqbtc-cli` expected under each
 version's `releases/<tag>/bin/` directory.
+
+The wallet migration decision covers
+[wallet_migration.py](../test/functional/wallet_migration.py). That suite calls
+`skip_if_no_previous_releases()` and starts a current node plus an old node with
+`version=280200` and `-deprecatedrpc=create_bdb`. The old node therefore uses
+the same expected v28.2 binary layout:
+
+- `releases/v28.2/bin/pqbtcd`
+- `releases/v28.2/bin/pqbtc-cli`
 
 If `PREVIOUS_RELEASES_DIR` is set, the same versioned layouts are expected below
 that directory instead.
@@ -144,6 +153,36 @@ would not prove PQBTC compatibility. `wallet_backwards_compatibility.py` is
 therefore classified as `legacy_only` reference coverage and remains outside
 `pq_required`.
 
+## Wallet Migration Decision
+
+The 2026-07-16 repository audit confirms that the old node is the inherited
+signed Bitcoin Core v28.2 release, not a PQBTC release. Its source and generated
+manuals identify Bitcoin Core, `bitcoind`, and `bitcoin-cli`, and contain no
+PQBTC or post-quantum implementation. The fork's `v1.0.0-rc1` and `v1.0.0`
+tags instead identify as v30.2 and provide no executable prior-release assets
+for this v28.2 harness.
+
+The suite creates legacy BDB wallets through the v28.2 node and tests current
+Bitcoin Core migration mechanics across a broad inherited surface:
+
+- conversion to SQLite descriptor wallets with timestamped legacy backups,
+  address, balance, transaction, metadata, keypool, encryption, and wallet-flag
+  preservation
+- partitioning imported scripts and partial-key multisig state into spendable,
+  watch-only, and solvables wallets across raw scripts, P2WSH, miniscript, and
+  Taproot cases
+- named, unnamed, direct-file, absolute, relative, and nested wallet paths,
+  plus restoration of the BDB backup on the old node
+- rollback and cleanup for migration, destination-wallet, cross-chain load,
+  and pruned-history failures while preserving the original BDB wallet
+
+Those checks protect migration from a Bitcoin Core v28.2 wallet format that
+PQBTC never shipped and does not support as an upgrade source. Building or
+renaming the inherited binaries could exercise the upstream migration
+mechanics, but it would not prove a prior-PQBTC wallet guarantee.
+`wallet_migration.py` is therefore classified as `legacy_only` reference
+coverage and remains outside `pq_required`.
+
 ## Reconsideration Boundaries
 
 Reopen these decisions only if an authentic PQBTC release matching the suite's
@@ -154,11 +193,9 @@ release payloads.
 
 ## Remaining Asset-Dependent Suites
 
-After the coinstats, unsupported-UTXO, mempool, and wallet-backwards decisions,
-one `pq_backlog` suite remains previous-release dependent and requires a
-separate decision:
-
-1. `wallet_migration.py`
+None. The coinstats, unsupported-UTXO, mempool, wallet-backwards, and wallet
+migration suites now have explicit `legacy_only` dispositions, and no suite
+remains in `pq_backlog`.
 
 ## Validation Snapshot
 
@@ -166,8 +203,8 @@ Current local validation without previous-release assets:
 
 - `python3 ci/test/check_ci_inventory.py`
   - result: passed
-  - counts: `pq_required: 120`, `pq_backlog: 1`, `legacy_only: 13`
-- `build/test/functional/test_runner.py --jobs=1 wallet_backwards_compatibility.py`
+  - counts: `pq_required: 120`, `pq_backlog: 0`, `legacy_only: 14`
+- `build/test/functional/test_runner.py --jobs=1 wallet_migration.py`
   - result: skipped
   - skip reason: previous releases not available or disabled
   - interpretation: confirms that this run is not evidence for a required PQ

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-07-15
+## Updated: 2026-07-16
 ## Current Phase: Phase 1 - Wallet And Block Surface Expansion
 
 ## Purpose
@@ -20,10 +20,10 @@ and PR `#156` has now landed the adjacent
 `mining_template_verification.py` promotion files. PR `#159` classified
 `feature_coinstatsindex_compatibility.py` as `legacy_only`, and PR `#160` did
 the same for `feature_unsupported_utxo_db.py`. PR `#161` classified
-`mempool_compatibility.py` as `legacy_only`. The current bounded decision also
-classifies `wallet_backwards_compatibility.py` as `legacy_only` because its
-v0.20.1-through-v25.0 wallet transitions use Bitcoin Core releases, not a prior
-PQBTC release lineage.
+`mempool_compatibility.py` as `legacy_only`, and PR `#162` did the same for
+`wallet_backwards_compatibility.py`. The current bounded decision classifies
+`wallet_migration.py` as `legacy_only` because it migrates BDB wallets created
+by Bitcoin Core v28.2, not a prior PQBTC release.
 
 The current asset boundary is recorded in
 [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md). The
@@ -38,7 +38,10 @@ provenance boundary: Track A does not support migrating a Bitcoin Core 0.14
 datadir into the new PQBTC chain. Nor does it support upgrading from or
 downgrading to Bitcoin Core v0.20.1 through a shared `mempool.dat` file. The
 same boundary applies to loading, upgrading, downgrading, or migrating wallet
-files across inherited Bitcoin Core v0.20.1 through v25.0 releases.
+files across inherited Bitcoin Core v0.20.1 through v25.0 releases, including
+the v28.2 BDB-to-descriptor migration contract in `wallet_migration.py`. All
+tracked suites now have an explicit policy class and none remains in
+`pq_backlog`.
 
 ## Current Working Thesis
 
@@ -54,44 +57,40 @@ files across inherited Bitcoin Core v0.20.1 through v25.0 releases.
 
 Preferred next owned tranche:
 
-1. `wallet_migration.py` one-suite PQ relevance decision
-   - Why next: this is the final suite in `pq_backlog`. It uses Bitcoin Core
-     v28.2 to create legacy BDB wallets and checks their migration to current
-     descriptor wallets, so it needs an explicit decision about whether that
-     inherited migration contract belongs on PQBTC's supported path.
-   - Exact files for the next PR:
-     - `ci/test/functional_suite_inventory.json`
-     - `docs/CI_COMPLETENESS.md`
-     - `docs/PREVIOUS_RELEASE_ASSET_BOUNDARY.md`
-     - `docs/TRACK_A_STATUS.md`
-   - Minimum validation only:
+1. Close the current Track A inventory tranche and select any future gate from
+   a fresh risk-based posture review
+   - Why next: all `276` tracked functional suites now have explicit policy
+     classes and `pq_backlog` is empty. The inventory no longer implies an
+     automatic next promotion.
+   - Minimum closeout evidence:
      - `python3 ci/test/check_ci_inventory.py`
-     - `build/test/functional/test_runner.py --jobs=1 wallet_migration.py`
-     - expected local result without authentic prior assets: skipped, which is
-       boundary evidence rather than promotion evidence
+     - a clean post-merge Promotion Matrix on `main`
+   - Before another promotion PR:
+     - identify one concrete confidence gap from the current `dual_profile` or
+       policy docs
+     - record its owner, tracking issue, bounded contract, and targeted test
+       before changing its policy class
    - Stays deferred:
-     - no other `pq_backlog` suite; this is the final inventory disposition
+     - broad mechanical review of all `dual_profile` suites
+     - a PQBTC wallet migration guarantee without an authentic prior-PQBTC
+       wallet lineage
 
 Alternate rebalance:
 
-2. Stop after the wallet-backwards classification until authentic prior-release
-   evidence exists
-   - Why alternate: the final `pq_backlog` suite depends on an inherited
-     previous-release wallet format and may resolve to an explicit legacy
-     boundary rather than a required PQ gate.
+2. Hold the current inventory as the reviewed baseline
+   - Why alternate: zero backlog is a valid stopping point until a new
+     risk-ranked PQ confidence gap is selected explicitly.
 
 ## Current Queue
 
 1. Keep this handoff synced to the live inventory state:
    - `pq_required`: 120
-   - `pq_backlog`: 1
-   - `legacy_only`: 13
-   - latest bounded slice: `wallet_backwards_compatibility.py`
+   - `pq_backlog`: 0
+   - `legacy_only`: 14
+   - latest bounded slice: `wallet_migration.py`
      legacy-boundary decision
-2. Review `wallet_migration.py` as the final one-suite PQ relevance decision
-   without treating a skipped run as promotion evidence. Its provenance
-   boundary is listed above and in
-   [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md).
+2. Do not infer another promotion from queue order. Select the next Track A
+   tranche through the fresh posture review described above.
 
 
 ## Historical Queue Ledger


### PR DESCRIPTION
## Summary

- classify `wallet_migration.py` as `legacy_only`
- record the inherited Bitcoin Core v28.2 BDB-to-descriptor migration boundary
- update inventory counts to `pq_required: 120`, `pq_backlog: 0`, `dual_profile: 142`, and `legacy_only: 14`
- close the current Track A backlog without implying another automatic promotion

## Audit

The suite creates legacy BDB wallets with an inherited Bitcoin Core v28.2 node and tests current-node conversion to SQLite descriptor wallets. Its coverage includes spendable, watch-only, and solvables partitioning; balances, transactions, metadata, keypool, encryption, and wallet flags; wallet path variants and backups; raw scripts, P2WSH, miniscript, and Taproot cases; and rollback for migration, cross-chain, and pruned-history failures.

PQBTC did not ship a v28.2 wallet lineage or support upstream Bitcoin Core wallets as an upgrade source. The suite remains useful inherited reference coverage, but it is not a PQBTC previous-release guarantee.

## Validation

- `git diff --check`
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 wallet_migration.py` (skipped: previous releases not available or disabled)

The skip is boundary evidence, not promotion evidence.
