### PR TITLE
security: hold nonconformant PQSig rc2 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,36 @@ A Bitcoin Core fork with post-quantum signatures from genesis.
 
 ## Overview
 
-This project implements a Bitcoin-like UTXO chain using hash-based post-quantum signatures (WOTS+C / PORS+FP in the SPHINCS framework) instead of ECDSA/Schnorr.
+This project is a Bitcoin Core-derived research chain for evaluating
+post-quantum transaction signatures and their wallet, policy, and consensus
+integration.
 
 ### Key Properties
 
 | Property | Value |
 |----------|-------|
-| Signature scheme | PQSig v0 (WOTS+C + PORS+FP) |
+| Implemented research profile | PQSig rc2 (`ALG_ID=0x01`) |
 | Signature size | 4,480 bytes |
 | Public key size | 33 bytes (1-byte ALG_ID + 32-byte core) |
-| Max signatures/key | 2^40 |
-| Security level | NIST Level 1 (~128-bit classical) |
+| Production approval | None - release hold |
+| Claimed security/budget | Not established for the rc2 implementation |
 | Block weight | 16,000,000 WU |
 | PoW | SHA-256d (unchanged from Bitcoin) |
 
 ## Documentation
 
 - [Protocol Specification](docs/Spec.md) - Normative spec with MUST/SHOULD language
+- [Signature Production Readiness](docs/PQSIG_PRODUCTION_READINESS.md) - Controlling cryptographic evidence, release hold, and replacement gates
 - [Core Diff Plan](docs/CORE_DIFF_PLAN.md) - Bitcoin Core fork implementation phases
 
 ## Status
 
-**Active implementation** - frozen PQ-only consensus, descriptor-native PQ
-wallet flows, and PQ PSBT handling are in-tree. Current work is focused on CI
-completeness, Taproot replacement migration coverage, and operational
-hardening.
+**Research only - production release hold.** The implemented rc2 signature path
+does not conform to security-critical WOTS+C/PORS+FP invariants claimed by the
+draft specification. Do not use it to secure real funds or describe it as
+production quantum-resistant cryptography. Existing consensus, wallet, PSBT,
+and CI coverage remains useful integration evidence while a final-standard
+candidate is implemented and independently reviewed.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,20 @@
 
 ## Supported Versions
 
-See our website for versions of Bitcoin Core that are currently supported with
-security updates: https://bitcoincore.org/en/lifecycle/#schedule
+No PQBTC version is supported for production use. The implemented rc2
+signature profile is under an explicit cryptographic release hold; do not use
+it to secure real funds. See
+[`docs/PQSIG_PRODUCTION_READINESS.md`](docs/PQSIG_PRODUCTION_READINESS.md).
+
+The inherited Bitcoin Core lifecycle does not make this fork a supported
+Bitcoin Core release.
 
 ## Reporting a Vulnerability
 
-To report security issues send an email to security@bitcoincore.org (not for support).
+Use this repository's private GitHub security-advisory channel for sensitive
+PQBTC findings. Do not send fork-specific findings to the Bitcoin Core security
+contacts below. Those contacts apply only when a finding also affects upstream
+Bitcoin Core.
 
 The following keys may be used to communicate sensitive information to developers:
 

