### PR TITLE
research: add SLH-DSA reference harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ integration.
 
 - [Protocol Specification](docs/Spec.md) - Normative spec with MUST/SHOULD language
 - [Signature Production Readiness](docs/PQSIG_PRODUCTION_READINESS.md) - Controlling cryptographic evidence, release hold, and replacement gates
+- [SLH-DSA-SHA2-128s Reference](docs/SLH_DSA_SHA2_128S_REFERENCE.md) - Isolated FIPS 205 vector, interoperability, and measurement baseline
 - [Core Diff Plan](docs/CORE_DIFF_PLAN.md) - Bitcoin Core fork implementation phases
 
 ## Status

--- a/ci/test/test_slh_dsa_reference.py
+++ b/ci/test/test_slh_dsa_reference.py
@@ -1,0 +1,54 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REFERENCE_DIR = REPO_ROOT / "contrib" / "slh-dsa-ref"
+DRIVER_PATH = REFERENCE_DIR / "compare_oracles.py"
+MANIFEST_PATH = REFERENCE_DIR / "vectors.json"
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+compare_oracles = load_module(DRIVER_PATH, "compare_oracles")
+
+
+class SLHDSAReferenceTests(unittest.TestCase):
+    def setUp(self):
+        self.manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf8"))
+
+    def test_manifest_contract(self):
+        compare_oracles.validate_manifest(self.manifest)
+
+    def test_private_keys_embed_the_expected_public_keys(self):
+        vectors = self.manifest["vectors"]
+        for name in ("nist_keygen_tg1_tc1", "pqbtc_sighash_v1"):
+            vector = vectors[name]
+            self.assertTrue(
+                vector["expected_private_key_hex"].endswith(vector["expected_public_key_hex"])
+            )
+
+    def test_manifest_only_cli(self):
+        result = subprocess.run(
+            [sys.executable, str(DRIVER_PATH), "--manifest-only"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("manifest validation passed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/slh-dsa-ref/README.md
+++ b/contrib/slh-dsa-ref/README.md
@@ -1,0 +1,39 @@
+# SLH-DSA Reference Harness
+
+This directory contains an isolated interoperability and measurement harness
+for the FIPS 205 `SLH-DSA-SHA2-128s` candidate. It is not linked into PQBTC,
+does not define consensus behavior, and does not allocate or activate an
+`ALG_ID`.
+
+## Evidence Sources
+
+- NIST ACVP vectors pinned in `vectors.json`
+- OpenSSL 3.5 or later as one independent implementation
+- `slh-dsa/slhdsa-c` at the exact commit pinned in `vectors.json` as the second
+  independent implementation
+
+The adapters use deterministic signing only for exact vector comparison.
+Randomized signing remains the required posture for any future production
+proposal.
+
+## Run
+
+```bash
+python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only
+python3 contrib/slh-dsa-ref/compare_oracles.py \
+  --acvp-server /path/to/pinned/ACVP-Server \
+  --slhdsa-c /path/to/pinned/slhdsa-c \
+  --benchmark-iterations 10
+```
+
+The full run checks the NIST checkout commit and source-file hashes, re-extracts
+the selected vector fields, builds both adapters in a temporary directory,
+requires the pinned `slhdsa-c` Git commit, reproduces selected NIST
+key-generation and signature-generation vectors, enforces official accepted and
+rejected signature-verification cases, checks the PQBTC 32-byte sighash/context
+vector, compares complete signature bytes, and reports median key-generation,
+signing, and verification times plus signature-only block-space economics. Both
+external source checkouts must be clean and at their pinned commits.
+
+OpenSSL is a prototype oracle only. Passing this harness does not make OpenSSL a
+node dependency or approve SLH-DSA for consensus integration.

--- a/contrib/slh-dsa-ref/compare_oracles.py
+++ b/contrib/slh-dsa-ref/compare_oracles.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Build and compare independent SLH-DSA-SHA2-128s reference oracles."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import statistics
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+MANIFEST_PATH = HERE / "vectors.json"
+OPENSSL_SOURCE = HERE / "openssl_oracle.c"
+SLHDSA_C_SOURCE = HERE / "slhdsa_c_oracle.c"
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReferenceError(RuntimeError):
+    pass
+
+
+def load_manifest() -> dict:
+    with MANIFEST_PATH.open(encoding="utf8") as manifest_file:
+        manifest = json.load(manifest_file)
+    validate_manifest(manifest)
+    return manifest
+
+
+def require_hex(value: str, byte_length: int, label: str) -> None:
+    if len(value) != byte_length * 2 or re.fullmatch(r"[0-9a-f]+", value) is None:
+        raise ReferenceError(f"{label} must be {byte_length} lowercase-hex bytes")
+
+
+def validate_manifest(manifest: dict) -> None:
+    profile = manifest["profile"]
+    expected_profile = {
+        "name": "SLH-DSA-SHA2-128s",
+        "standard": "FIPS 205",
+        "signature_interface": "external",
+        "message_mode": "pure",
+        "public_key_bytes": 32,
+        "private_key_bytes": 64,
+        "keygen_seed_bytes": 48,
+        "signature_bytes": 7856,
+        "prototype_message_bytes": 32,
+    }
+    for name, expected in expected_profile.items():
+        if profile.get(name) != expected:
+            raise ReferenceError(f"profile {name} must be {expected!r}")
+
+    context_hex = profile["prototype_context_hex"]
+    if bytes.fromhex(context_hex).decode("ascii") != profile["prototype_context_ascii"]:
+        raise ReferenceError("prototype context hex/ascii mismatch")
+    if len(bytes.fromhex(context_hex)) > 255:
+        raise ReferenceError("prototype context exceeds FIPS 205 limit")
+
+    expected_cost_model = {
+        "held_rc2_signature_bytes": 4480,
+        "block_weight_limit": 16_000_000,
+        "signature_witness_weight_per_byte": 1,
+    }
+    if manifest.get("system_cost_model") != expected_cost_model:
+        raise ReferenceError("system cost model does not match the held PQBTC baseline")
+
+    sources = manifest["sources"]
+    for source_name in ("nist_acvp", "slhdsa_c"):
+        if re.fullmatch(r"[0-9a-f]{40}", sources[source_name]["commit"]) is None:
+            raise ReferenceError(f"{source_name} commit must be a full Git SHA")
+    expected_nist_files = {
+        "gen-val/json-files/SLH-DSA-keyGen-FIPS205/prompt.json",
+        "gen-val/json-files/SLH-DSA-keyGen-FIPS205/expectedResults.json",
+        "gen-val/json-files/SLH-DSA-sigGen-FIPS205/prompt.json",
+        "gen-val/json-files/SLH-DSA-sigGen-FIPS205/expectedResults.json",
+        "gen-val/json-files/SLH-DSA-sigVer-FIPS205/prompt.json",
+        "gen-val/json-files/SLH-DSA-sigVer-FIPS205/expectedResults.json",
+    }
+    nist_files = sources["nist_acvp"]["files"]
+    if set(nist_files) != expected_nist_files:
+        raise ReferenceError("NIST source file set does not match the reference contract")
+    for file_hash in nist_files.values():
+        if HEX_64.fullmatch(file_hash) is None:
+            raise ReferenceError("NIST source hashes must be SHA256 values")
+
+    vectors = manifest["vectors"]
+    keygen = vectors["nist_keygen_tg1_tc1"]
+    require_hex(keygen["seed_hex"], profile["keygen_seed_bytes"], "NIST keygen seed")
+    require_hex(keygen["expected_private_key_hex"], profile["private_key_bytes"], "NIST private key")
+    require_hex(keygen["expected_public_key_hex"], profile["public_key_bytes"], "NIST public key")
+
+    siggen = vectors["nist_siggen_tg19_tc161"]
+    require_hex(siggen["private_key_hex"], profile["private_key_bytes"], "NIST signing key")
+    if len(bytes.fromhex(siggen["context_hex"])) > 255:
+        raise ReferenceError("NIST context exceeds FIPS 205 limit")
+    if HEX_64.fullmatch(siggen["expected_signature_sha256"]) is None:
+        raise ReferenceError("NIST signature hash must be SHA256")
+
+    sigver = vectors["nist_sigver_tg19"]
+    expected_sigver_profile = {
+        "parameter_set": profile["name"],
+        "signature_interface": profile["signature_interface"],
+        "message_mode": profile["message_mode"],
+    }
+    for name, expected in expected_sigver_profile.items():
+        if sigver.get(name) != expected:
+            raise ReferenceError(f"NIST sigver {name} must be {expected!r}")
+    cases = sigver["cases"]
+    if len(cases) != 2:
+        raise ReferenceError("NIST sigver reference must contain exactly two cases")
+    if {case["test_case_id"] for case in cases} != {253, 266}:
+        raise ReferenceError("NIST sigver cases must be tcId 253 and 266")
+    if {case["expected_valid"] for case in cases} != {False, True}:
+        raise ReferenceError("NIST sigver cases must include acceptance and rejection")
+    for case in cases:
+        require_hex(case["public_key_hex"], profile["public_key_bytes"], "NIST sigver key")
+        if case["context_bytes"] > 255:
+            raise ReferenceError("NIST sigver context exceeds FIPS 205 limit")
+        if case["signature_bytes"] != profile["signature_bytes"]:
+            raise ReferenceError("NIST sigver signature size mismatch")
+        for field in ("message_sha256", "context_sha256", "signature_sha256"):
+            if HEX_64.fullmatch(case[field]) is None:
+                raise ReferenceError(f"NIST sigver {field} must be SHA256")
+
+    pqbtc = vectors["pqbtc_sighash_v1"]
+    require_hex(pqbtc["seed_hex"], profile["keygen_seed_bytes"], "PQBTC keygen seed")
+    require_hex(pqbtc["message_hex"], profile["prototype_message_bytes"], "PQBTC message")
+    require_hex(pqbtc["expected_private_key_hex"], profile["private_key_bytes"], "PQBTC private key")
+    require_hex(pqbtc["expected_public_key_hex"], profile["public_key_bytes"], "PQBTC public key")
+    if pqbtc["context_hex"] != context_hex:
+        raise ReferenceError("PQBTC vector does not use the frozen prototype context")
+    if HEX_64.fullmatch(pqbtc["expected_signature_sha256"]) is None:
+        raise ReferenceError("PQBTC signature hash must be SHA256")
+
+
+def run(command: list[str], cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        rendered = shlex.join(command)
+        raise ReferenceError(
+            f"command failed ({result.returncode}): {rendered}\n{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def parse_version(value: str, label: str) -> tuple[int, int, int]:
+    match = re.search(r"(?:OpenSSL )?(\d+)\.(\d+)\.(\d+)", value)
+    if match is None:
+        raise ReferenceError(f"cannot parse {label} version: {value}")
+    return tuple(int(part) for part in match.groups())
+
+
+def openssl_version() -> tuple[str, tuple[int, int, int]]:
+    output = run(["openssl", "version"]).strip()
+    version = parse_version(output, "OpenSSL CLI")
+    if version < (3, 5, 0):
+        raise ReferenceError("OpenSSL 3.5.0 or later is required")
+    pkg_config_output = run(["pkg-config", "--modversion", "openssl"]).strip()
+    pkg_config_version = parse_version(pkg_config_output, "OpenSSL pkg-config")
+    if pkg_config_version != version:
+        raise ReferenceError(
+            f"OpenSSL CLI/pkg-config mismatch: {version}, {pkg_config_version}"
+        )
+    return output, version
+
+
+def compile_openssl_oracle(build_dir: Path) -> Path:
+    openssl_version()
+    compiler = os.environ.get("CC", "cc")
+    pkg_config = shlex.split(run(["pkg-config", "--cflags", "--libs", "openssl"]))
+    output = build_dir / "openssl_slh_dsa_oracle"
+    command = [
+        compiler,
+        "-std=c11",
+        "-O2",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        str(OPENSSL_SOURCE),
+        "-o",
+        str(output),
+        *pkg_config,
+    ]
+    run(command)
+    return output
+
+
+def require_git_commit(source_dir: Path, expected_commit: str, source_name: str) -> None:
+    actual_commit = run(["git", "rev-parse", "HEAD"], cwd=source_dir).strip()
+    if actual_commit != expected_commit:
+        raise ReferenceError(
+            f"{source_name} commit mismatch: expected {expected_commit}, got {actual_commit}"
+        )
+    dirty = run(
+        ["git", "status", "--porcelain", "--untracked-files=all"], cwd=source_dir
+    ).strip()
+    if dirty:
+        raise ReferenceError(f"{source_name} checkout must be clean")
+
+
+def require_slhdsa_c_source(source_dir: Path, expected_commit: str) -> None:
+    if not (source_dir / "slh_dsa.h").is_file():
+        raise ReferenceError(f"missing slhdsa-c source at {source_dir}")
+    require_git_commit(source_dir, expected_commit, "slhdsa-c")
+
+
+def find_test(document: dict, group_id: int, test_id: int) -> tuple[dict, dict]:
+    group = next((group for group in document["testGroups"] if group["tgId"] == group_id), None)
+    if group is None:
+        raise ReferenceError(f"missing ACVP group {group_id}")
+    test = next((test for test in group["tests"] if test["tcId"] == test_id), None)
+    if test is None:
+        raise ReferenceError(f"missing ACVP test {group_id}/{test_id}")
+    return group, test
+
+
+def sha256_hex(hex_value: str) -> str:
+    return hashlib.sha256(bytes.fromhex(hex_value)).hexdigest()
+
+
+def verify_nist_sources(manifest: dict, source_dir: Path) -> dict:
+    source = manifest["sources"]["nist_acvp"]
+    require_git_commit(source_dir, source["commit"], "NIST ACVP")
+    loaded: dict[str, dict] = {}
+    for relative_path, expected_hash in source["files"].items():
+        path = source_dir / relative_path
+        if not path.is_file():
+            raise ReferenceError(f"missing NIST source file: {path}")
+        actual_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual_hash != expected_hash:
+            raise ReferenceError(
+                f"NIST source hash mismatch for {relative_path}: "
+                f"expected {expected_hash}, got {actual_hash}"
+            )
+        loaded[relative_path] = json.loads(path.read_text(encoding="utf8"))
+
+    vectors = manifest["vectors"]
+    keygen_prompt = loaded["gen-val/json-files/SLH-DSA-keyGen-FIPS205/prompt.json"]
+    keygen_expected = loaded[
+        "gen-val/json-files/SLH-DSA-keyGen-FIPS205/expectedResults.json"
+    ]
+    keygen_group, keygen_test = find_test(keygen_prompt, 1, 1)
+    _, keygen_result = find_test(keygen_expected, 1, 1)
+    if keygen_group.get("parameterSet") != "SLH-DSA-SHA2-128s":
+        raise ReferenceError("NIST keygen parameter set mismatch")
+    expected_keygen = vectors["nist_keygen_tg1_tc1"]
+    require_equal(
+        "NIST source keygen seed",
+        (keygen_test["skSeed"] + keygen_test["skPrf"] + keygen_test["pkSeed"]).lower(),
+        expected_keygen["seed_hex"],
+    )
+    require_equal(
+        "NIST source private key",
+        keygen_result["sk"].lower(),
+        expected_keygen["expected_private_key_hex"],
+    )
+    require_equal(
+        "NIST source public key",
+        keygen_result["pk"].lower(),
+        expected_keygen["expected_public_key_hex"],
+    )
+
+    siggen_prompt = loaded["gen-val/json-files/SLH-DSA-sigGen-FIPS205/prompt.json"]
+    siggen_expected = loaded[
+        "gen-val/json-files/SLH-DSA-sigGen-FIPS205/expectedResults.json"
+    ]
+    siggen_group, siggen_test = find_test(siggen_prompt, 19, 161)
+    _, siggen_result = find_test(siggen_expected, 19, 161)
+    expected_siggen = vectors["nist_siggen_tg19_tc161"]
+    expected_group = {
+        "parameterSet": "SLH-DSA-SHA2-128s",
+        "deterministic": True,
+        "signatureInterface": "external",
+        "preHash": "pure",
+    }
+    for name, expected_value in expected_group.items():
+        if siggen_group.get(name) != expected_value:
+            raise ReferenceError(f"NIST siggen group {name} mismatch")
+    for source_name, manifest_name in (
+        ("sk", "private_key_hex"),
+        ("message", "message_hex"),
+        ("context", "context_hex"),
+    ):
+        require_equal(
+            f"NIST source siggen {source_name}",
+            siggen_test[source_name].lower(),
+            expected_siggen[manifest_name],
+        )
+    require_equal(
+        "NIST source signature hash",
+        sha256_hex(siggen_result["signature"]),
+        expected_siggen["expected_signature_sha256"],
+    )
+
+    sigver_prompt = loaded["gen-val/json-files/SLH-DSA-sigVer-FIPS205/prompt.json"]
+    sigver_expected = loaded[
+        "gen-val/json-files/SLH-DSA-sigVer-FIPS205/expectedResults.json"
+    ]
+    sigver_group, _ = find_test(sigver_prompt, 19, 253)
+    expected_sigver = vectors["nist_sigver_tg19"]
+    expected_group = {
+        "parameterSet": expected_sigver["parameter_set"],
+        "signatureInterface": expected_sigver["signature_interface"],
+        "preHash": expected_sigver["message_mode"],
+    }
+    for name, expected_value in expected_group.items():
+        if sigver_group.get(name) != expected_value:
+            raise ReferenceError(f"NIST sigver group {name} mismatch")
+
+    sigver_cases: list[dict] = []
+    for expected_case in expected_sigver["cases"]:
+        test_id = expected_case["test_case_id"]
+        _, source_case = find_test(sigver_prompt, 19, test_id)
+        _, source_result = find_test(sigver_expected, 19, test_id)
+        require_equal(
+            f"NIST source sigver {test_id} public key",
+            source_case["pk"].lower(),
+            expected_case["public_key_hex"],
+        )
+        for field in ("message", "context", "signature"):
+            source_hex = source_case[field].lower()
+            if len(source_hex) != expected_case[f"{field}_bytes"] * 2:
+                raise ReferenceError(f"NIST source sigver {test_id} {field} size mismatch")
+            require_equal(
+                f"NIST source sigver {test_id} {field} hash",
+                sha256_hex(source_hex),
+                expected_case[f"{field}_sha256"],
+            )
+        if source_result.get("testPassed") is not expected_case["expected_valid"]:
+            raise ReferenceError(f"NIST source sigver {test_id} result mismatch")
+        sigver_cases.append(
+            {
+                "test_case_id": test_id,
+                "public_key_hex": source_case["pk"].lower(),
+                "message_hex": source_case["message"].lower(),
+                "context_hex": source_case["context"].lower(),
+                "signature_hex": source_case["signature"].lower(),
+                "expected_valid": expected_case["expected_valid"],
+            }
+        )
+
+    return {
+        "siggen_signature_hex": siggen_result["signature"].lower(),
+        "sigver_cases": sigver_cases,
+    }
+
+
+def compile_slhdsa_c_oracle(build_dir: Path, source_dir: Path, expected_commit: str) -> Path:
+    require_slhdsa_c_source(source_dir, expected_commit)
+    sources = sorted(str(path) for path in source_dir.glob("*.c"))
+    if not sources:
+        raise ReferenceError("slhdsa-c source list is empty")
+    compiler = os.environ.get("CC", "cc")
+    output = build_dir / "slhdsa_c_oracle"
+    command = [
+        compiler,
+        "-std=c99",
+        "-O2",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        f"-I{source_dir}",
+        str(SLHDSA_C_SOURCE),
+        *sources,
+        "-o",
+        str(output),
+    ]
+    run(command)
+    return output
+
+
+def parse_oracle_output(output: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for line in output.splitlines():
+        if "=" not in line:
+            raise ReferenceError(f"invalid oracle output line: {line}")
+        name, value = line.split("=", 1)
+        parsed[name] = value
+    return parsed
+
+
+def oracle_keygen(executable: Path, seed_hex: str) -> dict[str, str]:
+    return parse_oracle_output(run([str(executable), "keygen", seed_hex]))
+
+
+def oracle_sign(
+    executable: Path, private_key_hex: str, message_hex: str, context_hex: str
+) -> dict[str, str]:
+    result = parse_oracle_output(
+        run([str(executable), "sign", private_key_hex, message_hex, context_hex])
+    )
+    if result.get("verified") != "1":
+        raise ReferenceError(f"oracle {executable.name} did not self-verify")
+    return result
+
+
+def oracle_verify(
+    executable: Path,
+    public_key_hex: str,
+    message_hex: str,
+    context_hex: str,
+    signature_hex: str,
+) -> dict[str, str]:
+    result = parse_oracle_output(
+        run(
+            [
+                str(executable),
+                "verify",
+                public_key_hex,
+                message_hex,
+                context_hex,
+                signature_hex,
+            ]
+        )
+    )
+    if result.get("verified") not in {"0", "1"}:
+        raise ReferenceError(f"oracle {executable.name} returned invalid verify result")
+    return result
+
+
+def signature_hash(signature_hex: str, expected_bytes: int) -> str:
+    require_hex(signature_hex, expected_bytes, "signature")
+    return hashlib.sha256(bytes.fromhex(signature_hex)).hexdigest()
+
+
+def require_equal(label: str, *values: str) -> None:
+    if len(set(values)) != 1:
+        raise ReferenceError(f"{label} mismatch")
+
+
+def median_ms(values: list[int]) -> float:
+    return round(statistics.median(values) / 1_000_000, 3)
+
+
+def evaluate(
+    manifest: dict,
+    openssl_oracle: Path,
+    slhdsa_c_oracle: Path,
+    benchmark_iterations: int,
+    nist_source_vectors: dict,
+) -> dict:
+    profile = manifest["profile"]
+    vectors = manifest["vectors"]
+    oracles = {
+        "openssl": openssl_oracle,
+        "slhdsa_c": slhdsa_c_oracle,
+    }
+
+    keygen_vector = vectors["nist_keygen_tg1_tc1"]
+    keygen_results = {
+        name: oracle_keygen(executable, keygen_vector["seed_hex"])
+        for name, executable in oracles.items()
+    }
+    for result in keygen_results.values():
+        require_equal("NIST public key", result["pk"], keygen_vector["expected_public_key_hex"])
+        require_equal("NIST private key", result["sk"], keygen_vector["expected_private_key_hex"])
+    require_equal("oracle NIST public key", *(result["pk"] for result in keygen_results.values()))
+    require_equal("oracle NIST private key", *(result["sk"] for result in keygen_results.values()))
+
+    siggen_vector = vectors["nist_siggen_tg19_tc161"]
+    siggen_results = {
+        name: oracle_sign(
+            executable,
+            siggen_vector["private_key_hex"],
+            siggen_vector["message_hex"],
+            siggen_vector["context_hex"],
+        )
+        for name, executable in oracles.items()
+    }
+    siggen_hashes = {
+        name: signature_hash(result["signature"], profile["signature_bytes"])
+        for name, result in siggen_results.items()
+    }
+    require_equal(
+        "NIST signature hash",
+        *siggen_hashes.values(),
+        siggen_vector["expected_signature_sha256"],
+    )
+    require_equal(
+        "NIST signature bytes", *(result["signature"] for result in siggen_results.values())
+    )
+    require_equal(
+        "NIST source signature bytes",
+        *(result["signature"] for result in siggen_results.values()),
+        nist_source_vectors["siggen_signature_hex"],
+    )
+
+    for case in nist_source_vectors["sigver_cases"]:
+        verify_results = {
+            name: oracle_verify(
+                executable,
+                case["public_key_hex"],
+                case["message_hex"],
+                case["context_hex"],
+                case["signature_hex"],
+            )
+            for name, executable in oracles.items()
+        }
+        expected_result = "1" if case["expected_valid"] else "0"
+        require_equal(
+            f"NIST sigver tcId {case['test_case_id']}",
+            *(result["verified"] for result in verify_results.values()),
+            expected_result,
+        )
+
+    pqbtc_vector = vectors["pqbtc_sighash_v1"]
+    benchmark: dict[str, dict[str, list[int]]] = {
+        name: {"keygen_ns": [], "sign_ns": [], "verify_ns": []} for name in oracles
+    }
+    profile_signatures: dict[str, str] = {}
+    for _ in range(benchmark_iterations):
+        for name, executable in oracles.items():
+            generated = oracle_keygen(executable, pqbtc_vector["seed_hex"])
+            require_equal("PQBTC public key", generated["pk"], pqbtc_vector["expected_public_key_hex"])
+            require_equal("PQBTC private key", generated["sk"], pqbtc_vector["expected_private_key_hex"])
+            signed = oracle_sign(
+                executable,
+                generated["sk"],
+                pqbtc_vector["message_hex"],
+                pqbtc_vector["context_hex"],
+            )
+            signature_digest = signature_hash(signed["signature"], profile["signature_bytes"])
+            require_equal(
+                "PQBTC signature hash",
+                signature_digest,
+                pqbtc_vector["expected_signature_sha256"],
+            )
+            if name in profile_signatures:
+                require_equal("deterministic PQBTC signature", profile_signatures[name], signed["signature"])
+            profile_signatures[name] = signed["signature"]
+            benchmark[name]["keygen_ns"].append(int(generated["keygen_ns"]))
+            benchmark[name]["sign_ns"].append(int(signed["sign_ns"]))
+            benchmark[name]["verify_ns"].append(int(signed["verify_ns"]))
+
+    require_equal("PQBTC signature bytes", *profile_signatures.values())
+    version_text, _ = openssl_version()
+    cost_model = manifest["system_cost_model"]
+    rc2_signature_weight = (
+        cost_model["held_rc2_signature_bytes"]
+        * cost_model["signature_witness_weight_per_byte"]
+    )
+    slh_signature_weight = (
+        profile["signature_bytes"] * cost_model["signature_witness_weight_per_byte"]
+    )
+    rc2_capacity = cost_model["block_weight_limit"] // rc2_signature_weight
+    slh_capacity = cost_model["block_weight_limit"] // slh_signature_weight
+    return {
+        "status": "PASS",
+        "profile": profile["name"],
+        "openssl_version": version_text,
+        "slhdsa_c_commit": manifest["sources"]["slhdsa_c"]["commit"],
+        "checks": {
+            "nist_source_provenance": "PASS",
+            "nist_keygen": "PASS",
+            "nist_siggen": "PASS",
+            "nist_sigver_accept_reject": "PASS",
+            "pqbtc_sighash_vector": "PASS",
+            "full_signature_byte_agreement": "PASS",
+        },
+        "signature_sha256": {
+            "nist": siggen_vector["expected_signature_sha256"],
+            "pqbtc": pqbtc_vector["expected_signature_sha256"],
+        },
+        "block_space_model": {
+            **cost_model,
+            "slh_dsa_signature_bytes": profile["signature_bytes"],
+            "signature_size_increase_percent": round(
+                (profile["signature_bytes"] / cost_model["held_rc2_signature_bytes"] - 1)
+                * 100,
+                2,
+            ),
+            "rc2_signature_only_capacity": rc2_capacity,
+            "slh_dsa_signature_only_capacity": slh_capacity,
+            "capacity_ratio_percent": round(slh_capacity / rc2_capacity * 100, 2),
+        },
+        "benchmark": {
+            name: {
+                "iterations": benchmark_iterations,
+                "median_keygen_ms": median_ms(values["keygen_ns"]),
+                "median_sign_ms": median_ms(values["sign_ns"]),
+                "median_verify_ms": median_ms(values["verify_ns"]),
+            }
+            for name, values in benchmark.items()
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--acvp-server",
+        type=Path,
+        help="path to the pinned usnistgov/ACVP-Server checkout (required for a full run)",
+    )
+    parser.add_argument(
+        "--slhdsa-c",
+        type=Path,
+        default=Path(os.environ["SLHDSA_C_DIR"]) if "SLHDSA_C_DIR" in os.environ else None,
+        help="path to the pinned slh-dsa/slhdsa-c checkout",
+    )
+    parser.add_argument(
+        "--benchmark-iterations",
+        type=int,
+        default=1,
+        help="repeat the PQBTC vector for median timings (1-10)",
+    )
+    parser.add_argument(
+        "--manifest-only",
+        action="store_true",
+        help="validate the checked-in profile and vector manifest without external oracles",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifest = load_manifest()
+        if args.manifest_only:
+            print("SLH-DSA reference manifest validation passed")
+            return 0
+        if args.slhdsa_c is None:
+            raise ReferenceError("--slhdsa-c or SLHDSA_C_DIR is required")
+        if args.acvp_server is None:
+            raise ReferenceError("--acvp-server is required for a full run")
+        if not 1 <= args.benchmark_iterations <= 10:
+            raise ReferenceError("--benchmark-iterations must be between 1 and 10")
+
+        nist_source_vectors = verify_nist_sources(manifest, args.acvp_server.resolve())
+
+        with tempfile.TemporaryDirectory(prefix="pqbtc-slh-dsa-") as temporary:
+            build_dir = Path(temporary)
+            openssl_oracle = compile_openssl_oracle(build_dir)
+            slhdsa_c_oracle = compile_slhdsa_c_oracle(
+                build_dir,
+                args.slhdsa_c.resolve(),
+                manifest["sources"]["slhdsa_c"]["commit"],
+            )
+            report = evaluate(
+                manifest,
+                openssl_oracle,
+                slhdsa_c_oracle,
+                args.benchmark_iterations,
+                nist_source_vectors,
+            )
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    except (OSError, KeyError, ReferenceError, ValueError) as error:
+        print(f"compare_oracles.py: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/slh-dsa-ref/openssl_oracle.c
+++ b/contrib/slh-dsa-ref/openssl_oracle.c
@@ -1,0 +1,403 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <openssl/core_names.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/params.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define ALGORITHM "SLH-DSA-SHA2-128s"
+#define KEYGEN_SEED_SIZE 48
+#define PRIVATE_KEY_SIZE 64
+#define PUBLIC_KEY_SIZE 32
+#define SIGNATURE_SIZE 7856
+
+static uint64_t MonotonicNs(void)
+{
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return 0;
+    return (uint64_t)now.tv_sec * UINT64_C(1000000000) + (uint64_t)now.tv_nsec;
+}
+
+static int HexDigit(const char value)
+{
+    if (value >= '0' && value <= '9') return value - '0';
+    if (value >= 'a' && value <= 'f') return value - 'a' + 10;
+    if (value >= 'A' && value <= 'F') return value - 'A' + 10;
+    return -1;
+}
+
+static unsigned char* DecodeHex(const char* hex, size_t* output_size)
+{
+    const size_t hex_size = strlen(hex);
+    if ((hex_size & 1U) != 0) return NULL;
+
+    *output_size = hex_size / 2;
+    unsigned char* output = malloc(*output_size == 0 ? 1 : *output_size);
+    if (output == NULL) return NULL;
+
+    for (size_t i = 0; i < *output_size; ++i) {
+        const int high = HexDigit(hex[2 * i]);
+        const int low = HexDigit(hex[2 * i + 1]);
+        if (high < 0 || low < 0) {
+            free(output);
+            return NULL;
+        }
+        output[i] = (unsigned char)((high << 4) | low);
+    }
+    return output;
+}
+
+static void PrintHex(const char* name, const unsigned char* data, const size_t size)
+{
+    printf("%s=", name);
+    for (size_t i = 0; i < size; ++i) printf("%02x", data[i]);
+    putchar('\n');
+}
+
+static void PrintOpenSSLError(const char* operation)
+{
+    fprintf(stderr, "openssl_oracle: %s failed\n", operation);
+    ERR_print_errors_fp(stderr);
+}
+
+static int ExportKeys(EVP_PKEY* key, unsigned char* private_key, unsigned char* public_key)
+{
+    size_t private_key_size = 0;
+    size_t public_key_size = 0;
+    if (EVP_PKEY_get_octet_string_param(
+            key, OSSL_PKEY_PARAM_PRIV_KEY, private_key, PRIVATE_KEY_SIZE, &private_key_size) <= 0 ||
+        private_key_size != PRIVATE_KEY_SIZE) {
+        PrintOpenSSLError("private-key export");
+        return 0;
+    }
+    if (EVP_PKEY_get_octet_string_param(
+            key, OSSL_PKEY_PARAM_PUB_KEY, public_key, PUBLIC_KEY_SIZE, &public_key_size) <= 0 ||
+        public_key_size != PUBLIC_KEY_SIZE) {
+        PrintOpenSSLError("public-key export");
+        return 0;
+    }
+    return 1;
+}
+
+static EVP_PKEY* GenerateKey(const unsigned char* seed, uint64_t* elapsed_ns)
+{
+    EVP_PKEY_CTX* context = EVP_PKEY_CTX_new_from_name(NULL, ALGORITHM, NULL);
+    EVP_PKEY* key = NULL;
+    if (context == NULL || EVP_PKEY_keygen_init(context) <= 0) {
+        PrintOpenSSLError("keygen initialization");
+        EVP_PKEY_CTX_free(context);
+        return NULL;
+    }
+
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_SLH_DSA_SEED, (void*)seed, KEYGEN_SEED_SIZE),
+        OSSL_PARAM_construct_end(),
+    };
+    if (EVP_PKEY_CTX_set_params(context, parameters) <= 0) {
+        PrintOpenSSLError("keygen seed setup");
+        EVP_PKEY_CTX_free(context);
+        return NULL;
+    }
+
+    const uint64_t started = MonotonicNs();
+    const int generated = EVP_PKEY_keygen(context, &key);
+    *elapsed_ns = MonotonicNs() - started;
+    EVP_PKEY_CTX_free(context);
+    if (generated <= 0) {
+        PrintOpenSSLError("key generation");
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    return key;
+}
+
+static EVP_PKEY* ImportPrivateKey(const unsigned char* private_key)
+{
+    EVP_PKEY_CTX* context = EVP_PKEY_CTX_new_from_name(NULL, ALGORITHM, NULL);
+    EVP_PKEY* key = NULL;
+    unsigned char public_key[PUBLIC_KEY_SIZE];
+    memcpy(public_key, private_key + PRIVATE_KEY_SIZE - PUBLIC_KEY_SIZE, PUBLIC_KEY_SIZE);
+
+    if (context == NULL || EVP_PKEY_fromdata_init(context) <= 0) {
+        PrintOpenSSLError("key import initialization");
+        EVP_PKEY_CTX_free(context);
+        return NULL;
+    }
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PRIV_KEY, (void*)private_key, PRIVATE_KEY_SIZE),
+        OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY, public_key, PUBLIC_KEY_SIZE),
+        OSSL_PARAM_construct_end(),
+    };
+    if (EVP_PKEY_fromdata(context, &key, EVP_PKEY_KEYPAIR, parameters) <= 0) {
+        PrintOpenSSLError("private-key import");
+        EVP_PKEY_CTX_free(context);
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    EVP_PKEY_CTX_free(context);
+    return key;
+}
+
+static EVP_PKEY* ImportPublicKey(const unsigned char* public_key)
+{
+    EVP_PKEY_CTX* context = EVP_PKEY_CTX_new_from_name(NULL, ALGORITHM, NULL);
+    EVP_PKEY* key = NULL;
+
+    if (context == NULL || EVP_PKEY_fromdata_init(context) <= 0) {
+        PrintOpenSSLError("public-key import initialization");
+        EVP_PKEY_CTX_free(context);
+        return NULL;
+    }
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(
+            OSSL_PKEY_PARAM_PUB_KEY, (void*)public_key, PUBLIC_KEY_SIZE),
+        OSSL_PARAM_construct_end(),
+    };
+    if (EVP_PKEY_fromdata(context, &key, EVP_PKEY_PUBLIC_KEY, parameters) <= 0) {
+        PrintOpenSSLError("public-key import");
+        EVP_PKEY_CTX_free(context);
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    EVP_PKEY_CTX_free(context);
+    return key;
+}
+
+static int VerifySignature(
+    EVP_PKEY* key,
+    const unsigned char* message,
+    const size_t message_size,
+    unsigned char* context_string,
+    const size_t context_size,
+    const unsigned char* signature,
+    const size_t signature_size,
+    uint64_t* verify_ns)
+{
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING, context_string, context_size),
+        OSSL_PARAM_construct_end(),
+    };
+    EVP_SIGNATURE* algorithm = EVP_SIGNATURE_fetch(NULL, ALGORITHM, NULL);
+    EVP_PKEY_CTX* verify_context = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
+    int result = -1;
+
+    if (algorithm == NULL || verify_context == NULL ||
+        EVP_PKEY_verify_message_init(verify_context, algorithm, parameters) <= 0) {
+        PrintOpenSSLError("verify initialization");
+        goto cleanup;
+    }
+    const uint64_t verify_started = MonotonicNs();
+    result = EVP_PKEY_verify(
+        verify_context, signature, signature_size, message, message_size);
+    *verify_ns = MonotonicNs() - verify_started;
+    if (result < 0) PrintOpenSSLError("verification");
+
+cleanup:
+    EVP_PKEY_CTX_free(verify_context);
+    EVP_SIGNATURE_free(algorithm);
+    return result;
+}
+
+static int SignAndVerify(
+    EVP_PKEY* key,
+    const unsigned char* message,
+    const size_t message_size,
+    unsigned char* context_string,
+    const size_t context_size,
+    unsigned char* signature,
+    uint64_t* sign_ns,
+    uint64_t* verify_ns)
+{
+    int deterministic = 1;
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING, context_string, context_size),
+        OSSL_PARAM_construct_int(OSSL_SIGNATURE_PARAM_DETERMINISTIC, &deterministic),
+        OSSL_PARAM_construct_end(),
+    };
+    EVP_SIGNATURE* algorithm = EVP_SIGNATURE_fetch(NULL, ALGORITHM, NULL);
+    EVP_PKEY_CTX* sign_context = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
+    size_t signature_size = SIGNATURE_SIZE;
+    int result = 0;
+
+    if (algorithm == NULL || sign_context == NULL ||
+        EVP_PKEY_sign_message_init(sign_context, algorithm, parameters) <= 0) {
+        PrintOpenSSLError("sign initialization");
+        goto cleanup;
+    }
+
+    const uint64_t sign_started = MonotonicNs();
+    if (EVP_PKEY_sign(sign_context, signature, &signature_size, message, message_size) <= 0 ||
+        signature_size != SIGNATURE_SIZE) {
+        PrintOpenSSLError("signing");
+        goto cleanup;
+    }
+    *sign_ns = MonotonicNs() - sign_started;
+
+    result = VerifySignature(
+        key,
+        message,
+        message_size,
+        context_string,
+        context_size,
+        signature,
+        signature_size,
+        verify_ns);
+    if (result == 0) fprintf(stderr, "openssl_oracle: generated signature did not verify\n");
+
+cleanup:
+    EVP_PKEY_CTX_free(sign_context);
+    EVP_SIGNATURE_free(algorithm);
+    return result > 0;
+}
+
+static int RunKeygen(const char* seed_hex)
+{
+    size_t seed_size = 0;
+    unsigned char* seed = DecodeHex(seed_hex, &seed_size);
+    unsigned char private_key[PRIVATE_KEY_SIZE];
+    unsigned char public_key[PUBLIC_KEY_SIZE];
+    uint64_t keygen_ns = 0;
+    int result = 1;
+
+    if (seed == NULL || seed_size != KEYGEN_SEED_SIZE) {
+        fprintf(stderr, "openssl_oracle: keygen seed must be %d bytes\n", KEYGEN_SEED_SIZE);
+        goto cleanup;
+    }
+    EVP_PKEY* key = GenerateKey(seed, &keygen_ns);
+    if (key == NULL) goto cleanup;
+    if (!ExportKeys(key, private_key, public_key)) {
+        EVP_PKEY_free(key);
+        goto cleanup;
+    }
+    EVP_PKEY_free(key);
+
+    PrintHex("pk", public_key, sizeof(public_key));
+    PrintHex("sk", private_key, sizeof(private_key));
+    printf("keygen_ns=%llu\n", (unsigned long long)keygen_ns);
+    result = 0;
+
+cleanup:
+    free(seed);
+    return result;
+}
+
+static int RunSign(const char* key_hex, const char* message_hex, const char* context_hex)
+{
+    size_t key_size = 0;
+    size_t message_size = 0;
+    size_t context_size = 0;
+    unsigned char* private_key = DecodeHex(key_hex, &key_size);
+    unsigned char* message = DecodeHex(message_hex, &message_size);
+    unsigned char* context_string = DecodeHex(context_hex, &context_size);
+    unsigned char* signature = NULL;
+    uint64_t sign_ns = 0;
+    uint64_t verify_ns = 0;
+    int result = 1;
+
+    if (private_key == NULL || key_size != PRIVATE_KEY_SIZE || message == NULL ||
+        context_string == NULL || context_size > 255) {
+        fprintf(stderr, "openssl_oracle: invalid sign input\n");
+        goto cleanup;
+    }
+    EVP_PKEY* key = ImportPrivateKey(private_key);
+    if (key == NULL) goto cleanup;
+    signature = malloc(SIGNATURE_SIZE);
+    if (signature == NULL || !SignAndVerify(
+                                 key,
+                                 message,
+                                 message_size,
+                                 context_string,
+                                 context_size,
+                                 signature,
+                                 &sign_ns,
+                                 &verify_ns)) {
+        EVP_PKEY_free(key);
+        goto cleanup;
+    }
+    EVP_PKEY_free(key);
+
+    PrintHex("signature", signature, SIGNATURE_SIZE);
+    printf("verified=1\n");
+    printf("sign_ns=%llu\n", (unsigned long long)sign_ns);
+    printf("verify_ns=%llu\n", (unsigned long long)verify_ns);
+    result = 0;
+
+cleanup:
+    free(signature);
+    free(context_string);
+    free(message);
+    free(private_key);
+    return result;
+}
+
+static int RunVerify(
+    const char* key_hex,
+    const char* message_hex,
+    const char* context_hex,
+    const char* signature_hex)
+{
+    size_t key_size = 0;
+    size_t message_size = 0;
+    size_t context_size = 0;
+    size_t signature_size = 0;
+    unsigned char* public_key = DecodeHex(key_hex, &key_size);
+    unsigned char* message = DecodeHex(message_hex, &message_size);
+    unsigned char* context_string = DecodeHex(context_hex, &context_size);
+    unsigned char* signature = DecodeHex(signature_hex, &signature_size);
+    uint64_t verify_ns = 0;
+    int result = 1;
+
+    if (public_key == NULL || key_size != PUBLIC_KEY_SIZE || message == NULL ||
+        context_string == NULL || context_size > 255 || signature == NULL) {
+        fprintf(stderr, "openssl_oracle: invalid verify input\n");
+        goto cleanup;
+    }
+    EVP_PKEY* key = ImportPublicKey(public_key);
+    if (key == NULL) goto cleanup;
+    const int verified = VerifySignature(
+        key,
+        message,
+        message_size,
+        context_string,
+        context_size,
+        signature,
+        signature_size,
+        &verify_ns);
+    EVP_PKEY_free(key);
+    if (verified < 0) goto cleanup;
+
+    printf("verified=%d\n", verified == 1);
+    printf("verify_ns=%llu\n", (unsigned long long)verify_ns);
+    result = 0;
+
+cleanup:
+    free(signature);
+    free(context_string);
+    free(message);
+    free(public_key);
+    return result;
+}
+
+int main(const int argc, char** argv)
+{
+    if (argc == 3 && strcmp(argv[1], "keygen") == 0) return RunKeygen(argv[2]);
+    if (argc == 5 && strcmp(argv[1], "sign") == 0) return RunSign(argv[2], argv[3], argv[4]);
+    if (argc == 6 && strcmp(argv[1], "verify") == 0) {
+        return RunVerify(argv[2], argv[3], argv[4], argv[5]);
+    }
+
+    fprintf(stderr, "usage: %s keygen <seed-hex>\n", argv[0]);
+    fprintf(stderr, "       %s sign <sk-hex> <message-hex> <context-hex>\n", argv[0]);
+    fprintf(stderr, "       %s verify <pk-hex> <message-hex> <context-hex> <signature-hex>\n", argv[0]);
+    return 2;
+}

--- a/contrib/slh-dsa-ref/slhdsa_c_oracle.c
+++ b/contrib/slh-dsa-ref/slhdsa_c_oracle.c
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <slh_dsa.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define KEYGEN_SEED_SIZE 48
+#define PRIVATE_KEY_SIZE 64
+#define PUBLIC_KEY_SIZE 32
+#define SIGNATURE_SIZE 7856
+
+static uint64_t MonotonicNs(void)
+{
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return 0;
+    return (uint64_t)now.tv_sec * UINT64_C(1000000000) + (uint64_t)now.tv_nsec;
+}
+
+static int HexDigit(const char value)
+{
+    if (value >= '0' && value <= '9') return value - '0';
+    if (value >= 'a' && value <= 'f') return value - 'a' + 10;
+    if (value >= 'A' && value <= 'F') return value - 'A' + 10;
+    return -1;
+}
+
+static uint8_t* DecodeHex(const char* hex, size_t* output_size)
+{
+    const size_t hex_size = strlen(hex);
+    if ((hex_size & 1U) != 0) return NULL;
+
+    *output_size = hex_size / 2;
+    uint8_t* output = malloc(*output_size == 0 ? 1 : *output_size);
+    if (output == NULL) return NULL;
+
+    for (size_t i = 0; i < *output_size; ++i) {
+        const int high = HexDigit(hex[2 * i]);
+        const int low = HexDigit(hex[2 * i + 1]);
+        if (high < 0 || low < 0) {
+            free(output);
+            return NULL;
+        }
+        output[i] = (uint8_t)((high << 4) | low);
+    }
+    return output;
+}
+
+static void PrintHex(const char* name, const uint8_t* data, const size_t size)
+{
+    printf("%s=", name);
+    for (size_t i = 0; i < size; ++i) printf("%02x", data[i]);
+    putchar('\n');
+}
+
+static int RunKeygen(const char* seed_hex)
+{
+    size_t seed_size = 0;
+    uint8_t* seed = DecodeHex(seed_hex, &seed_size);
+    uint8_t private_key[PRIVATE_KEY_SIZE];
+    uint8_t public_key[PUBLIC_KEY_SIZE];
+    int result = 1;
+
+    if (seed == NULL || seed_size != KEYGEN_SEED_SIZE) {
+        fprintf(stderr, "slhdsa_c_oracle: keygen seed must be %d bytes\n", KEYGEN_SEED_SIZE);
+        goto cleanup;
+    }
+    const uint64_t started = MonotonicNs();
+    const int generated = slh_keygen_internal(
+        private_key,
+        public_key,
+        seed,
+        seed + 16,
+        seed + 32,
+        &slh_dsa_sha2_128s);
+    const uint64_t keygen_ns = MonotonicNs() - started;
+    if (generated != 0) {
+        fprintf(stderr, "slhdsa_c_oracle: key generation failed\n");
+        goto cleanup;
+    }
+
+    PrintHex("pk", public_key, sizeof(public_key));
+    PrintHex("sk", private_key, sizeof(private_key));
+    printf("keygen_ns=%llu\n", (unsigned long long)keygen_ns);
+    result = 0;
+
+cleanup:
+    free(seed);
+    return result;
+}
+
+static int RunSign(const char* key_hex, const char* message_hex, const char* context_hex)
+{
+    size_t key_size = 0;
+    size_t message_size = 0;
+    size_t context_size = 0;
+    uint8_t* private_key = DecodeHex(key_hex, &key_size);
+    uint8_t* message = DecodeHex(message_hex, &message_size);
+    uint8_t* context_string = DecodeHex(context_hex, &context_size);
+    uint8_t public_key[PUBLIC_KEY_SIZE];
+    uint8_t* signature = NULL;
+    int result = 1;
+
+    if (private_key == NULL || key_size != PRIVATE_KEY_SIZE || message == NULL ||
+        context_string == NULL || context_size > 255) {
+        fprintf(stderr, "slhdsa_c_oracle: invalid sign input\n");
+        goto cleanup;
+    }
+    memcpy(public_key, private_key + PRIVATE_KEY_SIZE - PUBLIC_KEY_SIZE, PUBLIC_KEY_SIZE);
+    signature = malloc(SIGNATURE_SIZE);
+    if (signature == NULL) goto cleanup;
+
+    const uint64_t sign_started = MonotonicNs();
+    const size_t signature_size = slh_sign(
+        signature,
+        message,
+        message_size,
+        context_string,
+        context_size,
+        private_key,
+        NULL,
+        &slh_dsa_sha2_128s);
+    const uint64_t sign_ns = MonotonicNs() - sign_started;
+    if (signature_size != SIGNATURE_SIZE) {
+        fprintf(stderr, "slhdsa_c_oracle: signing failed\n");
+        goto cleanup;
+    }
+
+    const uint64_t verify_started = MonotonicNs();
+    const int verified = slh_verify(
+        message,
+        message_size,
+        signature,
+        signature_size,
+        context_string,
+        context_size,
+        public_key,
+        &slh_dsa_sha2_128s);
+    const uint64_t verify_ns = MonotonicNs() - verify_started;
+    if (verified != 1) {
+        fprintf(stderr, "slhdsa_c_oracle: verification failed\n");
+        goto cleanup;
+    }
+
+    PrintHex("signature", signature, signature_size);
+    printf("verified=1\n");
+    printf("sign_ns=%llu\n", (unsigned long long)sign_ns);
+    printf("verify_ns=%llu\n", (unsigned long long)verify_ns);
+    result = 0;
+
+cleanup:
+    free(signature);
+    free(context_string);
+    free(message);
+    free(private_key);
+    return result;
+}
+
+static int RunVerify(
+    const char* key_hex,
+    const char* message_hex,
+    const char* context_hex,
+    const char* signature_hex)
+{
+    size_t key_size = 0;
+    size_t message_size = 0;
+    size_t context_size = 0;
+    size_t signature_size = 0;
+    uint8_t* public_key = DecodeHex(key_hex, &key_size);
+    uint8_t* message = DecodeHex(message_hex, &message_size);
+    uint8_t* context_string = DecodeHex(context_hex, &context_size);
+    uint8_t* signature = DecodeHex(signature_hex, &signature_size);
+    int result = 1;
+
+    if (public_key == NULL || key_size != PUBLIC_KEY_SIZE || message == NULL ||
+        context_string == NULL || context_size > 255 || signature == NULL) {
+        fprintf(stderr, "slhdsa_c_oracle: invalid verify input\n");
+        goto cleanup;
+    }
+    const uint64_t verify_started = MonotonicNs();
+    const int verified = slh_verify(
+        message,
+        message_size,
+        signature,
+        signature_size,
+        context_string,
+        context_size,
+        public_key,
+        &slh_dsa_sha2_128s);
+    const uint64_t verify_ns = MonotonicNs() - verify_started;
+
+    printf("verified=%d\n", verified == 1);
+    printf("verify_ns=%llu\n", (unsigned long long)verify_ns);
+    result = 0;
+
+cleanup:
+    free(signature);
+    free(context_string);
+    free(message);
+    free(public_key);
+    return result;
+}
+
+int main(const int argc, char** argv)
+{
+    if (argc == 3 && strcmp(argv[1], "keygen") == 0) return RunKeygen(argv[2]);
+    if (argc == 5 && strcmp(argv[1], "sign") == 0) return RunSign(argv[2], argv[3], argv[4]);
+    if (argc == 6 && strcmp(argv[1], "verify") == 0) {
+        return RunVerify(argv[2], argv[3], argv[4], argv[5]);
+    }
+
+    fprintf(stderr, "usage: %s keygen <seed-hex>\n", argv[0]);
+    fprintf(stderr, "       %s sign <sk-hex> <message-hex> <context-hex>\n", argv[0]);
+    fprintf(stderr, "       %s verify <pk-hex> <message-hex> <context-hex> <signature-hex>\n", argv[0]);
+    return 2;
+}

--- a/contrib/slh-dsa-ref/vectors.json
+++ b/contrib/slh-dsa-ref/vectors.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "profile": {
+    "name": "SLH-DSA-SHA2-128s",
+    "standard": "FIPS 205",
+    "signature_interface": "external",
+    "message_mode": "pure",
+    "public_key_bytes": 32,
+    "private_key_bytes": 64,
+    "keygen_seed_bytes": 48,
+    "signature_bytes": 7856,
+    "prototype_message_bytes": 32,
+    "prototype_context_hex": "50514254432f74782d7369676e61747572652f7631",
+    "prototype_context_ascii": "PQBTC/tx-signature/v1",
+    "test_signing": "deterministic",
+    "production_signing_if_selected": "randomized"
+  },
+  "system_cost_model": {
+    "held_rc2_signature_bytes": 4480,
+    "block_weight_limit": 16000000,
+    "signature_witness_weight_per_byte": 1
+  },
+  "sources": {
+    "nist_acvp": {
+      "repository": "https://github.com/usnistgov/ACVP-Server",
+      "commit": "15c0f3deeefbfa8cb6cd32a99e1ca3b738c66bf0",
+      "files": {
+        "gen-val/json-files/SLH-DSA-keyGen-FIPS205/prompt.json": "bce170976f257ee3dfc8c54ea46722ccb553539847daa6d8048f0216cc28b51c",
+        "gen-val/json-files/SLH-DSA-keyGen-FIPS205/expectedResults.json": "f35f74b6676d6b369c87e88c36698f28c14d5929d31e507d910288c69258afee",
+        "gen-val/json-files/SLH-DSA-sigGen-FIPS205/prompt.json": "afa673eacdf0aec53512a159159b7632684adfcd0d88f8640a7f6f5796aacdc8",
+        "gen-val/json-files/SLH-DSA-sigGen-FIPS205/expectedResults.json": "71e8e0f7e4b0cfd1747314299204d9d4d50968d200a4ae873921eaa7aabeaad1",
+        "gen-val/json-files/SLH-DSA-sigVer-FIPS205/prompt.json": "4e7beb1233e47baa0acdd36417c66c45811aa40a4e32ffdb1a35d93b13b289fb",
+        "gen-val/json-files/SLH-DSA-sigVer-FIPS205/expectedResults.json": "259f5e2a0665de0adc0fefa45b5db3a2a6ed13c3c44d14bdaf64a80aee12c687"
+      }
+    },
+    "openssl": {
+      "minimum_version": "3.5.0",
+      "documentation": "https://docs.openssl.org/3.5/man7/EVP_SIGNATURE-SLH-DSA/",
+      "role": "independent prototype oracle; not a node dependency"
+    },
+    "slhdsa_c": {
+      "repository": "https://github.com/slh-dsa/slhdsa-c",
+      "commit": "2b111e076a3bf0b6041651cf8746acf5ade56cc7",
+      "license_expression": "Apache-2.0 OR ISC OR MIT",
+      "role": "independent portable-C oracle; not vendored or linked into the node"
+    }
+  },
+  "vectors": {
+    "nist_keygen_tg1_tc1": {
+      "source": "SLH-DSA-keyGen-FIPS205 tgId=1 tcId=1",
+      "seed_hex": "173d04c938c1c36bf289c3c022d04b1463ae23c41aa546da589774ac20b745c40d794777914c99766827f0f09ca972be",
+      "expected_private_key_hex": "173d04c938c1c36bf289c3c022d04b1463ae23c41aa546da589774ac20b745c40d794777914c99766827f0f09ca972be0162c10219d422adba1359e6aa65299c",
+      "expected_public_key_hex": "0d794777914c99766827f0f09ca972be0162c10219d422adba1359e6aa65299c"
+    },
+    "nist_siggen_tg19_tc161": {
+      "source": "SLH-DSA-sigGen-FIPS205 tgId=19 tcId=161",
+      "deterministic": true,
+      "signature_interface": "external",
+      "message_mode": "pure",
+      "private_key_hex": "9ae2f36b1eb8295acdaa5589d996788f06977d16ac51524d770152e02de29c8adb30f66d17e197683997000bc98342af9b0862379ca9f32edb1a2ef3a9262207",
+      "message_hex": "20",
+      "context_hex": "0610d63cca608f79c617f1c311fb4cf35d63982536a41b2c305a21d56641ad213b9b0253e8518f46642033680f25f91d936c184f78f6170864be8e59a6f399fa7f01e80b19df5f76b3111c4eac7febbeb4c7c9ff3b2c2324a61b3348c84257816ee0e8fbe3aee55c6c547c9b1abe239707569cfd7408da68fdccb9fe3bcbca2fac370ccf17f31551c53e07169520f0601a6e14937204b87bb0ffeff8ffab9a736a12bc0b1e3d051ce90f022d848a68ecc5b8aad63f354269422b0d1d0ffe60c86b8ba0fd0db518c44454c8b46dfaa7bd1dfef75f7305ff0b10cac037024a70b1c470282b4885ebbd181edb3f4052330362106780b0243893b7e983f97230e3",
+      "expected_signature_sha256": "8ceee1f1b9feeb53f65e63a54c2ef252bfa4307df171ecdc2367923ef63d5223"
+    },
+    "nist_sigver_tg19": {
+      "source": "SLH-DSA-sigVer-FIPS205 tgId=19",
+      "parameter_set": "SLH-DSA-SHA2-128s",
+      "signature_interface": "external",
+      "message_mode": "pure",
+      "cases": [
+        {
+          "test_case_id": 253,
+          "expected_valid": false,
+          "public_key_hex": "7958846fc89119a3776fb1e129b09a09412124223f267550272aea4111c502ba",
+          "message_bytes": 439,
+          "message_sha256": "8d6d44b0c899304f6367c1145b829fab34028e4484e4d8bf14d24bcf7b94856e",
+          "context_bytes": 119,
+          "context_sha256": "490a02b3b4f51da3ad0b0138edec9ada9cf308ea85a1abea0c5c2c6784f2268f",
+          "signature_bytes": 7856,
+          "signature_sha256": "e240cbc0d396bf20c3f05b1c203824bb4f089587d264bd96ec73893989f77385"
+        },
+        {
+          "test_case_id": 266,
+          "expected_valid": true,
+          "public_key_hex": "cf5339f7b748f3b48c0bbf22392e6f4254aeaa7d529078de7c056d3e71973df5",
+          "message_bytes": 24,
+          "message_sha256": "c2c767245bc7243ed27f0455eaf3e0393f3447e7c365c620933d6b2c15a8391a",
+          "context_bytes": 255,
+          "context_sha256": "87b5b27a181a56b2e7e3ca8dc161f75875c1d3ad3a6a9b72fc584bdb63aa7e9e",
+          "signature_bytes": 7856,
+          "signature_sha256": "8afce9948aa64e564daacd9467a39577a5241823196844d4452edd250c3052bb"
+        }
+      ]
+    },
+    "pqbtc_sighash_v1": {
+      "source": "repo-defined deterministic interoperability vector",
+      "seed_hex": "173d04c938c1c36bf289c3c022d04b1463ae23c41aa546da589774ac20b745c40d794777914c99766827f0f09ca972be",
+      "message_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      "context_hex": "50514254432f74782d7369676e61747572652f7631",
+      "expected_private_key_hex": "173d04c938c1c36bf289c3c022d04b1463ae23c41aa546da589774ac20b745c40d794777914c99766827f0f09ca972be0162c10219d422adba1359e6aa65299c",
+      "expected_public_key_hex": "0d794777914c99766827f0f09ca972be0162c10219d422adba1359e6aa65299c",
+      "expected_signature_sha256": "14bf1a85f8fed8e18c61a3dfb25393527056da47b2d627e652bcfc4a105600e4"
+    }
+  }
+}

--- a/docs/PQSIG_PRODUCTION_READINESS.md
+++ b/docs/PQSIG_PRODUCTION_READINESS.md
@@ -95,9 +95,10 @@ record.
 
 ## Implementation Direction
 
-1. Implement an isolated `SLH-DSA-SHA2-128s` prototype against the exact FIPS
-   205 API, encodings, context rules, and test vectors. Do not assign an active
-   `ALG_ID` or connect it to Script yet.
+1. Maintain the isolated `SLH-DSA-SHA2-128s` prototype in
+   `SLH_DSA_SHA2_128S_REFERENCE.md` against the exact FIPS 205 API, encodings,
+   context rules, and test vectors. Do not assign an active `ALG_ID` or connect
+   it to Script yet.
 2. Implement or bind an isolated `ML-DSA-44` comparator for size, signing,
    verification, wallet, and block-economics measurements.
 3. Use OpenSSL 3.5 or later only as a prototype and differential-test oracle.

--- a/docs/README_PQBTC.md
+++ b/docs/README_PQBTC.md
@@ -24,6 +24,7 @@ integration.
 
 - [Protocol Specification](Spec.md) - Normative spec with MUST/SHOULD language
 - [Signature Production Readiness](PQSIG_PRODUCTION_READINESS.md) - Controlling cryptographic evidence, release hold, and replacement gates
+- [SLH-DSA-SHA2-128s Reference](SLH_DSA_SHA2_128S_REFERENCE.md) - Isolated FIPS 205 vector, interoperability, and measurement baseline
 - [Core Diff Plan](CORE_DIFF_PLAN.md) - Bitcoin Core fork implementation phases
 - [Track A: Native PQ Bitcoin](TRACK_A_NATIVE_PQ_BITCOIN.md) - Strategic anchor, scope, non-goals, and how adjacent approaches fit
 - [Track A 90-Day Roadmap](TRACK_A_90_DAY_ROADMAP.md) - Concrete execution plan for April 6, 2026 through July 5, 2026

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: RESEARCH-INDEX-v1
-## Updated: 2026-04-06
+## Updated: 2026-07-18
 ## Consensus-Relevant: NO
 
 ## Purpose
@@ -15,7 +15,11 @@ answer specific classes of questions instead of listing every file in `docs/`.
 
 ## Current State
 
-- The repo has a strong internal design corpus in Markdown.
+- The implemented rc2 profile is under a production release hold; integration
+  coverage does not establish its claimed cryptographic security.
+- An isolated FIPS 205 `SLH-DSA-SHA2-128s` reference harness now provides
+  pinned official keygen/sign/verify vectors, two-oracle interoperability, and
+  initial timings without changing consensus behavior.
 - No PDF papers are currently checked into this repo.
 - Delving Bitcoin now provides concrete adjacent research references that are
   directly relevant to Track A, especially around SHRINCS / SHRIMPS and
@@ -65,6 +69,11 @@ answer specific classes of questions instead of listing every file in `docs/`.
 
 ## PQSig Construction And Encoding
 
+- [PQSIG_PRODUCTION_READINESS.md](PQSIG_PRODUCTION_READINESS.md)
+  Controlling cryptographic release hold and replacement gates.
+- [SLH_DSA_SHA2_128S_REFERENCE.md](SLH_DSA_SHA2_128S_REFERENCE.md)
+  Isolated standards-conformance and measurement baseline for the first final-
+  standard candidate.
 - [PQSIG_INTERNALS.md](PQSIG_INTERNALS.md)
   Best internal explainer for how the signature system is assembled.
 - [PQSIG_WIRE_FORMAT.md](PQSIG_WIRE_FORMAT.md)

--- a/docs/SLH_DSA_SHA2_128S_REFERENCE.md
+++ b/docs/SLH_DSA_SHA2_128S_REFERENCE.md
@@ -1,0 +1,150 @@
+# SLH-DSA-SHA2-128s Reference Prototype
+
+## Status: REFERENCE ONLY - NOT CONSENSUS
+## Spec-ID: SLH-DSA-SHA2-128S-REFERENCE-v1
+## Updated: 2026-07-18
+## Consensus-Relevant: NO
+
+## Decision Boundary
+
+This slice establishes a reproducible standards-conformance and performance
+baseline for one final-standard candidate. It does not select the candidate for
+production, add a node dependency, allocate an `ALG_ID`, modify Script, or
+change the consensus accepted set. The production hold in
+`PQSIG_PRODUCTION_READINESS.md` remains in force.
+
+## Frozen Reference Contract
+
+| Property | Reference value |
+| --- | --- |
+| Standard | NIST FIPS 205 |
+| Parameter set | `SLH-DSA-SHA2-128s` |
+| Security category | 1 |
+| Interface | External |
+| Message mode | Pure SLH-DSA, not HashSLH-DSA |
+| Prototype message | Exactly 32 bytes |
+| Prototype context | ASCII `PQBTC/tx-signature/v1` |
+| Public key | 32 bytes |
+| Private key | 64 bytes |
+| Signature | 7,856 bytes |
+| Exact-vector signing | Deterministic |
+| Future production posture | Randomized signing, if separately approved |
+
+Pure SLH-DSA internally binds `0x00 || len(ctx) || ctx || message` as specified
+by FIPS 205. The prototype signs the 32-byte Bitcoin-style sighash digest as the
+message and uses a fixed context to prevent signatures from being silently
+reinterpreted by another protocol. The exact context remains a prototype
+contract, not a consensus allocation.
+
+## Reproducible Evidence
+
+The checked-in manifest at `contrib/slh-dsa-ref/vectors.json` records:
+
+- NIST ACVP repository commit
+  `15c0f3deeefbfa8cb6cd32a99e1ca3b738c66bf0`
+- SHA256 checksums for the six key-generation, signature-generation, and
+  signature-verification source files
+- NIST key-generation group 1, test case 1
+- NIST deterministic external/pure signature-generation group 19, test case
+  161
+- NIST external/pure signature-verification group 19, test cases 253 (reject)
+  and 266 (accept, with the maximum 255-byte context)
+- portable `slhdsa-c` commit
+  `2b111e076a3bf0b6041651cf8746acf5ade56cc7`
+- one repo-defined 32-byte sighash/context interoperability vector
+
+The selected NIST signature has SHA256
+`8ceee1f1b9feeb53f65e63a54c2ef252bfa4307df171ecdc2367923ef63d5223`.
+The PQBTC prototype signature has SHA256
+`14bf1a85f8fed8e18c61a3dfb25393527056da47b2d627e652bcfc4a105600e4`.
+
+`compare_oracles.py` builds two adapters in a temporary directory:
+
+1. OpenSSL 3.5 or later
+2. the exact pinned `slh-dsa/slhdsa-c` checkout
+
+Both independently reproduce the NIST keypair, reproduce the full 7,856-byte
+NIST signature, self-verify it, return the official outcomes for the selected
+accept/reject verification cases, and produce the same complete PQBTC prototype
+signature. OpenSSL and `slhdsa-c` remain external research oracles and are not
+linked into PQBTC.
+
+Run:
+
+```bash
+python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only
+python3 contrib/slh-dsa-ref/compare_oracles.py \
+  --acvp-server /path/to/pinned/ACVP-Server \
+  --slhdsa-c /path/to/pinned/slhdsa-c \
+  --benchmark-iterations 10
+```
+
+## Prototype Measurements
+
+Local arm64 macOS measurement on 2026-07-18, using OpenSSL 3.6.3 and the pinned
+portable-C oracle compiled with `-O2`. Values are medians of ten repetitions
+of the fixed PQBTC vector and are directional, not release envelopes. They time
+the adapter's cryptographic calls and exclude compilation, process startup, and
+OpenSSL context initialization.
+
+| Oracle | Key generation | Sign | Verify |
+| --- | ---: | ---: | ---: |
+| OpenSSL 3.6.3 | 19.384 ms | 146.434 ms | 0.114 ms |
+| `slhdsa-c` | 40.896 ms | 298.063 ms | 0.228 ms |
+
+Verification is fast enough to justify deeper node-level evaluation. Signing
+latency is user-visible and requires wallet batching, hardware-signer, and
+multi-input transaction measurements before selection.
+
+## Bitcoin-System Implications
+
+- The 32-byte raw public key preserves the compact key size used by the current
+  research profile. A future script-layer tag would be a separate consensus
+  design decision.
+- A 7,856-byte signature is 75.36% larger than the held 4,480-byte rc2
+  signature.
+- At a 16,000,000-WU block limit, a signature-only upper bound falls from 3,571
+  rc2 signatures to 2,036 SLH-DSA signatures, or 57.01% of the rc2 upper bound.
+  Real transaction capacity is lower because this excludes transaction,
+  witness, script, and compact size overhead. The harness emits this calculation
+  from its checked-in cost model rather than relying on prose-only arithmetic.
+- The signature exceeds Bitcoin's retained 520-byte general stack-element
+  limit. The current node permits only the exact 4,480-byte rc2 signature in a
+  narrowly matched witness shape, so it rejects this 7,856-byte reference
+  signature today. Any future support requires an explicit consensus and policy
+  sizing design; being below the separate 10,000-byte script-size limit does
+  not make it admissible.
+- SLH-DSA is stateless, so it avoids state-reuse and backup-coordination failure
+  modes. Randomized signing still requires a sound entropy path and specified
+  failure behavior.
+- Hardware signers and PSBT flows must bind the exact 32-byte digest, context,
+  algorithm, and randomized-signing policy without silent fallback.
+
+## What This Evidence Establishes
+
+Established:
+
+1. the exact FIPS 205 parameter set is available in two independent
+   implementations
+2. both implementations match selected official NIST keygen, siggen, and
+   positive/negative sigver vectors
+3. both implementations agree byte-for-byte on a PQBTC-shaped 32-byte message
+   and fixed context
+4. the candidate has a reproducible local timing baseline
+
+Not established:
+
+1. a production-quality consensus implementation
+2. constant-time signing or adequate secret erasure
+3. complete ACVP, broad malformed-input, fuzz, or sanitizer coverage
+4. acceptable block, mempool, wallet, backup, PSBT, or hardware-signer behavior
+5. an activation, migration, or algorithm-agility design
+6. independent cryptographic and consensus-code review
+
+## Next Gate
+
+The next bounded slice should add randomized-signing interoperability, broader
+mutation and malformed-input vectors, and a complete selected-profile ACVP run.
+Only after that evidence is green should PQBTC compare the same system-level
+contract against `ML-DSA-44`. No candidate should enter `src/crypto`, Script,
+wallet activation, or the `ALG_ID` registry during these reference slices.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -26,6 +26,12 @@ The next implementation lane is isolated standards conformance: first a FIPS
 inventory policy class, `ALG_ID`, Script rule, or consensus accepted set changes
 as part of this safety closeout.
 
+The first isolated reference slice is recorded in
+`SLH_DSA_SHA2_128S_REFERENCE.md`. It pins NIST ACVP and portable-C source
+commits, requires official keygen/sign/verify outcomes plus full byte agreement
+between OpenSSL and `slhdsa-c`, and records initial arm64 timings without adding
+either implementation to the node.
+
 Keep the live `pq_required` gate aligned with the repo as it exists today. PR
 `#163` closed the initial inventory tranche at `pq_required: 120`,
 `pq_backlog: 0`, `legacy_only: 14`, and `dual_profile: 142`. Promotion Matrix
@@ -1598,6 +1604,7 @@ Aineko must ask before:
 - `SHRINCS_DECISION_TRACK.md`
 - `PQSIG_PROFILE_COMPARISON.md`
 - `PQSIG_PRODUCTION_READINESS.md`
+- `SLH_DSA_SHA2_128S_REFERENCE.md`
 - `GENESIS_AND_NETWORK_POSTURE.md`
 - `RESEARCH_INDEX.md`
 - `PSBT_REPLACEMENT_TRANCHE.md`


### PR DESCRIPTION
## Summary
- freeze the reference-only FIPS 205 SLH-DSA-SHA2-128s external/pure contract
- pin NIST ACVP sources and a clean slhdsa-c checkout, then compare OpenSSL and slhdsa-c byte-for-byte
- cover selected official keygen, deterministic siggen, accepted sigver, and rejected sigver cases
- record ten-sample timing and signature-only block-space economics
- document wallet/consensus implications without touching src, Script, wallet activation, or ALG_ID

## Validation
- `git diff --check`
- `python3 -m unittest ci.test.test_slh_dsa_reference`
- `python3 -m unittest discover -s ci/test -p 'test_*.py'`\n- `python3 ci/test/check_ci_inventory.py`\n- `python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only`\n- `python3 contrib/slh-dsa-ref/compare_oracles.py --acvp-server /tmp/acvp-server --slhdsa-c /tmp/slhdsa-c --benchmark-iterations 10`\n\nStrict oracle result: all provenance, keygen, siggen, sigver accept/reject, PQBTC vector, and full-byte agreement checks pass. Local project lint reached repository checks but the scripted-diff check requires GNU sed; this macOS host has BSD sed. Optional local mlc, ruff, vulture, lief, and shellcheck tools were not installed.