### PR TITLE
ci: configure MSVC without Node action

### DIFF
--- a/.github/ci-windows-env.py
+++ b/.github/ci-windows-env.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026-present The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+"""Import the Visual Studio developer environment into GitHub Actions."""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def command_output(command: list[str] | str) -> str:
+    return subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def main() -> None:
+    vswhere = (
+        Path(os.environ["ProgramFiles(x86)"])
+        / "Microsoft Visual Studio"
+        / "Installer"
+        / "vswhere.exe"
+    )
+    installation_path = command_output(
+        [
+            str(vswhere),
+            "-latest",
+            "-products",
+            "*",
+            "-requires",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "-property",
+            "installationPath",
+        ]
+    ).strip()
+    if not installation_path:
+        raise RuntimeError("Microsoft Visual Studio with C++ tools was not found")
+
+    vsdevcmd = Path(installation_path) / "Common7" / "Tools" / "VsDevCmd.bat"
+    if not vsdevcmd.is_file():
+        raise FileNotFoundError(vsdevcmd)
+
+    comspec = os.environ["COMSPEC"]
+    environment = command_output(
+        f'"{comspec}" /d /s /c ""{vsdevcmd}" -arch=x64 -no_logo && set"'
+    )
+    original_environment = {name.upper(): value for name, value in os.environ.items()}
+
+    github_env = Path(os.environ["GITHUB_ENV"])
+    with github_env.open("a", encoding="utf-8", newline="\n") as env_file:
+        for line in environment.splitlines():
+            if "=" not in line:
+                continue
+            name, value = line.split("=", 1)
+            if not name or original_environment.get(name.upper()) == value:
+                continue
+            print(f"Exporting {name}")
+            env_file.write(f"{name}={value}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/promotion-matrix.yml
+++ b/.github/workflows/promotion-matrix.yml
@@ -271,10 +271,9 @@ jobs:
       - *CHECKOUT
 
       - name: Configure Developer Command Prompt for Microsoft Visual C++
-        # Using microsoft/setup-msbuild is not enough.
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
+        # setup-msbuild only adds MSBuild to PATH; native builds need the full VC environment.
+        shell: pwsh
+        run: py -3 .github/ci-windows-env.py
 
       - name: Get tool information
         shell: pwsh


### PR DESCRIPTION
## Summary
- replace the unreleased Node 20 `ilammy/msvc-dev-cmd` action
- locate Visual Studio with `vswhere` and import `VsDevCmd.bat` environment changes through `GITHUB_ENV`
- leave Track A inventory and policy classes unchanged

## Validation
- Python syntax compilation
- promotion matrix YAML parse
- `git diff --check`
- `python3 ci/test/check_ci_inventory.py`
- `python3 -m unittest discover -s ci/test -p 'test_*.py'`
- `test/lint/lint-files.py`
- PR checks: 8/8 successful
- branch [Promotion Matrix run #111](https://github.com/scottdhughes/quantum-proof-bitcoin/actions/runs/29606273613): 21/21 successful
- Windows standard and fuzz jobs passed with zero annotations