### PR TITLE
test: assert platform PQBTC data directory names

### DIFF
--- a/docs/FEATURE_CONFIG_ARGS_POSTURE.md
+++ b/docs/FEATURE_CONFIG_ARGS_POSTURE.md
@@ -1,15 +1,16 @@
 # PQBTC `feature_config_args.py` Posture
 
 ## Status: ACTIVE
-## Spec-ID: FEATURE-CONFIG-ARGS-POSTURE-v1
+## Spec-ID: FEATURE-CONFIG-ARGS-POSTURE-v2
 ## Updated: 2026-07-17
-## Frozen-By: track-a-config-namespace-20260717
+## Frozen-By: track-a-default-datadir-namespace-170
 ## Consensus-Relevant: NO
 
 ## Purpose
 
 Define the bounded Track A contract for PQBTC configuration-file discovery,
-diagnostics, and precedence under the `pqbtc.conf` operator namespace.
+diagnostics, precedence, and platform default data-directory naming under the
+PQBTC operator namespace.
 
 ## Current Owned Surface
 
@@ -30,6 +31,10 @@ the configuration-namespace boundary selected in
   configuration source and detects a second ignored `pqbtc.conf`
 - `includeconf`, parser diagnostics, chain sections, and command-line-over-file
   datadir precedence remain functional under the renamed configuration file
+- startup reports the PQBTC default data-directory namespace: `.pqbtc` on
+  Linux and other Unix-like platforms, `Library/Application Support/PQBTC` on
+  macOS, and `PQBTC` under the existing roaming application-data path or the
+  fresh local application-data path on Windows
 
 The complete inherited suite also exercises argument logging, network-active
 and seed options, parser errors, and selected chain-specific options. Those
@@ -40,10 +45,10 @@ this tranche is the configuration namespace above.
 
 This posture note does **not** mean:
 
-- platform default datadir names such as `.pqbtc` or
-  `Library/Application Support/PQBTC` are asserted by this suite
-- the Windows environment-override paths are covered; the two affected
-  default-directory tests remain skipped on Windows
+- synthetic Windows `APPDATA` or `LOCALAPPDATA` overrides are covered; the two
+  affected default-directory tests remain skipped because production resolves
+  those folders through `SHGetSpecialFolderPathW`, while the cross-platform
+  namespace assertion uses the runner's actual shell-folder path
 - `pqbtc`, `pqbtcd`, `pqbtc-node`, GUI, service-file, user-agent, or network
   identity surfaces are owned by this gate
 - every inherited argument-parser behavior is PQ-specific
@@ -63,6 +68,8 @@ Targeted confidence pass run on 2026-07-17:
     - `pqbtc.conf` discovery and diagnostics remain stable
     - explicit and ignored configuration-file boundaries remain stable
     - include and datadir precedence remain stable under the PQBTC namespace
+    - the macOS default data directory remains
+      `Library/Application Support/PQBTC`
 
 The test requires local node RPC listeners. A restricted sandbox run that
 blocked local binds failed before the test body; the same commit passed with
@@ -77,6 +84,8 @@ seconds locally without an additional build target.
 
 - `feature_config_args.py` is a required PQBTC configuration-namespace gate
 - the promotion closes the concrete gap selected by issue `#165`
+- the follow-up under issue `#170` closes the platform default data-directory
+  naming gap without changing an inventory policy class
 - the inventory remains at zero backlog after this one-for-one move from
   `dual_profile` to `pq_required`
 - future operator-identity promotions require a fresh bounded risk decision;

--- a/docs/TRACK_A_RISK_REVIEW.md
+++ b/docs/TRACK_A_RISK_REVIEW.md
@@ -38,6 +38,22 @@ The owned contract is recorded in
 policy-class changes return to `HOLD` until another bounded risk review selects
 a concrete PQ-specific gap.
 
