### PR TITLE
docs: select ML-DSA-44 engineering candidate

### DIFF
--- a/docs/PQSIG_CANDIDATE_SELECTION.md
+++ b/docs/PQSIG_CANDIDATE_SELECTION.md
@@ -1,0 +1,268 @@
+# PQBTC Signature Candidate Selection
+
+## Status: ML_DSA_44_ENGINEERING_CANDIDATE - RELEASE_HOLD
+## Spec-ID: PQSIG-CANDIDATE-SELECTION-v1
+## Decided: 2026-07-18
+## Consensus-Relevant: NO
+
+## Decision
+
+Select FIPS 204 `ML-DSA-44` as PQBTC's primary engineering candidate for the
+next isolated evidence and protocol-design work. Retain FIPS 205
+`SLH-DSA-SHA2-128s` as the conservative fallback and reference baseline.
+
+The explicit selection outcome is:
+
+`ML_DSA_44_ENGINEERING_CANDIDATE`
+
+This is not production approval. The `RELEASE_HOLD` in
+`PQSIG_PRODUCTION_READINESS.md` remains controlling. This record does not add
+an implementation to the node, allocate an `ALG_ID`, change Script, modify a
+wallet path, or change the consensus accepted set.
+
+## Scope And Evidence Boundary
+
+This decision compares two isolated, final-standard reference profiles:
+
+- `ML_DSA_44_REFERENCE.md`
+- `SLH_DSA_SHA2_128S_REFERENCE.md`
+
+Both reference harnesses have official ACVP coverage, deterministic and
+randomized interoperability evidence, malformed-input tests, bounded
+sanitizer coverage, and directional arm64 macOS measurements. Those results
+establish reproducible prototype behavior. They do not establish production
+implementation quality, acceptable consensus resource bounds, side-channel
+resistance, or independent cryptographic review.
+
+The choice is therefore an engineering-priority decision. It is not a claim
+that ML-DSA is cryptographically superior to SLH-DSA or ready to protect real
+value.
+
+## Official Standards Refresh
+
+The official-source boundary was refreshed on 2026-07-18. Downloaded static
+artifacts were identified as PDF or XLSX files before hashing.
+
+| Artifact | Status | SHA256 |
+| --- | --- | --- |
+| FIPS 204 PDF | Final, 2024-08-13 | `57239b9f84c03227eda3ca0991204dc7764c79af9ce2e6824eda774918d46b6b` |
+| FIPS 204 potential updates | Updated 2026-02-27 | `0e8ba77b46db71fda2c18e67111303335745a938686cad6faf35eac148f7ed3e` |
+| FIPS 204 Section 6 guidance | Dated 2025-03-19 | `4a1d4b8d5aefef56069eb91bd464d5b5e177372e03bdde2541655e8e24d7a056` |
+| FIPS 205 PDF | Final, 2024-08-13 | `8ef34228276f3386d23cb0da8c14592b8cfb0db3358016bba64df7a004f8d13d` |
+| SP 800-230 IPD | Draft, 2026-04-13 | `62d092f787a1f79260454bf332b642ff3b5b73dbcce2678a133a1406065e452e` |
+| CSWP 39upd1 | Final update, 2026-06-29 | `e6b147d23eba193653f2abb3abe03fc25e63a9a91df918440b5445f9f58e9ac6` |
+
+Official sources:
+
+- [FIPS 204](https://csrc.nist.gov/pubs/fips/204/final)
+- [FIPS 205](https://csrc.nist.gov/pubs/fips/205/final)
+- [NIST PQC FIPS FAQ](https://csrc.nist.gov/Projects/post-quantum-cryptography/faqs)
+- [SP 800-230 initial public draft](https://csrc.nist.gov/pubs/sp/800/230/ipd)
+- [CSWP 39upd1](https://csrc.nist.gov/pubs/cswp/39/upd1/considerations-for-achieving-crypto-agility/final)
+
+The refresh changes no selected-profile vector bytes:
+
+1. FIPS 204 remains final. Its 2026-02-23 planning note points to the
+   potential-updates spreadsheet. The current spreadsheet matches the hash
+   already pinned by the ML-DSA harness and describes future corrections, not
+   a replacement parameter set.
+2. The live NIST PQC FIPS FAQ, last revised 2026-06-16 for this question,
+   permits an ML-DSA key-generation seed to serve as the stored or transported
+   private-key representation when standard derivation reproduces the required
+   outputs. This makes a 32-byte seed a viable backup primitive, but does not
+   select a wallet encoding or expanded-key cache policy.
+3. The 2025-03-19 Section 6 guidance still permits a separately validated
+   external-`mu` boundary in specified module arrangements. PQBTC continues to
+   use the external/pure Section 5 API in its comparator and does not select an
+   external-`mu` interface.
+4. FIPS 205 remains final. Its publication page exposes no replacement or
+   errata artifact that changes the selected `SLH-DSA-SHA2-128s` baseline.
+5. SP 800-230 remains an initial public draft. Its comment period is closed,
+   but its limited-use profiles impose a strict `2^24` signatures-per-key
+   limit and are not approved for general-purpose use. They are excluded from
+   this decision.
+6. CSWP 39upd1 is final guidance on cryptographic agility. PQBTC applies it by
+   requiring explicit algorithm binding and a replacement path; agility must
+   never reinterpret an existing output under different signature semantics.
+
+## Measured Comparison
+
+### Encoded Size And Weight
+
+| Property | ML-DSA-44 | SLH-DSA-SHA2-128s |
+| --- | ---: | ---: |
+| Public key | 1,312 bytes | 32 bytes |
+| Signature | 2,420 bytes | 7,856 bytes |
+| Raw public key plus signature | 3,732 bytes | 7,888 bytes |
+| Raw-payload upper bound at 16,000,000 WU | 4,287 | 2,028 |
+
+The ML-DSA raw payload is 52.69% smaller. The raw-payload upper bounds assume
+all bytes receive witness weight and omit transaction, script, compact-size,
+commitment, and reveal overhead. They are comparison aids, not block-capacity
+or fee claims.
+
+ML-DSA's public key is expensive if placed directly in non-witness output
+data. A hash-commit-and-reveal design could move that cost, but would also
+change transaction visibility, recovery, and spending semantics. No such
+design is selected here.
+
+Both candidates exceed Bitcoin's retained 520-byte general stack-element
+limit. Neither fits the current rc2-only witness exception. Either candidate
+requires a new, explicit consensus and policy sizing design.
+
+### Directional Prototype Timing
+
+The common OpenSSL 3.6.3 oracle provides the closest current same-codebase
+comparison. Values are medians of ten fixed-vector runs on arm64 macOS and are
+not release envelopes.
+
+| Operation | ML-DSA-44 | SLH-DSA-SHA2-128s |
+| --- | ---: | ---: |
+| Key generation | 0.099 ms | 15.811 ms |
+| Randomized signing | 0.752 ms | 135.831 ms |
+| Randomized verification | 0.052 ms | 0.120 ms |
+
+On this narrow baseline, ML-DSA randomized signing is about 181 times faster
+and verification is about 2.3 times faster. The result favors ML-DSA for
+wallet responsiveness and block-validation headroom, but supported-platform,
+worst-case, adversarial-input, and full-block measurements remain required.
+
+## Qualitative Comparison
+
+### Security Assumptions And Standards
+
+- ML-DSA-44 is a final FIPS 204 category-2 structured-lattice profile.
+- SLH-DSA-SHA2-128s is a final FIPS 205 category-1 stateless hash-based
+  profile.
+- Category numbers are comparison targets, not a complete ranking of
+  construction risk, implementation risk, or Bitcoin-system safety.
+- SLH-DSA has the more conservative primitive assumption. ML-DSA has the
+  stronger size and performance fit for this application.
+
+### Implementation Independence And Maturity
+
+- The SLH-DSA harness compares OpenSSL with an independently developed
+  portable implementation.
+- The ML-DSA harness compares separate codebases, but `mldsa-native` descends
+  from the `pq-crystals` reference implementation. Its agreement with OpenSSL
+  is strong differential evidence, not fully independent implementation
+  evidence or external review.
+- Both candidates require a production implementation selected for auditability
+  rather than a host OpenSSL consensus dependency.
+
+SLH-DSA therefore leads on current implementation-independence evidence.
+ML-DSA does not advance to consensus work until that gap is closed.
+
+### Signing, Entropy, And Side Channels
+
+- Both candidates support deterministic testing and randomized production
+  postures. Production entropy acquisition, failure behavior, and retry rules
+  remain unfrozen.
+- ML-DSA production work must evaluate rejection sampling, structured-lattice
+  arithmetic, fault behavior, constant-time signing, and secret erasure.
+- SLH-DSA production work must evaluate long-running signer behavior,
+  hash-based implementation leakage, constant-time handling, and secret
+  erasure.
+- Neither current harness establishes side-channel resistance.
+
+### Wallet, Backup, PSBT, And Hardware Signers
+
+- The NIST FAQ clarification allows ML-DSA wallets to back up a 32-byte
+  key-generation seed instead of a 2,560-byte expanded private key. Expanded
+  keys may be derived or cached only under a separately specified erasure and
+  integrity policy.
+- SLH-DSA has a 64-byte private key and 32-byte public key, but its 7,856-byte
+  signatures and much slower signing path burden PSBT transport, hardware
+  signers, QR or air-gapped workflows, fees, and multi-input transactions.
+- ML-DSA's 1,312-byte public key burdens descriptors and commitment design,
+  while its smaller signature and faster signing path are materially easier
+  to carry through transaction and signer workflows.
+- Neither candidate has an approved descriptor, PSBT, backup, hardware-signer,
+  or recovery contract.
+
+### Strict Encoding And Reviewability
+
+- Both final standards provide fixed parameter-set encodings suitable for
+  exact-length parsing.
+- Consensus must bind the algorithm, context, sighash mode, public-key
+  commitment, signature length, and activation rules without profile
+  negotiation or fallback.
+- SLH-DSA uses simpler underlying assumptions but a larger hash-tree verifier
+  and much larger untrusted input.
+- ML-DSA is smaller and faster but requires specialist review of lattice
+  arithmetic, malformed keys, rejection sampling, and side channels.
+
+## Selection Rationale
+
+ML-DSA-44 is selected for engineering work because:
+
+1. both candidates are final NIST standards with green isolated conformance
+   evidence
+2. ML-DSA's raw key-plus-signature payload is 52.69% smaller
+3. the current same-oracle timing baseline gives ML-DSA a decisive signing
+   advantage and a meaningful verification advantage
+4. NIST's seed-storage clarification removes expanded-private-key size as a
+   wallet backup blocker
+5. the remaining ML-DSA risks are concrete gates that can be tested and
+   reviewed before consensus integration
+
+SLH-DSA-SHA2-128s remains the fallback because its hash-based assumptions,
+compact keys, and stronger current implementation-independence evidence are
+valuable if ML-DSA fails review. Its signature size and signing cost make it a
+weaker first engineering fit for PQBTC.
+
+Selecting a primary engineering candidate is preferable to an undirected
+`HOLD`: it focuses independent implementation, audit, benchmarking, and
+protocol-design work. Production nevertheless remains on `HOLD` until all
+readiness gates pass.
+
+## Rejection And Fallback Criteria
+
+Return the engineering selection to `HOLD`, then reassess the SLH-DSA fallback,
+if any of these occur:
+
+1. a genuinely independent ML-DSA implementation disagrees on final-standard
+   vectors or cross-verification
+2. standards updates change the selected profile or canonical encodings
+3. external review identifies an unresolved construction, implementation,
+   side-channel, or fault-attack risk
+4. worst-case verification or malformed-input behavior cannot be bounded for
+   block and mempool validation
+5. no strict transaction, wallet, backup, and hardware-signer design can meet
+   the project's usability and resource constraints
+
+## Next Gates
+
+The next work is evidence acquisition, not node integration:
+
+1. add a genuinely independent ML-DSA implementation that does not descend
+   from the same reference lineage and require exact-vector and
+   cross-verification agreement
+2. obtain external cryptographic review covering the selected mode,
+   randomization, rejection sampling, side channels, fault behavior, secret
+   erasure, and key derivation
+3. measure supported-platform and worst-case signer, verifier, malformed-input,
+   multi-input transaction, and full-block costs
+4. only after those gates, write a separate consensus-design specification for
+   canonical key commitment, reveal, context, sighash, Script limits, policy,
+   activation, and algorithm binding
+
+No external network or user funds depend on rc2. Once a reviewed replacement
+is ready, the implementation plan should remove rc2 rather than preserve a
+dual-algorithm migration path. Future agility must still use explicit,
+immutable algorithm bindings so an existing output can never be reinterpreted.
+
+## Validation Contract
+
+This decision slice is complete when these commands pass:
+
+```bash
+git diff --check
+python3 ci/test/check_ci_inventory.py
+python3 -m unittest discover -s ci/test -p 'test_*dsa_reference.py'
+python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only
+python3 contrib/ml-dsa-ref/compare_oracles.py --manifest-only
+```
+
+The functional-suite inventory remains `pq_required: 121`, `pq_backlog: 0`,
+`legacy_only: 14`, and `dual_profile: 141`.

--- a/docs/PQSIG_PRODUCTION_READINESS.md
+++ b/docs/PQSIG_PRODUCTION_READINESS.md
@@ -58,12 +58,25 @@ than a local patch.
 
 - NIST FIPS 204 standardizes ML-DSA:
   https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf
+- NIST's 2026-02-23 FIPS 204 planning note points to a potential-updates
+  spreadsheet. The 2026-07-18 refresh matches the SHA256 already pinned by the
+  ML-DSA comparator, so it changes no selected-profile vector bytes:
+  https://csrc.nist.gov/pubs/fips/204/final
+- NIST's PQC FIPS FAQ, last revised 2026-06-16 for the key-format question,
+  permits the ML-DSA key-generation seed to represent the stored or transported
+  private key when standard derivation reproduces the required outputs:
+  https://csrc.nist.gov/Projects/post-quantum-cryptography/faqs
 - NIST FIPS 205 standardizes SLH-DSA:
   https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf
 - NIST SP 800-230 is an initial public draft, not a final standard. Its
   Bitcoin-oriented `SLH-DSA-*-128-24` profiles have a strict `2^24`
-  signatures-per-key limit and are not approved for general-purpose use:
+  signatures-per-key limit and are not approved for general-purpose use. Its
+  public comment period is closed, but NIST has not published a final:
   https://csrc.nist.gov/pubs/sp/800/230/ipd
+- NIST CSWP 39upd1 is final cryptographic-agility guidance. Any PQBTC agility
+  mechanism must use explicit algorithm binding and must not reinterpret an
+  existing output under replacement signature semantics:
+  https://csrc.nist.gov/pubs/cswp/39/upd1/considerations-for-achieving-crypto-agility/final
 - Kudinov and Nick's Bitcoin-specific hash-signature work is a 2025 preprint,
   not a NIST standard:
   https://eprint.iacr.org/2025/2203
@@ -86,15 +99,22 @@ authentication-set construction, and hypertree addressing are security
 invariants, not optional serialization details. Incrementally repairing rc2
 would amount to implementing and reviewing a new consensus algorithm.
 
-FIPS 205 is the conservative first implementation target because it is final,
-stateless, hash-based, and has compact public keys. Its 7,856-byte signatures
-increase block-space and bandwidth cost relative to rc2. FIPS 204 is a useful
-standardized efficiency comparator, but it adds structured-lattice assumptions
-and much larger public keys. The isolated ML-DSA-44 comparator now passes its
-complete selected-profile ACVP and two-codebase differential contract, but its
-portable oracle descends from the `pq-crystals` reference implementation and
-does not replace independent cryptographic review. Neither profile is selected
-for activation by this record.
+FIPS 205 remains the conservative fallback because it is final, stateless,
+hash-based, and has compact public keys. Its 7,856-byte signatures impose high
+block-space, bandwidth, signer, and hardware-wallet costs. FIPS 204 adds
+structured-lattice assumptions and much larger public keys, but offers a much
+smaller combined payload and substantially faster signing. The isolated
+ML-DSA-44 comparator now passes its complete selected-profile ACVP and
+two-codebase differential contract, but its portable oracle descends from the
+`pq-crystals` reference implementation and does not replace independent
+cryptographic review.
+
+`PQSIG_CANDIDATE_SELECTION.md` selects `ML-DSA-44` as the primary engineering
+candidate because its raw key-plus-signature payload, signing latency, and
+verification latency fit PQBTC materially better than the current
+`SLH-DSA-SHA2-128s` baseline. The hash-based profile remains the conservative
+fallback. This prioritizes evidence and design work; neither profile is
+selected for activation by this record.
 
 ## Implementation Direction
 
@@ -117,9 +137,10 @@ for activation by this record.
    a final publication and an explicit one-key-per-output usage-limit design.
 6. Retire rc2 or replace it with a ground-up, exact construction. Do not patch
    isolated symptoms while retaining the current security claims.
-7. Produce a measured SLH-DSA versus ML-DSA selection memo. The memo may retain
-   `HOLD`; neither a smaller signature nor faster benchmark is sufficient by
-   itself to select a consensus primitive.
+7. Apply the measured decision in `PQSIG_CANDIDATE_SELECTION.md`: advance
+   `ML-DSA-44` only through independent implementation evidence, external
+   cryptographic review, and worst-case system measurements. Preserve
+   `SLH-DSA-SHA2-128s` as the fallback and keep production on `HOLD`.
 
 ## Required Gates Before Consensus Integration
 

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -26,6 +26,10 @@ answer specific classes of questions instead of listing every file in `docs/`.
   evidence, malformed-input and sanitizer coverage, timings, and a raw-payload
   cost model. Its documented implementation-lineage limitation keeps external
   cryptographic review as an unsatisfied gate.
+- `PQSIG_CANDIDATE_SELECTION.md` selects `ML-DSA-44` as the primary
+  engineering candidate, retains `SLH-DSA-SHA2-128s` as the conservative
+  fallback, and preserves the production release hold. No consensus or wallet
+  integration is authorized by that selection.
 - No PDF papers are currently checked into this repo.
 - Delving Bitcoin now provides concrete adjacent research references that are
   directly relevant to Track A, especially around SHRINCS / SHRIMPS and
@@ -77,6 +81,9 @@ answer specific classes of questions instead of listing every file in `docs/`.
 
 - [PQSIG_PRODUCTION_READINESS.md](PQSIG_PRODUCTION_READINESS.md)
   Controlling cryptographic release hold and replacement gates.
+- [PQSIG_CANDIDATE_SELECTION.md](PQSIG_CANDIDATE_SELECTION.md)
+  Measured comparison, official-standards refresh, engineering selection, and
+  rejection/fallback gates for ML-DSA-44 versus SLH-DSA-SHA2-128s.
 - [SLH_DSA_SHA2_128S_REFERENCE.md](SLH_DSA_SHA2_128S_REFERENCE.md)
   Isolated standards-conformance and measurement baseline for the first final-
   standard candidate.
@@ -137,6 +144,17 @@ answer specific classes of questions instead of listing every file in `docs/`.
 
 ## External References
 
+- NIST FIPS 204:
+  [Module-Lattice-Based Digital Signature Standard](https://csrc.nist.gov/pubs/fips/204/final)
+  Controlling final standard and potential-updates boundary for ML-DSA.
+- NIST FIPS 205:
+  [Stateless Hash-Based Digital Signature Standard](https://csrc.nist.gov/pubs/fips/205/final)
+  Controlling final standard for the retained SLH-DSA fallback.
+- NIST CSWP 39upd1, June 29, 2026:
+  [Considerations for Achieving Crypto Agility](https://csrc.nist.gov/pubs/cswp/39/upd1/considerations-for-achieving-crypto-agility/final)
+  Current official agility framing. PQBTC applies it through explicit,
+  immutable algorithm binding rather than reinterpretation of existing
+  outputs.
 - Blockstream Research, March 3, 2026:
   [Quantum-resistant transaction signing on Liquid using Simplicity smart contracts](https://blog.blockstream.com/blockstream-research-demonstrates-quantum-resistant-transaction-signing-on-liquid-using-simplicity-smart-contracts/)
   Use as an adjacent benchmark for opt-in deployment on a Bitcoin-like system,

--- a/docs/SHRINCS_DECISION_TRACK.md
+++ b/docs/SHRINCS_DECISION_TRACK.md
@@ -30,6 +30,9 @@ This document is a sequencing rule, not an activation decision.
 - PQBTC has working Bitcoin integration around a PQ-shaped signature fixture.
   It does not yet have a cryptographically approved production signature
   profile.
+- `PQSIG_CANDIDATE_SELECTION.md` selects FIPS 204 `ML-DSA-44` as the primary
+  engineering candidate and retains FIPS 205 `SLH-DSA-SHA2-128s` as the
+  conservative fallback. Production remains on `HOLD`.
 
 ## Decision Rule
 
@@ -38,6 +41,8 @@ This document is a sequencing rule, not an activation decision.
   architecture override.
 - Do evaluate SHRINCS-family options in parallel, with explicit acceptance
   criteria and a clean go / no-go checkpoint before launch-facing signoff.
+- Do not reinterpret the ML-DSA engineering selection as consensus approval or
+  as permission to weaken the SLH-DSA fallback evidence.
 
 The repo should avoid mixing two kinds of uncertainty in one step:
 
@@ -112,23 +117,34 @@ Before any proposal to replace `PQSig rc2`, require:
    - retain the production `HOLD`
    - or select a final-standard candidate for a separate engineering proposal
 
+`PQSIG_CANDIDATE_SELECTION.md` satisfies item 8 by selecting `ML-DSA-44` for
+engineering work while retaining the production hold. Items 2, 3, 5, 6, and 7
+remain future consensus-design work, and independent implementation plus
+external cryptographic review remain mandatory before that work starts.
+
 ## Near-Term Default
 
 The default near-term choice is:
 
 - do not ship rc2 or represent it as production-ready cryptography
 - preserve current wallet / PSBT / CI / ops work as integration evidence
-- build isolated FIPS 205 and FIPS 204 reference prototypes before proposing a
-  new consensus profile
+- retain the isolated FIPS 205 and FIPS 204 reference evidence
+- focus the next evidence work on the selected ML-DSA-44 candidate without
+  entering consensus code
 
 ## Immediate Next Steps
 
 1. Preserve the rc2 production hold and executable conformance evidence.
 2. Retain the completed isolated `SLH-DSA-SHA2-128s` reference prototype.
 3. Retain the completed isolated `ML-DSA-44` comparator.
-4. Produce a measured candidate-selection memo or explicitly retain `HOLD`.
-5. Make no `ALG_ID`, Script, or activation change until the readiness gates are
-   met in a separate proposal.
+4. Apply the measured `ML_DSA_44_ENGINEERING_CANDIDATE` decision without
+   treating it as production approval.
+5. Obtain a genuinely independent ML-DSA implementation and external
+   cryptographic review.
+6. Measure supported-platform and worst-case transaction and block costs.
+7. Only after those gates, write a separate consensus-design specification.
+8. Make no `ALG_ID`, Script, wallet, or activation change until the readiness
+   gates are met in a separate proposal.
 
 ## Non-Goals
 

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -66,9 +66,16 @@ recorded. `mldsa-native` descends from the `pq-crystals` reference
 implementation, so the result is differential evidence rather than independent
 cryptographic review.
 
-The next bounded cryptographic slice is a measured SLH-DSA versus ML-DSA
-selection memo. It may explicitly retain `HOLD`; no consensus integration is
-authorized by either green reference harness.
+The measured decision in `PQSIG_CANDIDATE_SELECTION.md` selects FIPS 204
+`ML-DSA-44` as the primary engineering candidate and retains FIPS 205
+`SLH-DSA-SHA2-128s` as the conservative fallback. Production remains on
+`HOLD`; no consensus integration is authorized by the selection or either
+green reference harness.
+
+The next bounded cryptographic work is to obtain a genuinely independent
+ML-DSA implementation and external cryptographic review, then close
+supported-platform and worst-case system measurements. A consensus-design
+specification follows only after those gates.
 
 Keep the live `pq_required` gate aligned with the repo as it exists today. PR
 `#163` closed the initial inventory tranche at `pq_required: 120`,
@@ -155,13 +162,16 @@ Future selection boundary:
 
 Cryptography implementation lane:
 
-3. Build isolated final-standard reference prototypes
+3. Advance the selected ML-DSA-44 engineering evidence
    - retain the completed FIPS 205 `SLH-DSA-SHA2-128s` evidence baseline
    - retain the completed FIPS 204 `ML-DSA-44` comparator baseline
-   - compare both candidates in a separate measured selection memo
-   - preserve the documented implementation-lineage limit and require external
-     cryptographic review before consensus work
-   - do not allocate or activate an `ALG_ID` in the prototype slices
+   - apply `ML_DSA_44_ENGINEERING_CANDIDATE` as an evidence priority, not
+     production approval
+   - close the documented implementation-lineage limit with a genuinely
+     independent implementation
+   - require external cryptographic review and supported-platform worst-case
+     measurements before consensus-design work
+   - do not allocate or activate an `ALG_ID` in the evidence slices
 
 ## Current Queue
 
@@ -180,6 +190,10 @@ Cryptography implementation lane:
      [FEATURE_CONFIG_ARGS_POSTURE.md](FEATURE_CONFIG_ARGS_POSTURE.md)
 2. `HOLD`: do not infer another promotion from queue order. Require a fresh
    risk decision before changing another policy class.
+3. Cryptographic production remains on `HOLD` while `ML-DSA-44` advances only
+   as the selected engineering candidate. The next gates are independent
+   implementation evidence, external cryptographic review, and worst-case
+   system measurements; Script and wallet integration remain out of scope.
 
 
 ## Historical Queue Ledger
@@ -1673,6 +1687,12 @@ Aineko must ask before:
 Entries below are dated decision snapshots. Use Current Follow-On Candidates
 above as the controlling live next-PR handoff when these older notes disagree.
 
+- 2026-07-18: The measured final-standard comparison selected FIPS 204
+  `ML-DSA-44` as `ML_DSA_44_ENGINEERING_CANDIDATE`, retained FIPS 205
+  `SLH-DSA-SHA2-128s` as the conservative fallback, and kept production on
+  `HOLD`. The selection authorizes independent implementation, external-review,
+  and worst-case measurement work only. It does not authorize consensus,
+  Script, wallet, or `ALG_ID` changes.
 - 2026-07-18: Cryptographic conformance review placed all production activation
   on hold. The rc2 implementation does not enforce the WOTS+C fixed-sum rule,
   does not implement the cited PORS+FP grinding/authentication-set behavior,
@@ -2596,6 +2616,11 @@ above as the controlling live next-PR handoff when these older notes disagree.
 - There is no active inventory blocker. The selected configuration-namespace
   gap is promoted, its platform default-datadir namespace is asserted, and no
   suites remain in `pq_backlog`.
+- Production cryptography remains blocked on independent ML-DSA implementation
+  evidence, external cryptographic review, constant-time and secret-erasure
+  analysis, supported-platform and worst-case validation cost, and a separate
+  consensus-design specification. Engineering-candidate selection closes none
+  of those gates.
 - A further promotion requires a newly reviewed PQ confidence gap with a named
   owner, open tracking issue, bounded contract, targeted test, and acceptable
   CI cost. Until another selection exists, `HOLD` is the intended baseline


### PR DESCRIPTION
## Summary
- select FIPS 204 ML-DSA-44 as the primary engineering candidate while retaining the production release hold
- retain SLH-DSA-SHA2-128s as the conservative fallback and record explicit rejection criteria
- refresh official NIST standards, errata, FAQ, draft-profile, and crypto-agility evidence
- update the controlling readiness, research-index, decision-track, and Track A handoff documents
- make no consensus, Script, wallet, ALG_ID, node, workflow, or inventory-policy change

## Validation
- `git diff --check`
- `git diff --cached --check`
- `python3 ci/test/check_ci_inventory.py`
- `python3 -m unittest discover -s ci/test -p 'test_*dsa_reference.py'` (16 passed)
- `python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only`
- `python3 contrib/ml-dsa-ref/compare_oracles.py --manifest-only`
- `python3 test/lint/lint-files.py`

Inventory remains `pq_required: 121`, `pq_backlog: 0`, `legacy_only: 14`, and `dual_profile: 141`.