### PR TITLE
research: complete SLH-DSA randomized evidence

### DIFF
--- a/ci/test/test_slh_dsa_reference.py
+++ b/ci/test/test_slh_dsa_reference.py
@@ -1,3 +1,4 @@
+import copy
 import importlib.util
 import json
 import subprocess
@@ -37,6 +38,47 @@ class SLHDSAReferenceTests(unittest.TestCase):
             self.assertTrue(
                 vector["expected_private_key_hex"].endswith(vector["expected_public_key_hex"])
             )
+
+    def test_complete_selected_profile_acvp_contract(self):
+        coverage = self.manifest["acvp_coverage"]
+        self.assertEqual(coverage["keygen"]["test_case_ids"], list(range(1, 11)))
+        self.assertEqual(
+            [group["test_case_ids"] for group in coverage["siggen"]],
+            [list(range(157, 164)), list(range(469, 476))],
+        )
+        self.assertEqual(coverage["sigver"]["test_case_ids"], list(range(253, 267)))
+        self.assertEqual(coverage["sigver"]["accepted_test_case_ids"], [258, 266])
+        self.assertEqual(coverage["total_cases"], 38)
+
+    def test_randomized_posture_and_source_pins(self):
+        profile = self.manifest["profile"]
+        sources = self.manifest["sources"]
+        self.assertEqual(profile["randomizer_bytes"], 16)
+        self.assertEqual(
+            profile["exact_vector_signing"], "deterministic_or_fixed_randomizer"
+        )
+        self.assertEqual(profile["production_signing_if_selected"], "randomized")
+        self.assertEqual(sources["openssl"]["version"], "3.6.3")
+        for name in ("nist_acvp", "openssl", "slhdsa_c"):
+            self.assertRegex(sources[name]["commit"], r"^[0-9a-f]{40}$")
+
+    def test_manifest_rejects_coverage_drift(self):
+        mutated = copy.deepcopy(self.manifest)
+        mutated["acvp_coverage"]["sigver"]["test_case_ids"].pop()
+        with self.assertRaisesRegex(compare_oracles.ReferenceError, "ACVP coverage"):
+            compare_oracles.validate_manifest(mutated)
+
+    def test_hex_mutation_is_bounded(self):
+        original = "00112233"
+        mutated = compare_oracles.flip_hex_byte(original, 2)
+        self.assertEqual(mutated, "00112333")
+        self.assertEqual(len(mutated), len(original))
+
+    def test_adapters_enforce_exact_signature_length(self):
+        for source_name in ("openssl_oracle.c", "slhdsa_c_oracle.c"):
+            source = (REFERENCE_DIR / source_name).read_text(encoding="utf8")
+            self.assertIn("if (signature_size != SIGNATURE_SIZE)", source)
+            self.assertIn('printf("verified=0\\n")', source)
 
     def test_manifest_only_cli(self):
         result = subprocess.run(

--- a/contrib/slh-dsa-ref/README.md
+++ b/contrib/slh-dsa-ref/README.md
@@ -8,13 +8,16 @@ does not define consensus behavior, and does not allocate or activate an
 ## Evidence Sources
 
 - NIST ACVP vectors pinned in `vectors.json`
-- OpenSSL 3.5 or later as one independent implementation
+- an OpenSSL 3.6.3 runtime plus a clean checkout at the exact source commit
+  pinned in `vectors.json` as one independent implementation
 - `slh-dsa/slhdsa-c` at the exact commit pinned in `vectors.json` as the second
   independent implementation
 
-The adapters use deterministic signing only for exact vector comparison.
-Randomized signing remains the required posture for any future production
-proposal.
+The adapters use deterministic signing for deterministic vectors and explicit
+16-byte randomizer injection for randomized vectors. The driver also exercises
+OpenSSL's DRBG-backed signing path and supplies fresh operating-system entropy
+to the portable implementation's caller-owned `addrnd` input. Randomized
+signing remains the required posture for any future production proposal.
 
 ## Run
 
@@ -22,18 +25,27 @@ proposal.
 python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only
 python3 contrib/slh-dsa-ref/compare_oracles.py \
   --acvp-server /path/to/pinned/ACVP-Server \
+  --openssl-source /path/to/pinned/openssl \
   --slhdsa-c /path/to/pinned/slhdsa-c \
-  --benchmark-iterations 10
+  --benchmark-iterations 10 \
+  --sanitizers
 ```
 
 The full run checks the NIST checkout commit and source-file hashes, re-extracts
-the selected vector fields, builds both adapters in a temporary directory,
-requires the pinned `slhdsa-c` Git commit, reproduces selected NIST
-key-generation and signature-generation vectors, enforces official accepted and
-rejected signature-verification cases, checks the PQBTC 32-byte sighash/context
-vector, compares complete signature bytes, and reports median key-generation,
-signing, and verification times plus signature-only block-space economics. Both
-external source checkouts must be clean and at their pinned commits.
+the complete external/pure SHA2-128s profile, and requires clean OpenSSL,
+`slhdsa-c`, and ACVP source checkouts at their pinned commits. It executes all
+10 key-generation cases, all 7 deterministic and 7 randomized
+signature-generation cases, and all 14 signature-verification cases. It also
+checks the PQBTC 32-byte sighash/context vector, complete signature-byte and
+cross-verification agreement, randomized-signature diversity, empty/maximum
+context boundaries, malformed lengths and key/message/context/signature
+mutations, and optional ASan/UBSan adapter runs. The report includes separate
+deterministic and randomized timing medians plus signature-only block-space
+economics.
+
+The portable API expects callers to validate the exact 7,856-byte signature
+length before verification. Both adapters enforce that precondition and return
+a normal verification failure for short or long signatures.
 
 OpenSSL is a prototype oracle only. Passing this harness does not make OpenSSL a
 node dependency or approve SLH-DSA for consensus integration.

--- a/contrib/slh-dsa-ref/compare_oracles.py
+++ b/contrib/slh-dsa-ref/compare_oracles.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import shlex
 import statistics
 import subprocess
@@ -40,6 +41,9 @@ def require_hex(value: str, byte_length: int, label: str) -> None:
 
 
 def validate_manifest(manifest: dict) -> None:
+    if manifest.get("schema_version") != 2:
+        raise ReferenceError("manifest schema_version must be 2")
+
     profile = manifest["profile"]
     expected_profile = {
         "name": "SLH-DSA-SHA2-128s",
@@ -49,8 +53,11 @@ def validate_manifest(manifest: dict) -> None:
         "public_key_bytes": 32,
         "private_key_bytes": 64,
         "keygen_seed_bytes": 48,
+        "randomizer_bytes": 16,
         "signature_bytes": 7856,
         "prototype_message_bytes": 32,
+        "exact_vector_signing": "deterministic_or_fixed_randomizer",
+        "production_signing_if_selected": "randomized",
     }
     for name, expected in expected_profile.items():
         if profile.get(name) != expected:
@@ -70,10 +77,45 @@ def validate_manifest(manifest: dict) -> None:
     if manifest.get("system_cost_model") != expected_cost_model:
         raise ReferenceError("system cost model does not match the held PQBTC baseline")
 
+    expected_acvp_coverage = {
+        "keygen": {
+            "group_id": 1,
+            "test_case_ids": list(range(1, 11)),
+        },
+        "siggen": [
+            {
+                "group_id": 19,
+                "deterministic": True,
+                "signature_interface": "external",
+                "message_mode": "pure",
+                "test_case_ids": list(range(157, 164)),
+            },
+            {
+                "group_id": 55,
+                "deterministic": False,
+                "signature_interface": "external",
+                "message_mode": "pure",
+                "test_case_ids": list(range(469, 476)),
+            },
+        ],
+        "sigver": {
+            "group_id": 19,
+            "signature_interface": "external",
+            "message_mode": "pure",
+            "test_case_ids": list(range(253, 267)),
+            "accepted_test_case_ids": [258, 266],
+        },
+        "total_cases": 38,
+    }
+    if manifest.get("acvp_coverage") != expected_acvp_coverage:
+        raise ReferenceError("ACVP coverage does not match the frozen 38-case contract")
+
     sources = manifest["sources"]
-    for source_name in ("nist_acvp", "slhdsa_c"):
+    for source_name in ("nist_acvp", "openssl", "slhdsa_c"):
         if re.fullmatch(r"[0-9a-f]{40}", sources[source_name]["commit"]) is None:
             raise ReferenceError(f"{source_name} commit must be a full Git SHA")
+    if sources["openssl"].get("version") != "3.6.3":
+        raise ReferenceError("OpenSSL source and runtime version must be 3.6.3")
     expected_nist_files = {
         "gen-val/json-files/SLH-DSA-keyGen-FIPS205/prompt.json",
         "gen-val/json-files/SLH-DSA-keyGen-FIPS205/expectedResults.json",
@@ -92,7 +134,11 @@ def validate_manifest(manifest: dict) -> None:
     vectors = manifest["vectors"]
     keygen = vectors["nist_keygen_tg1_tc1"]
     require_hex(keygen["seed_hex"], profile["keygen_seed_bytes"], "NIST keygen seed")
-    require_hex(keygen["expected_private_key_hex"], profile["private_key_bytes"], "NIST private key")
+    require_hex(
+        keygen["expected_private_key_hex"],
+        profile["private_key_bytes"],
+        "NIST private key",
+    )
     require_hex(keygen["expected_public_key_hex"], profile["public_key_bytes"], "NIST public key")
 
     siggen = vectors["nist_siggen_tg19_tc161"]
@@ -131,7 +177,11 @@ def validate_manifest(manifest: dict) -> None:
     pqbtc = vectors["pqbtc_sighash_v1"]
     require_hex(pqbtc["seed_hex"], profile["keygen_seed_bytes"], "PQBTC keygen seed")
     require_hex(pqbtc["message_hex"], profile["prototype_message_bytes"], "PQBTC message")
-    require_hex(pqbtc["expected_private_key_hex"], profile["private_key_bytes"], "PQBTC private key")
+    require_hex(
+        pqbtc["expected_private_key_hex"],
+        profile["private_key_bytes"],
+        "PQBTC private key",
+    )
     require_hex(pqbtc["expected_public_key_hex"], profile["public_key_bytes"], "PQBTC public key")
     if pqbtc["context_hex"] != context_hex:
         raise ReferenceError("PQBTC vector does not use the frozen prototype context")
@@ -156,6 +206,18 @@ def run(command: list[str], cwd: Path | None = None) -> str:
     return result.stdout
 
 
+def require_command_failure(command: list[str], label: str) -> None:
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 0:
+        raise ReferenceError(f"{label} unexpectedly succeeded")
+
+
 def parse_version(value: str, label: str) -> tuple[int, int, int]:
     match = re.search(r"(?:OpenSSL )?(\d+)\.(\d+)\.(\d+)", value)
     if match is None:
@@ -163,11 +225,14 @@ def parse_version(value: str, label: str) -> tuple[int, int, int]:
     return tuple(int(part) for part in match.groups())
 
 
-def openssl_version() -> tuple[str, tuple[int, int, int]]:
+def openssl_version(expected_version: str) -> tuple[str, tuple[int, int, int]]:
     output = run(["openssl", "version"]).strip()
     version = parse_version(output, "OpenSSL CLI")
-    if version < (3, 5, 0):
-        raise ReferenceError("OpenSSL 3.5.0 or later is required")
+    expected = parse_version(expected_version, "expected OpenSSL")
+    if version != expected:
+        raise ReferenceError(
+            f"OpenSSL runtime mismatch: expected {expected_version}, got {version}"
+        )
     pkg_config_output = run(["pkg-config", "--modversion", "openssl"]).strip()
     pkg_config_version = parse_version(pkg_config_output, "OpenSSL pkg-config")
     if pkg_config_version != version:
@@ -177,15 +242,29 @@ def openssl_version() -> tuple[str, tuple[int, int, int]]:
     return output, version
 
 
-def compile_openssl_oracle(build_dir: Path) -> Path:
-    openssl_version()
+def compiler_mode_flags(sanitized: bool) -> list[str]:
+    if sanitized:
+        return [
+            "-O1",
+            "-g",
+            "-fno-omit-frame-pointer",
+            "-fsanitize=address,undefined",
+        ]
+    return ["-O2"]
+
+
+def compile_openssl_oracle(
+    build_dir: Path, expected_version: str, sanitized: bool = False
+) -> Path:
+    openssl_version(expected_version)
     compiler = os.environ.get("CC", "cc")
     pkg_config = shlex.split(run(["pkg-config", "--cflags", "--libs", "openssl"]))
-    output = build_dir / "openssl_slh_dsa_oracle"
+    suffix = "_sanitized" if sanitized else ""
+    output = build_dir / f"openssl_slh_dsa_oracle{suffix}"
     command = [
         compiler,
         "-std=c11",
-        "-O2",
+        *compiler_mode_flags(sanitized),
         "-Wall",
         "-Wextra",
         "-Werror",
@@ -217,6 +296,17 @@ def require_slhdsa_c_source(source_dir: Path, expected_commit: str) -> None:
     require_git_commit(source_dir, expected_commit, "slhdsa-c")
 
 
+def require_openssl_source(source_dir: Path, expected_commit: str) -> None:
+    required_files = (
+        "crypto/slh_dsa/slh_dsa.c",
+        "doc/man7/EVP_SIGNATURE-SLH-DSA.pod",
+        "providers/implementations/signature/slh_dsa_sig.c.in",
+    )
+    if any(not (source_dir / relative_path).is_file() for relative_path in required_files):
+        raise ReferenceError(f"missing OpenSSL SLH-DSA source at {source_dir}")
+    require_git_commit(source_dir, expected_commit, "OpenSSL")
+
+
 def find_test(document: dict, group_id: int, test_id: int) -> tuple[dict, dict]:
     group = next((group for group in document["testGroups"] if group["tgId"] == group_id), None)
     if group is None:
@@ -229,6 +319,28 @@ def find_test(document: dict, group_id: int, test_id: int) -> tuple[dict, dict]:
 
 def sha256_hex(hex_value: str) -> str:
     return hashlib.sha256(bytes.fromhex(hex_value)).hexdigest()
+
+
+def require_acvp_group(
+    document: dict,
+    group_id: int,
+    expected_metadata: dict,
+    expected_test_ids: list[int],
+    label: str,
+) -> dict:
+    group = next(
+        (candidate for candidate in document["testGroups"] if candidate["tgId"] == group_id),
+        None,
+    )
+    if group is None:
+        raise ReferenceError(f"missing {label} group {group_id}")
+    for name, expected_value in expected_metadata.items():
+        if group.get(name) != expected_value:
+            raise ReferenceError(f"{label} group {group_id} {name} mismatch")
+    actual_test_ids = [test["tcId"] for test in group["tests"]]
+    if actual_test_ids != expected_test_ids:
+        raise ReferenceError(f"{label} group {group_id} test-case set mismatch")
+    return group
 
 
 def verify_nist_sources(manifest: dict, source_dir: Path) -> dict:
@@ -247,91 +359,208 @@ def verify_nist_sources(manifest: dict, source_dir: Path) -> dict:
             )
         loaded[relative_path] = json.loads(path.read_text(encoding="utf8"))
 
+    profile = manifest["profile"]
+    coverage = manifest["acvp_coverage"]
     vectors = manifest["vectors"]
     keygen_prompt = loaded["gen-val/json-files/SLH-DSA-keyGen-FIPS205/prompt.json"]
     keygen_expected = loaded[
         "gen-val/json-files/SLH-DSA-keyGen-FIPS205/expectedResults.json"
     ]
-    keygen_group, keygen_test = find_test(keygen_prompt, 1, 1)
-    _, keygen_result = find_test(keygen_expected, 1, 1)
-    if keygen_group.get("parameterSet") != "SLH-DSA-SHA2-128s":
-        raise ReferenceError("NIST keygen parameter set mismatch")
-    expected_keygen = vectors["nist_keygen_tg1_tc1"]
+    keygen_contract = coverage["keygen"]
+    keygen_group = require_acvp_group(
+        keygen_prompt,
+        keygen_contract["group_id"],
+        {"parameterSet": profile["name"]},
+        keygen_contract["test_case_ids"],
+        "NIST keygen",
+    )
+    keygen_cases: list[dict] = []
+    for source_case in keygen_group["tests"]:
+        test_id = source_case["tcId"]
+        _, source_result = find_test(keygen_expected, keygen_contract["group_id"], test_id)
+        seed_hex = (
+            source_case["skSeed"] + source_case["skPrf"] + source_case["pkSeed"]
+        ).lower()
+        private_key_hex = source_result["sk"].lower()
+        public_key_hex = source_result["pk"].lower()
+        require_hex(seed_hex, profile["keygen_seed_bytes"], f"NIST keygen {test_id} seed")
+        require_hex(
+            private_key_hex,
+            profile["private_key_bytes"],
+            f"NIST keygen {test_id} private key",
+        )
+        require_hex(
+            public_key_hex,
+            profile["public_key_bytes"],
+            f"NIST keygen {test_id} public key",
+        )
+        keygen_cases.append(
+            {
+                "test_case_id": test_id,
+                "seed_hex": seed_hex,
+                "private_key_hex": private_key_hex,
+                "public_key_hex": public_key_hex,
+            }
+        )
+
+    representative_keygen = vectors["nist_keygen_tg1_tc1"]
+    first_keygen = keygen_cases[0]
     require_equal(
         "NIST source keygen seed",
-        (keygen_test["skSeed"] + keygen_test["skPrf"] + keygen_test["pkSeed"]).lower(),
-        expected_keygen["seed_hex"],
+        first_keygen["seed_hex"],
+        representative_keygen["seed_hex"],
     )
     require_equal(
         "NIST source private key",
-        keygen_result["sk"].lower(),
-        expected_keygen["expected_private_key_hex"],
+        first_keygen["private_key_hex"],
+        representative_keygen["expected_private_key_hex"],
     )
     require_equal(
         "NIST source public key",
-        keygen_result["pk"].lower(),
-        expected_keygen["expected_public_key_hex"],
+        first_keygen["public_key_hex"],
+        representative_keygen["expected_public_key_hex"],
     )
 
     siggen_prompt = loaded["gen-val/json-files/SLH-DSA-sigGen-FIPS205/prompt.json"]
     siggen_expected = loaded[
         "gen-val/json-files/SLH-DSA-sigGen-FIPS205/expectedResults.json"
     ]
-    siggen_group, siggen_test = find_test(siggen_prompt, 19, 161)
-    _, siggen_result = find_test(siggen_expected, 19, 161)
-    expected_siggen = vectors["nist_siggen_tg19_tc161"]
-    expected_group = {
-        "parameterSet": "SLH-DSA-SHA2-128s",
-        "deterministic": True,
-        "signatureInterface": "external",
-        "preHash": "pure",
-    }
-    for name, expected_value in expected_group.items():
-        if siggen_group.get(name) != expected_value:
-            raise ReferenceError(f"NIST siggen group {name} mismatch")
+    siggen_cases: list[dict] = []
+    for siggen_contract in coverage["siggen"]:
+        group_id = siggen_contract["group_id"]
+        group = require_acvp_group(
+            siggen_prompt,
+            group_id,
+            {
+                "parameterSet": profile["name"],
+                "deterministic": siggen_contract["deterministic"],
+                "signatureInterface": siggen_contract["signature_interface"],
+                "preHash": siggen_contract["message_mode"],
+            },
+            siggen_contract["test_case_ids"],
+            "NIST siggen",
+        )
+        for source_case in group["tests"]:
+            test_id = source_case["tcId"]
+            _, source_result = find_test(siggen_expected, group_id, test_id)
+            randomizer_hex = source_case.get("additionalRandomness")
+            if siggen_contract["deterministic"]:
+                if randomizer_hex is not None:
+                    raise ReferenceError(
+                        f"NIST deterministic siggen {test_id} has additional randomness"
+                    )
+            else:
+                if randomizer_hex is None:
+                    raise ReferenceError(f"NIST randomized siggen {test_id} lacks randomness")
+                randomizer_hex = randomizer_hex.lower()
+                require_hex(
+                    randomizer_hex,
+                    profile["randomizer_bytes"],
+                    f"NIST siggen {test_id} randomizer",
+                )
+            signature_hex = source_result["signature"].lower()
+            require_hex(
+                source_case["sk"].lower(),
+                profile["private_key_bytes"],
+                f"NIST siggen {test_id} private key",
+            )
+            require_hex(
+                signature_hex,
+                profile["signature_bytes"],
+                f"NIST siggen {test_id} signature",
+            )
+            context_hex = source_case.get("context", "").lower()
+            if len(bytes.fromhex(context_hex)) > 255:
+                raise ReferenceError(f"NIST siggen {test_id} context exceeds 255 bytes")
+            siggen_cases.append(
+                {
+                    "group_id": group_id,
+                    "test_case_id": test_id,
+                    "deterministic": siggen_contract["deterministic"],
+                    "private_key_hex": source_case["sk"].lower(),
+                    "message_hex": source_case["message"].lower(),
+                    "context_hex": context_hex,
+                    "randomizer_hex": randomizer_hex,
+                    "signature_hex": signature_hex,
+                }
+            )
+
+    representative_siggen = vectors["nist_siggen_tg19_tc161"]
+    selected_siggen = next(case for case in siggen_cases if case["test_case_id"] == 161)
     for source_name, manifest_name in (
-        ("sk", "private_key_hex"),
-        ("message", "message_hex"),
-        ("context", "context_hex"),
+        ("private_key_hex", "private_key_hex"),
+        ("message_hex", "message_hex"),
+        ("context_hex", "context_hex"),
     ):
         require_equal(
             f"NIST source siggen {source_name}",
-            siggen_test[source_name].lower(),
-            expected_siggen[manifest_name],
+            selected_siggen[source_name],
+            representative_siggen[manifest_name],
         )
     require_equal(
         "NIST source signature hash",
-        sha256_hex(siggen_result["signature"]),
-        expected_siggen["expected_signature_sha256"],
+        sha256_hex(selected_siggen["signature_hex"]),
+        representative_siggen["expected_signature_sha256"],
     )
 
     sigver_prompt = loaded["gen-val/json-files/SLH-DSA-sigVer-FIPS205/prompt.json"]
     sigver_expected = loaded[
         "gen-val/json-files/SLH-DSA-sigVer-FIPS205/expectedResults.json"
     ]
-    sigver_group, _ = find_test(sigver_prompt, 19, 253)
-    expected_sigver = vectors["nist_sigver_tg19"]
-    expected_group = {
-        "parameterSet": expected_sigver["parameter_set"],
-        "signatureInterface": expected_sigver["signature_interface"],
-        "preHash": expected_sigver["message_mode"],
-    }
-    for name, expected_value in expected_group.items():
-        if sigver_group.get(name) != expected_value:
-            raise ReferenceError(f"NIST sigver group {name} mismatch")
-
+    sigver_contract = coverage["sigver"]
+    sigver_group = require_acvp_group(
+        sigver_prompt,
+        sigver_contract["group_id"],
+        {
+            "parameterSet": profile["name"],
+            "signatureInterface": sigver_contract["signature_interface"],
+            "preHash": sigver_contract["message_mode"],
+        },
+        sigver_contract["test_case_ids"],
+        "NIST sigver",
+    )
+    accepted_ids = set(sigver_contract["accepted_test_case_ids"])
     sigver_cases: list[dict] = []
-    for expected_case in expected_sigver["cases"]:
+    for source_case in sigver_group["tests"]:
+        test_id = source_case["tcId"]
+        _, source_result = find_test(
+            sigver_expected, sigver_contract["group_id"], test_id
+        )
+        expected_valid = test_id in accepted_ids
+        if source_result.get("testPassed") is not expected_valid:
+            raise ReferenceError(f"NIST source sigver {test_id} result mismatch")
+        public_key_hex = source_case["pk"].lower()
+        context_hex = source_case["context"].lower()
+        require_hex(
+            public_key_hex,
+            profile["public_key_bytes"],
+            f"NIST sigver {test_id} public key",
+        )
+        if len(bytes.fromhex(context_hex)) > 255:
+            raise ReferenceError(f"NIST sigver {test_id} context exceeds 255 bytes")
+        sigver_cases.append(
+            {
+                "test_case_id": test_id,
+                "public_key_hex": public_key_hex,
+                "message_hex": source_case["message"].lower(),
+                "context_hex": context_hex,
+                "signature_hex": source_case["signature"].lower(),
+                "expected_valid": expected_valid,
+            }
+        )
+
+    representative_sigver = vectors["nist_sigver_tg19"]
+    sigver_by_id = {case["test_case_id"]: case for case in sigver_cases}
+    for expected_case in representative_sigver["cases"]:
         test_id = expected_case["test_case_id"]
-        _, source_case = find_test(sigver_prompt, 19, test_id)
-        _, source_result = find_test(sigver_expected, 19, test_id)
+        source_case = sigver_by_id[test_id]
         require_equal(
             f"NIST source sigver {test_id} public key",
-            source_case["pk"].lower(),
+            source_case["public_key_hex"],
             expected_case["public_key_hex"],
         )
         for field in ("message", "context", "signature"):
-            source_hex = source_case[field].lower()
+            source_hex = source_case[f"{field}_hex"]
             if len(source_hex) != expected_case[f"{field}_bytes"] * 2:
                 raise ReferenceError(f"NIST source sigver {test_id} {field} size mismatch")
             require_equal(
@@ -339,36 +568,37 @@ def verify_nist_sources(manifest: dict, source_dir: Path) -> dict:
                 sha256_hex(source_hex),
                 expected_case[f"{field}_sha256"],
             )
-        if source_result.get("testPassed") is not expected_case["expected_valid"]:
+        if source_case["expected_valid"] is not expected_case["expected_valid"]:
             raise ReferenceError(f"NIST source sigver {test_id} result mismatch")
-        sigver_cases.append(
-            {
-                "test_case_id": test_id,
-                "public_key_hex": source_case["pk"].lower(),
-                "message_hex": source_case["message"].lower(),
-                "context_hex": source_case["context"].lower(),
-                "signature_hex": source_case["signature"].lower(),
-                "expected_valid": expected_case["expected_valid"],
-            }
-        )
 
+    actual_total = len(keygen_cases) + len(siggen_cases) + len(sigver_cases)
+    if actual_total != coverage["total_cases"]:
+        raise ReferenceError("NIST selected-profile ACVP case count mismatch")
     return {
-        "siggen_signature_hex": siggen_result["signature"].lower(),
+        "keygen_cases": keygen_cases,
+        "siggen_cases": siggen_cases,
         "sigver_cases": sigver_cases,
+        "total_cases": actual_total,
     }
 
 
-def compile_slhdsa_c_oracle(build_dir: Path, source_dir: Path, expected_commit: str) -> Path:
+def compile_slhdsa_c_oracle(
+    build_dir: Path,
+    source_dir: Path,
+    expected_commit: str,
+    sanitized: bool = False,
+) -> Path:
     require_slhdsa_c_source(source_dir, expected_commit)
     sources = sorted(str(path) for path in source_dir.glob("*.c"))
     if not sources:
         raise ReferenceError("slhdsa-c source list is empty")
     compiler = os.environ.get("CC", "cc")
-    output = build_dir / "slhdsa_c_oracle"
+    suffix = "_sanitized" if sanitized else ""
+    output = build_dir / f"slhdsa_c_oracle{suffix}"
     command = [
         compiler,
         "-std=c99",
-        "-O2",
+        *compiler_mode_flags(sanitized),
         "-Wall",
         "-Wextra",
         "-Werror",
@@ -397,10 +627,22 @@ def oracle_keygen(executable: Path, seed_hex: str) -> dict[str, str]:
 
 
 def oracle_sign(
-    executable: Path, private_key_hex: str, message_hex: str, context_hex: str
+    executable: Path,
+    private_key_hex: str,
+    message_hex: str,
+    context_hex: str,
+    randomizer_hex: str | None = None,
+    randomized: bool = False,
 ) -> dict[str, str]:
+    if randomizer_hex is not None and randomized:
+        raise ReferenceError("fixed and default randomized signing are mutually exclusive")
+    command = "sign-randomized" if randomized else "sign"
+    arguments = [str(executable), command, private_key_hex, message_hex, context_hex]
+    if randomizer_hex is not None:
+        arguments[1] = "sign-with-randomizer"
+        arguments.append(randomizer_hex)
     result = parse_oracle_output(
-        run([str(executable), "sign", private_key_hex, message_hex, context_hex])
+        run(arguments)
     )
     if result.get("verified") != "1":
         raise ReferenceError(f"oracle {executable.name} did not self-verify")
@@ -441,112 +683,541 @@ def require_equal(label: str, *values: str) -> None:
         raise ReferenceError(f"{label} mismatch")
 
 
+def flip_hex_byte(value: str, byte_index: int) -> str:
+    data = bytearray.fromhex(value)
+    data[byte_index] ^= 1
+    return data.hex()
+
+
+def require_verification(
+    oracles: dict[str, Path],
+    public_key_hex: str,
+    message_hex: str,
+    context_hex: str,
+    signature_hex: str,
+    expected: str,
+    label: str,
+) -> None:
+    results = {
+        name: oracle_verify(
+            executable,
+            public_key_hex,
+            message_hex,
+            context_hex,
+            signature_hex,
+        )["verified"]
+        for name, executable in oracles.items()
+    }
+    require_equal(label, *results.values(), expected)
+
+
 def median_ms(values: list[int]) -> float:
     return round(statistics.median(values) / 1_000_000, 3)
 
 
-def evaluate(
-    manifest: dict,
-    openssl_oracle: Path,
-    slhdsa_c_oracle: Path,
-    benchmark_iterations: int,
-    nist_source_vectors: dict,
-) -> dict:
-    profile = manifest["profile"]
-    vectors = manifest["vectors"]
-    oracles = {
-        "openssl": openssl_oracle,
-        "slhdsa_c": slhdsa_c_oracle,
-    }
-
-    keygen_vector = vectors["nist_keygen_tg1_tc1"]
-    keygen_results = {
-        name: oracle_keygen(executable, keygen_vector["seed_hex"])
-        for name, executable in oracles.items()
-    }
-    for result in keygen_results.values():
-        require_equal("NIST public key", result["pk"], keygen_vector["expected_public_key_hex"])
-        require_equal("NIST private key", result["sk"], keygen_vector["expected_private_key_hex"])
-    require_equal("oracle NIST public key", *(result["pk"] for result in keygen_results.values()))
-    require_equal("oracle NIST private key", *(result["sk"] for result in keygen_results.values()))
-
-    siggen_vector = vectors["nist_siggen_tg19_tc161"]
-    siggen_results = {
-        name: oracle_sign(
-            executable,
-            siggen_vector["private_key_hex"],
-            siggen_vector["message_hex"],
-            siggen_vector["context_hex"],
-        )
-        for name, executable in oracles.items()
-    }
-    siggen_hashes = {
-        name: signature_hash(result["signature"], profile["signature_bytes"])
-        for name, result in siggen_results.items()
-    }
-    require_equal(
-        "NIST signature hash",
-        *siggen_hashes.values(),
-        siggen_vector["expected_signature_sha256"],
-    )
-    require_equal(
-        "NIST signature bytes", *(result["signature"] for result in siggen_results.values())
-    )
-    require_equal(
-        "NIST source signature bytes",
-        *(result["signature"] for result in siggen_results.values()),
-        nist_source_vectors["siggen_signature_hex"],
-    )
-
-    for case in nist_source_vectors["sigver_cases"]:
-        verify_results = {
-            name: oracle_verify(
-                executable,
+def evaluate_acvp(profile: dict, oracles: dict[str, Path], source_cases: dict) -> None:
+    for case in source_cases["keygen_cases"]:
+        results = {
+            name: oracle_keygen(executable, case["seed_hex"])
+            for name, executable in oracles.items()
+        }
+        for result in results.values():
+            require_equal(
+                f"NIST keygen {case['test_case_id']} public key",
+                result["pk"],
                 case["public_key_hex"],
+            )
+            require_equal(
+                f"NIST keygen {case['test_case_id']} private key",
+                result["sk"],
+                case["private_key_hex"],
+            )
+        require_equal(
+            f"oracle keygen {case['test_case_id']} public key",
+            *(result["pk"] for result in results.values()),
+        )
+        require_equal(
+            f"oracle keygen {case['test_case_id']} private key",
+            *(result["sk"] for result in results.values()),
+        )
+
+    for case in source_cases["siggen_cases"]:
+        results = {
+            name: oracle_sign(
+                executable,
+                case["private_key_hex"],
                 case["message_hex"],
                 case["context_hex"],
-                case["signature_hex"],
+                randomizer_hex=case["randomizer_hex"],
             )
             for name, executable in oracles.items()
         }
-        expected_result = "1" if case["expected_valid"] else "0"
+        for result in results.values():
+            signature_hash(result["signature"], profile["signature_bytes"])
+            require_equal(
+                f"NIST siggen {case['test_case_id']} signature",
+                result["signature"],
+                case["signature_hex"],
+            )
         require_equal(
-            f"NIST sigver tcId {case['test_case_id']}",
-            *(result["verified"] for result in verify_results.values()),
-            expected_result,
+            f"oracle siggen {case['test_case_id']} signature",
+            *(result["signature"] for result in results.values()),
+        )
+        public_key_hex = case["private_key_hex"][-profile["public_key_bytes"] * 2 :]
+        require_verification(
+            oracles,
+            public_key_hex,
+            case["message_hex"],
+            case["context_hex"],
+            case["signature_hex"],
+            "1",
+            f"cross-verification for NIST siggen {case['test_case_id']}",
         )
 
-    pqbtc_vector = vectors["pqbtc_sighash_v1"]
-    benchmark: dict[str, dict[str, list[int]]] = {
-        name: {"keygen_ns": [], "sign_ns": [], "verify_ns": []} for name in oracles
+    for case in source_cases["sigver_cases"]:
+        require_verification(
+            oracles,
+            case["public_key_hex"],
+            case["message_hex"],
+            case["context_hex"],
+            case["signature_hex"],
+            "1" if case["expected_valid"] else "0",
+            f"NIST sigver {case['test_case_id']}",
+        )
+
+
+def evaluate_randomized_interoperability(
+    profile: dict, oracles: dict[str, Path], pqbtc_vector: dict
+) -> dict:
+    randomizers = [secrets.token_hex(profile["randomizer_bytes"]) for _ in range(2)]
+    while randomizers[0] == randomizers[1]:
+        randomizers[1] = secrets.token_hex(profile["randomizer_bytes"])
+
+    fixed_signatures: list[str] = []
+    for index, randomizer_hex in enumerate(randomizers, start=1):
+        results = {
+            name: oracle_sign(
+                executable,
+                pqbtc_vector["expected_private_key_hex"],
+                pqbtc_vector["message_hex"],
+                pqbtc_vector["context_hex"],
+                randomizer_hex=randomizer_hex,
+            )
+            for name, executable in oracles.items()
+        }
+        require_equal(
+            f"fixed-randomizer signature round {index}",
+            *(result["signature"] for result in results.values()),
+        )
+        signature_hex = next(iter(results.values()))["signature"]
+        signature_hash(signature_hex, profile["signature_bytes"])
+        fixed_signatures.append(signature_hex)
+        require_verification(
+            oracles,
+            pqbtc_vector["expected_public_key_hex"],
+            pqbtc_vector["message_hex"],
+            pqbtc_vector["context_hex"],
+            signature_hex,
+            "1",
+            f"fixed-randomizer cross-verification round {index}",
+        )
+    if fixed_signatures[0] == fixed_signatures[1]:
+        raise ReferenceError("distinct fixed randomizers produced the same signature")
+
+    openssl_signatures = [
+        oracle_sign(
+            oracles["openssl"],
+            pqbtc_vector["expected_private_key_hex"],
+            pqbtc_vector["message_hex"],
+            pqbtc_vector["context_hex"],
+            randomized=True,
+        )["signature"]
+        for _ in range(2)
+    ]
+    if openssl_signatures[0] == openssl_signatures[1]:
+        raise ReferenceError("OpenSSL DRBG signing repeated a signature")
+    for index, signature_hex in enumerate(openssl_signatures, start=1):
+        signature_hash(signature_hex, profile["signature_bytes"])
+        require_verification(
+            oracles,
+            pqbtc_vector["expected_public_key_hex"],
+            pqbtc_vector["message_hex"],
+            pqbtc_vector["context_hex"],
+            signature_hex,
+            "1",
+            f"OpenSSL DRBG cross-verification round {index}",
+        )
+    return {
+        "fixed_randomizer_rounds": len(fixed_signatures),
+        "openssl_drbg_rounds": len(openssl_signatures),
     }
-    profile_signatures: dict[str, str] = {}
+
+
+def evaluate_boundaries_and_mutations(
+    profile: dict,
+    oracles: dict[str, Path],
+    pqbtc_vector: dict,
+    deterministic_signature_hex: str,
+) -> dict:
+    boundary_cases = (
+        ("empty message and context", "", ""),
+        ("maximum context", pqbtc_vector["message_hex"], "a5" * 255),
+    )
+    for label, message_hex, context_hex in boundary_cases:
+        results = {
+            name: oracle_sign(
+                executable,
+                pqbtc_vector["expected_private_key_hex"],
+                message_hex,
+                context_hex,
+            )
+            for name, executable in oracles.items()
+        }
+        require_equal(
+            f"{label} signature bytes",
+            *(result["signature"] for result in results.values()),
+        )
+        signature_hex = next(iter(results.values()))["signature"]
+        signature_hash(signature_hex, profile["signature_bytes"])
+        require_verification(
+            oracles,
+            pqbtc_vector["expected_public_key_hex"],
+            message_hex,
+            context_hex,
+            signature_hex,
+            "1",
+            f"{label} cross-verification",
+        )
+
+    public_key_hex = pqbtc_vector["expected_public_key_hex"]
+    message_hex = pqbtc_vector["message_hex"]
+    context_hex = pqbtc_vector["context_hex"]
+    mutations = (
+        (
+            "public key",
+            flip_hex_byte(public_key_hex, 0),
+            message_hex,
+            context_hex,
+            deterministic_signature_hex,
+        ),
+        (
+            "message first byte",
+            public_key_hex,
+            flip_hex_byte(message_hex, 0),
+            context_hex,
+            deterministic_signature_hex,
+        ),
+        (
+            "message last byte",
+            public_key_hex,
+            flip_hex_byte(message_hex, -1),
+            context_hex,
+            deterministic_signature_hex,
+        ),
+        (
+            "context first byte",
+            public_key_hex,
+            message_hex,
+            flip_hex_byte(context_hex, 0),
+            deterministic_signature_hex,
+        ),
+        (
+            "context last byte",
+            public_key_hex,
+            message_hex,
+            flip_hex_byte(context_hex, -1),
+            deterministic_signature_hex,
+        ),
+        (
+            "signature first byte",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            flip_hex_byte(deterministic_signature_hex, 0),
+        ),
+        (
+            "signature middle byte",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            flip_hex_byte(
+                deterministic_signature_hex, profile["signature_bytes"] // 2
+            ),
+        ),
+        (
+            "signature last byte",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            flip_hex_byte(deterministic_signature_hex, -1),
+        ),
+        (
+            "signature truncated",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            deterministic_signature_hex[:-2],
+        ),
+        (
+            "signature extended",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            deterministic_signature_hex + "00",
+        ),
+        ("signature empty", public_key_hex, message_hex, context_hex, ""),
+    )
+    for label, key, message, context, signature in mutations:
+        require_verification(
+            oracles,
+            key,
+            message,
+            context,
+            signature,
+            "0",
+            f"mutated {label} rejection",
+        )
+
+    oversized_context = "00" * 256
+    malformed_commands = 0
+    for executable in oracles.values():
+        commands = (
+            [str(executable), "keygen", pqbtc_vector["seed_hex"][:-2]],
+            [str(executable), "keygen", pqbtc_vector["seed_hex"] + "00"],
+            [
+                str(executable),
+                "sign",
+                pqbtc_vector["expected_private_key_hex"][:-2],
+                message_hex,
+                context_hex,
+            ],
+            [
+                str(executable),
+                "sign",
+                pqbtc_vector["expected_private_key_hex"] + "00",
+                message_hex,
+                context_hex,
+            ],
+            [
+                str(executable),
+                "sign",
+                pqbtc_vector["expected_private_key_hex"],
+                message_hex,
+                oversized_context,
+            ],
+            [
+                str(executable),
+                "sign-with-randomizer",
+                pqbtc_vector["expected_private_key_hex"],
+                message_hex,
+                context_hex,
+                "00" * 15,
+            ],
+            [
+                str(executable),
+                "sign-with-randomizer",
+                pqbtc_vector["expected_private_key_hex"],
+                message_hex,
+                context_hex,
+                "00" * 17,
+            ],
+            [
+                str(executable),
+                "verify",
+                public_key_hex[:-2],
+                message_hex,
+                context_hex,
+                deterministic_signature_hex,
+            ],
+            [
+                str(executable),
+                "verify",
+                public_key_hex + "00",
+                message_hex,
+                context_hex,
+                deterministic_signature_hex,
+            ],
+            [
+                str(executable),
+                "verify",
+                public_key_hex,
+                message_hex,
+                oversized_context,
+                deterministic_signature_hex,
+            ],
+        )
+        for index, command in enumerate(commands, start=1):
+            require_command_failure(command, f"{executable.name} malformed input {index}")
+            malformed_commands += 1
+    return {
+        "boundary_cases": len(boundary_cases),
+        "cryptographic_rejections": len(mutations),
+        "malformed_input_rejections": malformed_commands,
+    }
+
+
+def benchmark_profile(
+    profile: dict,
+    oracles: dict[str, Path],
+    pqbtc_vector: dict,
+    benchmark_iterations: int,
+) -> dict:
+    benchmark = {
+        name: {
+            "keygen_ns": [],
+            "deterministic_sign_ns": [],
+            "deterministic_verify_ns": [],
+            "randomized_sign_ns": [],
+            "randomized_verify_ns": [],
+        }
+        for name in oracles
+    }
     for _ in range(benchmark_iterations):
+        deterministic_signatures: dict[str, str] = {}
         for name, executable in oracles.items():
             generated = oracle_keygen(executable, pqbtc_vector["seed_hex"])
-            require_equal("PQBTC public key", generated["pk"], pqbtc_vector["expected_public_key_hex"])
-            require_equal("PQBTC private key", generated["sk"], pqbtc_vector["expected_private_key_hex"])
-            signed = oracle_sign(
+            require_equal(
+                "PQBTC public key", generated["pk"], pqbtc_vector["expected_public_key_hex"]
+            )
+            require_equal(
+                "PQBTC private key", generated["sk"], pqbtc_vector["expected_private_key_hex"]
+            )
+            deterministic = oracle_sign(
                 executable,
                 generated["sk"],
                 pqbtc_vector["message_hex"],
                 pqbtc_vector["context_hex"],
             )
-            signature_digest = signature_hash(signed["signature"], profile["signature_bytes"])
             require_equal(
-                "PQBTC signature hash",
-                signature_digest,
+                "PQBTC deterministic signature hash",
+                signature_hash(deterministic["signature"], profile["signature_bytes"]),
                 pqbtc_vector["expected_signature_sha256"],
             )
-            if name in profile_signatures:
-                require_equal("deterministic PQBTC signature", profile_signatures[name], signed["signature"])
-            profile_signatures[name] = signed["signature"]
+            deterministic_signatures[name] = deterministic["signature"]
+            if name == "openssl":
+                randomized = oracle_sign(
+                    executable,
+                    generated["sk"],
+                    pqbtc_vector["message_hex"],
+                    pqbtc_vector["context_hex"],
+                    randomized=True,
+                )
+            else:
+                randomized = oracle_sign(
+                    executable,
+                    generated["sk"],
+                    pqbtc_vector["message_hex"],
+                    pqbtc_vector["context_hex"],
+                    randomizer_hex=secrets.token_hex(profile["randomizer_bytes"]),
+                )
+            signature_hash(randomized["signature"], profile["signature_bytes"])
+            require_verification(
+                oracles,
+                generated["pk"],
+                pqbtc_vector["message_hex"],
+                pqbtc_vector["context_hex"],
+                randomized["signature"],
+                "1",
+                f"{name} randomized benchmark signature",
+            )
             benchmark[name]["keygen_ns"].append(int(generated["keygen_ns"]))
-            benchmark[name]["sign_ns"].append(int(signed["sign_ns"]))
-            benchmark[name]["verify_ns"].append(int(signed["verify_ns"]))
+            benchmark[name]["deterministic_sign_ns"].append(int(deterministic["sign_ns"]))
+            benchmark[name]["deterministic_verify_ns"].append(int(deterministic["verify_ns"]))
+            benchmark[name]["randomized_sign_ns"].append(int(randomized["sign_ns"]))
+            benchmark[name]["randomized_verify_ns"].append(int(randomized["verify_ns"]))
+        require_equal("PQBTC deterministic signature bytes", *deterministic_signatures.values())
 
-    require_equal("PQBTC signature bytes", *profile_signatures.values())
-    version_text, _ = openssl_version()
+    return {
+        name: {
+            "iterations": benchmark_iterations,
+            "median_keygen_ms": median_ms(values["keygen_ns"]),
+            "deterministic": {
+                "median_sign_ms": median_ms(values["deterministic_sign_ns"]),
+                "median_verify_ms": median_ms(values["deterministic_verify_ns"]),
+            },
+            "randomized": {
+                "median_sign_ms": median_ms(values["randomized_sign_ns"]),
+                "median_verify_ms": median_ms(values["randomized_verify_ns"]),
+            },
+        }
+        for name, values in benchmark.items()
+    }
+
+
+def evaluate_sanitized_smoke(
+    profile: dict, oracles: dict[str, Path], pqbtc_vector: dict
+) -> dict:
+    deterministic = {
+        name: oracle_sign(
+            executable,
+            pqbtc_vector["expected_private_key_hex"],
+            pqbtc_vector["message_hex"],
+            pqbtc_vector["context_hex"],
+        )["signature"]
+        for name, executable in oracles.items()
+    }
+    require_equal("sanitized deterministic signatures", *deterministic.values())
+    boundary_report = evaluate_boundaries_and_mutations(
+        profile,
+        oracles,
+        pqbtc_vector,
+        next(iter(deterministic.values())),
+    )
+    randomizer_hex = secrets.token_hex(profile["randomizer_bytes"])
+    randomized = {
+        name: oracle_sign(
+            executable,
+            pqbtc_vector["expected_private_key_hex"],
+            pqbtc_vector["message_hex"],
+            pqbtc_vector["context_hex"],
+            randomizer_hex=randomizer_hex,
+        )["signature"]
+        for name, executable in oracles.items()
+    }
+    require_equal("sanitized fixed-randomizer signatures", *randomized.values())
+    return boundary_report
+
+
+def evaluate(
+    manifest: dict,
+    oracles: dict[str, Path],
+    benchmark_iterations: int,
+    nist_source_vectors: dict,
+    sanitized_report: dict | None,
+) -> dict:
+    profile = manifest["profile"]
+    vectors = manifest["vectors"]
+    evaluate_acvp(profile, oracles, nist_source_vectors)
+
+    pqbtc_vector = vectors["pqbtc_sighash_v1"]
+    deterministic_results = {
+        name: oracle_sign(
+            executable,
+            pqbtc_vector["expected_private_key_hex"],
+            pqbtc_vector["message_hex"],
+            pqbtc_vector["context_hex"],
+        )
+        for name, executable in oracles.items()
+    }
+    require_equal(
+        "PQBTC deterministic signature bytes",
+        *(result["signature"] for result in deterministic_results.values()),
+    )
+    deterministic_signature = next(iter(deterministic_results.values()))["signature"]
+    require_equal(
+        "PQBTC deterministic signature hash",
+        signature_hash(deterministic_signature, profile["signature_bytes"]),
+        pqbtc_vector["expected_signature_sha256"],
+    )
+    randomized_report = evaluate_randomized_interoperability(profile, oracles, pqbtc_vector)
+    mutation_report = evaluate_boundaries_and_mutations(
+        profile, oracles, pqbtc_vector, deterministic_signature
+    )
+    benchmark = benchmark_profile(
+        profile, oracles, pqbtc_vector, benchmark_iterations
+    )
+
+    version_text, _ = openssl_version(manifest["sources"]["openssl"]["version"])
     cost_model = manifest["system_cost_model"]
     rc2_signature_weight = (
         cost_model["held_rc2_signature_bytes"]
@@ -561,17 +1232,30 @@ def evaluate(
         "status": "PASS",
         "profile": profile["name"],
         "openssl_version": version_text,
+        "openssl_commit": manifest["sources"]["openssl"]["commit"],
         "slhdsa_c_commit": manifest["sources"]["slhdsa_c"]["commit"],
         "checks": {
             "nist_source_provenance": "PASS",
-            "nist_keygen": "PASS",
-            "nist_siggen": "PASS",
-            "nist_sigver_accept_reject": "PASS",
+            "nist_selected_profile_acvp_38_cases": "PASS",
+            "nist_deterministic_and_randomized_siggen": "PASS",
+            "nist_sigver_all_accept_reject_cases": "PASS",
             "pqbtc_sighash_vector": "PASS",
             "full_signature_byte_agreement": "PASS",
+            "randomized_interoperability": "PASS",
+            "boundary_and_mutation_rejection": "PASS",
+            "adapter_asan_ubsan": "PASS" if sanitized_report is not None else "NOT_RUN",
         },
+        "acvp": {
+            "total_cases": nist_source_vectors["total_cases"],
+            "keygen_cases": len(nist_source_vectors["keygen_cases"]),
+            "siggen_cases": len(nist_source_vectors["siggen_cases"]),
+            "sigver_cases": len(nist_source_vectors["sigver_cases"]),
+        },
+        "randomized_interoperability": randomized_report,
+        "negative_testing": mutation_report,
+        "sanitized_smoke": sanitized_report,
         "signature_sha256": {
-            "nist": siggen_vector["expected_signature_sha256"],
+            "nist": vectors["nist_siggen_tg19_tc161"]["expected_signature_sha256"],
             "pqbtc": pqbtc_vector["expected_signature_sha256"],
         },
         "block_space_model": {
@@ -586,15 +1270,7 @@ def evaluate(
             "slh_dsa_signature_only_capacity": slh_capacity,
             "capacity_ratio_percent": round(slh_capacity / rc2_capacity * 100, 2),
         },
-        "benchmark": {
-            name: {
-                "iterations": benchmark_iterations,
-                "median_keygen_ms": median_ms(values["keygen_ns"]),
-                "median_sign_ms": median_ms(values["sign_ns"]),
-                "median_verify_ms": median_ms(values["verify_ns"]),
-            }
-            for name, values in benchmark.items()
-        },
+        "benchmark": benchmark,
     }
 
 
@@ -612,6 +1288,16 @@ def parse_args() -> argparse.Namespace:
         help="path to the pinned slh-dsa/slhdsa-c checkout",
     )
     parser.add_argument(
+        "--openssl-source",
+        type=Path,
+        default=(
+            Path(os.environ["OPENSSL_SOURCE_DIR"])
+            if "OPENSSL_SOURCE_DIR" in os.environ
+            else None
+        ),
+        help="path to the pinned OpenSSL source checkout",
+    )
+    parser.add_argument(
         "--benchmark-iterations",
         type=int,
         default=1,
@@ -621,6 +1307,11 @@ def parse_args() -> argparse.Namespace:
         "--manifest-only",
         action="store_true",
         help="validate the checked-in profile and vector manifest without external oracles",
+    )
+    parser.add_argument(
+        "--sanitizers",
+        action="store_true",
+        help="also build and exercise both adapters with ASan and UBSan",
     )
     return parser.parse_args()
 
@@ -634,27 +1325,58 @@ def main() -> int:
             return 0
         if args.slhdsa_c is None:
             raise ReferenceError("--slhdsa-c or SLHDSA_C_DIR is required")
+        if args.openssl_source is None:
+            raise ReferenceError("--openssl-source or OPENSSL_SOURCE_DIR is required")
         if args.acvp_server is None:
             raise ReferenceError("--acvp-server is required for a full run")
         if not 1 <= args.benchmark_iterations <= 10:
             raise ReferenceError("--benchmark-iterations must be between 1 and 10")
 
         nist_source_vectors = verify_nist_sources(manifest, args.acvp_server.resolve())
+        require_openssl_source(
+            args.openssl_source.resolve(), manifest["sources"]["openssl"]["commit"]
+        )
 
         with tempfile.TemporaryDirectory(prefix="pqbtc-slh-dsa-") as temporary:
             build_dir = Path(temporary)
-            openssl_oracle = compile_openssl_oracle(build_dir)
+            openssl_oracle = compile_openssl_oracle(
+                build_dir, manifest["sources"]["openssl"]["version"]
+            )
             slhdsa_c_oracle = compile_slhdsa_c_oracle(
                 build_dir,
                 args.slhdsa_c.resolve(),
                 manifest["sources"]["slhdsa_c"]["commit"],
             )
+            oracles = {
+                "openssl": openssl_oracle,
+                "slhdsa_c": slhdsa_c_oracle,
+            }
+            sanitized_report = None
+            if args.sanitizers:
+                sanitized_oracles = {
+                    "openssl": compile_openssl_oracle(
+                        build_dir,
+                        manifest["sources"]["openssl"]["version"],
+                        sanitized=True,
+                    ),
+                    "slhdsa_c": compile_slhdsa_c_oracle(
+                        build_dir,
+                        args.slhdsa_c.resolve(),
+                        manifest["sources"]["slhdsa_c"]["commit"],
+                        sanitized=True,
+                    ),
+                }
+                sanitized_report = evaluate_sanitized_smoke(
+                    manifest["profile"],
+                    sanitized_oracles,
+                    manifest["vectors"]["pqbtc_sighash_v1"],
+                )
             report = evaluate(
                 manifest,
-                openssl_oracle,
-                slhdsa_c_oracle,
+                oracles,
                 args.benchmark_iterations,
                 nist_source_vectors,
+                sanitized_report,
             )
         print(json.dumps(report, indent=2, sort_keys=True))
         return 0

--- a/contrib/slh-dsa-ref/openssl_oracle.c
+++ b/contrib/slh-dsa-ref/openssl_oracle.c
@@ -19,6 +19,7 @@
 #define KEYGEN_SEED_SIZE 48
 #define PRIVATE_KEY_SIZE 64
 #define PUBLIC_KEY_SIZE 32
+#define RANDOMIZER_SIZE 16
 #define SIGNATURE_SIZE 7856
 
 static uint64_t MonotonicNs(void)
@@ -100,7 +101,8 @@ static EVP_PKEY* GenerateKey(const unsigned char* seed, uint64_t* elapsed_ns)
     }
 
     OSSL_PARAM parameters[] = {
-        OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_SLH_DSA_SEED, (void*)seed, KEYGEN_SEED_SIZE),
+        OSSL_PARAM_construct_octet_string(
+            OSSL_PKEY_PARAM_SLH_DSA_SEED, (void*)seed, KEYGEN_SEED_SIZE),
         OSSL_PARAM_construct_end(),
     };
     if (EVP_PKEY_CTX_set_params(context, parameters) <= 0) {
@@ -134,7 +136,8 @@ static EVP_PKEY* ImportPrivateKey(const unsigned char* private_key)
         return NULL;
     }
     OSSL_PARAM parameters[] = {
-        OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PRIV_KEY, (void*)private_key, PRIVATE_KEY_SIZE),
+        OSSL_PARAM_construct_octet_string(
+            OSSL_PKEY_PARAM_PRIV_KEY, (void*)private_key, PRIVATE_KEY_SIZE),
         OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY, public_key, PUBLIC_KEY_SIZE),
         OSSL_PARAM_construct_end(),
     };
@@ -184,7 +187,8 @@ static int VerifySignature(
     uint64_t* verify_ns)
 {
     OSSL_PARAM parameters[] = {
-        OSSL_PARAM_construct_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING, context_string, context_size),
+        OSSL_PARAM_construct_octet_string(
+            OSSL_SIGNATURE_PARAM_CONTEXT_STRING, context_string, context_size),
         OSSL_PARAM_construct_end(),
     };
     EVP_SIGNATURE* algorithm = EVP_SIGNATURE_fetch(NULL, ALGORITHM, NULL);
@@ -214,16 +218,26 @@ static int SignAndVerify(
     const size_t message_size,
     unsigned char* context_string,
     const size_t context_size,
+    unsigned char* test_entropy,
+    const size_t test_entropy_size,
+    const int randomized,
     unsigned char* signature,
     uint64_t* sign_ns,
     uint64_t* verify_ns)
 {
-    int deterministic = 1;
-    OSSL_PARAM parameters[] = {
-        OSSL_PARAM_construct_octet_string(OSSL_SIGNATURE_PARAM_CONTEXT_STRING, context_string, context_size),
-        OSSL_PARAM_construct_int(OSSL_SIGNATURE_PARAM_DETERMINISTIC, &deterministic),
-        OSSL_PARAM_construct_end(),
-    };
+    int deterministic = randomized ? 0 : 1;
+    OSSL_PARAM parameters[4];
+    size_t parameter_index = 0;
+    parameters[parameter_index++] = OSSL_PARAM_construct_octet_string(
+        OSSL_SIGNATURE_PARAM_CONTEXT_STRING, context_string, context_size);
+    if (test_entropy != NULL) {
+        parameters[parameter_index++] = OSSL_PARAM_construct_octet_string(
+            OSSL_SIGNATURE_PARAM_TEST_ENTROPY, test_entropy, test_entropy_size);
+    } else {
+        parameters[parameter_index++] = OSSL_PARAM_construct_int(
+            OSSL_SIGNATURE_PARAM_DETERMINISTIC, &deterministic);
+    }
+    parameters[parameter_index] = OSSL_PARAM_construct_end();
     EVP_SIGNATURE* algorithm = EVP_SIGNATURE_fetch(NULL, ALGORITHM, NULL);
     EVP_PKEY_CTX* sign_context = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
     size_t signature_size = SIGNATURE_SIZE;
@@ -291,21 +305,31 @@ cleanup:
     return result;
 }
 
-static int RunSign(const char* key_hex, const char* message_hex, const char* context_hex)
+static int RunSign(
+    const char* key_hex,
+    const char* message_hex,
+    const char* context_hex,
+    const char* randomizer_hex,
+    const int randomized)
 {
     size_t key_size = 0;
     size_t message_size = 0;
     size_t context_size = 0;
+    size_t randomizer_size = 0;
     unsigned char* private_key = DecodeHex(key_hex, &key_size);
     unsigned char* message = DecodeHex(message_hex, &message_size);
     unsigned char* context_string = DecodeHex(context_hex, &context_size);
+    unsigned char* randomizer =
+        randomizer_hex == NULL ? NULL : DecodeHex(randomizer_hex, &randomizer_size);
     unsigned char* signature = NULL;
     uint64_t sign_ns = 0;
     uint64_t verify_ns = 0;
     int result = 1;
 
     if (private_key == NULL || key_size != PRIVATE_KEY_SIZE || message == NULL ||
-        context_string == NULL || context_size > 255) {
+        context_string == NULL || context_size > 255 ||
+        (randomizer_hex != NULL &&
+         (randomizer == NULL || randomizer_size != RANDOMIZER_SIZE))) {
         fprintf(stderr, "openssl_oracle: invalid sign input\n");
         goto cleanup;
     }
@@ -318,6 +342,9 @@ static int RunSign(const char* key_hex, const char* message_hex, const char* con
                                  message_size,
                                  context_string,
                                  context_size,
+                                 randomizer,
+                                 randomizer_size,
+                                 randomized,
                                  signature,
                                  &sign_ns,
                                  &verify_ns)) {
@@ -334,6 +361,7 @@ static int RunSign(const char* key_hex, const char* message_hex, const char* con
 
 cleanup:
     free(signature);
+    free(randomizer);
     free(context_string);
     free(message);
     free(private_key);
@@ -360,6 +388,12 @@ static int RunVerify(
     if (public_key == NULL || key_size != PUBLIC_KEY_SIZE || message == NULL ||
         context_string == NULL || context_size > 255 || signature == NULL) {
         fprintf(stderr, "openssl_oracle: invalid verify input\n");
+        goto cleanup;
+    }
+    if (signature_size != SIGNATURE_SIZE) {
+        printf("verified=0\n");
+        printf("verify_ns=0\n");
+        result = 0;
         goto cleanup;
     }
     EVP_PKEY* key = ImportPublicKey(public_key);
@@ -391,13 +425,29 @@ cleanup:
 int main(const int argc, char** argv)
 {
     if (argc == 3 && strcmp(argv[1], "keygen") == 0) return RunKeygen(argv[2]);
-    if (argc == 5 && strcmp(argv[1], "sign") == 0) return RunSign(argv[2], argv[3], argv[4]);
+    if (argc == 5 && strcmp(argv[1], "sign") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], NULL, 0);
+    }
+    if (argc == 5 && strcmp(argv[1], "sign-randomized") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], NULL, 1);
+    }
+    if (argc == 6 && strcmp(argv[1], "sign-with-randomizer") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], argv[5], 0);
+    }
     if (argc == 6 && strcmp(argv[1], "verify") == 0) {
         return RunVerify(argv[2], argv[3], argv[4], argv[5]);
     }
 
     fprintf(stderr, "usage: %s keygen <seed-hex>\n", argv[0]);
     fprintf(stderr, "       %s sign <sk-hex> <message-hex> <context-hex>\n", argv[0]);
-    fprintf(stderr, "       %s verify <pk-hex> <message-hex> <context-hex> <signature-hex>\n", argv[0]);
+    fprintf(stderr, "       %s sign-randomized <sk-hex> <message-hex> <context-hex>\n", argv[0]);
+    fprintf(stderr,
+            "       %s sign-with-randomizer <sk-hex> <message-hex> "
+            "<context-hex> <randomizer-hex>\n",
+            argv[0]);
+    fprintf(stderr,
+            "       %s verify <pk-hex> <message-hex> <context-hex> "
+            "<signature-hex>\n",
+            argv[0]);
     return 2;
 }

--- a/contrib/slh-dsa-ref/slhdsa_c_oracle.c
+++ b/contrib/slh-dsa-ref/slhdsa_c_oracle.c
@@ -15,6 +15,7 @@
 #define KEYGEN_SEED_SIZE 48
 #define PRIVATE_KEY_SIZE 64
 #define PUBLIC_KEY_SIZE 32
+#define RANDOMIZER_SIZE 16
 #define SIGNATURE_SIZE 7856
 
 static uint64_t MonotonicNs(void)
@@ -96,20 +97,29 @@ cleanup:
     return result;
 }
 
-static int RunSign(const char* key_hex, const char* message_hex, const char* context_hex)
+static int RunSign(
+    const char* key_hex,
+    const char* message_hex,
+    const char* context_hex,
+    const char* randomizer_hex)
 {
     size_t key_size = 0;
     size_t message_size = 0;
     size_t context_size = 0;
+    size_t randomizer_size = 0;
     uint8_t* private_key = DecodeHex(key_hex, &key_size);
     uint8_t* message = DecodeHex(message_hex, &message_size);
     uint8_t* context_string = DecodeHex(context_hex, &context_size);
+    uint8_t* randomizer =
+        randomizer_hex == NULL ? NULL : DecodeHex(randomizer_hex, &randomizer_size);
     uint8_t public_key[PUBLIC_KEY_SIZE];
     uint8_t* signature = NULL;
     int result = 1;
 
     if (private_key == NULL || key_size != PRIVATE_KEY_SIZE || message == NULL ||
-        context_string == NULL || context_size > 255) {
+        context_string == NULL || context_size > 255 ||
+        (randomizer_hex != NULL &&
+         (randomizer == NULL || randomizer_size != RANDOMIZER_SIZE))) {
         fprintf(stderr, "slhdsa_c_oracle: invalid sign input\n");
         goto cleanup;
     }
@@ -125,7 +135,7 @@ static int RunSign(const char* key_hex, const char* message_hex, const char* con
         context_string,
         context_size,
         private_key,
-        NULL,
+        randomizer,
         &slh_dsa_sha2_128s);
     const uint64_t sign_ns = MonotonicNs() - sign_started;
     if (signature_size != SIGNATURE_SIZE) {
@@ -157,6 +167,7 @@ static int RunSign(const char* key_hex, const char* message_hex, const char* con
 
 cleanup:
     free(signature);
+    free(randomizer);
     free(context_string);
     free(message);
     free(private_key);
@@ -182,6 +193,12 @@ static int RunVerify(
     if (public_key == NULL || key_size != PUBLIC_KEY_SIZE || message == NULL ||
         context_string == NULL || context_size > 255 || signature == NULL) {
         fprintf(stderr, "slhdsa_c_oracle: invalid verify input\n");
+        goto cleanup;
+    }
+    if (signature_size != SIGNATURE_SIZE) {
+        printf("verified=0\n");
+        printf("verify_ns=0\n");
+        result = 0;
         goto cleanup;
     }
     const uint64_t verify_started = MonotonicNs();
@@ -211,13 +228,25 @@ cleanup:
 int main(const int argc, char** argv)
 {
     if (argc == 3 && strcmp(argv[1], "keygen") == 0) return RunKeygen(argv[2]);
-    if (argc == 5 && strcmp(argv[1], "sign") == 0) return RunSign(argv[2], argv[3], argv[4]);
+    if (argc == 5 && strcmp(argv[1], "sign") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], NULL);
+    }
+    if (argc == 6 && strcmp(argv[1], "sign-with-randomizer") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], argv[5]);
+    }
     if (argc == 6 && strcmp(argv[1], "verify") == 0) {
         return RunVerify(argv[2], argv[3], argv[4], argv[5]);
     }
 
     fprintf(stderr, "usage: %s keygen <seed-hex>\n", argv[0]);
     fprintf(stderr, "       %s sign <sk-hex> <message-hex> <context-hex>\n", argv[0]);
-    fprintf(stderr, "       %s verify <pk-hex> <message-hex> <context-hex> <signature-hex>\n", argv[0]);
+    fprintf(stderr,
+            "       %s sign-with-randomizer <sk-hex> <message-hex> "
+            "<context-hex> <randomizer-hex>\n",
+            argv[0]);
+    fprintf(stderr,
+            "       %s verify <pk-hex> <message-hex> <context-hex> "
+            "<signature-hex>\n",
+            argv[0]);
     return 2;
 }

--- a/contrib/slh-dsa-ref/vectors.json
+++ b/contrib/slh-dsa-ref/vectors.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "profile": {
     "name": "SLH-DSA-SHA2-128s",
     "standard": "FIPS 205",
@@ -8,12 +8,43 @@
     "public_key_bytes": 32,
     "private_key_bytes": 64,
     "keygen_seed_bytes": 48,
+    "randomizer_bytes": 16,
     "signature_bytes": 7856,
     "prototype_message_bytes": 32,
     "prototype_context_hex": "50514254432f74782d7369676e61747572652f7631",
     "prototype_context_ascii": "PQBTC/tx-signature/v1",
-    "test_signing": "deterministic",
+    "exact_vector_signing": "deterministic_or_fixed_randomizer",
     "production_signing_if_selected": "randomized"
+  },
+  "acvp_coverage": {
+    "keygen": {
+      "group_id": 1,
+      "test_case_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    },
+    "siggen": [
+      {
+        "group_id": 19,
+        "deterministic": true,
+        "signature_interface": "external",
+        "message_mode": "pure",
+        "test_case_ids": [157, 158, 159, 160, 161, 162, 163]
+      },
+      {
+        "group_id": 55,
+        "deterministic": false,
+        "signature_interface": "external",
+        "message_mode": "pure",
+        "test_case_ids": [469, 470, 471, 472, 473, 474, 475]
+      }
+    ],
+    "sigver": {
+      "group_id": 19,
+      "signature_interface": "external",
+      "message_mode": "pure",
+      "test_case_ids": [253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266],
+      "accepted_test_case_ids": [258, 266]
+    },
+    "total_cases": 38
   },
   "system_cost_model": {
     "held_rc2_signature_bytes": 4480,
@@ -34,8 +65,10 @@
       }
     },
     "openssl": {
-      "minimum_version": "3.5.0",
-      "documentation": "https://docs.openssl.org/3.5/man7/EVP_SIGNATURE-SLH-DSA/",
+      "repository": "https://github.com/openssl/openssl",
+      "commit": "aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f",
+      "version": "3.6.3",
+      "documentation": "https://docs.openssl.org/3.6/man7/EVP_SIGNATURE-SLH-DSA/",
       "role": "independent prototype oracle; not a node dependency"
     },
     "slhdsa_c": {

--- a/docs/PQSIG_PRODUCTION_READINESS.md
+++ b/docs/PQSIG_PRODUCTION_READINESS.md
@@ -97,12 +97,14 @@ record.
 
 1. Maintain the isolated `SLH-DSA-SHA2-128s` prototype in
    `SLH_DSA_SHA2_128S_REFERENCE.md` against the exact FIPS 205 API, encodings,
-   context rules, and test vectors. Do not assign an active `ALG_ID` or connect
-   it to Script yet.
+   context rules, and test vectors. Its complete selected-profile ACVP,
+   randomized interoperability, mutation, and bounded sanitizer tranche is
+   green. Do not assign an active `ALG_ID` or connect it to Script yet.
 2. Implement or bind an isolated `ML-DSA-44` comparator for size, signing,
    verification, wallet, and block-economics measurements.
-3. Use OpenSSL 3.5 or later only as a prototype and differential-test oracle.
-   Do not introduce a host OpenSSL dependency into consensus verification.
+3. Use the OpenSSL 3.6.3 runtime and pinned source checkout only as a prototype
+   and differential-test oracle. Do not introduce a host OpenSSL dependency
+   into consensus verification.
 4. Obtain a second independent implementation or vector source for every
    candidate. A repo-local signer and repo-local verifier are not independent
    evidence.

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -18,8 +18,9 @@ answer specific classes of questions instead of listing every file in `docs/`.
 - The implemented rc2 profile is under a production release hold; integration
   coverage does not establish its claimed cryptographic security.
 - An isolated FIPS 205 `SLH-DSA-SHA2-128s` reference harness now provides
-  pinned official keygen/sign/verify vectors, two-oracle interoperability, and
-  initial timings without changing consensus behavior.
+  all 38 applicable external/pure ACVP cases, pinned two-oracle deterministic
+  and randomized interoperability, malformed-input and sanitizer evidence, and
+  timings without changing consensus behavior.
 - No PDF papers are currently checked into this repo.
 - Delving Bitcoin now provides concrete adjacent research references that are
   directly relevant to Track A, especially around SHRINCS / SHRIMPS and

--- a/docs/SLH_DSA_SHA2_128S_REFERENCE.md
+++ b/docs/SLH_DSA_SHA2_128S_REFERENCE.md
@@ -1,7 +1,7 @@
 # SLH-DSA-SHA2-128s Reference Prototype
 
 ## Status: REFERENCE ONLY - NOT CONSENSUS
-## Spec-ID: SLH-DSA-SHA2-128S-REFERENCE-v1
+## Spec-ID: SLH-DSA-SHA2-128S-REFERENCE-v2
 ## Updated: 2026-07-18
 ## Consensus-Relevant: NO
 
@@ -27,7 +27,7 @@ change the consensus accepted set. The production hold in
 | Public key | 32 bytes |
 | Private key | 64 bytes |
 | Signature | 7,856 bytes |
-| Exact-vector signing | Deterministic |
+| Exact-vector signing | Deterministic or NIST-supplied fixed randomizer |
 | Future production posture | Randomized signing, if separately approved |
 
 Pure SLH-DSA internally binds `0x00 || len(ctx) || ctx || message` as specified
@@ -44,11 +44,14 @@ The checked-in manifest at `contrib/slh-dsa-ref/vectors.json` records:
   `15c0f3deeefbfa8cb6cd32a99e1ca3b738c66bf0`
 - SHA256 checksums for the six key-generation, signature-generation, and
   signature-verification source files
-- NIST key-generation group 1, test case 1
-- NIST deterministic external/pure signature-generation group 19, test case
-  161
-- NIST external/pure signature-verification group 19, test cases 253 (reject)
-  and 266 (accept, with the maximum 255-byte context)
+- all 10 NIST key-generation group 1 cases
+- all 7 deterministic external/pure signature-generation group 19 cases
+- all 7 randomized external/pure signature-generation group 55 cases, each
+  with its official 16-byte `additionalRandomness`
+- all 14 external/pure signature-verification group 19 cases, including exact,
+  short, and long signatures; cases 258 and 266 are the two accepted cases
+- OpenSSL 3.6.3 source commit
+  `aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f`
 - portable `slhdsa-c` commit
   `2b111e076a3bf0b6041651cf8746acf5ade56cc7`
 - one repo-defined 32-byte sighash/context interoperability vector
@@ -60,14 +63,17 @@ The PQBTC prototype signature has SHA256
 
 `compare_oracles.py` builds two adapters in a temporary directory:
 
-1. OpenSSL 3.5 or later
+1. an OpenSSL 3.6.3 runtime with a checkout at the pinned source commit
 2. the exact pinned `slh-dsa/slhdsa-c` checkout
 
-Both independently reproduce the NIST keypair, reproduce the full 7,856-byte
-NIST signature, self-verify it, return the official outcomes for the selected
-accept/reject verification cases, and produce the same complete PQBTC prototype
-signature. OpenSSL and `slhdsa-c` remain external research oracles and are not
-linked into PQBTC.
+Both independently reproduce every selected-profile NIST keypair and complete
+7,856-byte deterministic or fixed-randomizer signature, cross-verify every
+generated signature, and return all official verification outcomes. They also
+produce the same complete PQBTC prototype signature for the same explicit
+randomizer. OpenSSL's default DRBG path and two independent caller-supplied
+randomizers produce distinct signatures that both implementations accept.
+OpenSSL and `slhdsa-c` remain external research oracles and are not linked into
+PQBTC.
 
 Run:
 
@@ -75,22 +81,32 @@ Run:
 python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only
 python3 contrib/slh-dsa-ref/compare_oracles.py \
   --acvp-server /path/to/pinned/ACVP-Server \
+  --openssl-source /path/to/pinned/openssl \
   --slhdsa-c /path/to/pinned/slhdsa-c \
-  --benchmark-iterations 10
+  --benchmark-iterations 10 \
+  --sanitizers
 ```
+
+The run requires all three Git source checkouts to be clean and at their exact
+pinned commits. It also requires the installed OpenSSL CLI and `pkg-config`
+library to report exactly version 3.6.3. The adapter links that installed
+library; the source checkout establishes review provenance but is not compiled
+by this harness.
 
 ## Prototype Measurements
 
 Local arm64 macOS measurement on 2026-07-18, using OpenSSL 3.6.3 and the pinned
 portable-C oracle compiled with `-O2`. Values are medians of ten repetitions
 of the fixed PQBTC vector and are directional, not release envelopes. They time
-the adapter's cryptographic calls and exclude compilation, process startup, and
-OpenSSL context initialization.
+the adapter's cryptographic calls and exclude compilation, process startup,
+entropy acquisition, cross-verification, and OpenSSL context initialization.
+OpenSSL randomized signing uses its default DRBG; the portable oracle receives
+a fresh 16-byte randomizer from Python's operating-system-backed `secrets` API.
 
-| Oracle | Key generation | Sign | Verify |
-| --- | ---: | ---: | ---: |
-| OpenSSL 3.6.3 | 19.384 ms | 146.434 ms | 0.114 ms |
-| `slhdsa-c` | 40.896 ms | 298.063 ms | 0.228 ms |
+| Oracle | Keygen | Deterministic sign | Deterministic verify | Randomized sign | Randomized verify |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| OpenSSL 3.6.3 | 15.811 ms | 137.726 ms | 0.116 ms | 135.831 ms | 0.120 ms |
+| `slhdsa-c` | 32.766 ms | 278.600 ms | 0.227 ms | 274.088 ms | 0.237 ms |
 
 Verification is fast enough to justify deeper node-level evaluation. Signing
 latency is user-visible and requires wallet batching, hardware-signer, and
@@ -114,6 +130,12 @@ multi-input transaction measurements before selection.
   signature today. Any future support requires an explicit consensus and policy
   sizing design; being below the separate 10,000-byte script-size limit does
   not make it admissible.
+- The portable `slhdsa-c` verifier assumes its caller supplies a complete
+  signature and reads the leading `n` bytes before its later length-dependent
+  checks. ASan exposed an out-of-bounds read when the harness passed an empty
+  signature directly. Both adapters now enforce the exact 7,856-byte length and
+  return verification failure before entering either implementation. Any
+  future wrapper must preserve that precondition and test it under sanitizers.
 - SLH-DSA is stateless, so it avoids state-reuse and backup-coordination failure
   modes. Randomized signing still requires a sound entropy path and specified
   failure behavior.
@@ -126,25 +148,29 @@ Established:
 
 1. the exact FIPS 205 parameter set is available in two independent
    implementations
-2. both implementations match selected official NIST keygen, siggen, and
-   positive/negative sigver vectors
-3. both implementations agree byte-for-byte on a PQBTC-shaped 32-byte message
-   and fixed context
-4. the candidate has a reproducible local timing baseline
+2. both implementations match all 38 applicable external/pure SHA2-128s NIST
+   keygen, deterministic/randomized siggen, and sigver cases
+3. both implementations agree byte-for-byte for the same explicit randomizer
+   and cross-verify signatures generated with distinct randomizers
+4. empty messages/contexts, the maximum 255-byte context, malformed lengths,
+   and key/message/context/signature mutations have deterministic outcomes
+5. both adapters pass the bounded ASan/UBSan exercise
+6. the candidate has reproducible deterministic and randomized timing baselines
 
 Not established:
 
 1. a production-quality consensus implementation
 2. constant-time signing or adequate secret erasure
-3. complete ACVP, broad malformed-input, fuzz, or sanitizer coverage
+3. exhaustive fuzzing or sanitizer coverage of the OpenSSL library binary
 4. acceptable block, mempool, wallet, backup, PSBT, or hardware-signer behavior
 5. an activation, migration, or algorithm-agility design
 6. independent cryptographic and consensus-code review
 
 ## Next Gate
 
-The next bounded slice should add randomized-signing interoperability, broader
-mutation and malformed-input vectors, and a complete selected-profile ACVP run.
-Only after that evidence is green should PQBTC compare the same system-level
-contract against `ML-DSA-44`. No candidate should enter `src/crypto`, Script,
-wallet activation, or the `ALG_ID` registry during these reference slices.
+The next bounded slice is an equivalent isolated `ML-DSA-44` comparator using
+the same provenance, complete selected-profile ACVP, differential,
+randomized-signing, malformed-input, sanitizer, and measurement contract. A
+measured selection memo follows that comparator. No candidate should enter
+`src/crypto`, Script, wallet activation, or the `ALG_ID` registry before a
+selection and external cryptographic review.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -41,6 +41,15 @@ The slice changed no functional-suite inventory policy class, so the reviewed
 baseline remains `pq_required: 121`, `pq_backlog: 0`, `legacy_only: 14`, and
 `dual_profile: 141`.
 
+The follow-up SLH-DSA evidence tranche expands that isolated harness to all 38
+applicable external/pure SHA2-128s ACVP cases: 10 keygen, 7 deterministic
+siggen, 7 randomized siggen, and 14 sigver. It pins OpenSSL 3.6.3 source,
+requires cross-verification and randomized-signature diversity, exercises
+context and malformed-input boundaries, and runs both adapters under ASan and
+UBSan. The next cryptographic implementation slice is the equivalent isolated
+`ML-DSA-44` comparator; the production and consensus-integration hold remains
+in force.
+
 Keep the live `pq_required` gate aligned with the repo as it exists today. PR
 `#163` closed the initial inventory tranche at `pq_required: 120`,
 `pq_backlog: 0`, `legacy_only: 14`, and `dual_profile: 142`. Promotion Matrix
@@ -127,8 +136,8 @@ Future selection boundary:
 Cryptography implementation lane:
 
 3. Build isolated final-standard reference prototypes
-   - start with FIPS 205 `SLH-DSA-SHA2-128s`
-   - compare FIPS 204 `ML-DSA-44`
+   - retain the completed FIPS 205 `SLH-DSA-SHA2-128s` evidence baseline
+   - build the equivalent FIPS 204 `ML-DSA-44` comparator next
    - require official vectors and an independent differential oracle
    - do not allocate or activate an `ALG_ID` in the prototype slices
 


### PR DESCRIPTION
## Summary

- freeze and execute all 38 applicable external/pure SLH-DSA-SHA2-128s ACVP cases
- add deterministic, fixed-randomizer, and OpenSSL DRBG signing paths with bidirectional verification
- add context boundaries, malformed lengths, key/message/context/signature mutations, and ASan/UBSan adapter coverage
- pin OpenSSL 3.6.3 source provenance and update readiness/status evidence
- preserve the production hold and leave src, Script, wallet activation, ALG_ID, CI inventory, and consensus behavior unchanged

## Safety finding

ASan showed that the portable low-level verifier reads the leading n bytes before safely handling an empty signature. Both research adapters now reject any non-7,856-byte signature before invoking an implementation.

## Validation

- python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only
- python3 contrib/slh-dsa-ref/compare_oracles.py --acvp-server /tmp/acvp-server --openssl-source /tmp/openssl-3.6.3 --slhdsa-c /tmp/slhdsa-c --benchmark-iterations 10 --sanitizers
- python3 -m unittest ci.test.test_slh_dsa_reference
- python3 -m unittest discover -s ci/test -p 'test_*.py'
- python3 ci/test/check_ci_inventory.py
- git diff --check

The repository lint runner completed all available checks; this macOS host lacks GNU sed and optional mlc/ruff/vulture/lief/shellcheck tools.