+## Follow-Up Hardening Outcome
+
+Issue `#170` narrows one residual risk inside the already required
+`feature_config_args.py` gate without selecting another suite or changing an
+inventory policy class. The suite now asserts the startup-reported platform
+default data-directory namespace: `.pqbtc` on Linux and other Unix-like
+platforms, `Library/Application Support/PQBTC` on macOS, and `PQBTC` under the
+Windows roaming legacy path when it exists or the local application-data path
+otherwise.
+
+The two tests that rely on synthetic Windows `APPDATA` or `LOCALAPPDATA`
+overrides remain excluded on Windows. Production resolves those locations
+through `SHGetSpecialFolderPathW`, so a child environment override is not an
+equivalent test mechanism. The branch promotion matrix is the acceptance gate
+for the actual Windows and macOS paths.
+
 ## Review Method
 
 The review used Bitcoin Core v30.2 as the inherited baseline. The live fork
@@ -86,9 +102,10 @@ apart from the completed `wallet_migration.py` `legacy_only` boundary.
 | Taproot replacement deployment and active seams | the five `feature_taproot_replacement_*.py` required gates | `rpc_blockchain.py` is overlapping evidence, not an uncovered gate |
 | PQBTC operator namespace | source changes in `src/common/args.cpp` select `pqbtc.conf`; `NAMING.md` treats configuration separation as a launch contract | No required functional gate currently owns the `pqbtc.conf` path |
 
-The selected contract is deliberately narrower than all operator naming. It
-does not claim complete binary, GUI, service-file, default-datadir, or network
-identity coverage.
+The original selection contract was deliberately narrower than all operator
+naming and did not claim complete binary, GUI, service-file, default-datadir,
+or network identity coverage. Issue `#170` subsequently closes only the
+platform default-datadir namespace part of that residual boundary.
 
 ## Candidate 1: `feature_config_args.py`
 
@@ -127,8 +144,9 @@ The suite must continue to verify:
   change
 - inherited configuration parsing remains available under the renamed file
 
-The suite does not directly prove platform default datadir names such as
-`.pqbtc` or `Library/Application Support/PQBTC`.
+The original promotion contract did not directly prove platform default
+datadir names such as `.pqbtc` or `Library/Application Support/PQBTC`. Issue
+`#170` subsequently adds that bounded assertion to the already required gate.
 
 ### Targeted Test
 
@@ -278,7 +296,9 @@ environment evidence, not product failures.
 
 ## Residual Risks And Non-Goals
 
-- The selected suite does not assert platform default datadir names.
+- The suite does not emulate alternate Windows shell-folder locations through
+  synthetic `APPDATA` or `LOCALAPPDATA` child environments; it validates the
+  actual shell-folder path selected on the Windows runner.
 - It does not validate all binary, service, GUI, user-agent, or network-magic
   naming surfaces.
 - It does not add cryptographic or consensus evidence; those areas already

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -3,7 +3,7 @@
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
 ## Updated: 2026-07-17
-## Current Phase: Phase 1 - Config Namespace Gate Promoted; Baseline Hold
+## Current Phase: Phase 1 - Config Namespace Hardened; Baseline Hold
 
 ## Purpose
 
@@ -29,6 +29,13 @@ because the required replacement-deployment suite already owns that evidence.
 This separate slice promotes only `feature_config_args.py` under issue `#165`.
 The resulting baseline is `pq_required: 121`, `pq_backlog: 0`,
 `legacy_only: 14`, and `dual_profile: 141`.
+
+Issue `#170` is the bounded follow-up inside that already required gate. It
+asserts the startup-reported platform default data-directory namespace on
+Linux, macOS, and Windows while retaining the explicit Windows boundary for
+tests that depend on synthetic shell-folder environment overrides. It changes
+no inventory policy class, so the reviewed baseline remains `pq_required: 121`,
+`pq_backlog: 0`, `legacy_only: 14`, and `dual_profile: 141`.
 
 The current asset boundary is recorded in
 [PREVIOUS_RELEASE_ASSET_BOUNDARY.md](PREVIOUS_RELEASE_ASSET_BOUNDARY.md). The
@@ -63,9 +70,9 @@ tracked suites now have an explicit policy class and none remains in
 Preferred next owned tranche:
 
 1. Hold the reviewed post-promotion baseline
