### PR TITLE
research: add ML-DSA-44 reference comparator

### DIFF
--- a/ci/test/test_ml_dsa_reference.py
+++ b/ci/test/test_ml_dsa_reference.py
@@ -1,0 +1,110 @@
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REFERENCE_DIR = REPO_ROOT / "contrib" / "ml-dsa-ref"
+DRIVER_PATH = REFERENCE_DIR / "compare_oracles.py"
+MANIFEST_PATH = REFERENCE_DIR / "vectors.json"
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+compare_oracles = load_module(DRIVER_PATH, "compare_ml_dsa_oracles")
+
+
+class MLDSAReferenceTests(unittest.TestCase):
+    def setUp(self):
+        self.manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf8"))
+
+    def test_manifest_contract(self):
+        compare_oracles.validate_manifest(self.manifest)
+
+    def test_complete_selected_profile_acvp_contract(self):
+        coverage = self.manifest["acvp_coverage"]
+        self.assertEqual(coverage["keygen"]["test_case_ids"], list(range(1, 26)))
+        self.assertEqual(
+            [group["test_case_ids"] for group in coverage["siggen"]],
+            [list(range(1, 16)), list(range(181, 196))],
+        )
+        self.assertEqual(coverage["sigver"]["test_case_ids"], list(range(1, 16)))
+        self.assertEqual(coverage["sigver"]["accepted_test_case_ids"], [6, 7, 11])
+        self.assertEqual(coverage["total_cases"], 70)
+
+    def test_profile_and_randomized_posture(self):
+        profile = self.manifest["profile"]
+        self.assertEqual(profile["name"], "ML-DSA-44")
+        self.assertEqual(profile["nist_security_category"], 2)
+        self.assertEqual(profile["public_key_bytes"], 1312)
+        self.assertEqual(profile["private_key_bytes"], 2560)
+        self.assertEqual(profile["signature_bytes"], 2420)
+        self.assertEqual(profile["randomizer_bytes"], 32)
+        self.assertEqual(
+            profile["production_signing_if_selected"], "hedged_randomized"
+        )
+
+    def test_source_pins_and_lineage_limit(self):
+        sources = self.manifest["sources"]
+        self.assertEqual(sources["openssl"]["version"], "3.6.3")
+        self.assertEqual(sources["mldsa_native"]["tag"], "v1.0.0-beta2")
+        for name in ("nist_acvp", "openssl", "mldsa_native"):
+            self.assertRegex(sources[name]["commit"], r"^[0-9a-f]{40}$")
+        for name in (
+            "nist_fips204",
+            "nist_fips204_potential_updates",
+            "nist_fips204_section6_guidance",
+        ):
+            self.assertRegex(sources[name]["sha256"], r"^[0-9a-f]{64}$")
+        self.assertIn(
+            "not independent cryptographic review",
+            sources["mldsa_native"]["lineage_limit"],
+        )
+
+    def test_manifest_rejects_coverage_drift(self):
+        mutated = copy.deepcopy(self.manifest)
+        mutated["acvp_coverage"]["sigver"]["test_case_ids"].pop()
+        with self.assertRaisesRegex(compare_oracles.ReferenceError, "ACVP coverage"):
+            compare_oracles.validate_manifest(mutated)
+
+    def test_hex_mutation_is_bounded(self):
+        original = "00112233"
+        mutated = compare_oracles.flip_hex_byte(original, 2)
+        self.assertEqual(mutated, "00112333")
+        self.assertEqual(len(mutated), len(original))
+
+    def test_adapters_enforce_signature_and_key_boundaries(self):
+        for source_name in ("openssl_oracle.c", "mldsa_native_oracle.c"):
+            source = (REFERENCE_DIR / source_name).read_text(encoding="utf8")
+            self.assertIn("if (signature_size != SIGNATURE_SIZE)", source)
+            self.assertIn('printf("verified=0\\n")', source)
+            self.assertIn('strcmp(argv[1], "public-key")', source)
+        openssl_source = (REFERENCE_DIR / "openssl_oracle.c").read_text(encoding="utf8")
+        self.assertNotIn("private_key + PRIVATE_KEY_SIZE - PUBLIC_KEY_SIZE", openssl_source)
+        native_source = (REFERENCE_DIR / "mldsa_native_oracle.c").read_text(encoding="utf8")
+        self.assertIn("mldsa_pk_from_sk", native_source)
+
+    def test_manifest_only_cli(self):
+        result = subprocess.run(
+            [sys.executable, str(DRIVER_PATH), "--manifest-only"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("manifest validation passed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/ml-dsa-ref/README.md
+++ b/contrib/ml-dsa-ref/README.md
@@ -1,0 +1,57 @@
+# ML-DSA-44 Reference Harness
+
+This directory contains an isolated conformance and measurement harness for
+the FIPS 204 `ML-DSA-44` comparator. It is not linked into PQBTC, does not
+define consensus behavior, and does not allocate or activate an `ALG_ID`.
+
+## Evidence Sources
+
+- NIST FIPS 204, its February 27, 2026 potential-updates sheet, and NIST's
+  March 19, 2025 Section 6 guidance, all pinned by SHA256 in `vectors.json`
+- all 70 NIST ACVP external/pure ML-DSA-44 cases at the exact ACVP-Server
+  commit and source-file hashes pinned in `vectors.json`
+- an OpenSSL 3.6.3 runtime plus a clean checkout at its pinned source commit
+- `pq-code-package/mldsa-native` `v1.0.0-beta2` at its pinned commit
+
+The two adapters use all-zero randomness for deterministic vectors, explicit
+32-byte `rnd` injection for randomized ACVP vectors, and their native
+randomized APIs for diversity and cross-verification checks. Hedged randomized
+signing remains the required posture for any future production proposal.
+
+`mldsa-native` is a fork of the `pq-crystals` reference implementation. It is
+a separate portable-C code path from OpenSSL, but this ancestry means a green
+differential run is not a substitute for independent cryptographic review.
+
+## Run
+
+```bash
+python3 contrib/ml-dsa-ref/compare_oracles.py --manifest-only
+python3 contrib/ml-dsa-ref/compare_oracles.py \
+  --acvp-server /path/to/pinned/ACVP-Server \
+  --openssl-source /path/to/pinned/openssl \
+  --mldsa-native /path/to/pinned/mldsa-native \
+  --fips204 /path/to/NIST.FIPS.204.pdf \
+  --fips204-updates /path/to/fips-204-potential-updates.xlsx \
+  --fips204-section6-guidance /path/to/fips204-sec6-03192025.pdf \
+  --benchmark-iterations 10 \
+  --sanitizers
+```
+
+The full run requires clean Git checkouts at all pinned commits. It verifies
+the three NIST document checksums and six ACVP source checksums, then executes
+25 key-generation cases, 15 deterministic signature-generation cases, 15
+randomized signature-generation cases, and all 15 signature-verification
+accept/reject cases. It also checks complete signature-byte agreement,
+cross-verification, native randomized-signature diversity, empty and maximum
+contexts, malformed lengths, key/message/context/signature mutations, and
+bounded ASan/UBSan adapter runs. The JSON report includes ten-run timing
+medians and an explicitly scoped raw-payload block-space model.
+
+The current research adapter uses POSIX `/dev/urandom` to exercise
+`mldsa-native`'s randomized API. That wrapper path is intended for macOS/Linux
+evidence runs and is not a proposed node entropy implementation.
+
+Both adapters reject any signature whose decoded length is not exactly 2,420
+bytes before entering the implementation verifier. OpenSSL and
+`mldsa-native` are prototype oracles only; passing this harness neither makes
+either one a node dependency nor approves ML-DSA-44 for consensus integration.

--- a/contrib/ml-dsa-ref/compare_oracles.py
+++ b/contrib/ml-dsa-ref/compare_oracles.py
@@ -1,0 +1,1529 @@
+#!/usr/bin/env python3
+"""Build and compare pinned ML-DSA-44 reference oracles."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import secrets
+import shlex
+import statistics
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+MANIFEST_PATH = HERE / "vectors.json"
+OPENSSL_SOURCE = HERE / "openssl_oracle.c"
+MLDSA_NATIVE_SOURCE = HERE / "mldsa_native_oracle.c"
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReferenceError(RuntimeError):
+    pass
+
+
+def require_hex(value: str, byte_length: int, label: str) -> None:
+    if len(value) != byte_length * 2 or re.fullmatch(r"[0-9a-f]+", value) is None:
+        raise ReferenceError(f"{label} must be {byte_length} lowercase-hex bytes")
+
+
+def validate_manifest(manifest: dict) -> None:
+    if manifest.get("schema_version") != 2:
+        raise ReferenceError("manifest schema_version must be 2")
+
+    profile = manifest["profile"]
+    expected_profile = {
+        "name": "ML-DSA-44",
+        "standard": "FIPS 204",
+        "nist_security_category": 2,
+        "signature_interface": "external",
+        "message_mode": "pure",
+        "public_key_bytes": 1312,
+        "private_key_bytes": 2560,
+        "keygen_seed_bytes": 32,
+        "randomizer_bytes": 32,
+        "signature_bytes": 2420,
+        "prototype_message_bytes": 32,
+        "exact_vector_signing": "deterministic_or_fixed_randomizer",
+        "production_signing_if_selected": "hedged_randomized",
+    }
+    for name, expected in expected_profile.items():
+        if profile.get(name) != expected:
+            raise ReferenceError(f"profile {name} must be {expected!r}")
+
+    context_hex = profile["prototype_context_hex"]
+    if bytes.fromhex(context_hex).decode("ascii") != profile["prototype_context_ascii"]:
+        raise ReferenceError("prototype context hex/ascii mismatch")
+    if len(bytes.fromhex(context_hex)) > 255:
+        raise ReferenceError("prototype context exceeds FIPS 204 limit")
+
+    expected_cost_model = {
+        "held_rc2_signature_bytes": 4480,
+        "held_rc2_public_key_bytes": 33,
+        "block_weight_limit": 16_000_000,
+        "witness_weight_per_byte": 1,
+        "non_witness_weight_per_byte": 4,
+    }
+    if manifest.get("system_cost_model") != expected_cost_model:
+        raise ReferenceError("system cost model does not match the held PQBTC baseline")
+
+    expected_acvp_coverage = {
+        "keygen": {"group_id": 1, "test_case_ids": list(range(1, 26))},
+        "siggen": [
+            {
+                "group_id": 1,
+                "deterministic": True,
+                "signature_interface": "external",
+                "message_mode": "pure",
+                "test_case_ids": list(range(1, 16)),
+            },
+            {
+                "group_id": 13,
+                "deterministic": False,
+                "signature_interface": "external",
+                "message_mode": "pure",
+                "test_case_ids": list(range(181, 196)),
+            },
+        ],
+        "sigver": {
+            "group_id": 1,
+            "signature_interface": "external",
+            "message_mode": "pure",
+            "test_case_ids": list(range(1, 16)),
+            "accepted_test_case_ids": [6, 7, 11],
+        },
+        "total_cases": 70,
+    }
+    if manifest.get("acvp_coverage") != expected_acvp_coverage:
+        raise ReferenceError("ACVP coverage does not match the frozen 70-case contract")
+
+    sources = manifest["sources"]
+    for source_name in ("nist_acvp", "openssl", "mldsa_native"):
+        if re.fullmatch(r"[0-9a-f]{40}", sources[source_name]["commit"]) is None:
+            raise ReferenceError(f"{source_name} commit must be a full Git SHA")
+    if sources["openssl"].get("version") != "3.6.3":
+        raise ReferenceError("OpenSSL source and runtime version must be 3.6.3")
+    if sources["mldsa_native"].get("tag") != "v1.0.0-beta2":
+        raise ReferenceError("mldsa-native tag must be v1.0.0-beta2")
+    for source_name in (
+        "nist_fips204",
+        "nist_fips204_potential_updates",
+        "nist_fips204_section6_guidance",
+    ):
+        if HEX_64.fullmatch(sources[source_name].get("sha256", "")) is None:
+            raise ReferenceError(f"{source_name} must pin a SHA256 value")
+
+    expected_nist_files = {
+        "gen-val/json-files/ML-DSA-keyGen-FIPS204/prompt.json",
+        "gen-val/json-files/ML-DSA-keyGen-FIPS204/expectedResults.json",
+        "gen-val/json-files/ML-DSA-sigGen-FIPS204/prompt.json",
+        "gen-val/json-files/ML-DSA-sigGen-FIPS204/expectedResults.json",
+        "gen-val/json-files/ML-DSA-sigVer-FIPS204/prompt.json",
+        "gen-val/json-files/ML-DSA-sigVer-FIPS204/expectedResults.json",
+    }
+    nist_files = sources["nist_acvp"]["files"]
+    if set(nist_files) != expected_nist_files:
+        raise ReferenceError("NIST source file set does not match the reference contract")
+    if any(HEX_64.fullmatch(value) is None for value in nist_files.values()):
+        raise ReferenceError("NIST source hashes must be SHA256 values")
+
+    vectors = manifest["vectors"]
+    keygen = vectors["nist_keygen_tg1_tc1"]
+    require_hex(keygen["seed_hex"], profile["keygen_seed_bytes"], "NIST keygen seed")
+    for field in ("expected_private_key_sha256", "expected_public_key_sha256"):
+        if HEX_64.fullmatch(keygen[field]) is None:
+            raise ReferenceError(f"NIST keygen {field} must be SHA256")
+
+    for vector_name, expected_group, expected_test, deterministic in (
+        ("nist_siggen_tg1_tc1", 1, 1, True),
+        ("nist_siggen_tg13_tc181", 13, 181, False),
+    ):
+        vector = vectors[vector_name]
+        if vector.get("group_id") != expected_group:
+            raise ReferenceError(f"{vector_name} group identity mismatch")
+        if vector.get("test_case_id") != expected_test:
+            raise ReferenceError(f"{vector_name} test identity mismatch")
+        if vector.get("deterministic") is not deterministic:
+            raise ReferenceError(f"{vector_name} deterministic flag mismatch")
+        if vector["context_bytes"] > 255:
+            raise ReferenceError("NIST context exceeds FIPS 204 limit")
+        for field in (
+            "private_key_sha256",
+            "message_sha256",
+            "context_sha256",
+            "expected_signature_sha256",
+        ):
+            if HEX_64.fullmatch(vector[field]) is None:
+                raise ReferenceError(f"{vector_name} {field} must be SHA256")
+        if deterministic:
+            if "randomizer_hex" in vector:
+                raise ReferenceError("deterministic vector must not include randomness")
+        else:
+            require_hex(
+                vector["randomizer_hex"],
+                profile["randomizer_bytes"],
+                "NIST randomizer",
+            )
+
+    sigver = vectors["nist_sigver_tg1"]
+    for name, expected in {
+        "parameter_set": profile["name"],
+        "signature_interface": profile["signature_interface"],
+        "message_mode": profile["message_mode"],
+    }.items():
+        if sigver.get(name) != expected:
+            raise ReferenceError(f"NIST sigver {name} must be {expected!r}")
+    cases = sigver["cases"]
+    if len(cases) != 2 or {case["test_case_id"] for case in cases} != {1, 6}:
+        raise ReferenceError("NIST sigver representatives must be tcId 1 and 6")
+    if {case["expected_valid"] for case in cases} != {False, True}:
+        raise ReferenceError("NIST sigver representatives must include accept and reject")
+    for case in cases:
+        if case["context_bytes"] > 255:
+            raise ReferenceError("NIST sigver context exceeds FIPS 204 limit")
+        if case["signature_bytes"] != profile["signature_bytes"]:
+            raise ReferenceError("NIST sigver signature size mismatch")
+        for field in (
+            "public_key_sha256",
+            "message_sha256",
+            "context_sha256",
+            "signature_sha256",
+        ):
+            if HEX_64.fullmatch(case[field]) is None:
+                raise ReferenceError(f"NIST sigver {field} must be SHA256")
+
+    pqbtc = vectors["pqbtc_sighash_v1"]
+    require_hex(pqbtc["seed_hex"], profile["keygen_seed_bytes"], "PQBTC keygen seed")
+    require_hex(pqbtc["message_hex"], profile["prototype_message_bytes"], "PQBTC message")
+    if pqbtc["context_hex"] != context_hex:
+        raise ReferenceError("PQBTC vector does not use the frozen prototype context")
+    for field in (
+        "expected_private_key_sha256",
+        "expected_public_key_sha256",
+        "expected_signature_sha256",
+    ):
+        if HEX_64.fullmatch(pqbtc[field]) is None:
+            raise ReferenceError(f"PQBTC {field} must be SHA256")
+
+
+def load_manifest() -> dict:
+    with MANIFEST_PATH.open(encoding="utf8") as manifest_file:
+        manifest = json.load(manifest_file)
+    validate_manifest(manifest)
+    return manifest
+
+
+def run(command: list[str], cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ReferenceError(
+            f"command failed ({result.returncode}): {shlex.join(command)}\n"
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def require_command_failure(command: list[str], label: str) -> None:
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 0:
+        raise ReferenceError(f"{label} unexpectedly succeeded")
+
+
+def parse_version(value: str, label: str) -> tuple[int, int, int]:
+    match = re.search(r"(?:OpenSSL )?(\d+)\.(\d+)\.(\d+)", value)
+    if match is None:
+        raise ReferenceError(f"cannot parse {label} version: {value}")
+    return tuple(int(part) for part in match.groups())
+
+
+def openssl_version(expected_version: str) -> tuple[str, tuple[int, int, int]]:
+    output = run(["openssl", "version"]).strip()
+    version = parse_version(output, "OpenSSL CLI")
+    expected = parse_version(expected_version, "expected OpenSSL")
+    if version != expected:
+        raise ReferenceError(
+            f"OpenSSL runtime mismatch: expected {expected_version}, got {version}"
+        )
+    pkg_config_version = parse_version(
+        run(["pkg-config", "--modversion", "openssl"]).strip(),
+        "OpenSSL pkg-config",
+    )
+    if pkg_config_version != version:
+        raise ReferenceError(
+            f"OpenSSL CLI/pkg-config mismatch: {version}, {pkg_config_version}"
+        )
+    return output, version
+
+
+def compiler_mode_flags(sanitized: bool) -> list[str]:
+    if sanitized:
+        return [
+            "-O1",
+            "-g",
+            "-fno-omit-frame-pointer",
+            "-fsanitize=address,undefined",
+        ]
+    return ["-O2"]
+
+
+def compile_openssl_oracle(
+    build_dir: Path, expected_version: str, sanitized: bool = False
+) -> Path:
+    openssl_version(expected_version)
+    compiler = os.environ.get("CC", "cc")
+    pkg_config = shlex.split(run(["pkg-config", "--cflags", "--libs", "openssl"]))
+    suffix = "_sanitized" if sanitized else ""
+    output = build_dir / f"openssl_ml_dsa_oracle{suffix}"
+    run(
+        [
+            compiler,
+            "-std=c11",
+            *compiler_mode_flags(sanitized),
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            str(OPENSSL_SOURCE),
+            "-o",
+            str(output),
+            *pkg_config,
+        ]
+    )
+    return output
+
+
+def require_git_commit(source_dir: Path, expected_commit: str, source_name: str) -> None:
+    actual_commit = run(["git", "rev-parse", "HEAD"], cwd=source_dir).strip()
+    if actual_commit != expected_commit:
+        raise ReferenceError(
+            f"{source_name} commit mismatch: expected {expected_commit}, got {actual_commit}"
+        )
+    dirty = run(
+        ["git", "status", "--porcelain", "--untracked-files=all"], cwd=source_dir
+    ).strip()
+    if dirty:
+        raise ReferenceError(f"{source_name} checkout must be clean")
+
+
+def require_openssl_source(source_dir: Path, expected_commit: str) -> None:
+    required_files = (
+        "crypto/ml_dsa/ml_dsa_sign.c",
+        "doc/man7/EVP_SIGNATURE-ML-DSA.pod",
+        "providers/implementations/signature/ml_dsa_sig.c.in",
+    )
+    if any(not (source_dir / relative_path).is_file() for relative_path in required_files):
+        raise ReferenceError(f"missing OpenSSL ML-DSA source at {source_dir}")
+    require_git_commit(source_dir, expected_commit, "OpenSSL")
+
+
+def require_mldsa_native_source(source_dir: Path, expected_commit: str) -> None:
+    required_files = (
+        "examples/monolithic_build/mldsa_native/mldsa_native.c",
+        "examples/monolithic_build/mldsa_native/mldsa_native.h",
+        "examples/monolithic_build/mldsa_native/mldsa_native_config.h",
+    )
+    if any(not (source_dir / relative_path).is_file() for relative_path in required_files):
+        raise ReferenceError(f"missing mldsa-native source at {source_dir}")
+    require_git_commit(source_dir, expected_commit, "mldsa-native")
+
+
+def require_artifact(path: Path, expected_sha256: str, label: str) -> None:
+    if not path.is_file():
+        raise ReferenceError(f"missing {label}: {path}")
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    if actual != expected_sha256:
+        raise ReferenceError(
+            f"{label} SHA256 mismatch: expected {expected_sha256}, got {actual}"
+        )
+
+
+def compile_mldsa_native_oracle(
+    build_dir: Path,
+    source_dir: Path,
+    expected_commit: str,
+    sanitized: bool = False,
+) -> Path:
+    require_mldsa_native_source(source_dir, expected_commit)
+    monolithic_dir = source_dir / "examples/monolithic_build/mldsa_native"
+    monolithic_source = monolithic_dir / "mldsa_native.c"
+    compiler = os.environ.get("CC", "cc")
+    suffix = "_sanitized" if sanitized else ""
+    output = build_dir / f"mldsa_native_oracle{suffix}"
+    run(
+        [
+            compiler,
+            "-std=c99",
+            *compiler_mode_flags(sanitized),
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-Wno-unknown-pragmas",
+            "-DMLD_CONFIG_PARAMETER_SET=44",
+            f"-I{monolithic_dir}",
+            str(MLDSA_NATIVE_SOURCE),
+            str(monolithic_source),
+            "-o",
+            str(output),
+        ]
+    )
+    return output
+
+
+def find_test(document: dict, group_id: int, test_id: int) -> tuple[dict, dict]:
+    group = next(
+        (candidate for candidate in document["testGroups"] if candidate["tgId"] == group_id),
+        None,
+    )
+    if group is None:
+        raise ReferenceError(f"missing ACVP group {group_id}")
+    test = next((candidate for candidate in group["tests"] if candidate["tcId"] == test_id), None)
+    if test is None:
+        raise ReferenceError(f"missing ACVP test {group_id}/{test_id}")
+    return group, test
+
+
+def require_acvp_group(
+    document: dict,
+    group_id: int,
+    expected_metadata: dict,
+    expected_test_ids: list[int],
+    label: str,
+) -> dict:
+    group = next(
+        (candidate for candidate in document["testGroups"] if candidate["tgId"] == group_id),
+        None,
+    )
+    if group is None:
+        raise ReferenceError(f"missing {label} group {group_id}")
+    for name, expected_value in expected_metadata.items():
+        if group.get(name) != expected_value:
+            raise ReferenceError(f"{label} group {group_id} {name} mismatch")
+    if [test["tcId"] for test in group["tests"]] != expected_test_ids:
+        raise ReferenceError(f"{label} group {group_id} test-case set mismatch")
+    return group
+
+
+def sha256_hex(hex_value: str) -> str:
+    return hashlib.sha256(bytes.fromhex(hex_value)).hexdigest()
+
+
+def require_equal(label: str, *values: str) -> None:
+    if len(set(values)) != 1:
+        raise ReferenceError(f"{label} mismatch")
+
+
+def verify_nist_sources(manifest: dict, source_dir: Path) -> dict:
+    source = manifest["sources"]["nist_acvp"]
+    require_git_commit(source_dir, source["commit"], "NIST ACVP")
+    loaded: dict[str, dict] = {}
+    for relative_path, expected_hash in source["files"].items():
+        path = source_dir / relative_path
+        if not path.is_file():
+            raise ReferenceError(f"missing NIST source file: {path}")
+        actual_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual_hash != expected_hash:
+            raise ReferenceError(
+                f"NIST source hash mismatch for {relative_path}: "
+                f"expected {expected_hash}, got {actual_hash}"
+            )
+        loaded[relative_path] = json.loads(path.read_text(encoding="utf8"))
+
+    profile = manifest["profile"]
+    coverage = manifest["acvp_coverage"]
+    vectors = manifest["vectors"]
+    prefix = "gen-val/json-files"
+
+    keygen_prompt = loaded[f"{prefix}/ML-DSA-keyGen-FIPS204/prompt.json"]
+    keygen_expected = loaded[f"{prefix}/ML-DSA-keyGen-FIPS204/expectedResults.json"]
+    keygen_contract = coverage["keygen"]
+    keygen_group = require_acvp_group(
+        keygen_prompt,
+        keygen_contract["group_id"],
+        {"parameterSet": profile["name"]},
+        keygen_contract["test_case_ids"],
+        "NIST keygen",
+    )
+    keygen_cases = []
+    for source_case in keygen_group["tests"]:
+        test_id = source_case["tcId"]
+        _, source_result = find_test(keygen_expected, keygen_contract["group_id"], test_id)
+        seed_hex = source_case["seed"].lower()
+        private_key_hex = source_result["sk"].lower()
+        public_key_hex = source_result["pk"].lower()
+        require_hex(seed_hex, profile["keygen_seed_bytes"], f"NIST keygen {test_id} seed")
+        require_hex(
+            private_key_hex,
+            profile["private_key_bytes"],
+            f"NIST keygen {test_id} private key",
+        )
+        require_hex(
+            public_key_hex,
+            profile["public_key_bytes"],
+            f"NIST keygen {test_id} public key",
+        )
+        keygen_cases.append(
+            {
+                "test_case_id": test_id,
+                "seed_hex": seed_hex,
+                "private_key_hex": private_key_hex,
+                "public_key_hex": public_key_hex,
+            }
+        )
+
+    representative_keygen = vectors["nist_keygen_tg1_tc1"]
+    first_keygen = keygen_cases[0]
+    require_equal("NIST keygen seed", first_keygen["seed_hex"], representative_keygen["seed_hex"])
+    require_equal(
+        "NIST keygen private-key hash",
+        sha256_hex(first_keygen["private_key_hex"]),
+        representative_keygen["expected_private_key_sha256"],
+    )
+    require_equal(
+        "NIST keygen public-key hash",
+        sha256_hex(first_keygen["public_key_hex"]),
+        representative_keygen["expected_public_key_sha256"],
+    )
+
+    siggen_prompt = loaded[f"{prefix}/ML-DSA-sigGen-FIPS204/prompt.json"]
+    siggen_expected = loaded[f"{prefix}/ML-DSA-sigGen-FIPS204/expectedResults.json"]
+    siggen_cases = []
+    for contract in coverage["siggen"]:
+        group_id = contract["group_id"]
+        group = require_acvp_group(
+            siggen_prompt,
+            group_id,
+            {
+                "parameterSet": profile["name"],
+                "deterministic": contract["deterministic"],
+                "signatureInterface": contract["signature_interface"],
+                "preHash": contract["message_mode"],
+            },
+            contract["test_case_ids"],
+            "NIST siggen",
+        )
+        for source_case in group["tests"]:
+            test_id = source_case["tcId"]
+            _, source_result = find_test(siggen_expected, group_id, test_id)
+            randomizer_hex = source_case.get("rnd")
+            if contract["deterministic"]:
+                if randomizer_hex is not None:
+                    raise ReferenceError(f"deterministic siggen {test_id} includes rnd")
+            else:
+                if randomizer_hex is None:
+                    raise ReferenceError(f"randomized siggen {test_id} lacks rnd")
+                randomizer_hex = randomizer_hex.lower()
+                require_hex(
+                    randomizer_hex,
+                    profile["randomizer_bytes"],
+                    f"NIST siggen {test_id} randomizer",
+                )
+            private_key_hex = source_case["sk"].lower()
+            message_hex = source_case["message"].lower()
+            context_hex = source_case.get("context", "").lower()
+            signature_hex = source_result["signature"].lower()
+            require_hex(
+                private_key_hex,
+                profile["private_key_bytes"],
+                f"NIST siggen {test_id} private key",
+            )
+            require_hex(
+                signature_hex,
+                profile["signature_bytes"],
+                f"NIST siggen {test_id} signature",
+            )
+            if len(bytes.fromhex(context_hex)) > 255:
+                raise ReferenceError(f"NIST siggen {test_id} context exceeds 255 bytes")
+            siggen_cases.append(
+                {
+                    "group_id": group_id,
+                    "test_case_id": test_id,
+                    "deterministic": contract["deterministic"],
+                    "private_key_hex": private_key_hex,
+                    "message_hex": message_hex,
+                    "context_hex": context_hex,
+                    "randomizer_hex": randomizer_hex,
+                    "signature_hex": signature_hex,
+                }
+            )
+
+    for vector_name, identity in (
+        ("nist_siggen_tg1_tc1", (1, 1)),
+        ("nist_siggen_tg13_tc181", (13, 181)),
+    ):
+        representative = vectors[vector_name]
+        selected = next(
+            case
+            for case in siggen_cases
+            if (case["group_id"], case["test_case_id"]) == identity
+        )
+        for source_field, manifest_field in (
+            ("private_key_hex", "private_key_sha256"),
+            ("message_hex", "message_sha256"),
+            ("context_hex", "context_sha256"),
+            ("signature_hex", "expected_signature_sha256"),
+        ):
+            require_equal(
+                f"{vector_name} {source_field} hash",
+                sha256_hex(selected[source_field]),
+                representative[manifest_field],
+            )
+        if len(bytes.fromhex(selected["message_hex"])) != representative["message_bytes"]:
+            raise ReferenceError(f"{vector_name} message size mismatch")
+        if len(bytes.fromhex(selected["context_hex"])) != representative["context_bytes"]:
+            raise ReferenceError(f"{vector_name} context size mismatch")
+        if selected["randomizer_hex"] is not None:
+            require_equal(
+                f"{vector_name} randomizer",
+                selected["randomizer_hex"],
+                representative["randomizer_hex"],
+            )
+
+    sigver_prompt = loaded[f"{prefix}/ML-DSA-sigVer-FIPS204/prompt.json"]
+    sigver_expected = loaded[f"{prefix}/ML-DSA-sigVer-FIPS204/expectedResults.json"]
+    sigver_contract = coverage["sigver"]
+    sigver_group = require_acvp_group(
+        sigver_prompt,
+        sigver_contract["group_id"],
+        {
+            "parameterSet": profile["name"],
+            "signatureInterface": sigver_contract["signature_interface"],
+            "preHash": sigver_contract["message_mode"],
+        },
+        sigver_contract["test_case_ids"],
+        "NIST sigver",
+    )
+    accepted_ids = set(sigver_contract["accepted_test_case_ids"])
+    sigver_cases = []
+    for source_case in sigver_group["tests"]:
+        test_id = source_case["tcId"]
+        _, source_result = find_test(sigver_expected, sigver_contract["group_id"], test_id)
+        expected_valid = test_id in accepted_ids
+        if source_result.get("testPassed") is not expected_valid:
+            raise ReferenceError(f"NIST sigver {test_id} result mismatch")
+        public_key_hex = source_case["pk"].lower()
+        message_hex = source_case["message"].lower()
+        context_hex = source_case.get("context", "").lower()
+        signature_hex = source_case["signature"].lower()
+        require_hex(
+            public_key_hex,
+            profile["public_key_bytes"],
+            f"NIST sigver {test_id} public key",
+        )
+        require_hex(
+            signature_hex,
+            profile["signature_bytes"],
+            f"NIST sigver {test_id} signature",
+        )
+        if len(bytes.fromhex(context_hex)) > 255:
+            raise ReferenceError(f"NIST sigver {test_id} context exceeds 255 bytes")
+        sigver_cases.append(
+            {
+                "test_case_id": test_id,
+                "public_key_hex": public_key_hex,
+                "message_hex": message_hex,
+                "context_hex": context_hex,
+                "signature_hex": signature_hex,
+                "expected_valid": expected_valid,
+            }
+        )
+
+    sigver_by_id = {case["test_case_id"]: case for case in sigver_cases}
+    for representative in vectors["nist_sigver_tg1"]["cases"]:
+        source_case = sigver_by_id[representative["test_case_id"]]
+        for source_field, manifest_field in (
+            ("public_key_hex", "public_key_sha256"),
+            ("message_hex", "message_sha256"),
+            ("context_hex", "context_sha256"),
+            ("signature_hex", "signature_sha256"),
+        ):
+            require_equal(
+                f"NIST sigver {source_case['test_case_id']} {source_field} hash",
+                sha256_hex(source_case[source_field]),
+                representative[manifest_field],
+            )
+        if len(bytes.fromhex(source_case["message_hex"])) != representative["message_bytes"]:
+            raise ReferenceError("NIST sigver representative message size mismatch")
+        if len(bytes.fromhex(source_case["context_hex"])) != representative["context_bytes"]:
+            raise ReferenceError("NIST sigver representative context size mismatch")
+        if source_case["expected_valid"] is not representative["expected_valid"]:
+            raise ReferenceError("NIST sigver representative result mismatch")
+
+    total_cases = len(keygen_cases) + len(siggen_cases) + len(sigver_cases)
+    if total_cases != coverage["total_cases"]:
+        raise ReferenceError("NIST selected-profile ACVP case count mismatch")
+    return {
+        "keygen_cases": keygen_cases,
+        "siggen_cases": siggen_cases,
+        "sigver_cases": sigver_cases,
+        "total_cases": total_cases,
+    }
+
+
+def parse_oracle_output(output: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for line in output.splitlines():
+        if "=" not in line:
+            raise ReferenceError(f"invalid oracle output line: {line}")
+        name, value = line.split("=", 1)
+        if name in parsed:
+            raise ReferenceError(f"duplicate oracle output field: {name}")
+        parsed[name] = value
+    return parsed
+
+
+def oracle_keygen(executable: Path, seed_hex: str) -> dict[str, str]:
+    return parse_oracle_output(run([str(executable), "keygen", seed_hex]))
+
+
+def oracle_public_key(executable: Path, private_key_hex: str) -> str:
+    result = parse_oracle_output(
+        run([str(executable), "public-key", private_key_hex])
+    )
+    public_key = result.get("pk")
+    if public_key is None:
+        raise ReferenceError(f"oracle {executable.name} omitted public key")
+    return public_key
+
+
+def oracle_sign(
+    executable: Path,
+    private_key_hex: str,
+    message_hex: str,
+    context_hex: str,
+    randomizer_hex: str | None = None,
+    randomized: bool = False,
+) -> dict[str, str]:
+    if randomizer_hex is not None and randomized:
+        raise ReferenceError("fixed and default randomized signing are mutually exclusive")
+    command = "sign-randomized" if randomized else "sign"
+    arguments = [str(executable), command, private_key_hex, message_hex, context_hex]
+    if randomizer_hex is not None:
+        arguments[1] = "sign-with-randomizer"
+        arguments.append(randomizer_hex)
+    result = parse_oracle_output(run(arguments))
+    if result.get("verified") != "1":
+        raise ReferenceError(f"oracle {executable.name} did not self-verify")
+    return result
+
+
+def oracle_verify(
+    executable: Path,
+    public_key_hex: str,
+    message_hex: str,
+    context_hex: str,
+    signature_hex: str,
+) -> dict[str, str]:
+    result = parse_oracle_output(
+        run(
+            [
+                str(executable),
+                "verify",
+                public_key_hex,
+                message_hex,
+                context_hex,
+                signature_hex,
+            ]
+        )
+    )
+    if result.get("verified") not in {"0", "1"}:
+        raise ReferenceError(f"oracle {executable.name} returned invalid verify result")
+    return result
+
+
+def signature_hash(signature_hex: str, expected_bytes: int) -> str:
+    require_hex(signature_hex, expected_bytes, "signature")
+    return sha256_hex(signature_hex)
+
+
+def flip_hex_byte(value: str, byte_index: int) -> str:
+    data = bytearray.fromhex(value)
+    data[byte_index] ^= 1
+    return data.hex()
+
+
+def require_verification(
+    oracles: dict[str, Path],
+    public_key_hex: str,
+    message_hex: str,
+    context_hex: str,
+    signature_hex: str,
+    expected: str,
+    label: str,
+) -> None:
+    results = {
+        name: oracle_verify(
+            executable,
+            public_key_hex,
+            message_hex,
+            context_hex,
+            signature_hex,
+        )["verified"]
+        for name, executable in oracles.items()
+    }
+    require_equal(label, *results.values(), expected)
+
+
+def evaluate_acvp(profile: dict, oracles: dict[str, Path], source_cases: dict) -> None:
+    for case in source_cases["keygen_cases"]:
+        results = {
+            name: oracle_keygen(executable, case["seed_hex"])
+            for name, executable in oracles.items()
+        }
+        for result in results.values():
+            require_equal(
+                f"NIST keygen {case['test_case_id']} public key",
+                result["pk"],
+                case["public_key_hex"],
+            )
+            require_equal(
+                f"NIST keygen {case['test_case_id']} private key",
+                result["sk"],
+                case["private_key_hex"],
+            )
+        require_equal(
+            f"oracle keygen {case['test_case_id']} public key",
+            *(result["pk"] for result in results.values()),
+        )
+        require_equal(
+            f"oracle keygen {case['test_case_id']} private key",
+            *(result["sk"] for result in results.values()),
+        )
+
+    for case in source_cases["siggen_cases"]:
+        results = {
+            name: oracle_sign(
+                executable,
+                case["private_key_hex"],
+                case["message_hex"],
+                case["context_hex"],
+                randomizer_hex=case["randomizer_hex"],
+            )
+            for name, executable in oracles.items()
+        }
+        for result in results.values():
+            signature_hash(result["signature"], profile["signature_bytes"])
+            require_equal(
+                f"NIST siggen {case['test_case_id']} signature",
+                result["signature"],
+                case["signature_hex"],
+            )
+        require_equal(
+            f"oracle siggen {case['test_case_id']} signature",
+            *(result["signature"] for result in results.values()),
+        )
+        public_keys = {
+            name: oracle_public_key(executable, case["private_key_hex"])
+            for name, executable in oracles.items()
+        }
+        require_equal(
+            f"oracle siggen {case['test_case_id']} public key",
+            *public_keys.values(),
+        )
+        require_verification(
+            oracles,
+            next(iter(public_keys.values())),
+            case["message_hex"],
+            case["context_hex"],
+            case["signature_hex"],
+            "1",
+            f"cross-verification for NIST siggen {case['test_case_id']}",
+        )
+
+    for case in source_cases["sigver_cases"]:
+        require_verification(
+            oracles,
+            case["public_key_hex"],
+            case["message_hex"],
+            case["context_hex"],
+            case["signature_hex"],
+            "1" if case["expected_valid"] else "0",
+            f"NIST sigver {case['test_case_id']}",
+        )
+
+
+def build_pqbtc_material(
+    profile: dict, oracles: dict[str, Path], vector: dict
+) -> dict[str, str]:
+    generated = {
+        name: oracle_keygen(executable, vector["seed_hex"])
+        for name, executable in oracles.items()
+    }
+    require_equal("PQBTC public key bytes", *(result["pk"] for result in generated.values()))
+    require_equal("PQBTC private key bytes", *(result["sk"] for result in generated.values()))
+    material = next(iter(generated.values()))
+    require_equal(
+        "PQBTC public key hash",
+        sha256_hex(material["pk"]),
+        vector["expected_public_key_sha256"],
+    )
+    require_equal(
+        "PQBTC private key hash",
+        sha256_hex(material["sk"]),
+        vector["expected_private_key_sha256"],
+    )
+    require_hex(material["pk"], profile["public_key_bytes"], "PQBTC public key")
+    require_hex(material["sk"], profile["private_key_bytes"], "PQBTC private key")
+    for name, executable in oracles.items():
+        require_equal(
+            f"{name} derived PQBTC public key",
+            oracle_public_key(executable, material["sk"]),
+            material["pk"],
+        )
+    return material
+
+
+def evaluate_randomized_interoperability(
+    profile: dict,
+    oracles: dict[str, Path],
+    vector: dict,
+    private_key_hex: str,
+    public_key_hex: str,
+) -> dict:
+    randomizers = [secrets.token_hex(profile["randomizer_bytes"]) for _ in range(2)]
+    while randomizers[0] == randomizers[1]:
+        randomizers[1] = secrets.token_hex(profile["randomizer_bytes"])
+
+    fixed_signatures = []
+    for index, randomizer_hex in enumerate(randomizers, start=1):
+        results = {
+            name: oracle_sign(
+                executable,
+                private_key_hex,
+                vector["message_hex"],
+                vector["context_hex"],
+                randomizer_hex=randomizer_hex,
+            )
+            for name, executable in oracles.items()
+        }
+        require_equal(
+            f"fixed-randomizer signature round {index}",
+            *(result["signature"] for result in results.values()),
+        )
+        signature_hex = next(iter(results.values()))["signature"]
+        signature_hash(signature_hex, profile["signature_bytes"])
+        fixed_signatures.append(signature_hex)
+        require_verification(
+            oracles,
+            public_key_hex,
+            vector["message_hex"],
+            vector["context_hex"],
+            signature_hex,
+            "1",
+            f"fixed-randomizer cross-verification round {index}",
+        )
+    if fixed_signatures[0] == fixed_signatures[1]:
+        raise ReferenceError("distinct fixed randomizers produced the same signature")
+
+    randomized_rounds = 0
+    for name, executable in oracles.items():
+        signatures = [
+            oracle_sign(
+                executable,
+                private_key_hex,
+                vector["message_hex"],
+                vector["context_hex"],
+                randomized=True,
+            )["signature"]
+            for _ in range(2)
+        ]
+        if signatures[0] == signatures[1]:
+            raise ReferenceError(f"{name} randomized signing repeated a signature")
+        for index, signature_hex in enumerate(signatures, start=1):
+            signature_hash(signature_hex, profile["signature_bytes"])
+            require_verification(
+                oracles,
+                public_key_hex,
+                vector["message_hex"],
+                vector["context_hex"],
+                signature_hex,
+                "1",
+                f"{name} randomized cross-verification round {index}",
+            )
+            randomized_rounds += 1
+    return {
+        "fixed_randomizer_rounds": len(fixed_signatures),
+        "default_randomized_rounds": randomized_rounds,
+    }
+
+
+def evaluate_boundaries_and_mutations(
+    profile: dict,
+    oracles: dict[str, Path],
+    vector: dict,
+    private_key_hex: str,
+    public_key_hex: str,
+    deterministic_signature_hex: str,
+) -> dict:
+    boundary_cases = (
+        ("empty message and context", "", ""),
+        ("maximum context", vector["message_hex"], "a5" * 255),
+    )
+    for label, message_hex, context_hex in boundary_cases:
+        results = {
+            name: oracle_sign(
+                executable,
+                private_key_hex,
+                message_hex,
+                context_hex,
+            )
+            for name, executable in oracles.items()
+        }
+        require_equal(
+            f"{label} signature bytes",
+            *(result["signature"] for result in results.values()),
+        )
+        signature_hex = next(iter(results.values()))["signature"]
+        require_verification(
+            oracles,
+            public_key_hex,
+            message_hex,
+            context_hex,
+            signature_hex,
+            "1",
+            f"{label} cross-verification",
+        )
+
+    message_hex = vector["message_hex"]
+    context_hex = vector["context_hex"]
+    mutations = (
+        (
+            "public key first byte",
+            flip_hex_byte(public_key_hex, 0),
+            message_hex,
+            context_hex,
+            deterministic_signature_hex,
+        ),
+        (
+            "public key last byte",
+            flip_hex_byte(public_key_hex, -1),
+            message_hex,
+            context_hex,
+            deterministic_signature_hex,
+        ),
+        (
+            "message first byte",
+            public_key_hex,
+            flip_hex_byte(message_hex, 0),
+            context_hex,
+            deterministic_signature_hex,
+        ),
+        (
+            "message last byte",
+            public_key_hex,
+            flip_hex_byte(message_hex, -1),
+            context_hex,
+            deterministic_signature_hex,
+        ),
+        (
+            "context first byte",
+            public_key_hex,
+            message_hex,
+            flip_hex_byte(context_hex, 0),
+            deterministic_signature_hex,
+        ),
+        (
+            "context last byte",
+            public_key_hex,
+            message_hex,
+            flip_hex_byte(context_hex, -1),
+            deterministic_signature_hex,
+        ),
+        (
+            "signature first byte",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            flip_hex_byte(deterministic_signature_hex, 0),
+        ),
+        (
+            "signature middle byte",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            flip_hex_byte(
+                deterministic_signature_hex, profile["signature_bytes"] // 2
+            ),
+        ),
+        (
+            "signature last byte",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            flip_hex_byte(deterministic_signature_hex, -1),
+        ),
+        (
+            "signature truncated",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            deterministic_signature_hex[:-2],
+        ),
+        (
+            "signature extended",
+            public_key_hex,
+            message_hex,
+            context_hex,
+            deterministic_signature_hex + "00",
+        ),
+        ("signature empty", public_key_hex, message_hex, context_hex, ""),
+    )
+    for label, key, message, context, signature in mutations:
+        require_verification(
+            oracles,
+            key,
+            message,
+            context,
+            signature,
+            "0",
+            f"mutated {label} rejection",
+        )
+
+    oversized_context = "00" * 256
+    malformed_commands = 0
+    for executable in oracles.values():
+        commands = (
+            [str(executable), "keygen", vector["seed_hex"][:-2]],
+            [str(executable), "keygen", vector["seed_hex"] + "00"],
+            [str(executable), "public-key", private_key_hex[:-2]],
+            [str(executable), "public-key", private_key_hex + "00"],
+            [str(executable), "sign", private_key_hex[:-2], message_hex, context_hex],
+            [str(executable), "sign", private_key_hex + "00", message_hex, context_hex],
+            [str(executable), "sign", private_key_hex, message_hex, oversized_context],
+            [
+                str(executable),
+                "sign-with-randomizer",
+                private_key_hex,
+                message_hex,
+                context_hex,
+                "00" * 31,
+            ],
+            [
+                str(executable),
+                "sign-with-randomizer",
+                private_key_hex,
+                message_hex,
+                context_hex,
+                "00" * 33,
+            ],
+            [
+                str(executable),
+                "verify",
+                public_key_hex[:-2],
+                message_hex,
+                context_hex,
+                deterministic_signature_hex,
+            ],
+            [
+                str(executable),
+                "verify",
+                public_key_hex + "00",
+                message_hex,
+                context_hex,
+                deterministic_signature_hex,
+            ],
+            [
+                str(executable),
+                "verify",
+                public_key_hex,
+                message_hex,
+                oversized_context,
+                deterministic_signature_hex,
+            ],
+        )
+        for index, command in enumerate(commands, start=1):
+            require_command_failure(command, f"{executable.name} malformed input {index}")
+            malformed_commands += 1
+    return {
+        "boundary_cases": len(boundary_cases),
+        "cryptographic_rejections": len(mutations),
+        "malformed_input_rejections": malformed_commands,
+    }
+
+
+def median_ms(values: list[int]) -> float:
+    return round(statistics.median(values) / 1_000_000, 3)
+
+
+def benchmark_profile(
+    profile: dict,
+    oracles: dict[str, Path],
+    vector: dict,
+    iterations: int,
+) -> dict:
+    values = {
+        name: {
+            "keygen_ns": [],
+            "deterministic_sign_ns": [],
+            "deterministic_verify_ns": [],
+            "randomized_sign_ns": [],
+            "randomized_verify_ns": [],
+        }
+        for name in oracles
+    }
+    for _ in range(iterations):
+        deterministic_signatures = []
+        for name, executable in oracles.items():
+            generated = oracle_keygen(executable, vector["seed_hex"])
+            deterministic = oracle_sign(
+                executable,
+                generated["sk"],
+                vector["message_hex"],
+                vector["context_hex"],
+            )
+            require_equal(
+                "PQBTC deterministic signature hash",
+                signature_hash(deterministic["signature"], profile["signature_bytes"]),
+                vector["expected_signature_sha256"],
+            )
+            randomized = oracle_sign(
+                executable,
+                generated["sk"],
+                vector["message_hex"],
+                vector["context_hex"],
+                randomized=True,
+            )
+            require_verification(
+                oracles,
+                generated["pk"],
+                vector["message_hex"],
+                vector["context_hex"],
+                randomized["signature"],
+                "1",
+                f"{name} randomized benchmark signature",
+            )
+            deterministic_signatures.append(deterministic["signature"])
+            values[name]["keygen_ns"].append(int(generated["keygen_ns"]))
+            values[name]["deterministic_sign_ns"].append(int(deterministic["sign_ns"]))
+            values[name]["deterministic_verify_ns"].append(int(deterministic["verify_ns"]))
+            values[name]["randomized_sign_ns"].append(int(randomized["sign_ns"]))
+            values[name]["randomized_verify_ns"].append(int(randomized["verify_ns"]))
+        require_equal("PQBTC deterministic signature bytes", *deterministic_signatures)
+
+    return {
+        name: {
+            "iterations": iterations,
+            "median_keygen_ms": median_ms(measurements["keygen_ns"]),
+            "deterministic": {
+                "median_sign_ms": median_ms(measurements["deterministic_sign_ns"]),
+                "median_verify_ms": median_ms(measurements["deterministic_verify_ns"]),
+            },
+            "randomized": {
+                "median_sign_ms": median_ms(measurements["randomized_sign_ns"]),
+                "median_verify_ms": median_ms(measurements["randomized_verify_ns"]),
+            },
+        }
+        for name, measurements in values.items()
+    }
+
+
+def evaluate_sanitized_smoke(
+    profile: dict, oracles: dict[str, Path], vector: dict
+) -> dict:
+    material = build_pqbtc_material(profile, oracles, vector)
+    deterministic = {
+        name: oracle_sign(
+            executable,
+            material["sk"],
+            vector["message_hex"],
+            vector["context_hex"],
+        )["signature"]
+        for name, executable in oracles.items()
+    }
+    require_equal("sanitized deterministic signatures", *deterministic.values())
+    return evaluate_boundaries_and_mutations(
+        profile,
+        oracles,
+        vector,
+        material["sk"],
+        material["pk"],
+        next(iter(deterministic.values())),
+    )
+
+
+def block_space_model(profile: dict, cost: dict) -> dict:
+    rc2_signature_bytes = cost["held_rc2_signature_bytes"]
+    mldsa_signature_bytes = profile["signature_bytes"]
+    rc2_revealed_bytes = rc2_signature_bytes + cost["held_rc2_public_key_bytes"]
+    mldsa_revealed_bytes = mldsa_signature_bytes + profile["public_key_bytes"]
+    block_limit = cost["block_weight_limit"]
+    return {
+        **cost,
+        "ml_dsa_signature_bytes": mldsa_signature_bytes,
+        "ml_dsa_public_key_bytes": profile["public_key_bytes"],
+        "signature_size_change_percent": round(
+            (mldsa_signature_bytes / rc2_signature_bytes - 1) * 100, 2
+        ),
+        "signature_only_witness_capacity": {
+            "held_rc2": block_limit // rc2_signature_bytes,
+            "ml_dsa_44": block_limit // mldsa_signature_bytes,
+        },
+        "signature_plus_public_key_bytes": {
+            "held_rc2": rc2_revealed_bytes,
+            "ml_dsa_44": mldsa_revealed_bytes,
+        },
+        "signature_plus_public_key_witness_capacity": {
+            "held_rc2": block_limit // rc2_revealed_bytes,
+            "ml_dsa_44": block_limit // mldsa_revealed_bytes,
+        },
+        "public_key_if_non_witness_weight": {
+            "held_rc2": cost["held_rc2_public_key_bytes"]
+            * cost["non_witness_weight_per_byte"],
+            "ml_dsa_44": profile["public_key_bytes"]
+            * cost["non_witness_weight_per_byte"],
+        },
+        "scope": "raw payload model only; no transaction encoding or activation design",
+    }
+
+
+def evaluate(
+    manifest: dict,
+    oracles: dict[str, Path],
+    source_cases: dict,
+    benchmark_iterations: int,
+    sanitized_report: dict | None,
+) -> dict:
+    profile = manifest["profile"]
+    vector = manifest["vectors"]["pqbtc_sighash_v1"]
+    evaluate_acvp(profile, oracles, source_cases)
+    material = build_pqbtc_material(profile, oracles, vector)
+
+    deterministic = {
+        name: oracle_sign(
+            executable,
+            material["sk"],
+            vector["message_hex"],
+            vector["context_hex"],
+        )["signature"]
+        for name, executable in oracles.items()
+    }
+    require_equal("PQBTC deterministic signature bytes", *deterministic.values())
+    deterministic_signature = next(iter(deterministic.values()))
+    require_equal(
+        "PQBTC deterministic signature hash",
+        signature_hash(deterministic_signature, profile["signature_bytes"]),
+        vector["expected_signature_sha256"],
+    )
+    randomized_report = evaluate_randomized_interoperability(
+        profile, oracles, vector, material["sk"], material["pk"]
+    )
+    negative_report = evaluate_boundaries_and_mutations(
+        profile,
+        oracles,
+        vector,
+        material["sk"],
+        material["pk"],
+        deterministic_signature,
+    )
+    benchmark = benchmark_profile(
+        profile, oracles, vector, benchmark_iterations
+    )
+    version_text, _ = openssl_version(manifest["sources"]["openssl"]["version"])
+    return {
+        "status": "PASS",
+        "profile": profile["name"],
+        "openssl_version": version_text,
+        "openssl_commit": manifest["sources"]["openssl"]["commit"],
+        "mldsa_native_commit": manifest["sources"]["mldsa_native"]["commit"],
+        "checks": {
+            "fips204_and_update_artifact_provenance": "PASS",
+            "nist_source_provenance": "PASS",
+            "nist_selected_profile_acvp_70_cases": "PASS",
+            "nist_deterministic_and_randomized_siggen": "PASS",
+            "nist_sigver_all_accept_reject_cases": "PASS",
+            "pqbtc_sighash_vector": "PASS",
+            "full_signature_byte_agreement": "PASS",
+            "randomized_interoperability": "PASS",
+            "boundary_and_mutation_rejection": "PASS",
+            "adapter_asan_ubsan": "PASS" if sanitized_report is not None else "NOT_RUN",
+        },
+        "acvp": {
+            "total_cases": source_cases["total_cases"],
+            "keygen_cases": len(source_cases["keygen_cases"]),
+            "siggen_cases": len(source_cases["siggen_cases"]),
+            "sigver_cases": len(source_cases["sigver_cases"]),
+        },
+        "randomized_interoperability": randomized_report,
+        "negative_testing": negative_report,
+        "sanitized_smoke": sanitized_report,
+        "signature_sha256": {
+            "nist_deterministic": manifest["vectors"]["nist_siggen_tg1_tc1"][
+                "expected_signature_sha256"
+            ],
+            "nist_randomized": manifest["vectors"]["nist_siggen_tg13_tc181"][
+                "expected_signature_sha256"
+            ],
+            "pqbtc": vector["expected_signature_sha256"],
+        },
+        "lineage_limit": manifest["sources"]["mldsa_native"]["lineage_limit"],
+        "block_space_model": block_space_model(profile, manifest["system_cost_model"]),
+        "benchmark": benchmark,
+    }
+
+
+def optional_path(environment_name: str) -> Path | None:
+    value = os.environ.get(environment_name)
+    return Path(value) if value else None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--acvp-server",
+        type=Path,
+        default=optional_path("ACVP_SERVER_DIR"),
+        help="path to the pinned usnistgov/ACVP-Server checkout",
+    )
+    parser.add_argument(
+        "--mldsa-native",
+        type=Path,
+        default=optional_path("MLDSA_NATIVE_DIR"),
+        help="path to the pinned pq-code-package/mldsa-native checkout",
+    )
+    parser.add_argument(
+        "--openssl-source",
+        type=Path,
+        default=optional_path("OPENSSL_SOURCE_DIR"),
+        help="path to the pinned OpenSSL source checkout",
+    )
+    parser.add_argument(
+        "--fips204",
+        type=Path,
+        default=optional_path("FIPS204_PATH"),
+        help="path to the pinned NIST.FIPS.204.pdf artifact",
+    )
+    parser.add_argument(
+        "--fips204-updates",
+        type=Path,
+        default=optional_path("FIPS204_UPDATES_PATH"),
+        help="path to the pinned FIPS 204 potential-updates spreadsheet",
+    )
+    parser.add_argument(
+        "--fips204-section6-guidance",
+        type=Path,
+        default=optional_path("FIPS204_SECTION6_GUIDANCE_PATH"),
+        help="path to the pinned NIST Section 6 guidance PDF",
+    )
+    parser.add_argument(
+        "--benchmark-iterations",
+        type=int,
+        default=1,
+        help="repeat the PQBTC vector for median timings (1-10)",
+    )
+    parser.add_argument(
+        "--manifest-only",
+        action="store_true",
+        help="validate the checked-in profile and provenance manifest only",
+    )
+    parser.add_argument(
+        "--sanitizers",
+        action="store_true",
+        help="also build and exercise both adapters with ASan and UBSan",
+    )
+    return parser.parse_args()
+
+
+def require_path(value: Path | None, option: str) -> Path:
+    if value is None:
+        raise ReferenceError(f"{option} or its documented environment variable is required")
+    return value.resolve()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifest = load_manifest()
+        if args.manifest_only:
+            print("ML-DSA-44 reference manifest validation passed")
+            return 0
+        if not 1 <= args.benchmark_iterations <= 10:
+            raise ReferenceError("--benchmark-iterations must be between 1 and 10")
+
+        acvp_server = require_path(args.acvp_server, "--acvp-server")
+        mldsa_native = require_path(args.mldsa_native, "--mldsa-native")
+        openssl_source = require_path(args.openssl_source, "--openssl-source")
+        fips204 = require_path(args.fips204, "--fips204")
+        fips204_updates = require_path(args.fips204_updates, "--fips204-updates")
+        section6_guidance = require_path(
+            args.fips204_section6_guidance, "--fips204-section6-guidance"
+        )
+
+        sources = manifest["sources"]
+        require_artifact(fips204, sources["nist_fips204"]["sha256"], "FIPS 204")
+        require_artifact(
+            fips204_updates,
+            sources["nist_fips204_potential_updates"]["sha256"],
+            "FIPS 204 potential updates",
+        )
+        require_artifact(
+            section6_guidance,
+            sources["nist_fips204_section6_guidance"]["sha256"],
+            "FIPS 204 Section 6 guidance",
+        )
+        source_cases = verify_nist_sources(manifest, acvp_server)
+        require_openssl_source(openssl_source, sources["openssl"]["commit"])
+        require_mldsa_native_source(
+            mldsa_native, sources["mldsa_native"]["commit"]
+        )
+
+        with tempfile.TemporaryDirectory(prefix="pqbtc-ml-dsa-") as temporary:
+            build_dir = Path(temporary)
+            oracles = {
+                "openssl": compile_openssl_oracle(
+                    build_dir, sources["openssl"]["version"]
+                ),
+                "mldsa_native": compile_mldsa_native_oracle(
+                    build_dir, mldsa_native, sources["mldsa_native"]["commit"]
+                ),
+            }
+            sanitized_report = None
+            if args.sanitizers:
+                sanitized_oracles = {
+                    "openssl": compile_openssl_oracle(
+                        build_dir, sources["openssl"]["version"], sanitized=True
+                    ),
+                    "mldsa_native": compile_mldsa_native_oracle(
+                        build_dir,
+                        mldsa_native,
+                        sources["mldsa_native"]["commit"],
+                        sanitized=True,
+                    ),
+                }
+                sanitized_report = evaluate_sanitized_smoke(
+                    manifest["profile"],
+                    sanitized_oracles,
+                    manifest["vectors"]["pqbtc_sighash_v1"],
+                )
+            report = evaluate(
+                manifest,
+                oracles,
+                source_cases,
+                args.benchmark_iterations,
+                sanitized_report,
+            )
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    except (OSError, KeyError, ReferenceError, ValueError) as error:
+        print(f"compare_oracles.py: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/ml-dsa-ref/mldsa_native_oracle.c
+++ b/contrib/ml-dsa-ref/mldsa_native_oracle.c
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <mldsa_native.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define KEYGEN_SEED_SIZE 32
+#define PRIVATE_KEY_SIZE 2560
+#define PUBLIC_KEY_SIZE 1312
+#define RANDOMIZER_SIZE 32
+#define SIGNATURE_SIZE 2420
+
+static uint64_t MonotonicNs(void)
+{
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return 0;
+    return (uint64_t)now.tv_sec * UINT64_C(1000000000) + (uint64_t)now.tv_nsec;
+}
+
+int randombytes(uint8_t* output, size_t output_size)
+{
+    FILE* source = fopen("/dev/urandom", "rb");
+    if (source == NULL) return -1;
+
+    while (output_size > 0) {
+        const size_t read_size = fread(output, 1, output_size, source);
+        if (read_size == 0) {
+            fclose(source);
+            return -1;
+        }
+        output += read_size;
+        output_size -= read_size;
+    }
+    return fclose(source) == 0 ? 0 : -1;
+}
+
+static int HexDigit(const char value)
+{
+    if (value >= '0' && value <= '9') return value - '0';
+    if (value >= 'a' && value <= 'f') return value - 'a' + 10;
+    if (value >= 'A' && value <= 'F') return value - 'A' + 10;
+    return -1;
+}
+
+static uint8_t* DecodeHex(const char* hex, size_t* output_size)
+{
+    const size_t hex_size = strlen(hex);
+    if ((hex_size & 1U) != 0) return NULL;
+
+    *output_size = hex_size / 2;
+    uint8_t* output = malloc(*output_size == 0 ? 1 : *output_size);
+    if (output == NULL) return NULL;
+
+    for (size_t i = 0; i < *output_size; ++i) {
+        const int high = HexDigit(hex[2 * i]);
+        const int low = HexDigit(hex[2 * i + 1]);
+        if (high < 0 || low < 0) {
+            free(output);
+            return NULL;
+        }
+        output[i] = (uint8_t)((high << 4) | low);
+    }
+    return output;
+}
+
+static void PrintHex(const char* name, const uint8_t* data, const size_t size)
+{
+    printf("%s=", name);
+    for (size_t i = 0; i < size; ++i) printf("%02x", data[i]);
+    putchar('\n');
+}
+
+static int RunKeygen(const char* seed_hex)
+{
+    size_t seed_size = 0;
+    uint8_t* seed = DecodeHex(seed_hex, &seed_size);
+    uint8_t private_key[PRIVATE_KEY_SIZE];
+    uint8_t public_key[PUBLIC_KEY_SIZE];
+    int result = 1;
+
+    if (seed == NULL || seed_size != KEYGEN_SEED_SIZE) {
+        fprintf(stderr, "mldsa_native_oracle: keygen seed must be %d bytes\n", KEYGEN_SEED_SIZE);
+        goto cleanup;
+    }
+    const uint64_t started = MonotonicNs();
+    const int generated = mldsa_keypair_internal(public_key, private_key, seed);
+    const uint64_t keygen_ns = MonotonicNs() - started;
+    if (generated != 0) {
+        fprintf(stderr, "mldsa_native_oracle: key generation failed\n");
+        goto cleanup;
+    }
+
+    PrintHex("pk", public_key, sizeof(public_key));
+    PrintHex("sk", private_key, sizeof(private_key));
+    printf("keygen_ns=%llu\n", (unsigned long long)keygen_ns);
+    result = 0;
+
+cleanup:
+    free(seed);
+    return result;
+}
+
+static int RunPublicKey(const char* key_hex)
+{
+    size_t key_size = 0;
+    uint8_t* private_key = DecodeHex(key_hex, &key_size);
+    uint8_t public_key[PUBLIC_KEY_SIZE];
+    int result = 1;
+
+    if (private_key == NULL || key_size != PRIVATE_KEY_SIZE) {
+        fprintf(stderr, "mldsa_native_oracle: private key must be %d bytes\n", PRIVATE_KEY_SIZE);
+        goto cleanup;
+    }
+    if (mldsa_pk_from_sk(public_key, private_key) != 0) {
+        fprintf(stderr, "mldsa_native_oracle: public-key derivation failed\n");
+        goto cleanup;
+    }
+
+    PrintHex("pk", public_key, sizeof(public_key));
+    result = 0;
+
+cleanup:
+    free(private_key);
+    return result;
+}
+
+static int RunSign(
+    const char* key_hex,
+    const char* message_hex,
+    const char* context_hex,
+    const char* randomizer_hex,
+    const int randomized)
+{
+    size_t key_size = 0;
+    size_t message_size = 0;
+    size_t context_size = 0;
+    size_t randomizer_size = 0;
+    uint8_t* private_key = DecodeHex(key_hex, &key_size);
+    uint8_t* message = DecodeHex(message_hex, &message_size);
+    uint8_t* context_string = DecodeHex(context_hex, &context_size);
+    uint8_t* randomizer =
+        randomizer_hex == NULL ? NULL : DecodeHex(randomizer_hex, &randomizer_size);
+    uint8_t deterministic_randomizer[RANDOMIZER_SIZE] = {0};
+    uint8_t prefix[257];
+    uint8_t public_key[PUBLIC_KEY_SIZE];
+    uint8_t* signature = NULL;
+    int result = 1;
+
+    if (private_key == NULL || key_size != PRIVATE_KEY_SIZE || message == NULL ||
+        context_string == NULL || context_size > 255 ||
+        (randomized && randomizer_hex != NULL) ||
+        (randomizer_hex != NULL &&
+         (randomizer == NULL || randomizer_size != RANDOMIZER_SIZE))) {
+        fprintf(stderr, "mldsa_native_oracle: invalid sign input\n");
+        goto cleanup;
+    }
+    if (mldsa_pk_from_sk(public_key, private_key) != 0) {
+        fprintf(stderr, "mldsa_native_oracle: invalid private key\n");
+        goto cleanup;
+    }
+    signature = malloc(SIGNATURE_SIZE);
+    if (signature == NULL) goto cleanup;
+
+    size_t signature_size = 0;
+    const uint64_t sign_started = MonotonicNs();
+    int signed_result = 0;
+    if (randomized) {
+        signed_result = mldsa_signature(
+            signature,
+            &signature_size,
+            message,
+            message_size,
+            context_string,
+            context_size,
+            private_key);
+    } else {
+        prefix[0] = 0;
+        prefix[1] = (uint8_t)context_size;
+        memcpy(prefix + 2, context_string, context_size);
+        const uint8_t* signing_randomizer =
+            randomizer == NULL ? deterministic_randomizer : randomizer;
+        signed_result = mldsa_signature_internal(
+            signature,
+            &signature_size,
+            message,
+            message_size,
+            prefix,
+            context_size + 2,
+            signing_randomizer,
+            private_key,
+            0);
+    }
+    const uint64_t sign_ns = MonotonicNs() - sign_started;
+    if (signed_result != 0 || signature_size != SIGNATURE_SIZE) {
+        fprintf(stderr, "mldsa_native_oracle: signing failed\n");
+        goto cleanup;
+    }
+
+    const uint64_t verify_started = MonotonicNs();
+    const int verified = mldsa_verify(
+        signature,
+        signature_size,
+        message,
+        message_size,
+        context_string,
+        context_size,
+        public_key);
+    const uint64_t verify_ns = MonotonicNs() - verify_started;
+    if (verified != 0) {
+        fprintf(stderr, "mldsa_native_oracle: verification failed\n");
+        goto cleanup;
+    }
+
+    PrintHex("signature", signature, signature_size);
+    printf("verified=1\n");
+    printf("sign_ns=%llu\n", (unsigned long long)sign_ns);
+    printf("verify_ns=%llu\n", (unsigned long long)verify_ns);
+    result = 0;
+
+cleanup:
+    free(signature);
+    free(randomizer);
+    free(context_string);
+    free(message);
+    free(private_key);
+    return result;
+}
+
+static int RunVerify(
+    const char* key_hex,
+    const char* message_hex,
+    const char* context_hex,
+    const char* signature_hex)
+{
+    size_t key_size = 0;
+    size_t message_size = 0;
+    size_t context_size = 0;
+    size_t signature_size = 0;
+    uint8_t* public_key = DecodeHex(key_hex, &key_size);
+    uint8_t* message = DecodeHex(message_hex, &message_size);
+    uint8_t* context_string = DecodeHex(context_hex, &context_size);
+    uint8_t* signature = DecodeHex(signature_hex, &signature_size);
+    int result = 1;
+
+    if (public_key == NULL || key_size != PUBLIC_KEY_SIZE || message == NULL ||
+        context_string == NULL || context_size > 255 || signature == NULL) {
+        fprintf(stderr, "mldsa_native_oracle: invalid verify input\n");
+        goto cleanup;
+    }
+    if (signature_size != SIGNATURE_SIZE) {
+        printf("verified=0\n");
+        printf("verify_ns=0\n");
+        result = 0;
+        goto cleanup;
+    }
+    const uint64_t verify_started = MonotonicNs();
+    const int verified = mldsa_verify(
+        signature,
+        signature_size,
+        message,
+        message_size,
+        context_string,
+        context_size,
+        public_key);
+    const uint64_t verify_ns = MonotonicNs() - verify_started;
+
+    printf("verified=%d\n", verified == 0);
+    printf("verify_ns=%llu\n", (unsigned long long)verify_ns);
+    result = 0;
+
+cleanup:
+    free(signature);
+    free(context_string);
+    free(message);
+    free(public_key);
+    return result;
+}
+
+int main(const int argc, char** argv)
+{
+    if (argc == 3 && strcmp(argv[1], "keygen") == 0) return RunKeygen(argv[2]);
+    if (argc == 3 && strcmp(argv[1], "public-key") == 0) return RunPublicKey(argv[2]);
+    if (argc == 5 && strcmp(argv[1], "sign") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], NULL, 0);
+    }
+    if (argc == 5 && strcmp(argv[1], "sign-randomized") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], NULL, 1);
+    }
+    if (argc == 6 && strcmp(argv[1], "sign-with-randomizer") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], argv[5], 0);
+    }
+    if (argc == 6 && strcmp(argv[1], "verify") == 0) {
+        return RunVerify(argv[2], argv[3], argv[4], argv[5]);
+    }
+
+    fprintf(stderr, "usage: %s keygen <seed-hex>\n", argv[0]);
+    fprintf(stderr, "       %s public-key <sk-hex>\n", argv[0]);
+    fprintf(stderr, "       %s sign <sk-hex> <message-hex> <context-hex>\n", argv[0]);
+    fprintf(stderr, "       %s sign-randomized <sk-hex> <message-hex> <context-hex>\n", argv[0]);
+    fprintf(stderr,
+            "       %s sign-with-randomizer <sk-hex> <message-hex> "
+            "<context-hex> <randomizer-hex>\n",
+            argv[0]);
+    fprintf(stderr,
+            "       %s verify <pk-hex> <message-hex> <context-hex> "
+            "<signature-hex>\n",
+            argv[0]);
+    return 2;
+}

--- a/contrib/ml-dsa-ref/openssl_oracle.c
+++ b/contrib/ml-dsa-ref/openssl_oracle.c
@@ -1,0 +1,483 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <openssl/core_names.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/params.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define ALGORITHM "ML-DSA-44"
+#define KEYGEN_SEED_SIZE 32
+#define PRIVATE_KEY_SIZE 2560
+#define PUBLIC_KEY_SIZE 1312
+#define RANDOMIZER_SIZE 32
+#define SIGNATURE_SIZE 2420
+
+static uint64_t MonotonicNs(void)
+{
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return 0;
+    return (uint64_t)now.tv_sec * UINT64_C(1000000000) + (uint64_t)now.tv_nsec;
+}
+
+static int HexDigit(const char value)
+{
+    if (value >= '0' && value <= '9') return value - '0';
+    if (value >= 'a' && value <= 'f') return value - 'a' + 10;
+    if (value >= 'A' && value <= 'F') return value - 'A' + 10;
+    return -1;
+}
+
+static unsigned char* DecodeHex(const char* hex, size_t* output_size)
+{
+    const size_t hex_size = strlen(hex);
+    if ((hex_size & 1U) != 0) return NULL;
+
+    *output_size = hex_size / 2;
+    unsigned char* output = malloc(*output_size == 0 ? 1 : *output_size);
+    if (output == NULL) return NULL;
+
+    for (size_t i = 0; i < *output_size; ++i) {
+        const int high = HexDigit(hex[2 * i]);
+        const int low = HexDigit(hex[2 * i + 1]);
+        if (high < 0 || low < 0) {
+            free(output);
+            return NULL;
+        }
+        output[i] = (unsigned char)((high << 4) | low);
+    }
+    return output;
+}
+
+static void PrintHex(const char* name, const unsigned char* data, const size_t size)
+{
+    printf("%s=", name);
+    for (size_t i = 0; i < size; ++i) printf("%02x", data[i]);
+    putchar('\n');
+}
+
+static void PrintOpenSSLError(const char* operation)
+{
+    fprintf(stderr, "openssl_oracle: %s failed\n", operation);
+    ERR_print_errors_fp(stderr);
+}
+
+static int ExportKeys(EVP_PKEY* key, unsigned char* private_key, unsigned char* public_key)
+{
+    size_t private_key_size = 0;
+    size_t public_key_size = 0;
+    if (EVP_PKEY_get_octet_string_param(
+            key, OSSL_PKEY_PARAM_PRIV_KEY, private_key, PRIVATE_KEY_SIZE, &private_key_size) <= 0 ||
+        private_key_size != PRIVATE_KEY_SIZE) {
+        PrintOpenSSLError("private-key export");
+        return 0;
+    }
+    if (EVP_PKEY_get_octet_string_param(
+            key, OSSL_PKEY_PARAM_PUB_KEY, public_key, PUBLIC_KEY_SIZE, &public_key_size) <= 0 ||
+        public_key_size != PUBLIC_KEY_SIZE) {
+        PrintOpenSSLError("public-key export");
+        return 0;
+    }
+    return 1;
+}
+
+static EVP_PKEY* GenerateKey(const unsigned char* seed, uint64_t* elapsed_ns)
+{
+    EVP_PKEY_CTX* context = EVP_PKEY_CTX_new_from_name(NULL, ALGORITHM, NULL);
+    EVP_PKEY* key = NULL;
+    if (context == NULL || EVP_PKEY_keygen_init(context) <= 0) {
+        PrintOpenSSLError("keygen initialization");
+        EVP_PKEY_CTX_free(context);
+        return NULL;
+    }
+
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(
+            OSSL_PKEY_PARAM_ML_DSA_SEED, (void*)seed, KEYGEN_SEED_SIZE),
+        OSSL_PARAM_construct_end(),
+    };
+    if (EVP_PKEY_CTX_set_params(context, parameters) <= 0) {
+        PrintOpenSSLError("keygen seed setup");
+        EVP_PKEY_CTX_free(context);
+        return NULL;
+    }
+
+    const uint64_t started = MonotonicNs();
+    const int generated = EVP_PKEY_keygen(context, &key);
+    *elapsed_ns = MonotonicNs() - started;
+    EVP_PKEY_CTX_free(context);
+    if (generated <= 0) {
+        PrintOpenSSLError("key generation");
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    return key;
+}
+
+static EVP_PKEY* ImportPrivateKey(const unsigned char* private_key)
+{
+    EVP_PKEY_CTX* context = EVP_PKEY_CTX_new_from_name(NULL, ALGORITHM, NULL);
+    EVP_PKEY* key = NULL;
+
+    if (context == NULL || EVP_PKEY_fromdata_init(context) <= 0) {
+        PrintOpenSSLError("key import initialization");
+        EVP_PKEY_CTX_free(context);
+        return NULL;
+    }
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(
+            OSSL_PKEY_PARAM_PRIV_KEY, (void*)private_key, PRIVATE_KEY_SIZE),
+        OSSL_PARAM_construct_end(),
+    };
+    if (EVP_PKEY_fromdata(context, &key, EVP_PKEY_KEYPAIR, parameters) <= 0) {
+        PrintOpenSSLError("private-key import");
+        EVP_PKEY_CTX_free(context);
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    EVP_PKEY_CTX_free(context);
+    return key;
+}
+
+static EVP_PKEY* ImportPublicKey(const unsigned char* public_key)
+{
+    EVP_PKEY_CTX* context = EVP_PKEY_CTX_new_from_name(NULL, ALGORITHM, NULL);
+    EVP_PKEY* key = NULL;
+
+    if (context == NULL || EVP_PKEY_fromdata_init(context) <= 0) {
+        PrintOpenSSLError("public-key import initialization");
+        EVP_PKEY_CTX_free(context);
+        return NULL;
+    }
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(
+            OSSL_PKEY_PARAM_PUB_KEY, (void*)public_key, PUBLIC_KEY_SIZE),
+        OSSL_PARAM_construct_end(),
+    };
+    if (EVP_PKEY_fromdata(context, &key, EVP_PKEY_PUBLIC_KEY, parameters) <= 0) {
+        PrintOpenSSLError("public-key import");
+        EVP_PKEY_CTX_free(context);
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    EVP_PKEY_CTX_free(context);
+    return key;
+}
+
+static int VerifySignature(
+    EVP_PKEY* key,
+    const unsigned char* message,
+    const size_t message_size,
+    unsigned char* context_string,
+    const size_t context_size,
+    const unsigned char* signature,
+    const size_t signature_size,
+    uint64_t* verify_ns)
+{
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(
+            OSSL_SIGNATURE_PARAM_CONTEXT_STRING, context_string, context_size),
+        OSSL_PARAM_construct_end(),
+    };
+    EVP_SIGNATURE* algorithm = EVP_SIGNATURE_fetch(NULL, ALGORITHM, NULL);
+    EVP_PKEY_CTX* verify_context = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
+    int result = -1;
+
+    if (algorithm == NULL || verify_context == NULL ||
+        EVP_PKEY_verify_message_init(verify_context, algorithm, parameters) <= 0) {
+        PrintOpenSSLError("verify initialization");
+        goto cleanup;
+    }
+    const uint64_t verify_started = MonotonicNs();
+    result = EVP_PKEY_verify(
+        verify_context, signature, signature_size, message, message_size);
+    *verify_ns = MonotonicNs() - verify_started;
+    if (result < 0) PrintOpenSSLError("verification");
+
+cleanup:
+    EVP_PKEY_CTX_free(verify_context);
+    EVP_SIGNATURE_free(algorithm);
+    return result;
+}
+
+static int SignAndVerify(
+    EVP_PKEY* key,
+    const unsigned char* message,
+    const size_t message_size,
+    unsigned char* context_string,
+    const size_t context_size,
+    unsigned char* test_entropy,
+    const size_t test_entropy_size,
+    const int randomized,
+    unsigned char* signature,
+    uint64_t* sign_ns,
+    uint64_t* verify_ns)
+{
+    int deterministic = randomized ? 0 : 1;
+    OSSL_PARAM parameters[4];
+    size_t parameter_index = 0;
+    parameters[parameter_index++] = OSSL_PARAM_construct_octet_string(
+        OSSL_SIGNATURE_PARAM_CONTEXT_STRING, context_string, context_size);
+    if (test_entropy != NULL) {
+        parameters[parameter_index++] = OSSL_PARAM_construct_octet_string(
+            OSSL_SIGNATURE_PARAM_TEST_ENTROPY, test_entropy, test_entropy_size);
+    } else {
+        parameters[parameter_index++] = OSSL_PARAM_construct_int(
+            OSSL_SIGNATURE_PARAM_DETERMINISTIC, &deterministic);
+    }
+    parameters[parameter_index] = OSSL_PARAM_construct_end();
+    EVP_SIGNATURE* algorithm = EVP_SIGNATURE_fetch(NULL, ALGORITHM, NULL);
+    EVP_PKEY_CTX* sign_context = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
+    size_t signature_size = SIGNATURE_SIZE;
+    int result = 0;
+
+    if (algorithm == NULL || sign_context == NULL ||
+        EVP_PKEY_sign_message_init(sign_context, algorithm, parameters) <= 0) {
+        PrintOpenSSLError("sign initialization");
+        goto cleanup;
+    }
+
+    const uint64_t sign_started = MonotonicNs();
+    if (EVP_PKEY_sign(sign_context, signature, &signature_size, message, message_size) <= 0 ||
+        signature_size != SIGNATURE_SIZE) {
+        PrintOpenSSLError("signing");
+        goto cleanup;
+    }
+    *sign_ns = MonotonicNs() - sign_started;
+
+    result = VerifySignature(
+        key,
+        message,
+        message_size,
+        context_string,
+        context_size,
+        signature,
+        signature_size,
+        verify_ns);
+    if (result == 0) fprintf(stderr, "openssl_oracle: generated signature did not verify\n");
+
+cleanup:
+    EVP_PKEY_CTX_free(sign_context);
+    EVP_SIGNATURE_free(algorithm);
+    return result > 0;
+}
+
+static int RunKeygen(const char* seed_hex)
+{
+    size_t seed_size = 0;
+    unsigned char* seed = DecodeHex(seed_hex, &seed_size);
+    unsigned char private_key[PRIVATE_KEY_SIZE];
+    unsigned char public_key[PUBLIC_KEY_SIZE];
+    uint64_t keygen_ns = 0;
+    int result = 1;
+
+    if (seed == NULL || seed_size != KEYGEN_SEED_SIZE) {
+        fprintf(stderr, "openssl_oracle: keygen seed must be %d bytes\n", KEYGEN_SEED_SIZE);
+        goto cleanup;
+    }
+    EVP_PKEY* key = GenerateKey(seed, &keygen_ns);
+    if (key == NULL) goto cleanup;
+    if (!ExportKeys(key, private_key, public_key)) {
+        EVP_PKEY_free(key);
+        goto cleanup;
+    }
+    EVP_PKEY_free(key);
+
+    PrintHex("pk", public_key, sizeof(public_key));
+    PrintHex("sk", private_key, sizeof(private_key));
+    printf("keygen_ns=%llu\n", (unsigned long long)keygen_ns);
+    result = 0;
+
+cleanup:
+    free(seed);
+    return result;
+}
+
+static int RunPublicKey(const char* key_hex)
+{
+    size_t key_size = 0;
+    unsigned char* private_key = DecodeHex(key_hex, &key_size);
+    unsigned char public_key[PUBLIC_KEY_SIZE];
+    size_t public_key_size = 0;
+    int result = 1;
+
+    if (private_key == NULL || key_size != PRIVATE_KEY_SIZE) {
+        fprintf(stderr, "openssl_oracle: private key must be %d bytes\n", PRIVATE_KEY_SIZE);
+        goto cleanup;
+    }
+    EVP_PKEY* key = ImportPrivateKey(private_key);
+    if (key == NULL) goto cleanup;
+    if (EVP_PKEY_get_octet_string_param(
+            key, OSSL_PKEY_PARAM_PUB_KEY, public_key, sizeof(public_key), &public_key_size) <= 0 ||
+        public_key_size != PUBLIC_KEY_SIZE) {
+        PrintOpenSSLError("public-key derivation");
+        EVP_PKEY_free(key);
+        goto cleanup;
+    }
+    EVP_PKEY_free(key);
+
+    PrintHex("pk", public_key, sizeof(public_key));
+    result = 0;
+
+cleanup:
+    free(private_key);
+    return result;
+}
+
+static int RunSign(
+    const char* key_hex,
+    const char* message_hex,
+    const char* context_hex,
+    const char* randomizer_hex,
+    const int randomized)
+{
+    size_t key_size = 0;
+    size_t message_size = 0;
+    size_t context_size = 0;
+    size_t randomizer_size = 0;
+    unsigned char* private_key = DecodeHex(key_hex, &key_size);
+    unsigned char* message = DecodeHex(message_hex, &message_size);
+    unsigned char* context_string = DecodeHex(context_hex, &context_size);
+    unsigned char* randomizer =
+        randomizer_hex == NULL ? NULL : DecodeHex(randomizer_hex, &randomizer_size);
+    unsigned char* signature = NULL;
+    uint64_t sign_ns = 0;
+    uint64_t verify_ns = 0;
+    int result = 1;
+
+    if (private_key == NULL || key_size != PRIVATE_KEY_SIZE || message == NULL ||
+        context_string == NULL || context_size > 255 ||
+        (randomizer_hex != NULL &&
+         (randomizer == NULL || randomizer_size != RANDOMIZER_SIZE))) {
+        fprintf(stderr, "openssl_oracle: invalid sign input\n");
+        goto cleanup;
+    }
+    EVP_PKEY* key = ImportPrivateKey(private_key);
+    if (key == NULL) goto cleanup;
+    signature = malloc(SIGNATURE_SIZE);
+    if (signature == NULL || !SignAndVerify(
+                                 key,
+                                 message,
+                                 message_size,
+                                 context_string,
+                                 context_size,
+                                 randomizer,
+                                 randomizer_size,
+                                 randomized,
+                                 signature,
+                                 &sign_ns,
+                                 &verify_ns)) {
+        EVP_PKEY_free(key);
+        goto cleanup;
+    }
+    EVP_PKEY_free(key);
+
+    PrintHex("signature", signature, SIGNATURE_SIZE);
+    printf("verified=1\n");
+    printf("sign_ns=%llu\n", (unsigned long long)sign_ns);
+    printf("verify_ns=%llu\n", (unsigned long long)verify_ns);
+    result = 0;
+
+cleanup:
+    free(signature);
+    free(randomizer);
+    free(context_string);
+    free(message);
+    free(private_key);
+    return result;
+}
+
+static int RunVerify(
+    const char* key_hex,
+    const char* message_hex,
+    const char* context_hex,
+    const char* signature_hex)
+{
+    size_t key_size = 0;
+    size_t message_size = 0;
+    size_t context_size = 0;
+    size_t signature_size = 0;
+    unsigned char* public_key = DecodeHex(key_hex, &key_size);
+    unsigned char* message = DecodeHex(message_hex, &message_size);
+    unsigned char* context_string = DecodeHex(context_hex, &context_size);
+    unsigned char* signature = DecodeHex(signature_hex, &signature_size);
+    uint64_t verify_ns = 0;
+    int result = 1;
+
+    if (public_key == NULL || key_size != PUBLIC_KEY_SIZE || message == NULL ||
+        context_string == NULL || context_size > 255 || signature == NULL) {
+        fprintf(stderr, "openssl_oracle: invalid verify input\n");
+        goto cleanup;
+    }
+    if (signature_size != SIGNATURE_SIZE) {
+        printf("verified=0\n");
+        printf("verify_ns=0\n");
+        result = 0;
+        goto cleanup;
+    }
+    EVP_PKEY* key = ImportPublicKey(public_key);
+    if (key == NULL) goto cleanup;
+    const int verified = VerifySignature(
+        key,
+        message,
+        message_size,
+        context_string,
+        context_size,
+        signature,
+        signature_size,
+        &verify_ns);
+    EVP_PKEY_free(key);
+    if (verified < 0) goto cleanup;
+
+    printf("verified=%d\n", verified == 1);
+    printf("verify_ns=%llu\n", (unsigned long long)verify_ns);
+    result = 0;
+
+cleanup:
+    free(signature);
+    free(context_string);
+    free(message);
+    free(public_key);
+    return result;
+}
+
+int main(const int argc, char** argv)
+{
+    if (argc == 3 && strcmp(argv[1], "keygen") == 0) return RunKeygen(argv[2]);
+    if (argc == 3 && strcmp(argv[1], "public-key") == 0) return RunPublicKey(argv[2]);
+    if (argc == 5 && strcmp(argv[1], "sign") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], NULL, 0);
+    }
+    if (argc == 5 && strcmp(argv[1], "sign-randomized") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], NULL, 1);
+    }
+    if (argc == 6 && strcmp(argv[1], "sign-with-randomizer") == 0) {
+        return RunSign(argv[2], argv[3], argv[4], argv[5], 0);
+    }
+    if (argc == 6 && strcmp(argv[1], "verify") == 0) {
+        return RunVerify(argv[2], argv[3], argv[4], argv[5]);
+    }
+
+    fprintf(stderr, "usage: %s keygen <seed-hex>\n", argv[0]);
+    fprintf(stderr, "       %s public-key <sk-hex>\n", argv[0]);
+    fprintf(stderr, "       %s sign <sk-hex> <message-hex> <context-hex>\n", argv[0]);
+    fprintf(stderr, "       %s sign-randomized <sk-hex> <message-hex> <context-hex>\n", argv[0]);
+    fprintf(stderr,
+            "       %s sign-with-randomizer <sk-hex> <message-hex> "
+            "<context-hex> <randomizer-hex>\n",
+            argv[0]);
+    fprintf(stderr,
+            "       %s verify <pk-hex> <message-hex> <context-hex> "
+            "<signature-hex>\n",
+            argv[0]);
+    return 2;
+}

--- a/contrib/ml-dsa-ref/vectors.json
+++ b/contrib/ml-dsa-ref/vectors.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": 2,
+  "profile": {
+    "name": "ML-DSA-44",
+    "standard": "FIPS 204",
+    "nist_security_category": 2,
+    "signature_interface": "external",
+    "message_mode": "pure",
+    "public_key_bytes": 1312,
+    "private_key_bytes": 2560,
+    "keygen_seed_bytes": 32,
+    "randomizer_bytes": 32,
+    "signature_bytes": 2420,
+    "prototype_message_bytes": 32,
+    "prototype_context_hex": "50514254432f74782d7369676e61747572652f7631",
+    "prototype_context_ascii": "PQBTC/tx-signature/v1",
+    "exact_vector_signing": "deterministic_or_fixed_randomizer",
+    "production_signing_if_selected": "hedged_randomized"
+  },
+  "acvp_coverage": {
+    "keygen": {
+      "group_id": 1,
+      "test_case_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
+    },
+    "siggen": [
+      {
+        "group_id": 1,
+        "deterministic": true,
+        "signature_interface": "external",
+        "message_mode": "pure",
+        "test_case_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+      },
+      {
+        "group_id": 13,
+        "deterministic": false,
+        "signature_interface": "external",
+        "message_mode": "pure",
+        "test_case_ids": [181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195]
+      }
+    ],
+    "sigver": {
+      "group_id": 1,
+      "signature_interface": "external",
+      "message_mode": "pure",
+      "test_case_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+      "accepted_test_case_ids": [6, 7, 11]
+    },
+    "total_cases": 70
+  },
+  "system_cost_model": {
+    "held_rc2_signature_bytes": 4480,
+    "held_rc2_public_key_bytes": 33,
+    "block_weight_limit": 16000000,
+    "witness_weight_per_byte": 1,
+    "non_witness_weight_per_byte": 4
+  },
+  "sources": {
+    "nist_fips204": {
+      "url": "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf",
+      "sha256": "57239b9f84c03227eda3ca0991204dc7764c79af9ce2e6824eda774918d46b6b",
+      "published": "2024-08-13"
+    },
+    "nist_fips204_potential_updates": {
+      "url": "https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx",
+      "sha256": "0e8ba77b46db71fda2c18e67111303335745a938686cad6faf35eac148f7ed3e",
+      "last_updated": "2026-02-27",
+      "status": "potential corrections; not official changes"
+    },
+    "nist_fips204_section6_guidance": {
+      "url": "https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf",
+      "sha256": "4a1d4b8d5aefef56069eb91bd464d5b5e177372e03bdde2541655e8e24d7a056",
+      "dated": "2025-03-19"
+    },
+    "nist_acvp": {
+      "repository": "https://github.com/usnistgov/ACVP-Server",
+      "commit": "15c0f3deeefbfa8cb6cd32a99e1ca3b738c66bf0",
+      "files": {
+        "gen-val/json-files/ML-DSA-keyGen-FIPS204/prompt.json": "02fad612a060bbcf3bbbd164caf7e9da964ba385c90e08bcd26516e3bf8a023d",
+        "gen-val/json-files/ML-DSA-keyGen-FIPS204/expectedResults.json": "58dca0195226491c9cb117e1f0ec4cb11d4a1e3bd8b0f955371d80c99d4e8810",
+        "gen-val/json-files/ML-DSA-sigGen-FIPS204/prompt.json": "4305197be3c17be8f99338086eb8033ff2400f7d5b816123fc28b184c6e77a55",
+        "gen-val/json-files/ML-DSA-sigGen-FIPS204/expectedResults.json": "7b70ffeba6efe24e90760c751a7ebc4907931600645ebfa3f8a2459164d0a95d",
+        "gen-val/json-files/ML-DSA-sigVer-FIPS204/prompt.json": "2a9b7fcbefdd8e69dd6fbe6b4abb7130d855e8429aaa6f4904385e68b7e63d3a",
+        "gen-val/json-files/ML-DSA-sigVer-FIPS204/expectedResults.json": "33e0ea7dd9c3b0206712da50286ad746864371433977225ab77e8aae76358842"
+      }
+    },
+    "openssl": {
+      "repository": "https://github.com/openssl/openssl",
+      "commit": "aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f",
+      "version": "3.6.3",
+      "documentation": "https://docs.openssl.org/3.6/man7/EVP_SIGNATURE-ML-DSA/",
+      "role": "separate prototype oracle; not a node dependency"
+    },
+    "mldsa_native": {
+      "repository": "https://github.com/pq-code-package/mldsa-native",
+      "commit": "9b0ee84f4cf399043eca59eca4e5f8531ca1d61b",
+      "tag": "v1.0.0-beta2",
+      "license_expression": "Apache-2.0 OR ISC OR MIT",
+      "role": "portable-C prototype oracle; not vendored or linked into the node",
+      "lineage_limit": "mldsa-native is forked from the pq-crystals reference implementation; agreement with OpenSSL is strong differential evidence but not independent cryptographic review"
+    }
+  },
+  "vectors": {
+    "nist_keygen_tg1_tc1": {
+      "source": "ML-DSA-keyGen-FIPS204 tgId=1 tcId=1",
+      "seed_hex": "d71361c000f9a7bc99dfb425bcb6bb27c32c36ab444ff3708b2d93b4e66d5b5b",
+      "expected_private_key_sha256": "0196ccbde5fbd1804e8c784efb83998338076d586fe73ee07ba712ccc9fc32c2",
+      "expected_public_key_sha256": "451a808c522218fadbdab146fc12004b0741c7d069f238f43ad77216159f6a34"
+    },
+    "nist_siggen_tg1_tc1": {
+      "source": "ML-DSA-sigGen-FIPS204 tgId=1 tcId=1",
+      "group_id": 1,
+      "test_case_id": 1,
+      "deterministic": true,
+      "private_key_sha256": "5133df4ce6a2cf72399803405a1600fb7ebfca1ac09c8bbadb2a02504fc4ae60",
+      "message_bytes": 952,
+      "message_sha256": "3beb5f226c998410d63f638d30f9b4d94bc6564438c9cd1939fba88eef0bddc6",
+      "context_bytes": 111,
+      "context_sha256": "e69ad6b1149978cd99812796460133cbc127083df7e798007a18db92d30adf57",
+      "expected_signature_sha256": "f2554d7153750b4deed79f80e5aa237a219fc92f83e59e7317c8d2089c4e7b91"
+    },
+    "nist_siggen_tg13_tc181": {
+      "source": "ML-DSA-sigGen-FIPS204 tgId=13 tcId=181",
+      "group_id": 13,
+      "test_case_id": 181,
+      "deterministic": false,
+      "private_key_sha256": "fec77accd3a4e370db672a296dbb9c25f6265905b4cb54c207fceaa7ed485de1",
+      "message_bytes": 4519,
+      "message_sha256": "68d044fd79bb981d8bd154722fb9f8838856ccc57cb6cad69fd98a0bd41ab659",
+      "context_bytes": 0,
+      "context_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "randomizer_hex": "31cfa3107e691b2ba6957f5ded6d2cd9ba9d5794dd897c2ca2484a8021e9e36a",
+      "expected_signature_sha256": "8a17b6ff3f9633cd3c7cd0687d6384408e145bfd3725f6c57a8a2727f50ec989"
+    },
+    "nist_sigver_tg1": {
+      "source": "ML-DSA-sigVer-FIPS204 tgId=1",
+      "parameter_set": "ML-DSA-44",
+      "signature_interface": "external",
+      "message_mode": "pure",
+      "cases": [
+        {
+          "test_case_id": 1,
+          "expected_valid": false,
+          "public_key_sha256": "12f2e34ddc986a2fbdaf02b23d40cb76812e27fa58fc7923f0ea3ed231a51baf",
+          "message_bytes": 5175,
+          "message_sha256": "beff03f14d1abd94f18f26eae8646847dab314851c5c5ad7ac5663070646af8e",
+          "context_bytes": 35,
+          "context_sha256": "b798606615bcca6fc12f0a4e8d6fac7d4113ff288902c0331f7917d190706e30",
+          "signature_bytes": 2420,
+          "signature_sha256": "3fdac3f646a9ca430fa4ab902f571f3068f68b181bb8a68b75833935a0f83045"
+        },
+        {
+          "test_case_id": 6,
+          "expected_valid": true,
+          "public_key_sha256": "830ec0e82d91984439162f18aaa237a5614854c423dec21891ce2744addee251",
+          "message_bytes": 3965,
+          "message_sha256": "08685bc2d793bbbe4424cc6517b6699753c9fbd3710c6110d1dbf59f21c88f1f",
+          "context_bytes": 180,
+          "context_sha256": "791e1e57ea411b939b6db0110cddcd65f2613a0f117181fc0dac700f7313f189",
+          "signature_bytes": 2420,
+          "signature_sha256": "0025f9651848cbd3714d4f2af984d9838277d9267f96c61b068aa3b172a461b0"
+        }
+      ]
+    },
+    "pqbtc_sighash_v1": {
+      "source": "repo-defined deterministic interoperability vector",
+      "seed_hex": "d71361c000f9a7bc99dfb425bcb6bb27c32c36ab444ff3708b2d93b4e66d5b5b",
+      "message_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      "context_hex": "50514254432f74782d7369676e61747572652f7631",
+      "expected_private_key_sha256": "0196ccbde5fbd1804e8c784efb83998338076d586fe73ee07ba712ccc9fc32c2",
+      "expected_public_key_sha256": "451a808c522218fadbdab146fc12004b0741c7d069f238f43ad77216159f6a34",
+      "expected_signature_sha256": "98094b39d9ae1ad76fc734f9e0199ad37315dd4eb7a22f29561582239f64e131"
+    }
+  }
+}

--- a/docs/ML_DSA_44_REFERENCE.md
+++ b/docs/ML_DSA_44_REFERENCE.md
@@ -1,0 +1,204 @@
+# ML-DSA-44 Reference Comparator
+
+## Status: REFERENCE ONLY - NOT CONSENSUS
+## Spec-ID: ML-DSA-44-REFERENCE-v1
+## Updated: 2026-07-18
+## Consensus-Relevant: NO
+
+## Decision Boundary
+
+This slice establishes a reproducible conformance, interoperability, and cost
+baseline for the FIPS 204 `ML-DSA-44` comparator. It does not select ML-DSA for
+production, add a node dependency, allocate an `ALG_ID`, modify Script or
+wallet behavior, or change the consensus accepted set. The release hold in
+`PQSIG_PRODUCTION_READINESS.md` remains in force.
+
+## Frozen Reference Contract
+
+| Property | Reference value |
+| --- | --- |
+| Standard | NIST FIPS 204 |
+| Parameter set | `ML-DSA-44` |
+| NIST security category | 2 |
+| Interface | External |
+| Message mode | Pure ML-DSA, not HashML-DSA |
+| Prototype message | Exactly 32 bytes |
+| Prototype context | ASCII `PQBTC/tx-signature/v1` |
+| Key-generation seed | 32 bytes |
+| Public key | 1,312 bytes |
+| Expanded private key | 2,560 bytes |
+| Signing randomizer | 32 bytes |
+| Signature | 2,420 bytes |
+| Exact-vector signing | Deterministic or NIST-supplied fixed `rnd` |
+| Future production posture | Hedged randomized signing, if separately approved |
+
+Pure ML-DSA binds `0x00 || len(ctx) || ctx || message` before computing the
+message representative. The prototype signs the 32-byte Bitcoin-style sighash
+digest as the message and uses a fixed context to prevent silent cross-protocol
+reinterpretation. That context is a research contract, not a consensus
+allocation.
+
+## Standards And Update Boundary
+
+The manifest pins these NIST artifacts by SHA256:
+
+| Artifact | SHA256 |
+| --- | --- |
+| FIPS 204 PDF | `57239b9f84c03227eda3ca0991204dc7764c79af9ce2e6824eda774918d46b6b` |
+| Potential updates, last updated 2026-02-27 | `0e8ba77b46db71fda2c18e67111303335745a938686cad6faf35eac148f7ed3e` |
+| Section 6 guidance, dated 2025-03-19 | `4a1d4b8d5aefef56069eb91bd464d5b5e177372e03bdde2541655e8e24d7a056` |
+
+The potential-updates sheet states that its corrections are not official
+changes and introduce no new technical requirements. Relevant entries correct
+the explanatory `c_tilde` ordering to `mu || w1`, use `M'` consistently in
+Sections 6.2 and 6.3, and clarify several pseudocode/text defects. The pinned
+ACVP outputs and both oracles agree on the resulting key and signature bytes.
+
+NIST's Section 6 guidance permits a separately validated external-`mu`
+interface in specific module boundaries. This comparator does not select or
+exercise that interface: it tests the Section 5 external/pure message API and
+keeps context construction inside each oracle. A future hardware-signer or
+streaming design must specify and validate the `mu` trust boundary separately.
+
+## Reproducible Evidence
+
+`contrib/ml-dsa-ref/vectors.json` records:
+
+- NIST ACVP commit `15c0f3deeefbfa8cb6cd32a99e1ca3b738c66bf0`
+- SHA256 checksums for all six keygen, siggen, and sigver source files
+- all 25 external/pure ML-DSA-44 key-generation group 1 cases
+- all 15 deterministic external/pure signature-generation group 1 cases
+- all 15 randomized external/pure signature-generation group 13 cases, with
+  the official 32-byte `rnd` for each case
+- all 15 external/pure signature-verification group 1 cases; cases 6, 7, and
+  11 are accepted and the other 12 are rejected
+- OpenSSL 3.6.3 source commit
+  `aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f`
+- `mldsa-native` `v1.0.0-beta2` commit
+  `9b0ee84f4cf399043eca59eca4e5f8531ca1d61b`
+- one repo-defined 32-byte sighash/context interoperability vector
+
+Representative signature hashes are:
+
+| Vector | SHA256 |
+| --- | --- |
+| NIST deterministic siggen group 1 case 1 | `f2554d7153750b4deed79f80e5aa237a219fc92f83e59e7317c8d2089c4e7b91` |
+| NIST randomized siggen group 13 case 181 | `8a17b6ff3f9633cd3c7cd0687d6384408e145bfd3725f6c57a8a2727f50ec989` |
+| PQBTC prototype deterministic signature | `98094b39d9ae1ad76fc734f9e0199ad37315dd4eb7a22f29561582239f64e131` |
+
+The driver builds two adapters in a temporary directory. OpenSSL imports the
+expanded private key and derives its public key through the provider; it does
+not assume the public key is a suffix of the ML-DSA private key.
+`mldsa-native` uses `mldsa_pk_from_sk` and the exact FIPS prefix. Both reproduce
+all selected NIST bytes, derive the same keys, cross-verify every generated
+signature, and agree byte-for-byte when given the same explicit `rnd`.
+
+Each native randomized API is also exercised twice. All four signatures are
+distinct and accepted by both verifiers. Deterministic signing is retained for
+reproducible evidence only; any production proposal must preserve the hedged
+randomized posture and define entropy-failure behavior. The research-only
+`mldsa-native` adapter obtains those test bytes from POSIX `/dev/urandom`; that
+wrapper is not a node entropy design and limits the full harness to macOS/Linux.
+
+`mldsa-native` is a fork of the `pq-crystals` reference implementation. It is a
+separate portable-C code path from OpenSSL, so agreement is meaningful
+differential evidence. Its ancestry still limits independence, and this result
+must not be described as independent cryptographic review.
+
+Run:
+
+```bash
+python3 contrib/ml-dsa-ref/compare_oracles.py --manifest-only
+python3 contrib/ml-dsa-ref/compare_oracles.py \
+  --acvp-server /path/to/pinned/ACVP-Server \
+  --openssl-source /path/to/pinned/openssl \
+  --mldsa-native /path/to/pinned/mldsa-native \
+  --fips204 /path/to/NIST.FIPS.204.pdf \
+  --fips204-updates /path/to/fips-204-potential-updates.xlsx \
+  --fips204-section6-guidance /path/to/fips204-sec6-03192025.pdf \
+  --benchmark-iterations 10 \
+  --sanitizers
+```
+
+The full run requires clean source checkouts at the exact pinned commits. The
+installed OpenSSL CLI and `pkg-config` library must both report 3.6.3. The
+adapter links that installed library; the source checkout establishes review
+provenance and is not compiled by the harness.
+
+## Prototype Measurements
+
+Local arm64 macOS measurement on 2026-07-18, using OpenSSL 3.6.3 and the pinned
+portable-C oracle compiled with `-O2`. Values are medians of ten repetitions
+of the fixed PQBTC vector and are directional, not release envelopes. They
+time the adapter's cryptographic calls and exclude compilation, process
+startup, cross-verification, and OpenSSL context initialization.
+
+| Oracle | Keygen | Deterministic sign | Deterministic verify | Randomized sign | Randomized verify |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| OpenSSL 3.6.3 | 0.099 ms | 0.157 ms | 0.092 ms | 0.752 ms | 0.052 ms |
+| `mldsa-native` | 0.029 ms | 0.102 ms | 0.029 ms | 0.324 ms | 0.029 ms |
+
+The timing spread between deterministic and randomized calls includes random
+generation and variable rejection-sampling work. Supported-platform,
+worst-case, batch-verification, and block-validation measurements remain
+required before selection.
+
+## Bitcoin-System Implications
+
+- The 2,420-byte signature is 45.98% smaller than the held 4,480-byte rc2
+  signature, but the 1,312-byte public key is much larger than rc2's 33-byte
+  script key.
+- A raw `signature + public key` comparison is 3,732 bytes for ML-DSA-44 and
+  4,513 bytes for rc2. If both were witness bytes and all other transaction
+  costs were ignored, the 16,000,000-WU upper bounds would be 4,287 and 3,545
+  respectively. This is a payload model, not a transaction-capacity or fee
+  claim; output commitment, reveal, compact-size, script, and transaction
+  encoding are deliberately unfrozen.
+- If the full ML-DSA public key were placed directly in non-witness output
+  data, its raw weight contribution would be 5,248 WU before script overhead.
+  A hash-commit-and-reveal design would move cost and security behavior
+  elsewhere. Neither design is selected here.
+- The signature and public key both exceed Bitcoin's retained 520-byte general
+  stack-element limit. The current node's narrow exception recognizes only
+  the exact held rc2 witness shape, so this comparator is not admissible under
+  current consensus or policy.
+- ML-DSA is stateless, but wallet seed/import format, expanded-key caching,
+  secret erasure, backup recovery, descriptor encoding, PSBT transport, and
+  hardware-signer limits all require explicit contracts.
+- Structured-lattice security, implementation side channels, malformed-key
+  handling, and rejection-sampling behavior require external specialist
+  review. Vector agreement does not answer those questions.
+
+## What This Evidence Establishes
+
+Established:
+
+1. the exact final-standard ML-DSA-44 external/pure profile is frozen
+2. all 70 applicable selected-profile ACVP cases pass both codebases
+3. deterministic and fixed-randomizer key/signature outputs agree byte-for-byte
+4. native randomized outputs are distinct and cross-verify in both directions
+5. empty/maximum context, malformed lengths, and 12 cryptographic mutations
+   have explicit outcomes
+6. both adapters pass the bounded ASan/UBSan exercise
+7. the candidate has a reproducible ten-run performance and raw-payload model
+
+Not established:
+
+1. a production-quality consensus implementation
+2. fully independent implementation ancestry or external cryptographic review
+3. constant-time signing, adequate secret erasure, or fault-attack resistance
+4. exhaustive fuzzing or sanitizer coverage of the linked OpenSSL library
+5. acceptable wallet, descriptor, PSBT, hardware-signer, fee, or block behavior
+6. an activation, migration, public-key commitment, or algorithm-agility design
+
+## Next Gate
+
+Produce a measured candidate-selection memo comparing this baseline with
+`SLH_DSA_SHA2_128S_REFERENCE.md`. The memo must evaluate security assumptions,
+implementation maturity and lineage, key/signature economics, signer and
+verifier behavior, wallet/backup impact, and reviewability. It may select a
+candidate for a separate engineering proposal or retain `HOLD`.
+
+No candidate enters `src/crypto`, Script, wallet activation, or the `ALG_ID`
+registry before that selection, an explicit consensus design, and external
+cryptographic review.

--- a/docs/PQSIG_PRODUCTION_READINESS.md
+++ b/docs/PQSIG_PRODUCTION_READINESS.md
@@ -90,8 +90,11 @@ FIPS 205 is the conservative first implementation target because it is final,
 stateless, hash-based, and has compact public keys. Its 7,856-byte signatures
 increase block-space and bandwidth cost relative to rc2. FIPS 204 is a useful
 standardized efficiency comparator, but it adds structured-lattice assumptions
-and much larger public keys. Neither profile is selected for activation by this
-record.
+and much larger public keys. The isolated ML-DSA-44 comparator now passes its
+complete selected-profile ACVP and two-codebase differential contract, but its
+portable oracle descends from the `pq-crystals` reference implementation and
+does not replace independent cryptographic review. Neither profile is selected
+for activation by this record.
 
 ## Implementation Direction
 
@@ -100,8 +103,10 @@ record.
    context rules, and test vectors. Its complete selected-profile ACVP,
    randomized interoperability, mutation, and bounded sanitizer tranche is
    green. Do not assign an active `ALG_ID` or connect it to Script yet.
-2. Implement or bind an isolated `ML-DSA-44` comparator for size, signing,
-   verification, wallet, and block-economics measurements.
+2. Maintain the isolated FIPS 204 `ML-DSA-44` comparator in
+   `ML_DSA_44_REFERENCE.md`. Its 70-case ACVP, randomized interoperability,
+   mutation, sanitizer, timing, and raw-payload evidence is green. Preserve the
+   recorded implementation-lineage limitation.
 3. Use the OpenSSL 3.6.3 runtime and pinned source checkout only as a prototype
    and differential-test oracle. Do not introduce a host OpenSSL dependency
    into consensus verification.
@@ -112,6 +117,9 @@ record.
    a final publication and an explicit one-key-per-output usage-limit design.
 6. Retire rc2 or replace it with a ground-up, exact construction. Do not patch
    isolated symptoms while retaining the current security claims.
+7. Produce a measured SLH-DSA versus ML-DSA selection memo. The memo may retain
+   `HOLD`; neither a smaller signature nor faster benchmark is sufficient by
+   itself to select a consensus primitive.
 
 ## Required Gates Before Consensus Integration
 

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -21,6 +21,11 @@ answer specific classes of questions instead of listing every file in `docs/`.
   all 38 applicable external/pure ACVP cases, pinned two-oracle deterministic
   and randomized interoperability, malformed-input and sanitizer evidence, and
   timings without changing consensus behavior.
+- An equivalent isolated FIPS 204 `ML-DSA-44` comparator now provides all 70
+  applicable external/pure ACVP cases, exact and randomized differential
+  evidence, malformed-input and sanitizer coverage, timings, and a raw-payload
+  cost model. Its documented implementation-lineage limitation keeps external
+  cryptographic review as an unsatisfied gate.
 - No PDF papers are currently checked into this repo.
 - Delving Bitcoin now provides concrete adjacent research references that are
   directly relevant to Track A, especially around SHRINCS / SHRIMPS and
@@ -75,6 +80,9 @@ answer specific classes of questions instead of listing every file in `docs/`.
 - [SLH_DSA_SHA2_128S_REFERENCE.md](SLH_DSA_SHA2_128S_REFERENCE.md)
   Isolated standards-conformance and measurement baseline for the first final-
   standard candidate.
+- [ML_DSA_44_REFERENCE.md](ML_DSA_44_REFERENCE.md)
+  Isolated FIPS 204 comparator, provenance record, and measured implementation
+  baseline for the second final-standard candidate.
 - [PQSIG_INTERNALS.md](PQSIG_INTERNALS.md)
   Best internal explainer for how the signature system is assembled.
 - [PQSIG_WIRE_FORMAT.md](PQSIG_WIRE_FORMAT.md)

--- a/docs/SHRINCS_DECISION_TRACK.md
+++ b/docs/SHRINCS_DECISION_TRACK.md
@@ -109,8 +109,8 @@ Before any proposal to replace `PQSig rc2`, require:
 6. wallet, descriptor, and PSBT impact analysis
 7. recovery and operator-backup analysis
 8. a recommendation memo that says either:
-   - stay on `rc2` for launch
-   - or pivot before launch for explicitly stated reasons
+   - retain the production `HOLD`
+   - or select a final-standard candidate for a separate engineering proposal
 
 ## Near-Term Default
 
@@ -124,9 +124,10 @@ The default near-term choice is:
 ## Immediate Next Steps
 
 1. Preserve the rc2 production hold and executable conformance evidence.
-2. Build an isolated `SLH-DSA-SHA2-128s` reference prototype.
-3. Build an isolated `ML-DSA-44` comparator.
-4. Make no `ALG_ID`, Script, or activation change until the readiness gates are
+2. Retain the completed isolated `SLH-DSA-SHA2-128s` reference prototype.
+3. Retain the completed isolated `ML-DSA-44` comparator.
+4. Produce a measured candidate-selection memo or explicitly retain `HOLD`.
+5. Make no `ALG_ID`, Script, or activation change until the readiness gates are
    met in a separate proposal.
 
 ## Non-Goals

--- a/docs/SLH_DSA_SHA2_128S_REFERENCE.md
+++ b/docs/SLH_DSA_SHA2_128S_REFERENCE.md
@@ -168,9 +168,8 @@ Not established:
 
 ## Next Gate
 
-The next bounded slice is an equivalent isolated `ML-DSA-44` comparator using
-the same provenance, complete selected-profile ACVP, differential,
-randomized-signing, malformed-input, sanitizer, and measurement contract. A
-measured selection memo follows that comparator. No candidate should enter
-`src/crypto`, Script, wallet activation, or the `ALG_ID` registry before a
-selection and external cryptographic review.
+The equivalent isolated `ML-DSA-44` comparator is now recorded in
+`ML_DSA_44_REFERENCE.md`. The next bounded slice is a measured candidate-
+selection memo comparing the two final-standard baselines. No candidate should
+enter `src/crypto`, Script, wallet activation, or the `ALG_ID` registry before
+a selection and external cryptographic review.

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -21,10 +21,10 @@ secure real value or described as establishing its claimed `2^40` signing
 budget or NIST Level 1 security. `PQSIG_PRODUCTION_READINESS.md` is the
 controlling evidence and replacement-gate record.
 
-The next implementation lane is isolated standards conformance: first a FIPS
-205 `SLH-DSA-SHA2-128s` prototype, then a FIPS 204 `ML-DSA-44` comparator. No
-inventory policy class, `ALG_ID`, Script rule, or consensus accepted set changes
-as part of this safety closeout.
+The current implementation lane is isolated standards evidence. The FIPS 205
+`SLH-DSA-SHA2-128s` prototype and FIPS 204 `ML-DSA-44` comparator are both
+implemented without changing an inventory policy class, `ALG_ID`, Script rule,
+wallet path, or consensus accepted set.
 
 The first isolated reference slice is recorded in
 `SLH_DSA_SHA2_128S_REFERENCE.md`. It pins NIST ACVP and portable-C source
@@ -55,9 +55,20 @@ The slice changed no functional-suite inventory policy class, so the reviewed
 baseline remains `pq_required: 121`, `pq_backlog: 0`, `legacy_only: 14`, and
 `dual_profile: 141`.
 
-The next cryptographic implementation slice is the equivalent isolated
-`ML-DSA-44` comparator; the production and consensus-integration hold remains
-in force.
+The isolated `ML-DSA-44` comparator is recorded in
+`ML_DSA_44_REFERENCE.md`. It pins FIPS 204, NIST's potential-updates and
+Section 6 guidance artifacts, all 70 applicable external/pure ACVP cases,
+OpenSSL 3.6.3, and `mldsa-native` `v1.0.0-beta2`. The two codebases agree on
+all official and repo-defined exact outputs, cross-verify native randomized
+signatures, reject the bounded malformed/mutated corpus, and pass the adapter
+ASan/UBSan tranche. Ten-run arm64 timings and a raw-payload cost model are
+recorded. `mldsa-native` descends from the `pq-crystals` reference
+implementation, so the result is differential evidence rather than independent
+cryptographic review.
+
+The next bounded cryptographic slice is a measured SLH-DSA versus ML-DSA
+selection memo. It may explicitly retain `HOLD`; no consensus integration is
+authorized by either green reference harness.
 
 Keep the live `pq_required` gate aligned with the repo as it exists today. PR
 `#163` closed the initial inventory tranche at `pq_required: 120`,
@@ -146,8 +157,10 @@ Cryptography implementation lane:
 
 3. Build isolated final-standard reference prototypes
    - retain the completed FIPS 205 `SLH-DSA-SHA2-128s` evidence baseline
-   - build the equivalent FIPS 204 `ML-DSA-44` comparator next
-   - require official vectors and an independent differential oracle
+   - retain the completed FIPS 204 `ML-DSA-44` comparator baseline
+   - compare both candidates in a separate measured selection memo
+   - preserve the documented implementation-lineage limit and require external
+     cryptographic review before consensus work
    - do not allocate or activate an `ALG_ID` in the prototype slices
 
 ## Current Queue


### PR DESCRIPTION
## Summary
- pin FIPS 204, NIST update guidance, all 70 external/pure ML-DSA-44 ACVP cases, OpenSSL 3.6.3, and mldsa-native v1.0.0-beta2
- add exact/fixed-randomizer and native-randomized two-codebase differential adapters with malformed-input and ASan/UBSan coverage
- record measurements, raw-payload economics, wallet/consensus implications, and the mldsa-native lineage limitation
- keep the production hold in force; no consensus, Script, wallet, ALG_ID, workflow, or inventory-policy change

## Validation
- git diff --cached --check
- python3 -m unittest discover -s ci/test -p 'test_*.py' (23 passed)
- python3 ci/test/check_ci_inventory.py (121 / 0 / 14 / 141)
- python3 test/lint/lint-files.py
- python3 test/lint/lint-python-utf8-encoding.py
- full compare_oracles.py run: 70/70 ACVP cases, randomized cross-verification, 38 boundary/negative checks, both adapters under ASan/UBSan, 10 benchmark iterations

## Boundary
This is research evidence only. It does not select ML-DSA-44 or authorize consensus integration. External cryptographic review remains required.