### PR TITLE
ci: move actions to Node 24 runtimes

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -20,7 +20,7 @@ runs:
         esac
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         # Use host network to allow access to cirrus gha cache running on the host
         driver-opts: |
@@ -28,7 +28,7 @@ runs:
 
     # This is required to allow buildkit to access the actions cache
     - name: Expose actions cache variables
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         script: |
           Object.keys(process.env).forEach(function (key) {

--- a/.github/actions/restore-caches/action.yml
+++ b/.github/actions/restore-caches/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Restore Ccache cache
       id: ccache-cache
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@v5
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ env.CONTAINER_NAME }}-${{ github.run_id }}
@@ -14,7 +14,7 @@ runs:
 
     - name: Restore depends sources cache
       id: depends-sources
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@v5
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
@@ -23,7 +23,7 @@ runs:
 
     - name: Restore built depends cache
       id: depends-built
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@v5
       with:
         path: ${{ env.BASE_CACHE }}
         key: depends-built-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
@@ -32,7 +32,7 @@ runs:
 
     - name: Restore previous releases cache
       id: previous-releases
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@v5
       with:
         path: ${{ env.PREVIOUS_RELEASES_DIR }}
         key: previous-releases-${{ env.CONTAINER_NAME }}-${{ env.PREVIOUS_RELEASES_HASH }}

--- a/.github/actions/save-caches/action.yml
+++ b/.github/actions/save-caches/action.yml
@@ -11,28 +11,28 @@ runs:
         echo "previous releases direct cache hit to primary key: ${{ env.previous-releases-cache-hit }}"
 
     - name: Save Ccache cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@v5
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) }}
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ env.CONTAINER_NAME }}-${{ github.run_id }}
 
     - name: Save depends sources cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@v5
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.depends-sources-cache-hit != 'true') }}
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
 
     - name: Save built depends cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@v5
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.depends-built-cache-hit != 'true' )}}
       with:
         path: ${{ env.BASE_CACHE }}
         key: depends-built-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
 
     - name: Save previous releases cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@v5
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.previous-releases-cache-hit != 'true' )}}
       with:
         path: ${{ env.PREVIOUS_RELEASES_DIR }}

--- a/.github/workflows/promotion-matrix.yml
+++ b/.github/workflows/promotion-matrix.yml
@@ -78,7 +78,7 @@ jobs:
         uses: ./.github/actions/save-caches
 
       - name: Upload fuzz binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-fuzz-binary-${{ github.run_id }}
           path: ${{ env.BASE_BUILD_DIR }}/bin/fuzz
@@ -121,7 +121,7 @@ jobs:
           cache-provider: ${{ needs.runners.outputs.provider }}
 
       - name: Download fuzz binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: linux-fuzz-binary-${{ github.run_id }}
           path: ${{ env.BASE_BUILD_DIR }}/bin
@@ -228,7 +228,7 @@ jobs:
 
       - name: Restore Ccache cache
         id: ccache-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.job }}-${{ matrix.job-type }}-ccache-${{ github.run_id }}
@@ -240,7 +240,7 @@ jobs:
           FILE_ENV: ${{ matrix.file-env }}
 
       - name: Save Ccache cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -294,13 +294,13 @@ jobs:
           sed -i '1s/^/set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)\n/' "${VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake"
 
       - name: vcpkg tools cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:/vcpkg/downloads/tools
           key: ${{ github.job }}-vcpkg-tools
 
       - name: Restore vcpkg binary cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: vcpkg-binary-cache
         with:
           path: ~/AppData/Local/vcpkg/archives
@@ -311,7 +311,7 @@ jobs:
           cmake -B build -Werror=dev --preset vs2022 -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.generate-options }}
 
       - name: Save vcpkg binary cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: github.event_name != 'pull_request' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' && matrix.job-type == 'standard'
         with:
           path: ~/AppData/Local/vcpkg/archives
@@ -401,7 +401,7 @@ jobs:
         uses: ./.github/actions/save-caches
 
       - name: Upload built executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: x86_64-w64-mingw32-executables-${{ github.run_id }}
           path: |
@@ -423,7 +423,7 @@ jobs:
       - *CHECKOUT
 
       - name: Download built executables
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: x86_64-w64-mingw32-executables-${{ github.run_id }}
 


### PR DESCRIPTION
## Summary
- move artifact, cache, GitHub Script, and Docker Buildx actions to their Node 24 major lines
- preserve existing workflow inputs and cache/artifact behavior
- leave Track A inventory and policy classes unchanged

## Validation
- `git diff --check`
- YAML parse for all changed workflow/action files
- `python3 ci/test/check_ci_inventory.py`
- `python3 -m unittest discover -s ci/test -p 'test_*.py'`
- `test/lint/lint-files.py`
- verified each selected upstream action declares `runs.using: node24`