-   - Why next: the selected configuration-namespace gap is closed, all `276`
-     tracked functional suites retain explicit policy classes, and
-     `pq_backlog` remains empty.
+   - Why next: the selected configuration-namespace gap and its platform
+     default-datadir follow-up are closed, all `276` tracked functional suites
+     retain explicit policy classes, and `pq_backlog` remains empty.
    - `tool_bitcoin.py` remains deferred; its low runtime does not replace the
      missing dedicated issue and cross-platform/optional-IPC boundary.
    - `rpc_blockchain.py` remains rejected because its replacement-deployment
@@ -89,6 +96,7 @@ Future selection boundary:
    - `dual_profile`: 141
    - selection evidence: PR `#166` and
      [TRACK_A_RISK_REVIEW.md](TRACK_A_RISK_REVIEW.md)
+   - follow-up hardening: issue `#170`, with no inventory policy-class change
    - owned contract:
      [FEATURE_CONFIG_ARGS_POSTURE.md](FEATURE_CONFIG_ARGS_POSTURE.md)
 2. `HOLD`: do not infer another promotion from queue order. Require a fresh
@@ -2499,7 +2507,8 @@ above as the controlling live next-PR handoff when these older notes disagree.
 ## Blockers
 
 - There is no active inventory blocker. The selected configuration-namespace
-  gap is promoted and no suites remain in `pq_backlog`.
+  gap is promoted, its platform default-datadir namespace is asserted, and no
+  suites remain in `pq_backlog`.
 - A further promotion requires a newly reviewed PQ confidence gap with a named
   owner, open tracking issue, bounded contract, targeted test, and acceptable
   CI cost. Until another selection exists, `HOLD` is the intended baseline

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -180,9 +180,31 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(inc_conf_file2_path, 'w', encoding='utf-8') as conf:
             conf.write('')  # clear
 
+    def test_default_datadir_namespace(self):
+        self.log.info("Test that the platform default data directory uses the PQBTC namespace")
+
+        if platform.system() == "Windows":
+            legacy_datadir = Path(os.environ["APPDATA"]) / "PQBTC"
+            expected_datadir = (
+                legacy_datadir
+                if legacy_datadir.exists()
+                else Path(os.environ["LOCALAPPDATA"]) / "PQBTC"
+            )
+        else:
+            home = Path(os.environ.get("HOME") or "/")
+            expected_datadir = home / (
+                "Library/Application Support/PQBTC"
+                if platform.system() == "Darwin"
+                else ".pqbtc"
+            )
+
+        with self.nodes[0].assert_debug_log(expected_msgs=[f"Default data directory {expected_datadir}"]):
+            self.start_node(0)
+        self.stop_node(0)
+
     def test_config_file_log(self):
-        # Disable this test for windows currently because trying to override
-        # the default datadir through the environment does not seem to work.
+        # SHGetSpecialFolderPathW does not honor the synthetic APPDATA and
+        # LOCALAPPDATA child environment used by get_temp_default_datadir().
         if platform.system() == "Windows":
             return
 
@@ -429,8 +451,8 @@ class ConfArgsTest(BitcoinTestFramework):
         self.stop_node(0)
 
     def test_ignored_default_conf(self):
-        # Disable this test for windows currently because trying to override
-        # the default datadir through the environment does not seem to work.
+        # SHGetSpecialFolderPathW does not honor the synthetic APPDATA and
+        # LOCALAPPDATA child environment used by get_temp_default_datadir().
         if platform.system() == "Windows":
             return
 
@@ -491,6 +513,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.nodes[0].replace_in_config([('testnet4=', 'regtest='), ('[testnet4]', '[regtest]')])
 
     def run_test(self):
+        self.test_default_datadir_namespace()
         self.test_log_buffer()
         self.test_args_log()
         self.test_seed_peers()


### PR DESCRIPTION
## Summary

- assert the startup-reported PQBTC default data-directory path on Linux, macOS, and Windows
- retain and explain the Windows synthetic shell-folder override boundary
- update the configuration posture and Track A risk/status handoffs without changing inventory classes

## Validation

- `git diff --check`
- `python3 ci/test/check_ci_inventory.py`
- `build/test/functional/test_runner.py --jobs=1 feature_config_args.py` (passed, 15 s)

Closes #170