--- a/ci/test/test_pqsig_release_hold.py
+++ b/ci/test/test_pqsig_release_hold.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AUDIT_PATH = REPO_ROOT / "contrib" / "pqsig-ref" / "audit_rc2_conformance.py"
+
+
+class PQSigReleaseHoldTests(unittest.TestCase):
+    def run_audit(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(AUDIT_PATH), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def test_conformance_mode_fails_closed(self):
+        result = self.run_audit()
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("release_status=HOLD", result.stdout)
+
+    def test_checked_in_release_hold_evidence_reproduces(self):
+        result = self.run_audit("--expect-release-hold")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("WOTS+C fixed-sum encoding: NONCONFORMANT", result.stdout)
+        self.assertIn("PORS+FP distinct-index enforcement: NONCONFORMANT", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/pqsig-ref/README.md
+++ b/contrib/pqsig-ref/README.md
@@ -1,21 +1,28 @@
 # PQSig rc2 Reference Helpers
 
-This directory contains a deterministic reference model for the locked PQSig rc2
-wire/profile implementation used on the `v1.0.0-rc2` track:
+This directory contains a deterministic model of the held PQSig rc2
+wire/profile implementation:
 
 - fixed 33-byte `PK_script` (`ALG_ID || PK_seed || PK_root`)
 - fixed 4480-byte signature layout
 - deterministic exact-root signing and verification for the structured
   WOTS+C/PORS+FP/hypertree fields
 
+This model mirrors the implementation and is not an independent cryptographic
+reference. It must not be used as evidence that rc2 conforms to the cited
+WOTS+C/PORS+FP construction or is safe for production.
+
 ## Files
 
 - `pqsig_ref.py`: pure-Python sign/verify/key-derivation helper.
 - `gen_kat.py`: emits frozen KAT fixtures to
   `src/test/data/pqsig/kat_v1.json`.
+- `audit_rc2_conformance.py`: reproduces the known fixed-sum and distinct-index
+  conformance failures that keep rc2 under a release hold.
 
 ## Usage
 
 ```bash
 python3 contrib/pqsig-ref/gen_kat.py
+python3 contrib/pqsig-ref/audit_rc2_conformance.py --expect-release-hold
 ```

--- a/contrib/pqsig-ref/audit_rc2_conformance.py
+++ b/contrib/pqsig-ref/audit_rc2_conformance.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Reproduce known PQSig rc2 construction-level conformance failures.
+
+This is a primitive-level audit. It does not claim a complete transaction
+forgery. By default, detected nonconformance produces a failing exit status.
+Use --expect-release-hold only when validating the checked-in hold evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+import pqsig_ref as ref
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    name: str
+    nonconformant: bool
+    detail: str
+
+
+def _digit_sum(message: bytes) -> int:
+    return sum(ref._message_nibble(message, i) for i in range(ref.L))
+
+
+def audit_wots_fixed_sum() -> AuditResult:
+    """Show that unrestricted WOTS digits retain the chain-extension attack."""
+    sk_seed = bytes(range(32))
+    pk_seed = ref.derive_pk_seed(sk_seed)
+    layer = 0
+    leaf_index = 0
+    low_message = bytes(ref.N)
+    high_message = bytes([0xFF]) * ref.N
+
+    low_signature = ref._fill_wots_sig(sk_seed, pk_seed, low_message, layer, leaf_index)
+    advanced_signature = bytearray(len(low_signature))
+
+    for chunk_index in range(ref.L):
+        low_digit = ref._message_nibble(low_message, chunk_index)
+        high_digit = ref._message_nibble(high_message, chunk_index)
+        chunk_start = chunk_index * ref.N
+        chunk = low_signature[chunk_start : chunk_start + ref.N]
+        advanced = ref._advance_chain(
+            chunk,
+            pk_seed,
+            layer,
+            leaf_index,
+            chunk_index,
+            low_digit,
+            high_digit - low_digit,
+        )
+        advanced_signature[chunk_start : chunk_start + ref.N] = advanced
+
+    low_public = ref._reconstruct_wots_public_chunks(
+        low_signature, low_message, pk_seed, layer, leaf_index
+    )
+    high_public = ref._reconstruct_wots_public_chunks(
+        bytes(advanced_signature), high_message, pk_seed, layer, leaf_index
+    )
+    low_sum = _digit_sum(low_message)
+    high_sum = _digit_sum(high_message)
+    nonconformant = (
+        low_public == high_public
+        and low_sum != ref.SWN
+        and high_sum != ref.SWN
+    )
+
+    return AuditResult(
+        name="WOTS+C fixed-sum encoding",
+        nonconformant=nonconformant,
+        detail=(
+            f"same_public_key={low_public == high_public} "
+            f"digit_sums={low_sum},{high_sum} required_sum={ref.SWN}"
+        ),
+    )
+
+
+def audit_pors_distinct_indices() -> AuditResult:
+    """Show that the rc2 index extractor does not enforce distinct indices."""
+    indices = ref._derive_pors_indices(bytes(64))
+    unique_count = len(set(indices))
+    return AuditResult(
+        name="PORS+FP distinct-index enforcement",
+        nonconformant=unique_count != ref.K,
+        detail=f"indices={indices} unique={unique_count} required={ref.K}",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expect-release-hold",
+        action="store_true",
+        help="exit successfully only when all checked hold findings reproduce",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    results = [audit_wots_fixed_sum(), audit_pors_distinct_indices()]
+    for result in results:
+        status = "NONCONFORMANT" if result.nonconformant else "NOT_REPRODUCED"
+        print(f"{result.name}: {status}")
+        print(f"  {result.detail}")
+
+    hold_reproduced = all(result.nonconformant for result in results)
+    print(f"release_status={'HOLD' if hold_reproduced else 'REASSESS'}")
+
+    if args.expect_release_hold:
+        return 0 if hold_reproduced else 1
+    return 1 if hold_reproduced else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ALG_ID_REGISTRY.md
+++ b/docs/ALG_ID_REGISTRY.md
@@ -20,7 +20,7 @@ Define the assigned script-layer `ALG_ID` values, their lifecycle states, and th
 | ALG_ID | Profile | State | Owning Specs | Activation Notes |
 | --- | --- | --- | --- | --- |
 | `0x00` | none | `RESERVED_INVALID` | none | Permanent invalid sentinel; MUST fail. |
-| `0x01` | `rc2` | `ACTIVE` | `PQSIG_WIRE_FORMAT.md`, `PQSIG_INTERNALS.md`, `Spec.md` | Current GA PQSig profile. |
+| `0x01` | `rc2` | `ACTIVE` | `PQSIG_WIRE_FORMAT.md`, `PQSIG_INTERNALS.md`, `Spec.md` | Parser-active research profile; production release held by `PQSIG_PRODUCTION_READINESS.md`. |
 | `0x02` | `future-0x02` | `ALLOCATED_FUTURE` | `PQSIG_0X02_WIRE_FORMAT.md`, `PQSIG_0X02_INTERNALS.md` | Allocated for fixture and harness work only; still invalid in current releases. |
 | `0x03-0xff` | none | `UNALLOCATED` | none | Invalid until a future allocation freezes the profile and activates it later. |
 

--- a/docs/GA_ACCEPTANCE_CHECKLIST.md
+++ b/docs/GA_ACCEPTANCE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # PQBTC v1.0.0 GA Acceptance Checklist
 
-## Status: TRACKED
+## Status: RELEASE_HOLD
 ## Spec-ID: GA-CHECKLIST-v1.0.0
 ## Frozen-By: ga-governance-20260223
 ## Consensus-Relevant: NO
@@ -9,10 +9,23 @@
 
 Define hard, evidence-backed release gates for promoting from `v1.0.0-rc1` to `v1.0.0`.
 
-## Release Posture Update (2026-03-06)
+## Cryptographic Release Hold (2026-07-18)
+
+The March 2026 GA decision below is retained as historical evidence and is
+superseded for all future release activity.
+
+1. No rc2 tag, binary, or network is approved to secure real value.
+2. Existing regression, burn-in, and integration checks do not establish the
+   claimed WOTS+C/PORS+FP security properties.
+3. `PQSIG_PRODUCTION_READINESS.md` is the controlling cryptographic decision.
+4. GA cannot return to `PRECHECK` until a replacement candidate satisfies that
+   record's standards-conformance, independent-test, system-integration, and
+   external-review gates.
+
+## Historical Release Posture Update (2026-03-06)
 
 1. `v1.0.0` GA on the original `ALG_ID=0x00` profile is held.
-2. The active mitigation path is `v1.0.0-rc2`.
+2. The active mitigation path at that time was `v1.0.0-rc2`.
 3. rc2 retires `ALG_ID=0x00`, introduces `ALG_ID=0x01`, and resets burn-in because the controlled verify path changed.
 
 ## Scope Rebaseline (Safety-Only GA)
@@ -96,6 +109,8 @@ Rules:
    - proceed via `v1.0.0-rc2` path until all blockers are resolved and PRECHECK is rerun
 
 ## Decision Record
+
+Historical record; superseded by the 2026-07-18 cryptographic release hold.
 
 - Decision date (UTC): 2026-03-09
 - Approver: Scott Hughes

--- a/docs/GA_BURNIN_LOG.md
+++ b/docs/GA_BURNIN_LOG.md
@@ -1,9 +1,13 @@
 # PQBTC v1 RC Burn-in Log
 
-## Status: TRACKED
+## Status: HISTORICAL - RELEASE HOLD
 ## Spec-ID: GA-BURNIN-LOG-v1
 ## Frozen-By: ga-governance-20260223
 ## Consensus-Relevant: NO
+
+> **Superseded:** Passing burn-in evidence below does not establish
+> cryptographic conformance. Current release posture is controlled by
+> `PQSIG_PRODUCTION_READINESS.md`.
 
 ## Window
 
@@ -21,7 +25,7 @@ into the post-v1 operator bundle defined by `docs/OPS_SLO.md`. Checked-in operat
 ## RC2 Reset (2026-03-06)
 
 1. `v1.0.0` GA on the original `ALG_ID=0x00` profile is held.
-2. The active release path is now `v1.0.0-rc2`.
+2. The active release path at that time became `v1.0.0-rc2`.
 3. The controlled verify path changed on `2026-03-06`:
    - `src/crypto/pqsig/pqsig.cpp`
    - `src/crypto/pqsig/pqsig.h`

--- a/docs/PQSIG_INTERNALS.md
+++ b/docs/PQSIG_INTERNALS.md
@@ -1,12 +1,24 @@
 # PQSig Internals
 
-## Status: FROZEN
+## Status: FROZEN IMPLEMENTATION - RELEASE HOLD
 ## Spec-ID: PQSIG-INTERNALS-rc2
 ## Frozen-By: issue-48-rc2-reprofile-20260306
 ## Consensus-Relevant: YES
 
 ## Scope
-Consensus-locked internal parameterization for the PQSig rc2 profile in PQBTC.
+Consensus-locked internal behavior for the PQSig rc2 research profile in
+PQBTC. "Frozen" describes compatibility with the currently implemented parser
+and verifier; it does not mean the construction is cryptographically validated
+or approved for production. The controlling decision is
+`PQSIG_PRODUCTION_READINESS.md`.
+
+## Conformance Warning
+
+The behavior below diverges from security-critical rules of the cited WOTS+C
+and PORS+FP construction. In particular, rc2 does not enforce the WOTS+C fixed
+digit sum, does not grind for distinct PORS indices or a bounded authentication
+set, and does not implement the cited hypertree addressing model. The claimed
+`q_s=2^40` and security level therefore do not follow from these constants.
 
 ## Fixed Parameter Set
 - `q_s = 2^40`
@@ -37,7 +49,7 @@ Consensus-locked internal parameterization for the PQSig rc2 profile in PQBTC.
 - Hypertree auth paths bind those leaf public keys to an exact Merkle root.
 - Verification succeeds only when the reconstructed final layer root matches `PK.root` byte-for-byte.
 
-## Safety Properties
+## Parser And Encoding Properties
 - Parser treats signature and key inputs as hostile.
 - Parameter values are immutable consensus constants.
 - `ALG_ID` classification and parser/version-handling rules are defined in `ALG_ID_PARSER_COMPAT.md`; assigned values and lifecycle state are governed by `ALG_ID_REGISTRY.md`.

--- a/docs/PQSIG_PRODUCTION_READINESS.md
+++ b/docs/PQSIG_PRODUCTION_READINESS.md
@@ -1,0 +1,141 @@
+# PQBTC Signature Production Readiness
+
+## Status: RELEASE_HOLD
+## Spec-ID: PQSIG-PRODUCTION-READINESS-v1
+## Decided: 2026-07-18
+## Consensus-Relevant: NO
+
+## Decision
+
+PQBTC has no signature profile approved for production use. Do not release a
+network that carries real value, represent `PQSig rc2` as cryptographically
+conformant, or rely on its claimed `2^40` signing bound or NIST Level 1 security.
+
+The implemented `ALG_ID=0x01` path remains available only as a research and
+Bitcoin-integration fixture while a standards-conformant replacement is built
+and reviewed. This decision changes release posture, not the current consensus
+accepted set.
+
+## Evidence Classification
+
+### Observed In The Repository
+
+1. `src/crypto/pqsig/wotsc.h` signs the 32 raw base-16 message digits. It does
+   not encode or enforce the WOTS+C fixed digit sum `S_{w,n}=240`.
+2. `src/crypto/pqsig/pqsig.cpp` computes one deterministic `R` and one `Hmsg`.
+   The `max_counter` argument is range-checked, but signing performs no search.
+3. `src/crypto/pqsig/porsfp.h` extracts eight indices directly and does not
+   enforce that they are distinct.
+4. `src/crypto/pqsig/octopus.h` fills and folds 97 signer-chosen hash chunks. It
+   does not reconstruct the authentication-node set of the cited PORS+FP
+   construction.
+5. `src/crypto/pqsig/hypertree.h` identifies a leaf by layer and 11-bit leaf
+   index, without the per-tree address needed to realize a height-44 hypertree
+   as many selected subtrees.
+6. `contrib/pqsig-ref/pqsig_ref.py` mirrors those implementation choices. Its
+   vectors therefore check implementation stability, not conformance to an
+   independent construction or standard.
+
+Run the primitive-level reproducer with:
+
+```bash
+python3 contrib/pqsig-ref/audit_rc2_conformance.py --expect-release-hold
+build/bin/test_pqbtc --run_test=pqsig_tests/pqsig_rc2_release_hold_conformance_evidence
+```
+
+The Python audit and C++ unit test both start from a WOTS signature over
+all-zero digits, advance each chain to all-15 digits, and reconstruct the same
+WOTS public key. The two digit sums are 0 and 480 rather than the required 240.
+This is a construction-level counterexample, not a claim that either test
+produces a complete transaction forgery.
+
+The PORS check shows that the index extractor can return repeated indices and
+has no distinctness enforcement. The no-search signer and non-Merkle auth-pad
+observations remain source-backed findings that require replacement rather
+than a local patch.
+
+### External Standards And Research
+
+- NIST FIPS 204 standardizes ML-DSA:
+  https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf
+- NIST FIPS 205 standardizes SLH-DSA:
+  https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf
+- NIST SP 800-230 is an initial public draft, not a final standard. Its
+  Bitcoin-oriented `SLH-DSA-*-128-24` profiles have a strict `2^24`
+  signatures-per-key limit and are not approved for general-purpose use:
+  https://csrc.nist.gov/pubs/sp/800/230/ipd
+- Kudinov and Nick's Bitcoin-specific hash-signature work is a 2025 preprint,
+  not a NIST standard:
+  https://eprint.iacr.org/2025/2203
+
+Reference encoded sizes from the final standards:
+
+| Profile | Public key | Signature | Status |
+| --- | ---: | ---: | --- |
+| ML-DSA-44 | 1,312 bytes | 2,420 bytes | FIPS 204 final |
+| ML-DSA-65 | 1,952 bytes | 3,309 bytes | FIPS 204 final |
+| SLH-DSA-SHA2-128s | 32 bytes | 7,856 bytes | FIPS 205 final |
+| SLH-DSA-SHAKE-128s | 32 bytes | 7,856 bytes | FIPS 205 final |
+| SLH-DSA-SHA2-128-24 | 32 bytes | 3,856 bytes | SP 800-230 draft |
+
+### Engineering Inference
+
+The rc2 security claims do not follow from matching a parameter-table row or
+signature size. The omitted fixed-sum encoding, grinding rules,
+authentication-set construction, and hypertree addressing are security
+invariants, not optional serialization details. Incrementally repairing rc2
+would amount to implementing and reviewing a new consensus algorithm.
+
+FIPS 205 is the conservative first implementation target because it is final,
+stateless, hash-based, and has compact public keys. Its 7,856-byte signatures
+increase block-space and bandwidth cost relative to rc2. FIPS 204 is a useful
+standardized efficiency comparator, but it adds structured-lattice assumptions
+and much larger public keys. Neither profile is selected for activation by this
+record.
+
+## Implementation Direction
+
+1. Implement an isolated `SLH-DSA-SHA2-128s` prototype against the exact FIPS
+   205 API, encodings, context rules, and test vectors. Do not assign an active
+   `ALG_ID` or connect it to Script yet.
+2. Implement or bind an isolated `ML-DSA-44` comparator for size, signing,
+   verification, wallet, and block-economics measurements.
+3. Use OpenSSL 3.5 or later only as a prototype and differential-test oracle.
+   Do not introduce a host OpenSSL dependency into consensus verification.
+4. Obtain a second independent implementation or vector source for every
+   candidate. A repo-local signer and repo-local verifier are not independent
+   evidence.
+5. Monitor SP 800-230, but do not activate a draft profile. Reassess only after
+   a final publication and an explicit one-key-per-output usage-limit design.
+6. Retire rc2 or replace it with a ground-up, exact construction. Do not patch
+   isolated symptoms while retaining the current security claims.
+
+## Required Gates Before Consensus Integration
+
+A candidate may enter a separate consensus-integration proposal only after all
+of these are satisfied:
+
+1. exact final standard, parameter set, security category, and usage limits
+2. frozen canonical public-key, signature, context, and sighash encodings
+3. strict parser with no alternate encodings or silent profile negotiation
+4. official known-answer tests plus differential tests against an independent
+   implementation
+5. malformed-input, mutation, fuzz, sanitizer, and resource-exhaustion coverage
+6. constant-time and secret-erasure review for key generation and signing
+7. reproducible benchmarks on supported architectures, including worst-case
+   verification and block-validation cost
+8. wallet, descriptor, PSBT, backup, hardware-signer, fee, mempool, reorg, and
+   reindex contracts
+9. a deployment and algorithm-agility plan that cannot reinterpret existing
+   outputs
+10. independent cryptographic review and consensus-code audit
+11. public testnet soak with no real-value representation
+12. a new, explicit production go/no-go record that removes this hold
+
+## Hold Exit Criteria
+
+Green CI for the existing rc2 implementation is necessary regression evidence,
+but it cannot lift this hold. The hold exits only after one candidate passes all
+gates above and a separate change updates the protocol spec, algorithm registry,
+release checklist, and user-facing warnings. Until then, Track A remains on
+`HOLD` for production activation.

--- a/docs/PQSIG_PROFILE_COMPARISON.md
+++ b/docs/PQSIG_PROFILE_COMPARISON.md
@@ -1,22 +1,32 @@
 # PQBTC Signature-Profile Comparison Memo
 
-## Status: ACTIVE
+## Status: SUPERSEDED - RELEASE HOLD
 ## Spec-ID: PQSIG-PROFILE-COMPARISON-v1
 ## Started: 2026-04-13
 ## Consensus-Relevant: NO
 
+## Supersession Notice
+
+The 2026-04-13 launch recommendation in this memo is withdrawn. Repository
+conformance review found that the implemented rc2 path does not satisfy
+security-critical invariants of the construction it claims. The controlling
+decision and current candidate plan are in
+`PQSIG_PRODUCTION_READINESS.md`. Historical execution-maturity observations
+below do not establish cryptographic security.
+
 ## Purpose
 
-Compare the current active `PQSig rc2` profile against one concrete
-SHRINCS-family candidate and one compact-signature follow-on candidate, so the
-repo can make a disciplined launch decision instead of chasing whichever idea
-looks newest.
+Record the historical comparison of the implemented `PQSig rc2` profile
+against one concrete SHRINCS-family candidate and one compact-signature
+follow-on candidate, so the repo can make a disciplined launch decision instead
+of chasing whichever idea looks newest.
 
 This is a decision memo, not an activation spec.
 
 ## Scope And Evidence Level
 
-- `PQSig rc2` facts below are repo-backed current-state facts.
+- `PQSig rc2` size and integration facts below are repo-backed current-state
+  facts; its construction and security claims are not validated.
 - SHRINCS and SHRIMPS facts below are limited to what the repo's research corpus
   currently asserts directly:
   - `SHRINCS: 324-byte stateful post-quantum signatures with static backups`
@@ -26,14 +36,15 @@ This is a decision memo, not an activation spec.
 
 ## Compared Profiles
 
-### 1. Current Active Profile: `PQSig rc2`
+### 1. Implemented Held Profile: `PQSig rc2`
 
-- Status: implemented and active in PQBTC.
-- Construction: stateless SPHINCS-family profile using `WOTS+C` + `PORS+FP` +
-  hypertree.
+- Status: implemented for research and regression testing; production held.
+- Claimed construction: stateless SPHINCS-family profile using `WOTS+C` +
+  `PORS+FP` + hypertree. The implementation is nonconformant with critical
+  rules of that construction.
 - Signature size: `4480` bytes.
 - Public-key script size: `33` bytes.
-- `q_s`: `2^40`.
+- Claimed `q_s`: `2^40`; not established for the implementation.
 - Current repo posture: consensus, wallet managers, PSBT path, mempool,
   reorg, and tranche-level CI ownership already exist around this profile.
 
@@ -63,25 +74,26 @@ This is a decision memo, not an activation spec.
 
 | Dimension | `PQSig rc2` | SHRINCS-style candidate | SHRIMPS-style candidate |
 | --- | --- | --- | --- |
-| Current repo status | Active | Research only | Research only |
+| Current repo status | Implemented; held | Research only | Research only |
 | Signature size | `4480` bytes | `324` bytes | `2.5 KB` |
 | State model | Stateless | Stateful | Stateful / coordinated multi-device |
 | Wallet / PSBT integration in repo | Real | None | None |
 | Consensus integration in repo | Real | None | None |
 | Operator recovery simplicity | Higher | Lower | Medium at best |
-| Launch readiness | High | Low | Low |
+| Launch readiness | Blocked | Not evaluated | Not evaluated |
 | Migration cost from today | None | Very high | Very high |
 | Potential bandwidth / block-space upside | Baseline | Very high | Moderate to high |
-| Best role right now | Ship baseline | Evaluate as possible pre-launch pivot | Evaluate as later compact-signature follow-on |
+| Best role right now | Regression/integration fixture | Historical research input | Historical research input |
 
 ## What The Comparison Means
 
-### `PQSig rc2` Wins On Execution Maturity
+### `PQSig rc2` Has Execution Maturity, Not Security Evidence
 
 `PQSig rc2` is the only profile here with real consensus-critical parsing,
 signing, verification, wallet flow, PSBT flow, and tranche-level CI ownership
 inside the repo. That matters more than signature-size aesthetics while the
-project is still freezing launch-facing behavior.
+project is freezing launch-facing behavior. That integration maturity cannot
+compensate for a nonconformant signature construction.
 
 ### SHRINCS Wins On Compactness, But Reopens The Hardest Product Questions
 
@@ -105,39 +117,41 @@ later design lane than as the next thing to jam into the current launch path.
 
 ## Decision Criteria
 
-Any pre-launch pivot away from `PQSig rc2` should require all of the following:
+Any replacement for `PQSig rc2` requires all of the following:
 
 1. materially better system economics, not just a nicer signature-size number
 2. a wallet/recovery model that is safe for ordinary operators
 3. a credible C++ implementation and KAT/vector story
 4. a clear `ALG_ID` and wire-format plan
 5. a bounded migration cost that does not erase current Track A progress
-6. evidence that the new profile improves the launch story more than it delays
-   the launch
+6. independent cryptographic review and consensus-code audit
 
-If those conditions are not met, the smaller-signature candidate should remain a
-parallel research track rather than become the new active profile.
+If those conditions are not met, no profile should be activated.
 
 ## Recommendation
 
 ### Launch Recommendation Today
 
-Stay on `PQSig rc2` as the launch baseline.
+Hold production activation. `PQSig rc2` is not a launch baseline.
 
 Reason:
 
-- it is real, integrated, and testable now
-- the repo is still freezing wallet and migration boundaries
-- swapping profiles now would combine unfinished Bitcoin-integration work with
-  unfinished algorithm-selection work
+- its WOTS path does not enforce the fixed digit-sum invariant
+- its PORS path does not implement distinct-index grinding or the cited
+  authentication-set construction
+- its hypertree implementation does not establish the claimed signing budget
+- repo-local KATs compare two implementations of the same behavior rather than
+  an independent standard or construction
 
 ### Parallel Research Recommendation
 
-Rank the parallel evaluation lanes this way:
+Rank the replacement evaluation lanes this way:
 
-1. SHRINCS-style candidate as the main pre-launch comparison target
-2. SHRIMPS-style candidate as a compact-signature follow-on research lane
-3. broader algorithm-agility work only after the first two are made concrete
+1. FIPS 205 `SLH-DSA-SHA2-128s` as the conservative, hash-based reference
+   prototype
+2. FIPS 204 `ML-DSA-44` as the standardized efficiency comparator
+3. NIST SP 800-230 profiles only after the draft becomes final and their strict
+   usage limits are designed into wallet behavior
 
 ### Practical Interpretation
 
@@ -150,18 +164,15 @@ The right question is:
 - "Which profile gives PQBTC the best chance of launching as a coherent,
   operable block-0 chain?"
 
-Today, that answer is still `PQSig rc2`.
+Today, no profile has production approval.
 
 ## Next Actions
 
-1. Keep current Track A tranche work anchored to `PQSig rc2`.
-2. Build a narrower adoption memo for one concrete SHRINCS-style candidate:
-   - exact parameter set
-   - implementation path
-   - wallet/recovery consequences
-   - expected `ALG_ID` plan
-3. Revisit the pivot question only after that memo can answer the operator story
-   as clearly as it answers the cryptography story.
+1. Keep rc2 only as a held integration fixture.
+2. Build the isolated standards-conformance prototypes defined in
+   `PQSIG_PRODUCTION_READINESS.md`.
+3. Revisit consensus integration only after independent vectors, differential
+   testing, performance evidence, wallet analysis, and external review exist.
 
 ## Non-Goals
 

--- a/docs/PSBT_REPLACEMENT_TRANCHE.md
+++ b/docs/PSBT_REPLACEMENT_TRANCHE.md
@@ -97,7 +97,7 @@ The current tranche treats the following as the owned PQBTC contract:
 
 - identifier `pqbtc`
 - subtype `1`
-- binary value carrying the fixed-size PQ signature for the active profile
+- binary value carrying the fixed-size PQ signature for the implemented profile
 - key material bound to the active `pk_script`
 
 This is the current PQ-native bridge between wallet signing and PSBT

--- a/docs/RC_SIGNOFF_V1_RC1.md
+++ b/docs/RC_SIGNOFF_V1_RC1.md
@@ -1,9 +1,12 @@
 # PQBTC v1.0.0-rc1 Sign-off Evidence
 
-## Status: FROZEN
+## Status: FROZEN HISTORICAL - RELEASE HOLD
 ## Spec-ID: RC-SIGNOFF-v1.0.0-rc1
 ## Frozen-By: rc-stack-20260223
 ## Consensus-Relevant: NO
+
+> **Superseded:** This is immutable historical integration evidence, not a
+> current production sign-off. See `PQSIG_PRODUCTION_READINESS.md`.
 
 ## Scope
 This document captures immutable pre-tag evidence for `v1.0.0-rc1` from the

--- a/docs/README_PQBTC.md
+++ b/docs/README_PQBTC.md
@@ -4,28 +4,31 @@ A Bitcoin Core fork with post-quantum signatures from genesis.
 
 ## Overview
 
-This project implements a Bitcoin-like UTXO chain using hash-based post-quantum signatures (WOTS+C / PORS+FP in the SPHINCS framework) instead of ECDSA/Schnorr.
+This project is a Bitcoin Core-derived research chain for evaluating
+post-quantum transaction signatures and their wallet, policy, and consensus
+integration.
 
 ### Key Properties
 
 | Property | Value |
 |----------|-------|
-| Signature scheme | PQSig rc2 (WOTS+C + PORS+FP) |
+| Implemented research profile | PQSig rc2 (`ALG_ID=0x01`) |
 | Signature size | 4,480 bytes |
 | Public key size | 33 bytes (1-byte ALG_ID + 32-byte core) |
-| Max signatures/key | 2^40 |
-| Security level | NIST Level 1 (~128-bit classical) |
+| Production approval | None - release hold |
+| Claimed security/budget | Not established for the rc2 implementation |
 | Block weight | 16,000,000 WU |
 | PoW | SHA-256d (unchanged from Bitcoin) |
 
 ## Documentation
 
 - [Protocol Specification](Spec.md) - Normative spec with MUST/SHOULD language
+- [Signature Production Readiness](PQSIG_PRODUCTION_READINESS.md) - Controlling cryptographic evidence, release hold, and replacement gates
 - [Core Diff Plan](CORE_DIFF_PLAN.md) - Bitcoin Core fork implementation phases
 - [Track A: Native PQ Bitcoin](TRACK_A_NATIVE_PQ_BITCOIN.md) - Strategic anchor, scope, non-goals, and how adjacent approaches fit
 - [Track A 90-Day Roadmap](TRACK_A_90_DAY_ROADMAP.md) - Concrete execution plan for April 6, 2026 through July 5, 2026
 - [SHRINCS Decision Track](SHRINCS_DECISION_TRACK.md) - Controlled evaluation lane for SHRINCS-family adoption without destabilizing active Track A work
-- [Signature Profile Comparison Memo](PQSIG_PROFILE_COMPARISON.md) - Decision memo comparing active `PQSig rc2` against SHRINCS-style and SHRIMPS-style candidates
+- [Signature Profile Comparison Memo](PQSIG_PROFILE_COMPARISON.md) - Historical comparison memo, superseded by the production-readiness hold
 - [Genesis And Network Posture](GENESIS_AND_NETWORK_POSTURE.md) - Launch interpretation for a fresh block-0 chain, network identity, and non-goals around inherited Bitcoin history
 - [Research Index](RESEARCH_INDEX.md) - Curated map of the repo's internal research corpus and key external references
 - [Watch-Only `pq(...)` Contract](PQ_DESCRIPTOR_WATCHONLY_CONTRACT.md) - Fixed public PQ descriptor boundaries, import behavior, and test-backed expectations
@@ -35,14 +38,15 @@ This project implements a Bitcoin-like UTXO chain using hash-based post-quantum 
 
 ## Status
 
-**`v1.0.0` held; `v1.0.0-rc2` active** - the project is on the rc2 mitigation
-track after retiring the old `ALG_ID=0x00` profile before GA.
+**Research only - production release hold.** The implemented rc2 signature path
+does not conform to security-critical WOTS+C/PORS+FP invariants claimed by the
+draft specification. Do not use it to secure real funds or describe it as
+production quantum-resistant cryptography.
 
-The repo already includes frozen PQ-only consensus, descriptor-native PQ wallet
-managers, PQ PSBT signing/finalization support, and deterministic wallet
-backup/recovery coverage. Current work is focused on confidence/gating
-completeness, Taproot replacement migration coverage, and operational
-hardening rather than first-pass wallet implementation.
+The repo's consensus, wallet, PSBT, backup/recovery, and CI work remains useful
+integration evidence. It does not establish cryptographic security. The next
+cryptography work is an isolated final-standard prototype and independent
+conformance evaluation, not an rc2 release.
 
 ## RC Documentation
 

--- a/docs/RELEASE_V1_RC1.md
+++ b/docs/RELEASE_V1_RC1.md
@@ -1,21 +1,25 @@
 # PQBTC v1.0.0-rc1 Release Notes
 
-## Status: TRACKED
+## Status: HISTORICAL - RELEASE HOLD
 ## Spec-ID: RELEASE-v1.0.0-rc1
 ## Frozen-By: rc-prep-20260223
 ## Consensus-Relevant: NO
+
+> **Superseded:** This document records the 2026 rc1/rc2 release process. It is
+> not current release authorization. All PQBTC signature profiles are under the
+> production hold in `PQSIG_PRODUCTION_READINESS.md`.
 
 ## Summary
 
 `v1.0.0-rc1` is the PQ-first release candidate for node/consensus delivery.
 
-## Release Posture Update (2026-03-06)
+## Historical Release Posture Update (2026-03-06)
 
 `v1.0.0` GA on the original profile is held.
 
 Reason:
 1. issue `#48` exposed an accepted-set weakness in the old `ALG_ID=0x00` profile.
-2. the active release path is now `v1.0.0-rc2`.
+2. the active release path at that time became `v1.0.0-rc2`.
 3. rc2 retires `ALG_ID=0x00` before GA and introduces the exact public-root profile under `ALG_ID=0x01`.
 
 ## Locked v1 Decisions

--- a/docs/RUNBOOK_V1_RC1.md
+++ b/docs/RUNBOOK_V1_RC1.md
@@ -1,9 +1,13 @@
 # PQBTC v1.0.0-rc1 Operator/Tester Runbook
 
-## Status: TRACKED
+## Status: HISTORICAL - RELEASE HOLD
 ## Spec-ID: RUNBOOK-v1.0.0-rc1
 ## Frozen-By: rc-prep-20260223
 ## Consensus-Relevant: NO
+
+> **Superseded:** This runbook is historical test evidence, not permission to
+> operate a real-value network. Current release posture is controlled by
+> `PQSIG_PRODUCTION_READINESS.md`.
 
 ## Scope
 

--- a/docs/SHRINCS_DECISION_TRACK.md
+++ b/docs/SHRINCS_DECISION_TRACK.md
@@ -1,9 +1,16 @@
 # PQBTC SHRINCS-Family Decision Track
 
-## Status: ACTIVE
+## Status: SUPERSEDED - RELEASE HOLD
 ## Spec-ID: SHRINCS-DECISION-TRACK-v1
 ## Started: 2026-04-13
 ## Consensus-Relevant: NO
+
+## Supersession Notice
+
+This is a historical sequencing memo. Its statements that rc2 can remain a
+shipping baseline are withdrawn by `PQSIG_PRODUCTION_READINESS.md`. rc2 remains
+useful only as a held integration fixture, and no replacement may activate
+without the standards-conformance and review gates in that record.
 
 ## Purpose
 
@@ -14,14 +21,15 @@ This document is a sequencing rule, not an activation decision.
 
 ## Current Truth
 
-- The live chain profile remains `PQSig rc2` on `ALG_ID=0x01`.
-- The current active signature path is already hash-based and SPHINCS-family in
-  construction (`WOTS+C` + `PORS+FP` + hypertree), with fixed 33-byte
-  `PK_script` encoding and fixed 4480-byte signatures.
-- PQBTC therefore already has real PQ signing and verification. The open
-  question is not "should the repo become post-quantum at all," but "should the
-  current active profile later be replaced by a stronger or more practical
-  SHRINCS-family alternative?"
+- The implemented research profile remains `PQSig rc2` on `ALG_ID=0x01`, under
+  a production release hold.
+- The implemented signature path is hash-based in shape and claims a
+  SPHINCS-family construction (`WOTS+C` + `PORS+FP` + hypertree), with fixed
+  33-byte `PK_script` encoding and fixed 4480-byte signatures. Its conformance
+  and security claims are not established.
+- PQBTC has working Bitcoin integration around a PQ-shaped signature fixture.
+  It does not yet have a cryptographically approved production signature
+  profile.
 
 ## Decision Rule
 
@@ -44,7 +52,8 @@ ability to reason about causality.
 PQBTC is on track for SHRINCS-family evaluation only if all of the following
 stay true:
 
-1. `PQSig rc2` remains the stable execution baseline for current Track A work.
+1. `PQSig rc2` remains only a stable, held regression baseline for current
+   Track A integration work.
 2. The future-profile lane stays explicitly separate from required-gate tranche
    ownership.
 3. Any future-profile candidate is judged against operator and wallet reality,
@@ -83,8 +92,8 @@ stay true:
 ### 5. Launch Fit
 
 - Does the candidate meaningfully improve the launch story?
-- Is the benefit large enough to justify redoing the active profile before a
-  block-0 launch?
+- Is the benefit large enough to justify replacing the held profile before any
+  block-0 launch proposal?
 - If not, should it instead become a post-launch or later-`ALG_ID` migration
   candidate?
 
@@ -107,22 +116,18 @@ Before any proposal to replace `PQSig rc2`, require:
 
 The default near-term choice is:
 
-- keep shipping Track A on `PQSig rc2`
-- keep the current wallet / PSBT / CI / ops work focused on the active profile
-- treat SHRINCS, SHRIMPS, and other adjacent ideas as an evidence-gathering lane
-  until the repo has enough execution maturity to compare them cleanly
+- do not ship rc2 or represent it as production-ready cryptography
+- preserve current wallet / PSBT / CI / ops work as integration evidence
+- build isolated FIPS 205 and FIPS 204 reference prototypes before proposing a
+  new consensus profile
 
 ## Immediate Next Steps
 
-1. Keep current Track A tranche work anchored to the active rc2 profile.
-2. Build a small comparison memo between:
-   - current `PQSig rc2`
-   - a concrete SHRINCS-family candidate
-   - any compact-signature follow-on worth serious consideration later
-3. Decide whether the first future-profile step should be:
-   - a docs-only adoption memo
-   - a neutral `ALG_ID` allocation with explicit present-day rejection
-   - or a real implementation branch outside the current required gate
+1. Preserve the rc2 production hold and executable conformance evidence.
+2. Build an isolated `SLH-DSA-SHA2-128s` reference prototype.
+3. Build an isolated `ML-DSA-44` comparator.
+4. Make no `ALG_ID`, Script, or activation change until the readiness gates are
+   met in a separate proposal.
 
 ## Non-Goals
 

--- a/docs/Spec.md
+++ b/docs/Spec.md
@@ -1,7 +1,14 @@
-# Quantum-Proof Bitcoin Fork (Genesis Chain) — Protocol Spec v0 (DRAFT)
+# Quantum-Proof Bitcoin Fork (Genesis Chain) — Protocol Spec v0 (DRAFT, RELEASE HOLD)
 
-Status: Draft
-Last-Updated: 2026-04-06
+Status: Draft - Not Approved For Production
+Last-Updated: 2026-07-18
+
+> **Controlling safety notice:** This draft records intended and implemented
+> rc2 behavior, but the implementation does not satisfy security-critical
+> invariants of the cited WOTS+C/PORS+FP construction. Its `2^40` signing bound
+> and NIST Level 1 claim are not established. No signature profile in this repo
+> is approved to secure real value. See
+> [PQSIG_PRODUCTION_READINESS.md](PQSIG_PRODUCTION_READINESS.md).
 
 This document is a developer-facing protocol specification for a Bitcoin Core-derived chain
 starting from a new genesis block (height 0), with post-quantum (PQ) signatures required
@@ -10,8 +17,8 @@ for transaction authorization from genesis.
 Normative language: "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY" are
 to be interpreted as in RFC 2119.
 
-Primary external reference for the PQ signature construction and parameter
-selection used here:
+Primary external research reference for the intended PQ signature construction
+and parameter selection described here:
 
 - Mikhail Kudinov and Jonas Nick, "Hash-based Signature Schemes for Bitcoin"
   (IACR ePrint 2025/2203)
@@ -71,10 +78,12 @@ The chain uses Bitcoin-style transactions with witness support and weight accoun
 ## 4. PQ Signature System ("PQSig v0")
 
 ### 4.1 High-Level Construction
-PQSig v0 is a stateless, hash-based signature scheme in the SPHINCS framework, using:
+PQSig v0 intends to define a stateless, hash-based signature scheme in the
+SPHINCS framework, using:
 - WOTS+C for the one-time layer, and
 - PORS+FP for the few-time layer,
-with hypertree parameters chosen for q_s = 2^40 max signatures per public key.
+with hypertree parameters intended for q_s = 2^40 max signatures per public
+key. The current rc2 implementation does not establish this property.
 
 (See "Hash-based Signature Schemes for Bitcoin" for the WOTS+C, PORS+FP,
 SPHINCS-family substitution, and parameter-table background behind this
@@ -88,7 +97,8 @@ construction.)
 - PRFmsg output length: 256 bits (32 bytes).
 
 ### 4.3 Parameter Set (Consensus-Critical)
-PQSig v0 MUST use the following fixed parameter set (Table 1 row "W+C P+FP 2^40"):
+The intended PQSig v0 construction uses the following fixed parameter set
+(Table 1 row "W+C P+FP 2^40"):
 - q_s = 2^40
 - h = 44
 - d = 4
@@ -127,6 +137,11 @@ v0 rule:
   - the secret key,
   - the transaction digest,
   - and any explicit optional randomness input opt (if supported).
+
+Conformance status: rc2 does not implement this rule. It derives one `R`,
+performs no WOTS+C fixed-sum search or PORS+FP authentication-set search, and
+requires all encoded layer counters to be zero. This mismatch is a release
+blocker, not an approved alternative construction.
 
 ### 4.6 Public Key and Signature Encodings
 
@@ -220,7 +235,8 @@ Policy SHOULD enforce:
 
 ## 9. Upgrade and Versioning (Plan)
 - ALG_ID byte in PK_script provides a clean hook for future signature versions.
-- The active GA profile is PQSig rc2 with `ALG_ID = 0x01`; see `ALG_ID_REGISTRY.md`.
+- The implemented research profile is PQSig rc2 with `ALG_ID = 0x01`; it is
+  under the production hold in `PQSIG_PRODUCTION_READINESS.md`.
 - `ALG_ID = 0x02` is allocated to the neutral `future-0x02` fixture path and remains invalid in current releases.
 - Assigned values, lifecycle state, allocation rules, and reuse prohibitions are defined in `ALG_ID_REGISTRY.md`.
 - Current parser compatibility and explicit non-negotiation rules are frozen in `ALG_ID_PARSER_COMPAT.md`.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,8 +2,8 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-07-17
-## Current Phase: Phase 1 - Config Namespace Hardened; Baseline Hold
+## Updated: 2026-07-18
+## Current Phase: Phase 1 - Cryptographic Production Hold
 
 ## Purpose
 
@@ -13,6 +13,18 @@ This file is the working handoff for Aineko. When no more specific repo task is
 active, use this file to choose the next safe step for `quantum-proof-bitcoin`.
 
 ## Current Objective
+
+Preserve the completed CI inventory baseline while moving Track A onto an
+explicit cryptographic production hold. The implemented rc2 path remains a
+research and Bitcoin-integration fixture only; it must not be released to
+secure real value or described as establishing its claimed `2^40` signing
+budget or NIST Level 1 security. `PQSIG_PRODUCTION_READINESS.md` is the
+controlling evidence and replacement-gate record.
+
+The next implementation lane is isolated standards conformance: first a FIPS
+205 `SLH-DSA-SHA2-128s` prototype, then a FIPS 204 `ML-DSA-44` comparator. No
+inventory policy class, `ALG_ID`, Script rule, or consensus accepted set changes
+as part of this safety closeout.
 
 Keep the live `pq_required` gate aligned with the repo as it exists today. PR
 `#163` closed the initial inventory tranche at `pq_required: 120`,
@@ -63,7 +75,9 @@ tracked suites now have an explicit policy class and none remains in
 
 ## Current Working Thesis
 
-- `quantum-proof-bitcoin` stays on Track A: native post-quantum Bitcoin.
+- `quantum-proof-bitcoin` stays on Track A as a post-quantum Bitcoin research
+  and integration project; production activation is held until a conformant,
+  independently reviewed signature profile passes its release gates.
 - Track A assumes PQBTC launches as a new chain at block 0, not as an in-place
   continuation of inherited Bitcoin chain history.
 - Blockstream's Liquid/Simplicity work is a benchmark and adjacent migration
@@ -83,6 +97,8 @@ Preferred next owned tranche:
      missing dedicated issue and cross-platform/optional-IPC boundary.
    - `rpc_blockchain.py` remains rejected because its replacement-deployment
      evidence duplicates an existing required gate.
+   - production release remains blocked independently of CI inventory status;
+     green rc2 tests are regression evidence, not cryptographic approval.
 
 Future selection boundary:
 
@@ -92,6 +108,14 @@ Future selection boundary:
      command, expected CI cost, and promotion/rejection criteria before any
      further policy-class change
    - do not select a suite from inventory order or low runtime alone
+
+Cryptography implementation lane:
+
+3. Build isolated final-standard reference prototypes
+   - start with FIPS 205 `SLH-DSA-SHA2-128s`
+   - compare FIPS 204 `ML-DSA-44`
+   - require official vectors and an independent differential oracle
+   - do not allocate or activate an `ALG_ID` in the prototype slices
 
 ## Current Queue
 
@@ -1573,6 +1597,7 @@ Aineko must ask before:
 - `TRACK_A_90_DAY_ROADMAP.md`
 - `SHRINCS_DECISION_TRACK.md`
 - `PQSIG_PROFILE_COMPARISON.md`
+- `PQSIG_PRODUCTION_READINESS.md`
 - `GENESIS_AND_NETWORK_POSTURE.md`
 - `RESEARCH_INDEX.md`
 - `PSBT_REPLACEMENT_TRANCHE.md`
@@ -1601,13 +1626,19 @@ Aineko must ask before:
 Entries below are dated decision snapshots. Use Current Follow-On Candidates
 above as the controlling live next-PR handoff when these older notes disagree.
 
+- 2026-07-18: Cryptographic conformance review placed all production activation
+  on hold. The rc2 implementation does not enforce the WOTS+C fixed-sum rule,
+  does not implement the cited PORS+FP grinding/authentication-set behavior,
+  and does not establish its claimed hypertree signing budget. rc2 remains a
+  research integration fixture. `PQSIG_PRODUCTION_READINESS.md` defines the
+  standards-based replacement lane and hold exit criteria.
 - 2026-04-06: Track A confirmed as the repo anchor. No Liquid/Simplicity reset.
 - 2026-04-13: `SHRINCS_DECISION_TRACK.md` added to keep SHRINCS-family
   evaluation explicit but separate: the repo can study or benchmark a future
   profile in parallel, but the active Track A execution baseline remains
   `PQSig rc2` until a dedicated go / no-go decision says otherwise.
 - 2026-04-13: `PQSIG_PROFILE_COMPARISON.md` added as the first concrete
-  decision memo: the active launch recommendation remains `PQSig rc2`, a
+  decision memo: the then-active launch recommendation remained `PQSig rc2`, a
   SHRINCS-style profile is the main pre-launch comparison target, and
   SHRIMPS-style work stays a later compact-signature lane until wallet,
   recovery, and implementation costs are made concrete.

--- a/src/test/pqsig_tests.cpp
+++ b/src/test/pqsig_tests.cpp
@@ -5,6 +5,8 @@
 #include <crypto/pqsig/pqsig.h>
 #include <crypto/pqsig/pqsig_internal.h>
 #include <crypto/pqsig/params.h>
+#include <crypto/pqsig/porsfp.h>
+#include <crypto/pqsig/wotsc.h>
 #include <test/data/pqsig/future_vectors.json.h>
 #include <test/data/pqsig/invalid_vectors.json.h>
 #include <test/data/pqsig/kat_v1.json.h>
@@ -277,6 +279,81 @@ void ApplyMutation(
 }
 
 } // namespace
+
+BOOST_AUTO_TEST_CASE(pqsig_rc2_release_hold_conformance_evidence)
+{
+    std::array<uint8_t, pqsig::MSG32_SIZE> sk_seed{};
+    std::array<uint8_t, pqsig::params::N> pk_seed{};
+    for (size_t i = 0; i < sk_seed.size(); ++i) sk_seed[i] = static_cast<uint8_t>(i);
+    for (size_t i = 0; i < pk_seed.size(); ++i) pk_seed[i] = static_cast<uint8_t>(i + 32);
+
+    std::array<uint8_t, pqsig::params::N> low_message{};
+    std::array<uint8_t, pqsig::params::N> high_message{};
+    high_message.fill(0xff);
+    std::array<uint8_t, pqsig::params::HT_WOTS_SIZE> low_signature{};
+    std::array<uint8_t, pqsig::params::HT_WOTS_SIZE> advanced_signature{};
+
+    pqsig::wotsc::FillLayerSignature(
+        std::span<uint8_t>{low_signature},
+        std::span<const uint8_t>{sk_seed},
+        std::span<const uint8_t>{pk_seed},
+        std::span<const uint8_t>{low_message},
+        /*layer=*/0,
+        /*leaf_index=*/0,
+        /*metrics=*/nullptr);
+
+    uint32_t low_sum{0};
+    uint32_t high_sum{0};
+    for (size_t chunk_index = 0; chunk_index < pqsig::params::L; ++chunk_index) {
+        const uint8_t low_digit = pqsig::wotsc::MessageNibble(low_message, chunk_index);
+        const uint8_t high_digit = pqsig::wotsc::MessageNibble(high_message, chunk_index);
+        low_sum += low_digit;
+        high_sum += high_digit;
+        const auto advanced = pqsig::wotsc::AdvanceChain(
+            std::span<const uint8_t>{low_signature}.subspan(chunk_index * pqsig::params::N, pqsig::params::N),
+            std::span<const uint8_t>{pk_seed},
+            /*layer=*/0,
+            /*leaf_index=*/0,
+            chunk_index,
+            low_digit,
+            high_digit - low_digit,
+            /*metrics=*/nullptr);
+        std::copy(
+            advanced.begin(),
+            advanced.end(),
+            advanced_signature.begin() + static_cast<ptrdiff_t>(chunk_index * pqsig::params::N));
+    }
+
+    std::array<uint8_t, pqsig::params::HT_WOTS_SIZE> low_public{};
+    std::array<uint8_t, pqsig::params::HT_WOTS_SIZE> high_public{};
+    pqsig::wotsc::ReconstructPublicChunks(
+        low_public,
+        std::span<const uint8_t>{low_signature},
+        std::span<const uint8_t>{low_message},
+        /*layer=*/0,
+        /*leaf_index=*/0,
+        std::span<const uint8_t>{pk_seed},
+        /*metrics=*/nullptr);
+    pqsig::wotsc::ReconstructPublicChunks(
+        high_public,
+        std::span<const uint8_t>{advanced_signature},
+        std::span<const uint8_t>{high_message},
+        /*layer=*/0,
+        /*leaf_index=*/0,
+        std::span<const uint8_t>{pk_seed},
+        /*metrics=*/nullptr);
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(low_public.begin(), low_public.end(), high_public.begin(), high_public.end());
+    BOOST_CHECK_EQUAL(low_sum, 0U);
+    BOOST_CHECK_EQUAL(high_sum, pqsig::params::L * (pqsig::params::W - 1));
+    BOOST_CHECK_NE(low_sum, pqsig::params::SWN);
+    BOOST_CHECK_NE(high_sum, pqsig::params::SWN);
+
+    std::array<uint8_t, 64> repeated_index_hmsg{};
+    const auto indices = pqsig::porsfp::DeriveIndices(repeated_index_hmsg);
+    BOOST_CHECK(std::all_of(indices.begin(), indices.end(), [](const uint16_t index) { return index == 0; }));
+    BOOST_CHECK(std::adjacent_find(indices.begin(), indices.end()) != indices.end());
+}
 
 BOOST_AUTO_TEST_CASE(pqsig_kat_vectors)
 {


### PR DESCRIPTION
## Summary

- place the implemented PQSig rc2 profile under an explicit production release hold
- add executable Python and C++ evidence for the missing WOTS+C fixed-sum and PORS distinct-index invariants
- replace stale launch recommendations with a standards-backed FIPS 205/FIPS 204 evaluation path
- update user-facing, specification, GA, Track A, and historical release posture documents

## Security boundary

This PR does not change consensus behavior or the accepted signature set. The checked counterexample is primitive-level evidence, not a claim of a complete transaction forgery. rc2 remains available only as a research and Bitcoin-integration fixture.

## Validation

- `git diff --check`
- `python3 ci/test/check_ci_inventory.py`
- `python3 -m unittest discover -s ci/test -p "test_*.py"`
- `python3 contrib/pqsig-ref/audit_rc2_conformance.py --expect-release-hold`
- `cmake --build build --target test_pqbtc -j4`
- `build/bin/test_pqbtc --run_test=pqsig_tests`