### PR TITLE
ci: promote feature config args gate

### DIFF
--- a/ci/test/functional_suite_inventory.json
+++ b/ci/test/functional_suite_inventory.json
@@ -120,10 +120,10 @@
   },
   {
     "name": "feature_config_args.py",
-    "policy_class": "dual_profile",
+    "policy_class": "pq_required",
     "owner": "@scottdhughes",
-    "tracking_issue": "#15",
-    "notes": "Retained under the current non-gating dual-profile contract."
+    "tracking_issue": "#165",
+    "notes": "Now promoted into pq_required as the narrow PQBTC configuration-namespace gate: the suite verifies pqbtc.conf discovery and diagnostics, explicit and ignored configuration-file handling, includeconf behavior, and datadir/config precedence under the current PQBTC operator namespace; platform default datadir names and broader binary, GUI, service, user-agent, and network identity remain outside this contract."
   },
   {
     "name": "feature_csv_activation.py",

--- a/ci/test/pq_functional_tests.txt
+++ b/ci/test/pq_functional_tests.txt
@@ -6,6 +6,7 @@ feature_blocksdir.py
 feature_blocksxor.py
 feature_cltv.py
 feature_coinstatsindex.py
+feature_config_args.py
 feature_csv_activation.py
 feature_fastprune.py
 feature_index_prune.py

--- a/docs/CI_COMPLETENESS.md
+++ b/docs/CI_COMPLETENESS.md
@@ -36,9 +36,9 @@ The current functional corpus has `276` tracked test files, classified as:
 
 | Class | Count |
 |---|---|
-| `pq_required` | `120` |
+| `pq_required` | `121` |
 | `pq_backlog` | `0` |
-| `dual_profile` | `142` |
+| `dual_profile` | `141` |
 | `legacy_only` | `14` |
 
 Current required PQ-first gates:
@@ -95,74 +95,75 @@ Current required PQ-first gates:
 50. `feature_blocksxor.py`
 51. `feature_cltv.py`
 52. `feature_coinstatsindex.py`
-53. `feature_csv_activation.py`
-54. `feature_fastprune.py`
-55. `feature_index_prune.py`
-56. `feature_loadblock.py`
-57. `feature_pruning.py`
-58. `feature_reindex.py`
-59. `feature_reindex_init.py`
-60. `feature_reindex_readonly.py`
-61. `feature_remove_pruned_files_on_startup.py`
-62. `feature_utxo_set_hash.py`
-63. `feature_versionbits_warning.py`
-64. `rpc_psbt.py`
-65. `wallet_abandonconflict.py`
-66. `wallet_address_types.py`
-67. `wallet_assumeutxo.py`
-68. `wallet_avoid_mixing_output_types.py`
-69. `wallet_avoidreuse.py`
-70. `wallet_backup.py`
-71. `wallet_balance.py`
-72. `wallet_basic.py`
-73. `wallet_blank.py`
-74. `wallet_bumpfee.py`
-75. `wallet_change_address.py`
-76. `wallet_coinbase_category.py`
-77. `wallet_conflicts.py`
-78. `wallet_create_tx.py`
-79. `wallet_createwallet.py`
-80. `wallet_createwalletdescriptor.py`
-81. `wallet_crosschain.py`
-82. `wallet_descriptor.py`
-83. `wallet_disable.py`
-84. `wallet_encryption.py`
-85. `wallet_fallbackfee.py`
-86. `wallet_fast_rescan.py`
-87. `wallet_fundrawtransaction.py`
-88. `wallet_gethdkeys.py`
-89. `wallet_groups.py`
-90. `wallet_hd.py`
-91. `wallet_importdescriptors.py`
-92. `wallet_importprunedfunds.py`
-93. `wallet_keypool.py`
-94. `wallet_keypool_topup.py`
-95. `wallet_labels.py`
-96. `wallet_listdescriptors.py`
-97. `wallet_listreceivedby.py`
-98. `wallet_listsinceblock.py`
-99. `wallet_listtransactions.py`
-100. `wallet_miniscript.py`
-101. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
-102. `wallet_multisig_descriptor_psbt.py`
-103. `wallet_multiwallet.py`
-104. `wallet_orphanedreward.py`
-105. `wallet_reindex.py`
-106. `wallet_reorgsrestore.py`
-107. `wallet_rescan_unconfirmed.py`
-108. `wallet_resendwallettransactions.py`
-109. `wallet_send.py`
-110. `wallet_sendall.py`
-111. `wallet_sendmany.py`
-112. `wallet_signrawtransactionwithwallet.py`
-113. `wallet_simulaterawtx.py`
-114. `wallet_spend_unconfirmed.py`
-115. `wallet_startup.py`
-116. `wallet_timelock.py`
-117. `wallet_transactiontime_rescan.py`
-118. `wallet_txn_clone.py`
-119. `wallet_txn_doublespend.py`
-120. `wallet_v3_txs.py`
+53. `feature_config_args.py`
+54. `feature_csv_activation.py`
+55. `feature_fastprune.py`
+56. `feature_index_prune.py`
+57. `feature_loadblock.py`
+58. `feature_pruning.py`
+59. `feature_reindex.py`
+60. `feature_reindex_init.py`
+61. `feature_reindex_readonly.py`
+62. `feature_remove_pruned_files_on_startup.py`
+63. `feature_utxo_set_hash.py`
+64. `feature_versionbits_warning.py`
+65. `rpc_psbt.py`
+66. `wallet_abandonconflict.py`
+67. `wallet_address_types.py`
+68. `wallet_assumeutxo.py`
+69. `wallet_avoid_mixing_output_types.py`
+70. `wallet_avoidreuse.py`
+71. `wallet_backup.py`
+72. `wallet_balance.py`
+73. `wallet_basic.py`
+74. `wallet_blank.py`
+75. `wallet_bumpfee.py`
+76. `wallet_change_address.py`
+77. `wallet_coinbase_category.py`
+78. `wallet_conflicts.py`
+79. `wallet_create_tx.py`
+80. `wallet_createwallet.py`
+81. `wallet_createwalletdescriptor.py`
+82. `wallet_crosschain.py`
+83. `wallet_descriptor.py`
+84. `wallet_disable.py`
+85. `wallet_encryption.py`
+86. `wallet_fallbackfee.py`
+87. `wallet_fast_rescan.py`
+88. `wallet_fundrawtransaction.py`
+89. `wallet_gethdkeys.py`
+90. `wallet_groups.py`
+91. `wallet_hd.py`
+92. `wallet_importdescriptors.py`
+93. `wallet_importprunedfunds.py`
+94. `wallet_keypool.py`
+95. `wallet_keypool_topup.py`
+96. `wallet_labels.py`
+97. `wallet_listdescriptors.py`
+98. `wallet_listreceivedby.py`
+99. `wallet_listsinceblock.py`
+100. `wallet_listtransactions.py`
+101. `wallet_miniscript.py`
+102. `wallet_miniscript_decaying_multisig_descriptor_psbt.py`
+103. `wallet_multisig_descriptor_psbt.py`
+104. `wallet_multiwallet.py`
+105. `wallet_orphanedreward.py`
+106. `wallet_reindex.py`
+107. `wallet_reorgsrestore.py`
+108. `wallet_rescan_unconfirmed.py`
+109. `wallet_resendwallettransactions.py`
+110. `wallet_send.py`
+111. `wallet_sendall.py`
+112. `wallet_sendmany.py`
+113. `wallet_signrawtransactionwithwallet.py`
+114. `wallet_simulaterawtx.py`
+115. `wallet_spend_unconfirmed.py`
+116. `wallet_startup.py`
+117. `wallet_timelock.py`
+118. `wallet_transactiontime_rescan.py`
+119. `wallet_txn_clone.py`
+120. `wallet_txn_doublespend.py`
+121. `wallet_v3_txs.py`
 
 The previous wallet-confidence gap is closed in this tranche by promoting the
 existing PQ wallet suites into the required gate and adding PQ-native wallet,
@@ -528,6 +529,12 @@ reject reasons, difficulty, merkle-root, timestamp, and best-prevblk
 boundaries, transaction-bearing proposal checks without UTXO mutation,
 overspend and double-spend rejection, and concurrent proposal validation under
 the current legacy-compatible PQC profile.
+The risk-reviewed PQBTC configuration-namespace confidence gap is now also
+part of the required gate: `feature_config_args.py` covers `pqbtc.conf`
+discovery and diagnostics, explicit and ignored configuration-file handling,
+`includeconf`, and datadir/config precedence. This bounded gate does not claim
+platform default datadir names or broader binary, GUI, service, user-agent, or
+network identity coverage; those remain separate risk decisions.
 The inherited `feature_coinstatsindex_compatibility.py` suite is now
 `legacy_only`: it hard-codes Bitcoin Core v28.2 migration behavior, but this
 repository has no PQBTC v28.2 release lineage or authentic compatible binaries.

--- a/docs/FEATURE_CONFIG_ARGS_POSTURE.md
+++ b/docs/FEATURE_CONFIG_ARGS_POSTURE.md
@@ -1,0 +1,83 @@
+# PQBTC `feature_config_args.py` Posture
+
+## Status: ACTIVE
+## Spec-ID: FEATURE-CONFIG-ARGS-POSTURE-v1
+## Updated: 2026-07-17
+## Frozen-By: track-a-config-namespace-20260717
+## Consensus-Relevant: NO
+
+## Purpose
+
+Define the bounded Track A contract for PQBTC configuration-file discovery,
+diagnostics, and precedence under the `pqbtc.conf` operator namespace.
+
+## Current Owned Surface
+
+The current passing
+[feature_config_args.py](../test/functional/feature_config_args.py) suite owns
+the configuration-namespace boundary selected in
+[TRACK_A_RISK_REVIEW.md](TRACK_A_RISK_REVIEW.md):
+
+- the default test-node configuration path is named `pqbtc.conf`
+- a directory at that path and a directory reached through `includeconf`
+  produce explicit configuration-read errors
+- `-noconf` ignores `pqbtc.conf` and reports that exact filename when the file
+  exists
+- default, explicit, redundant, missing, and conflicting `-conf` paths retain
+  their expected startup behavior and identify `pqbtc.conf` where the default
+  namespace matters
+- a default-directory `pqbtc.conf` that redirects `datadir` logs the actual
+  configuration source and detects a second ignored `pqbtc.conf`
+- `includeconf`, parser diagnostics, chain sections, and command-line-over-file
+  datadir precedence remain functional under the renamed configuration file
+
+The complete inherited suite also exercises argument logging, network-active
+and seed options, parser errors, and selected chain-specific options. Those
+checks remain useful gate breadth, but the PQ-specific confidence claim in
+this tranche is the configuration namespace above.
+
+## What This Does Not Mean
+
+This posture note does **not** mean:
+
+- platform default datadir names such as `.pqbtc` or
+  `Library/Application Support/PQBTC` are asserted by this suite
+- the Windows environment-override paths are covered; the two affected
+  default-directory tests remain skipped on Windows
+- `pqbtc`, `pqbtcd`, `pqbtc-node`, GUI, service-file, user-agent, or network
+  identity surfaces are owned by this gate
+- every inherited argument-parser behavior is PQ-specific
+- this tranche changes consensus, cryptography, wallet, mempool, mining, or
+  P2P behavior
+
+Those surfaces require separate evidence and selection decisions.
+
+## Confidence Snapshot
+
+Targeted confidence pass run on 2026-07-17:
+
+- `build/test/functional/test_runner.py --jobs=1 feature_config_args.py`
+  - result: passed
+  - duration: 15 seconds
+  - current posture:
+    - `pqbtc.conf` discovery and diagnostics remain stable
+    - explicit and ignored configuration-file boundaries remain stable
+    - include and datadir precedence remain stable under the PQBTC namespace
+
+The test requires local node RPC listeners. A restricted sandbox run that
+blocked local binds failed before the test body; the same commit passed with
+local node networking enabled.
+
+## Expected CI Cost
+
+Low. The suite uses the existing functional-test build and completed in 15
+seconds locally without an additional build target.
+
+## Interpretation
+
+- `feature_config_args.py` is a required PQBTC configuration-namespace gate
+- the promotion closes the concrete gap selected by issue `#165`
+- the inventory remains at zero backlog after this one-for-one move from
+  `dual_profile` to `pq_required`
+- future operator-identity promotions require a fresh bounded risk decision;
+  `tool_bitcoin.py` is not promoted by implication

--- a/docs/TRACK_A_RISK_REVIEW.md
+++ b/docs/TRACK_A_RISK_REVIEW.md
@@ -11,8 +11,8 @@ Select `feature_config_args.py` as the next bounded Track A promotion
 candidate. The suite closes a launch-facing PQBTC configuration namespace gap
 that is not currently owned by a `pq_required` functional gate.
 
-This review does not change any inventory policy class. The current baseline
-remains:
+This review PR did not change any inventory policy class. Its reviewed
+baseline was:
 
 - `pq_required`: 120
 - `pq_backlog`: 0
@@ -21,6 +21,22 @@ remains:
 
 Promotion, posture documentation, inventory bookkeeping, targeted validation,
 and CI evidence belong in a separate PR tracked by issue `#165`.
+
+## Separate Promotion Outcome
+
+The separate bounded promotion slice implements the selected
+`feature_config_args.py` contract without promoting either deferred/rejected
+candidate. Its resulting baseline is:
+
+- `pq_required`: 121
+- `pq_backlog`: 0
+- `legacy_only`: 14
+- `dual_profile`: 141
+
+The owned contract is recorded in
+[FEATURE_CONFIG_ARGS_POSTURE.md](FEATURE_CONFIG_ARGS_POSTURE.md). Further
+policy-class changes return to `HOLD` until another bounded risk review selects
+a concrete PQ-specific gap.
 
 ## Review Method
 
@@ -271,9 +287,9 @@ environment evidence, not product failures.
   but it must be selected through another explicit risk decision.
 - No other `dual_profile` suite is promoted by implication.
 
-## Next Bounded Slice
+## Promotion Slice Contract
 
-Open a separate promotion PR for `feature_config_args.py` under issue `#165`:
+The separate promotion PR for `feature_config_args.py` under issue `#165`:
 
 1. add a configuration-namespace posture document
 2. change exactly one inventory policy class to `pq_required`
@@ -281,5 +297,5 @@ Open a separate promotion PR for `feature_config_args.py` under issue `#165`:
 4. run inventory validation and the targeted functional test
 5. merge only after required checks are green
 
-If that bounded contract cannot be maintained, record `HOLD` and preserve the
-zero-backlog baseline.
+If that bounded contract cannot be maintained in a future revision, revert to
+`HOLD` and preserve the zero-backlog baseline.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,8 +2,8 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-07-16
-## Current Phase: Phase 1 - Inventory Tranche Closed; Risk Review Pending
+## Updated: 2026-07-17
+## Current Phase: Phase 1 - Config Namespace Gate Promoted; Baseline Hold
 
 ## Purpose
 
@@ -14,21 +14,21 @@ active, use this file to choose the next safe step for `quantum-proof-bitcoin`.
 
 ## Current Objective
 
-Keep the live `pq_required` gate aligned with the repo as it exists today.
-`mining_prioritisetransaction.py` is already promoted in the live inventory,
-and PR `#156` has now landed the adjacent
-`mining_template_verification.py` promotion files. PR `#159` classified
-`feature_coinstatsindex_compatibility.py` as `legacy_only`, and PR `#160` did
-the same for `feature_unsupported_utxo_db.py`. PR `#161` classified
-`mempool_compatibility.py` as `legacy_only`, and PR `#162` did the same for
-`wallet_backwards_compatibility.py`. PR `#163` classified
-`wallet_migration.py` as `legacy_only` because it migrates BDB wallets created
-by Bitcoin Core v28.2, not a prior PQBTC release. That merge closed the current
-inventory tranche at `pq_required: 120`, `pq_backlog: 0`, `legacy_only: 14`,
-and `dual_profile: 142`. Promotion Matrix run `#106` (`29540363398`) then
-completed on `main` at merge commit
+Keep the live `pq_required` gate aligned with the repo as it exists today. PR
+`#163` closed the initial inventory tranche at `pq_required: 120`,
+`pq_backlog: 0`, `legacy_only: 14`, and `dual_profile: 142`. Promotion Matrix
+run `#106` (`29540363398`) then completed on `main` at merge commit
 `f363c99d4ef40a822477eef84b3afecfc76329fc` with all `26/26` checks
 successful on attempt 1.
+
+PR `#166` then landed the bounded dual-profile risk review. It selected
+`feature_config_args.py` because the launch-facing `pqbtc.conf` namespace had
+no required functional owner, deferred `tool_bitcoin.py` pending a dedicated
+issue and a bounded cross-platform contract, and rejected `rpc_blockchain.py`
+because the required replacement-deployment suite already owns that evidence.
+This separate slice promotes only `feature_config_args.py` under issue `#165`.
+The resulting baseline is `pq_required: 121`, `pq_backlog: 0`,
+`legacy_only: 14`, and `dual_profile: 141`.
 
 The current asset boundary is recorded in
 [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md). The
@@ -62,37 +62,37 @@ tracked suites now have an explicit policy class and none remains in
 
 Preferred next owned tranche:
 
-1. Run a separate risk-based posture review before selecting any future gate
-   - Why next: the current inventory tranche is closed, all `276` tracked
-     functional suites have explicit policy classes, and `pq_backlog` is empty.
-     The inventory no longer implies an automatic next promotion.
-   - Before another promotion PR:
-     - identify one concrete confidence gap from the current `dual_profile` or
-       policy docs
-     - record its owner, tracking issue, bounded contract, targeted test, and
-       acceptable CI cost before changing its policy class
-   - Stays deferred:
-     - broad mechanical review of all `dual_profile` suites
-     - a PQBTC wallet migration guarantee without an authentic prior-PQBTC
-       wallet lineage
+1. Hold the reviewed post-promotion baseline
+   - Why next: the selected configuration-namespace gap is closed, all `276`
+     tracked functional suites retain explicit policy classes, and
+     `pq_backlog` remains empty.
+   - `tool_bitcoin.py` remains deferred; its low runtime does not replace the
+     missing dedicated issue and cross-platform/optional-IPC boundary.
+   - `rpc_blockchain.py` remains rejected because its replacement-deployment
+     evidence duplicates an existing required gate.
 
-Alternate rebalance:
+Future selection boundary:
 
-2. Hold the current inventory as the reviewed baseline
-   - Why alternate: zero backlog is a valid stopping point until a new
-     risk-ranked PQ confidence gap is selected explicitly.
+2. Run another bounded risk review only when new evidence identifies a
+   launch-critical PQ confidence gap
+   - record the affected PQ path, owner, open issue, bounded contract, targeted
+     command, expected CI cost, and promotion/rejection criteria before any
+     further policy-class change
+   - do not select a suite from inventory order or low runtime alone
 
 ## Current Queue
 
-1. Preserve the closed inventory baseline:
-   - `pq_required`: 120
+1. Preserve the reviewed post-promotion baseline:
+   - `pq_required`: 121
    - `pq_backlog`: 0
    - `legacy_only`: 14
-   - `dual_profile`: 142
-   - closeout evidence: PR `#163` and Promotion Matrix run `#106`, with all
-     `26/26` checks successful
-2. Do not infer another promotion from queue order. Select the next Track A
-   tranche through the fresh posture review described above.
+   - `dual_profile`: 141
+   - selection evidence: PR `#166` and
+     [TRACK_A_RISK_REVIEW.md](TRACK_A_RISK_REVIEW.md)
+   - owned contract:
+     [FEATURE_CONFIG_ARGS_POSTURE.md](FEATURE_CONFIG_ARGS_POSTURE.md)
+2. `HOLD`: do not infer another promotion from queue order. Require a fresh
+   risk decision before changing another policy class.
 
 
 ## Historical Queue Ledger
@@ -2498,12 +2498,12 @@ above as the controlling live next-PR handoff when these older notes disagree.
 
 ## Blockers
 
-- There is no active inventory blocker. The current tranche is closed with no
-  suites in `pq_backlog`.
-- A future promotion requires a separately reviewed PQ confidence gap with a
-  named owner, tracking issue, bounded contract, targeted test, and acceptable
-  CI cost. Until that selection exists, holding the zero-backlog inventory is
-  the intended baseline rather than a blocked state.
+- There is no active inventory blocker. The selected configuration-namespace
+  gap is promoted and no suites remain in `pq_backlog`.
+- A further promotion requires a newly reviewed PQ confidence gap with a named
+  owner, open tracking issue, bounded contract, targeted test, and acceptable
+  CI cost. Until another selection exists, `HOLD` is the intended baseline
+  rather than a blocked state.
 - The five inherited previous-release compatibility suites are `legacy_only`,
   not asset-blocked promotion candidates. Do not reopen them or fabricate
   PQBTC v28.2 assets unless the supported migration policy changes. Their


### PR DESCRIPTION
## Summary
- promote `feature_config_args.py` from `dual_profile` to `pq_required` and add it to the canonical PQ functional gate
- define the bounded `pqbtc.conf` discovery, diagnostics, include, and datadir-precedence posture
- update completeness and Track A bookkeeping to `121 / 0 / 14 / 141`, with future selection returned to `HOLD`

## Validation
- `git diff --check`
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 feature_config_args.py`

Closes #165