### PR TITLE
research: add third ML-DSA implementation oracle

### DIFF
--- a/ci/test/test_ml_dsa_reference.py
+++ b/ci/test/test_ml_dsa_reference.py
@@ -58,7 +58,11 @@ class MLDSAReferenceTests(unittest.TestCase):
         sources = self.manifest["sources"]
         self.assertEqual(sources["openssl"]["version"], "3.6.3")
         self.assertEqual(sources["mldsa_native"]["tag"], "v1.0.0-beta2")
-        for name in ("nist_acvp", "openssl", "mldsa_native"):
+        self.assertEqual(sources["libcrux"]["version"], "0.0.10")
+        self.assertEqual(
+            sources["libcrux"]["tag"], "libcrux-ml-dsa-v0.0.10"
+        )
+        for name in ("nist_acvp", "openssl", "mldsa_native", "libcrux"):
             self.assertRegex(sources[name]["commit"], r"^[0-9a-f]{40}$")
         for name in (
             "nist_fips204",
@@ -69,6 +73,18 @@ class MLDSAReferenceTests(unittest.TestCase):
         self.assertIn(
             "not independent cryptographic review",
             sources["mldsa_native"]["lineage_limit"],
+        )
+        assessment = sources["libcrux"]["independence_assessment"]
+        self.assertEqual(
+            assessment["outcome"],
+            "separate_implementation_lineage_with_reference_influence",
+        )
+        self.assertFalse(assessment["normal_pqclean_or_pq_crystals_dependency"])
+        self.assertIn("not independent design", assessment["limit"])
+        self.assertRegex(sources["libcrux"]["crate_sha256"], r"^[0-9a-f]{64}$")
+        self.assertEqual(
+            set(sources["libcrux"]["fixed_advisories"]),
+            {"RUSTSEC-2026-0076", "RUSTSEC-2026-0077"},
         )
 
     def test_manifest_rejects_coverage_drift(self):
@@ -93,6 +109,33 @@ class MLDSAReferenceTests(unittest.TestCase):
         self.assertNotIn("private_key + PRIVATE_KEY_SIZE - PUBLIC_KEY_SIZE", openssl_source)
         native_source = (REFERENCE_DIR / "mldsa_native_oracle.c").read_text(encoding="utf8")
         self.assertIn("mldsa_pk_from_sk", native_source)
+        libcrux_source = (REFERENCE_DIR / "libcrux_oracle.rs").read_text(
+            encoding="utf8"
+        )
+        self.assertIn("const SIGNATURE_SIZE: usize = 2420", libcrux_source)
+        self.assertIn("signature_bytes.len() != SIGNATURE_SIZE", libcrux_source)
+        self.assertIn("MLDSA44VerificationKey::new", libcrux_source)
+        self.assertIn('command == "sign-with-randomizer"', libcrux_source)
+
+    def test_libcrux_malformed_hint_regressions_are_bounded(self):
+        profile = self.manifest["profile"]
+        bounded = bytes.fromhex(
+            compare_oracles.libcrux_malformed_hint_signature(profile, 81)
+        )
+        out_of_bounds = bytes.fromhex(
+            compare_oracles.libcrux_malformed_hint_signature(profile, 85)
+        )
+        self.assertEqual(len(bounded), profile["signature_bytes"])
+        self.assertEqual(len(out_of_bounds), profile["signature_bytes"])
+        hint_offset = 32 + 4 * 576
+        self.assertEqual(
+            bounded[hint_offset + 80 : hint_offset + 84],
+            bytes((21, 42, 63, 81)),
+        )
+        self.assertEqual(
+            out_of_bounds[hint_offset + 80 : hint_offset + 84],
+            bytes((21, 42, 63, 85)),
+        )
 
     def test_manifest_only_cli(self):
         result = subprocess.run(

--- a/contrib/ml-dsa-ref/README.md
+++ b/contrib/ml-dsa-ref/README.md
@@ -12,15 +12,26 @@ define consensus behavior, and does not allocate or activate an `ALG_ID`.
   commit and source-file hashes pinned in `vectors.json`
 - an OpenSSL 3.6.3 runtime plus a clean checkout at its pinned source commit
 - `pq-code-package/mldsa-native` `v1.0.0-beta2` at its pinned commit
+- `libcrux-ml-dsa` `v0.0.10` at its pinned source commit and annotated tag,
+  plus the exact crates.io archive pinned by SHA256
 
-The two adapters use all-zero randomness for deterministic vectors, explicit
-32-byte `rnd` injection for randomized ACVP vectors, and their native
-randomized APIs for diversity and cross-verification checks. Hedged randomized
-signing remains the required posture for any future production proposal.
+The three adapters use all-zero randomness for deterministic vectors, explicit
+32-byte `rnd` injection for randomized ACVP vectors, and their randomized APIs
+for diversity and cross-verification checks. Hedged randomized signing remains
+the required posture for any future production proposal.
 
 `mldsa-native` is a fork of the `pq-crystals` reference implementation. It is
 a separate portable-C code path from OpenSSL, but this ancestry means a green
 differential run is not a substitute for independent cryptographic review.
+
+`libcrux-ml-dsa` is a direct portable-Rust implementation with a separate Git
+history and no normal dependency on PQClean, `pq-crystals`, or
+`mldsa-native`. Its unit-test outputs and selected implementation comments cite
+PQ-Crystals, so the precise assessment is
+`separate_implementation_lineage_with_reference_influence`. Agreement closes
+the separate-implementation evidence gate; it does not establish independent
+design, external cryptographic review, side-channel safety, or production
+readiness.
 
 ## Run
 
@@ -30,6 +41,8 @@ python3 contrib/ml-dsa-ref/compare_oracles.py \
   --acvp-server /path/to/pinned/ACVP-Server \
   --openssl-source /path/to/pinned/openssl \
   --mldsa-native /path/to/pinned/mldsa-native \
+  --libcrux-source /path/to/full-history/pinned/libcrux \
+  --libcrux-crate /path/to/libcrux-ml-dsa-0.0.10.crate \
   --fips204 /path/to/NIST.FIPS.204.pdf \
   --fips204-updates /path/to/fips-204-potential-updates.xlsx \
   --fips204-section6-guidance /path/to/fips204-sec6-03192025.pdf \
@@ -37,21 +50,26 @@ python3 contrib/ml-dsa-ref/compare_oracles.py \
   --sanitizers
 ```
 
-The full run requires clean Git checkouts at all pinned commits. It verifies
+The full run requires clean Git checkouts at all pinned commits, including a
+full-history libcrux checkout for the ancestry check, the exact pinned libcrux
+crate archive, Rust and Cargo, and the locked Rust dependencies. It verifies
 the three NIST document checksums and six ACVP source checksums, then executes
 25 key-generation cases, 15 deterministic signature-generation cases, 15
 randomized signature-generation cases, and all 15 signature-verification
-accept/reject cases. It also checks complete signature-byte agreement,
-cross-verification, native randomized-signature diversity, empty and maximum
-contexts, malformed lengths, key/message/context/signature mutations, and
-bounded ASan/UBSan adapter runs. The JSON report includes ten-run timing
-medians and an explicitly scoped raw-payload block-space model.
+accept/reject cases against all three oracles. It also checks complete
+signature-byte agreement, cross-verification, randomized-signature diversity,
+empty and maximum contexts, malformed lengths, key/message/context/signature
+mutations, the two disclosed libcrux advisory regressions, and bounded
+ASan/UBSan runs for the two portable-C adapters. The JSON report includes
+ten-run timing medians and an explicitly scoped raw-payload block-space model.
 
-The current research adapter uses POSIX `/dev/urandom` to exercise
-`mldsa-native`'s randomized API. That wrapper path is intended for macOS/Linux
-evidence runs and is not a proposed node entropy implementation.
+The current `mldsa-native` and libcrux research adapters use POSIX
+`/dev/urandom` to exercise randomized signing. Those wrapper paths are intended
+for macOS/Linux evidence runs and are not a proposed node entropy
+implementation.
 
-Both adapters reject any signature whose decoded length is not exactly 2,420
-bytes before entering the implementation verifier. OpenSSL and
-`mldsa-native` are prototype oracles only; passing this harness neither makes
-either one a node dependency nor approves ML-DSA-44 for consensus integration.
+All three adapters reject any signature whose decoded length is not exactly
+2,420 bytes before entering the implementation verifier. OpenSSL,
+`mldsa-native`, and libcrux are prototype oracles only; passing this harness
+neither makes one a node dependency nor approves ML-DSA-44 for consensus
+integration.

--- a/contrib/ml-dsa-ref/compare_oracles.py
+++ b/contrib/ml-dsa-ref/compare_oracles.py
@@ -10,9 +10,11 @@ import os
 import re
 import secrets
 import shlex
+import shutil
 import statistics
 import subprocess
 import sys
+import tarfile
 import tempfile
 from pathlib import Path
 
@@ -21,11 +23,24 @@ HERE = Path(__file__).resolve().parent
 MANIFEST_PATH = HERE / "vectors.json"
 OPENSSL_SOURCE = HERE / "openssl_oracle.c"
 MLDSA_NATIVE_SOURCE = HERE / "mldsa_native_oracle.c"
+LIBCRUX_SOURCE = HERE / "libcrux_oracle.rs"
 HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 
 
 class ReferenceError(RuntimeError):
     pass
+
+
+class Oracle:
+    def __init__(
+        self,
+        executable: Path,
+        derives_public_key: bool = True,
+        sign_requires_public_key: bool = False,
+    ) -> None:
+        self.executable = executable
+        self.derives_public_key = derives_public_key
+        self.sign_requires_public_key = sign_requires_public_key
 
 
 def require_hex(value: str, byte_length: int, label: str) -> None:
@@ -34,8 +49,8 @@ def require_hex(value: str, byte_length: int, label: str) -> None:
 
 
 def validate_manifest(manifest: dict) -> None:
-    if manifest.get("schema_version") != 2:
-        raise ReferenceError("manifest schema_version must be 2")
+    if manifest.get("schema_version") != 3:
+        raise ReferenceError("manifest schema_version must be 3")
 
     profile = manifest["profile"]
     expected_profile = {
@@ -104,13 +119,44 @@ def validate_manifest(manifest: dict) -> None:
         raise ReferenceError("ACVP coverage does not match the frozen 70-case contract")
 
     sources = manifest["sources"]
-    for source_name in ("nist_acvp", "openssl", "mldsa_native"):
+    for source_name in ("nist_acvp", "openssl", "mldsa_native", "libcrux"):
         if re.fullmatch(r"[0-9a-f]{40}", sources[source_name]["commit"]) is None:
             raise ReferenceError(f"{source_name} commit must be a full Git SHA")
     if sources["openssl"].get("version") != "3.6.3":
         raise ReferenceError("OpenSSL source and runtime version must be 3.6.3")
     if sources["mldsa_native"].get("tag") != "v1.0.0-beta2":
         raise ReferenceError("mldsa-native tag must be v1.0.0-beta2")
+    libcrux = sources["libcrux"]
+    if libcrux.get("tag") != "libcrux-ml-dsa-v0.0.10":
+        raise ReferenceError("libcrux tag must be libcrux-ml-dsa-v0.0.10")
+    if libcrux.get("version") != "0.0.10":
+        raise ReferenceError("libcrux version must be 0.0.10")
+    for field in ("tag_object", "git_tree", "initial_implementation_commit"):
+        if re.fullmatch(r"[0-9a-f]{40}", libcrux.get(field, "")) is None:
+            raise ReferenceError(f"libcrux {field} must be a full Git object ID")
+    if HEX_64.fullmatch(libcrux.get("crate_sha256", "")) is None:
+        raise ReferenceError("libcrux crate_sha256 must be SHA256")
+    if libcrux.get("license_expression") != "Apache-2.0":
+        raise ReferenceError("libcrux license must be Apache-2.0")
+    assessment = libcrux.get("independence_assessment", {})
+    if assessment.get("outcome") != "separate_implementation_lineage_with_reference_influence":
+        raise ReferenceError("libcrux independence assessment outcome mismatch")
+    if assessment.get("normal_pqclean_or_pq_crystals_dependency") is not False:
+        raise ReferenceError("libcrux normal dependency assessment must be false")
+    expected_advisories = {
+        "RUSTSEC-2026-0076": {
+            "ghsa": "GHSA-xrf2-5r3p-5wgj",
+            "fixed_in": "0.0.8",
+            "upstream_test": "bad_hint_out_of_bounds",
+        },
+        "RUSTSEC-2026-0077": {
+            "ghsa": "GHSA-cp57-fq8g-qh6v",
+            "fixed_in": "0.0.8",
+            "upstream_test": "mask_exceeds_norm",
+        },
+    }
+    if libcrux.get("fixed_advisories") != expected_advisories:
+        raise ReferenceError("libcrux fixed-advisory contract mismatch")
     for source_name in (
         "nist_fips204",
         "nist_fips204_potential_updates",
@@ -343,6 +389,200 @@ def require_mldsa_native_source(source_dir: Path, expected_commit: str) -> None:
     if any(not (source_dir / relative_path).is_file() for relative_path in required_files):
         raise ReferenceError(f"missing mldsa-native source at {source_dir}")
     require_git_commit(source_dir, expected_commit, "mldsa-native")
+
+
+def require_libcrux_source(source_dir: Path, source: dict) -> None:
+    required_files = (
+        "LICENSE",
+        "libcrux-ml-dsa/Cargo.toml",
+        "libcrux-ml-dsa/CHANGELOG.md",
+        "libcrux-ml-dsa/src/IMPLEMENTATION-NOTES.md",
+        "libcrux-ml-dsa/src/ml_dsa_generic.rs",
+        "libcrux-ml-dsa/src/encoding/signature.rs",
+        "libcrux-ml-dsa/tests/self.rs",
+    )
+    if any(not (source_dir / relative_path).is_file() for relative_path in required_files):
+        raise ReferenceError(f"missing libcrux ML-DSA source at {source_dir}")
+    require_git_commit(source_dir, source["commit"], "libcrux")
+
+    tag_object = run(
+        ["git", "rev-parse", f"refs/tags/{source['tag']}"], cwd=source_dir
+    ).strip()
+    if tag_object != source["tag_object"]:
+        raise ReferenceError(
+            f"libcrux tag object mismatch: expected {source['tag_object']}, "
+            f"got {tag_object}"
+        )
+    tagged_commit = run(
+        ["git", "rev-parse", f"{source['tag']}^{{commit}}"], cwd=source_dir
+    ).strip()
+    if tagged_commit != source["commit"]:
+        raise ReferenceError(
+            f"libcrux tag commit mismatch: expected {source['commit']}, "
+            f"got {tagged_commit}"
+        )
+    tree = run(["git", "rev-parse", "HEAD:libcrux-ml-dsa"], cwd=source_dir).strip()
+    if tree != source["git_tree"]:
+        raise ReferenceError(
+            f"libcrux ML-DSA tree mismatch: expected {source['git_tree']}, got {tree}"
+        )
+    run(
+        [
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            source["initial_implementation_commit"],
+            "HEAD",
+        ],
+        cwd=source_dir,
+    )
+    ml_dsa_history = run(
+        ["git", "log", "--reverse", "--format=%H", "--", "libcrux-ml-dsa"],
+        cwd=source_dir,
+    ).splitlines()
+    if not ml_dsa_history or ml_dsa_history[0] != source["initial_implementation_commit"]:
+        raise ReferenceError("libcrux initial ML-DSA implementation commit mismatch")
+
+    cargo_manifest = (source_dir / "libcrux-ml-dsa/Cargo.toml").read_text(
+        encoding="utf8"
+    )
+    if re.search(r'^version = "0\.0\.10"$', cargo_manifest, re.MULTILINE) is None:
+        raise ReferenceError("libcrux source package version mismatch")
+    manifest_sections = cargo_manifest.split("[dependencies]", 1)
+    if len(manifest_sections) != 2:
+        raise ReferenceError("libcrux source has no normal dependency section")
+    dependency_section = manifest_sections[1].split("\n[", 1)[0]
+    if re.search(r"pqclean|pq[-_]crystals", dependency_section, re.IGNORECASE):
+        raise ReferenceError("libcrux has an unexpected normal PQClean/PQ-Crystals dependency")
+
+
+def prepare_libcrux_crate(build_dir: Path, artifact: Path, source: dict) -> Path:
+    require_artifact(artifact, source["crate_sha256"], "libcrux ML-DSA crate")
+    expected_root = f"libcrux-ml-dsa-{source['version']}"
+    extraction_root = build_dir / "libcrux-crate"
+    extraction_root.mkdir()
+    with tarfile.open(artifact, mode="r:gz") as archive:
+        members = archive.getmembers()
+        if not members:
+            raise ReferenceError("libcrux crate archive is empty")
+        for member in members:
+            member_path = Path(member.name)
+            if (
+                member_path.is_absolute()
+                or ".." in member_path.parts
+                or member_path.parts[0] != expected_root
+                or member.issym()
+                or member.islnk()
+                or not (member.isfile() or member.isdir())
+            ):
+                raise ReferenceError(f"unsafe libcrux crate member: {member.name}")
+        if sys.version_info >= (3, 12):
+            archive.extractall(extraction_root, filter="data")
+        else:
+            archive.extractall(extraction_root)
+
+    crate_dir = extraction_root / expected_root
+    vcs_info_path = crate_dir / ".cargo_vcs_info.json"
+    cargo_manifest_path = crate_dir / "Cargo.toml"
+    cargo_lock_path = crate_dir / "Cargo.lock"
+    if not all(path.is_file() for path in (vcs_info_path, cargo_manifest_path, cargo_lock_path)):
+        raise ReferenceError("libcrux crate is missing pinned package metadata")
+    vcs_info = json.loads(vcs_info_path.read_text(encoding="utf8"))
+    if vcs_info.get("git", {}).get("sha1") != source["commit"]:
+        raise ReferenceError("libcrux crate VCS commit mismatch")
+    cargo_manifest = cargo_manifest_path.read_text(encoding="utf8")
+    for pattern, label in (
+        (r'^name = "libcrux-ml-dsa"$', "package name"),
+        (r'^version = "0\.0\.10"$', "package version"),
+        (r'^license = "Apache-2\.0"$', "license"),
+    ):
+        if re.search(pattern, cargo_manifest, re.MULTILINE) is None:
+            raise ReferenceError(f"libcrux crate {label} mismatch")
+
+    examples_dir = crate_dir / "examples"
+    adapter_path = examples_dir / "pqbtc_oracle.rs"
+    shutil.copyfile(LIBCRUX_SOURCE, adapter_path)
+    cargo_manifest_path.write_text(
+        cargo_manifest
+        + "\n[[example]]\n"
+        + 'name = "pqbtc_oracle"\n'
+        + 'path = "examples/pqbtc_oracle.rs"\n',
+        encoding="utf8",
+    )
+    return crate_dir
+
+
+def compile_libcrux_oracle(build_dir: Path, crate_dir: Path) -> Path:
+    target_dir = build_dir / "libcrux-target"
+    normal_dependencies = run(
+        [
+            "cargo",
+            "tree",
+            "--manifest-path",
+            str(crate_dir / "Cargo.toml"),
+            "--locked",
+            "--edges",
+            "normal",
+            "--no-default-features",
+            "--features",
+            "std,mldsa44",
+            "--prefix",
+            "none",
+        ]
+    )
+    if re.search(
+        r"pqclean|pq[-_]crystals|mldsa[-_]native|pqcrypto[-_]mldsa",
+        normal_dependencies,
+        re.IGNORECASE,
+    ):
+        raise ReferenceError("libcrux has an unexpected normal reference dependency")
+    run(
+        [
+            "cargo",
+            "build",
+            "--manifest-path",
+            str(crate_dir / "Cargo.toml"),
+            "--target-dir",
+            str(target_dir),
+            "--locked",
+            "--release",
+            "--no-default-features",
+            "--features",
+            "std,mldsa44",
+            "--example",
+            "pqbtc_oracle",
+        ]
+    )
+    executable = target_dir / "release" / "examples" / "pqbtc_oracle"
+    if not executable.is_file():
+        raise ReferenceError("cargo did not produce the libcrux oracle executable")
+    return executable
+
+
+def run_libcrux_security_regressions(build_dir: Path, crate_dir: Path) -> dict:
+    target_dir = build_dir / "libcrux-security-target"
+    regressions = {
+        "RUSTSEC-2026-0076": "bad_hint_out_of_bounds",
+        "RUSTSEC-2026-0077": "mask_exceeds_norm",
+    }
+    for test_name in regressions.values():
+        run(
+            [
+                "cargo",
+                "test",
+                "--manifest-path",
+                str(crate_dir / "Cargo.toml"),
+                "--target-dir",
+                str(target_dir),
+                "--locked",
+                "--test",
+                "self",
+                test_name,
+                "--",
+                "--exact",
+            ]
+        )
+    return {advisory: {"test": test, "status": "PASS"} for advisory, test in regressions.items()}
 
 
 def require_artifact(path: Path, expected_sha256: str, label: str) -> None:
@@ -689,43 +929,58 @@ def parse_oracle_output(output: str) -> dict[str, str]:
     return parsed
 
 
-def oracle_keygen(executable: Path, seed_hex: str) -> dict[str, str]:
-    return parse_oracle_output(run([str(executable), "keygen", seed_hex]))
+def oracle_keygen(oracle: Oracle, seed_hex: str) -> dict[str, str]:
+    return parse_oracle_output(run([str(oracle.executable), "keygen", seed_hex]))
 
 
-def oracle_public_key(executable: Path, private_key_hex: str) -> str:
+def oracle_public_key(oracle: Oracle, private_key_hex: str) -> str:
+    if not oracle.derives_public_key:
+        raise ReferenceError(f"oracle {oracle.executable.name} cannot derive a public key")
     result = parse_oracle_output(
-        run([str(executable), "public-key", private_key_hex])
+        run([str(oracle.executable), "public-key", private_key_hex])
     )
     public_key = result.get("pk")
     if public_key is None:
-        raise ReferenceError(f"oracle {executable.name} omitted public key")
+        raise ReferenceError(f"oracle {oracle.executable.name} omitted public key")
     return public_key
 
 
 def oracle_sign(
-    executable: Path,
+    oracle: Oracle,
     private_key_hex: str,
     message_hex: str,
     context_hex: str,
     randomizer_hex: str | None = None,
     randomized: bool = False,
+    public_key_hex: str | None = None,
 ) -> dict[str, str]:
     if randomizer_hex is not None and randomized:
         raise ReferenceError("fixed and default randomized signing are mutually exclusive")
     command = "sign-randomized" if randomized else "sign"
-    arguments = [str(executable), command, private_key_hex, message_hex, context_hex]
+    arguments = [
+        str(oracle.executable),
+        command,
+        private_key_hex,
+        message_hex,
+        context_hex,
+    ]
     if randomizer_hex is not None:
         arguments[1] = "sign-with-randomizer"
         arguments.append(randomizer_hex)
+    if oracle.sign_requires_public_key:
+        if public_key_hex is None:
+            raise ReferenceError(
+                f"oracle {oracle.executable.name} requires a public key while signing"
+            )
+        arguments.append(public_key_hex)
     result = parse_oracle_output(run(arguments))
     if result.get("verified") != "1":
-        raise ReferenceError(f"oracle {executable.name} did not self-verify")
+        raise ReferenceError(f"oracle {oracle.executable.name} did not self-verify")
     return result
 
 
 def oracle_verify(
-    executable: Path,
+    oracle: Oracle,
     public_key_hex: str,
     message_hex: str,
     context_hex: str,
@@ -734,7 +989,7 @@ def oracle_verify(
     result = parse_oracle_output(
         run(
             [
-                str(executable),
+                str(oracle.executable),
                 "verify",
                 public_key_hex,
                 message_hex,
@@ -744,7 +999,9 @@ def oracle_verify(
         )
     )
     if result.get("verified") not in {"0", "1"}:
-        raise ReferenceError(f"oracle {executable.name} returned invalid verify result")
+        raise ReferenceError(
+            f"oracle {oracle.executable.name} returned invalid verify result"
+        )
     return result
 
 
@@ -760,7 +1017,7 @@ def flip_hex_byte(value: str, byte_index: int) -> str:
 
 
 def require_verification(
-    oracles: dict[str, Path],
+    oracles: dict[str, Oracle],
     public_key_hex: str,
     message_hex: str,
     context_hex: str,
@@ -770,22 +1027,36 @@ def require_verification(
 ) -> None:
     results = {
         name: oracle_verify(
-            executable,
+            oracle,
             public_key_hex,
             message_hex,
             context_hex,
             signature_hex,
         )["verified"]
-        for name, executable in oracles.items()
+        for name, oracle in oracles.items()
     }
     require_equal(label, *results.values(), expected)
 
 
-def evaluate_acvp(profile: dict, oracles: dict[str, Path], source_cases: dict) -> None:
+def derived_public_keys(
+    oracles: dict[str, Oracle], private_key_hex: str, label: str
+) -> dict[str, str]:
+    public_keys = {
+        name: oracle_public_key(oracle, private_key_hex)
+        for name, oracle in oracles.items()
+        if oracle.derives_public_key
+    }
+    if not public_keys:
+        raise ReferenceError(f"{label} has no public-key derivation oracle")
+    require_equal(label, *public_keys.values())
+    return public_keys
+
+
+def evaluate_acvp(profile: dict, oracles: dict[str, Oracle], source_cases: dict) -> None:
     for case in source_cases["keygen_cases"]:
         results = {
-            name: oracle_keygen(executable, case["seed_hex"])
-            for name, executable in oracles.items()
+            name: oracle_keygen(oracle, case["seed_hex"])
+            for name, oracle in oracles.items()
         }
         for result in results.values():
             require_equal(
@@ -808,15 +1079,22 @@ def evaluate_acvp(profile: dict, oracles: dict[str, Path], source_cases: dict) -
         )
 
     for case in source_cases["siggen_cases"]:
+        public_keys = derived_public_keys(
+            oracles,
+            case["private_key_hex"],
+            f"oracle siggen {case['test_case_id']} public key",
+        )
+        public_key = next(iter(public_keys.values()))
         results = {
             name: oracle_sign(
-                executable,
+                oracle,
                 case["private_key_hex"],
                 case["message_hex"],
                 case["context_hex"],
                 randomizer_hex=case["randomizer_hex"],
+                public_key_hex=public_key,
             )
-            for name, executable in oracles.items()
+            for name, oracle in oracles.items()
         }
         for result in results.values():
             signature_hash(result["signature"], profile["signature_bytes"])
@@ -829,17 +1107,9 @@ def evaluate_acvp(profile: dict, oracles: dict[str, Path], source_cases: dict) -
             f"oracle siggen {case['test_case_id']} signature",
             *(result["signature"] for result in results.values()),
         )
-        public_keys = {
-            name: oracle_public_key(executable, case["private_key_hex"])
-            for name, executable in oracles.items()
-        }
-        require_equal(
-            f"oracle siggen {case['test_case_id']} public key",
-            *public_keys.values(),
-        )
         require_verification(
             oracles,
-            next(iter(public_keys.values())),
+            public_key,
             case["message_hex"],
             case["context_hex"],
             case["signature_hex"],
@@ -860,11 +1130,11 @@ def evaluate_acvp(profile: dict, oracles: dict[str, Path], source_cases: dict) -
 
 
 def build_pqbtc_material(
-    profile: dict, oracles: dict[str, Path], vector: dict
+    profile: dict, oracles: dict[str, Oracle], vector: dict
 ) -> dict[str, str]:
     generated = {
-        name: oracle_keygen(executable, vector["seed_hex"])
-        for name, executable in oracles.items()
+        name: oracle_keygen(oracle, vector["seed_hex"])
+        for name, oracle in oracles.items()
     }
     require_equal("PQBTC public key bytes", *(result["pk"] for result in generated.values()))
     require_equal("PQBTC private key bytes", *(result["sk"] for result in generated.values()))
@@ -881,10 +1151,12 @@ def build_pqbtc_material(
     )
     require_hex(material["pk"], profile["public_key_bytes"], "PQBTC public key")
     require_hex(material["sk"], profile["private_key_bytes"], "PQBTC private key")
-    for name, executable in oracles.items():
+    for name, oracle in oracles.items():
+        if not oracle.derives_public_key:
+            continue
         require_equal(
             f"{name} derived PQBTC public key",
-            oracle_public_key(executable, material["sk"]),
+            oracle_public_key(oracle, material["sk"]),
             material["pk"],
         )
     return material
@@ -892,7 +1164,7 @@ def build_pqbtc_material(
 
 def evaluate_randomized_interoperability(
     profile: dict,
-    oracles: dict[str, Path],
+    oracles: dict[str, Oracle],
     vector: dict,
     private_key_hex: str,
     public_key_hex: str,
@@ -905,13 +1177,14 @@ def evaluate_randomized_interoperability(
     for index, randomizer_hex in enumerate(randomizers, start=1):
         results = {
             name: oracle_sign(
-                executable,
+                oracle,
                 private_key_hex,
                 vector["message_hex"],
                 vector["context_hex"],
                 randomizer_hex=randomizer_hex,
+                public_key_hex=public_key_hex,
             )
-            for name, executable in oracles.items()
+            for name, oracle in oracles.items()
         }
         require_equal(
             f"fixed-randomizer signature round {index}",
@@ -932,15 +1205,16 @@ def evaluate_randomized_interoperability(
     if fixed_signatures[0] == fixed_signatures[1]:
         raise ReferenceError("distinct fixed randomizers produced the same signature")
 
-    randomized_rounds = 0
-    for name, executable in oracles.items():
+    all_randomized_signatures = []
+    for name, oracle in oracles.items():
         signatures = [
             oracle_sign(
-                executable,
+                oracle,
                 private_key_hex,
                 vector["message_hex"],
                 vector["context_hex"],
                 randomized=True,
+                public_key_hex=public_key_hex,
             )["signature"]
             for _ in range(2)
         ]
@@ -957,16 +1231,18 @@ def evaluate_randomized_interoperability(
                 "1",
                 f"{name} randomized cross-verification round {index}",
             )
-            randomized_rounds += 1
+            all_randomized_signatures.append(signature_hex)
+    if len(set(all_randomized_signatures)) != len(all_randomized_signatures):
+        raise ReferenceError("randomized signing repeated a signature across oracles")
     return {
         "fixed_randomizer_rounds": len(fixed_signatures),
-        "default_randomized_rounds": randomized_rounds,
+        "default_randomized_rounds": len(all_randomized_signatures),
     }
 
 
 def evaluate_boundaries_and_mutations(
     profile: dict,
-    oracles: dict[str, Path],
+    oracles: dict[str, Oracle],
     vector: dict,
     private_key_hex: str,
     public_key_hex: str,
@@ -979,12 +1255,13 @@ def evaluate_boundaries_and_mutations(
     for label, message_hex, context_hex in boundary_cases:
         results = {
             name: oracle_sign(
-                executable,
+                oracle,
                 private_key_hex,
                 message_hex,
                 context_hex,
+                public_key_hex=public_key_hex,
             )
-            for name, executable in oracles.items()
+            for name, oracle in oracles.items()
         }
         require_equal(
             f"{label} signature bytes",
@@ -1098,33 +1375,35 @@ def evaluate_boundaries_and_mutations(
 
     oversized_context = "00" * 256
     malformed_commands = 0
-    for executable in oracles.values():
-        commands = (
-            [str(executable), "keygen", vector["seed_hex"][:-2]],
-            [str(executable), "keygen", vector["seed_hex"] + "00"],
-            [str(executable), "public-key", private_key_hex[:-2]],
-            [str(executable), "public-key", private_key_hex + "00"],
-            [str(executable), "sign", private_key_hex[:-2], message_hex, context_hex],
-            [str(executable), "sign", private_key_hex + "00", message_hex, context_hex],
-            [str(executable), "sign", private_key_hex, message_hex, oversized_context],
+    for oracle in oracles.values():
+        executable = str(oracle.executable)
+        sign_suffix = [public_key_hex] if oracle.sign_requires_public_key else []
+        commands = [
+            [executable, "keygen", vector["seed_hex"][:-2]],
+            [executable, "keygen", vector["seed_hex"] + "00"],
+            [executable, "sign", private_key_hex[:-2], message_hex, context_hex, *sign_suffix],
+            [executable, "sign", private_key_hex + "00", message_hex, context_hex, *sign_suffix],
+            [executable, "sign", private_key_hex, message_hex, oversized_context, *sign_suffix],
             [
-                str(executable),
+                executable,
                 "sign-with-randomizer",
                 private_key_hex,
                 message_hex,
                 context_hex,
                 "00" * 31,
+                *sign_suffix,
             ],
             [
-                str(executable),
+                executable,
                 "sign-with-randomizer",
                 private_key_hex,
                 message_hex,
                 context_hex,
                 "00" * 33,
+                *sign_suffix,
             ],
             [
-                str(executable),
+                executable,
                 "verify",
                 public_key_hex[:-2],
                 message_hex,
@@ -1132,7 +1411,7 @@ def evaluate_boundaries_and_mutations(
                 deterministic_signature_hex,
             ],
             [
-                str(executable),
+                executable,
                 "verify",
                 public_key_hex + "00",
                 message_hex,
@@ -1140,16 +1419,25 @@ def evaluate_boundaries_and_mutations(
                 deterministic_signature_hex,
             ],
             [
-                str(executable),
+                executable,
                 "verify",
                 public_key_hex,
                 message_hex,
                 oversized_context,
                 deterministic_signature_hex,
             ],
-        )
+        ]
+        if oracle.derives_public_key:
+            commands.extend(
+                (
+                    [executable, "public-key", private_key_hex[:-2]],
+                    [executable, "public-key", private_key_hex + "00"],
+                )
+            )
         for index, command in enumerate(commands, start=1):
-            require_command_failure(command, f"{executable.name} malformed input {index}")
+            require_command_failure(
+                command, f"{oracle.executable.name} malformed input {index}"
+            )
             malformed_commands += 1
     return {
         "boundary_cases": len(boundary_cases),
@@ -1164,7 +1452,7 @@ def median_ms(values: list[int]) -> float:
 
 def benchmark_profile(
     profile: dict,
-    oracles: dict[str, Path],
+    oracles: dict[str, Oracle],
     vector: dict,
     iterations: int,
 ) -> dict:
@@ -1180,13 +1468,14 @@ def benchmark_profile(
     }
     for _ in range(iterations):
         deterministic_signatures = []
-        for name, executable in oracles.items():
-            generated = oracle_keygen(executable, vector["seed_hex"])
+        for name, oracle in oracles.items():
+            generated = oracle_keygen(oracle, vector["seed_hex"])
             deterministic = oracle_sign(
-                executable,
+                oracle,
                 generated["sk"],
                 vector["message_hex"],
                 vector["context_hex"],
+                public_key_hex=generated["pk"],
             )
             require_equal(
                 "PQBTC deterministic signature hash",
@@ -1194,11 +1483,12 @@ def benchmark_profile(
                 vector["expected_signature_sha256"],
             )
             randomized = oracle_sign(
-                executable,
+                oracle,
                 generated["sk"],
                 vector["message_hex"],
                 vector["context_hex"],
                 randomized=True,
+                public_key_hex=generated["pk"],
             )
             require_verification(
                 oracles,
@@ -1235,17 +1525,18 @@ def benchmark_profile(
 
 
 def evaluate_sanitized_smoke(
-    profile: dict, oracles: dict[str, Path], vector: dict
+    profile: dict, oracles: dict[str, Oracle], vector: dict
 ) -> dict:
     material = build_pqbtc_material(profile, oracles, vector)
     deterministic = {
         name: oracle_sign(
-            executable,
+            oracle,
             material["sk"],
             vector["message_hex"],
             vector["context_hex"],
+            public_key_hex=material["pk"],
         )["signature"]
-        for name, executable in oracles.items()
+        for name, oracle in oracles.items()
     }
     require_equal("sanitized deterministic signatures", *deterministic.values())
     return evaluate_boundaries_and_mutations(
@@ -1256,6 +1547,59 @@ def evaluate_sanitized_smoke(
         material["pk"],
         next(iter(deterministic.values())),
     )
+
+
+def libcrux_malformed_hint_signature(profile: dict, final_counter: int) -> str:
+    if profile["name"] != "ML-DSA-44" or profile["signature_bytes"] != 2420:
+        raise ReferenceError("libcrux malformed-hint regression requires ML-DSA-44")
+    if final_counter not in {81, 85}:
+        raise ReferenceError("libcrux malformed-hint final counter must be 81 or 85")
+
+    signature = bytearray(profile["signature_bytes"])
+    hint_offset = 32 + 4 * 576
+    signature[hint_offset : hint_offset + 21] = bytes(range(1, 22))
+    signature[hint_offset + 21 : hint_offset + 42] = bytes(range(1, 22))
+    signature[hint_offset + 42 : hint_offset + 63] = bytes(range(1, 22))
+    signature[hint_offset + 63 : hint_offset + 80] = bytes(range(1, 18))
+    signature[hint_offset + 80 : hint_offset + 84] = bytes(
+        (21, 42, 63, final_counter)
+    )
+    return signature.hex()
+
+
+def evaluate_libcrux_advisory_regressions(
+    profile: dict,
+    oracles: dict[str, Oracle],
+    public_key_hex: str,
+    message_hex: str,
+    context_hex: str,
+    upstream_report: dict,
+) -> dict:
+    expected_advisories = {"RUSTSEC-2026-0076", "RUSTSEC-2026-0077"}
+    if set(upstream_report) != expected_advisories or any(
+        result.get("status") != "PASS" for result in upstream_report.values()
+    ):
+        raise ReferenceError("libcrux upstream security regressions did not pass")
+
+    malformed_hint_cases = {
+        "bounded_counter_overflow": libcrux_malformed_hint_signature(profile, 81),
+        "historical_out_of_bounds_counter": libcrux_malformed_hint_signature(profile, 85),
+    }
+    for label, signature_hex in malformed_hint_cases.items():
+        require_verification(
+            oracles,
+            public_key_hex,
+            message_hex,
+            context_hex,
+            signature_hex,
+            "0",
+            f"libcrux {label} rejection",
+        )
+    return {
+        "upstream_release_tests": upstream_report,
+        "ml_dsa_44_malformed_hint_rejections": len(malformed_hint_cases),
+        "no_panic": "PASS",
+    }
 
 
 def block_space_model(profile: dict, cost: dict) -> dict:
@@ -1295,10 +1639,11 @@ def block_space_model(profile: dict, cost: dict) -> dict:
 
 def evaluate(
     manifest: dict,
-    oracles: dict[str, Path],
+    oracles: dict[str, Oracle],
     source_cases: dict,
     benchmark_iterations: int,
     sanitized_report: dict | None,
+    libcrux_upstream_report: dict,
 ) -> dict:
     profile = manifest["profile"]
     vector = manifest["vectors"]["pqbtc_sighash_v1"]
@@ -1307,12 +1652,13 @@ def evaluate(
 
     deterministic = {
         name: oracle_sign(
-            executable,
+            oracle,
             material["sk"],
             vector["message_hex"],
             vector["context_hex"],
+            public_key_hex=material["pk"],
         )["signature"]
-        for name, executable in oracles.items()
+        for name, oracle in oracles.items()
     }
     require_equal("PQBTC deterministic signature bytes", *deterministic.values())
     deterministic_signature = next(iter(deterministic.values()))
@@ -1332,6 +1678,14 @@ def evaluate(
         material["pk"],
         deterministic_signature,
     )
+    advisory_report = evaluate_libcrux_advisory_regressions(
+        profile,
+        oracles,
+        material["pk"],
+        vector["message_hex"],
+        vector["context_hex"],
+        libcrux_upstream_report,
+    )
     benchmark = benchmark_profile(
         profile, oracles, vector, benchmark_iterations
     )
@@ -1342,6 +1696,8 @@ def evaluate(
         "openssl_version": version_text,
         "openssl_commit": manifest["sources"]["openssl"]["commit"],
         "mldsa_native_commit": manifest["sources"]["mldsa_native"]["commit"],
+        "libcrux_commit": manifest["sources"]["libcrux"]["commit"],
+        "libcrux_version": manifest["sources"]["libcrux"]["version"],
         "checks": {
             "fips204_and_update_artifact_provenance": "PASS",
             "nist_source_provenance": "PASS",
@@ -1352,6 +1708,8 @@ def evaluate(
             "full_signature_byte_agreement": "PASS",
             "randomized_interoperability": "PASS",
             "boundary_and_mutation_rejection": "PASS",
+            "libcrux_source_and_crate_provenance": "PASS",
+            "libcrux_disclosed_advisory_regressions": "PASS",
             "adapter_asan_ubsan": "PASS" if sanitized_report is not None else "NOT_RUN",
         },
         "acvp": {
@@ -1362,6 +1720,7 @@ def evaluate(
         },
         "randomized_interoperability": randomized_report,
         "negative_testing": negative_report,
+        "libcrux_advisory_regressions": advisory_report,
         "sanitized_smoke": sanitized_report,
         "signature_sha256": {
             "nist_deterministic": manifest["vectors"]["nist_siggen_tg1_tc1"][
@@ -1372,7 +1731,10 @@ def evaluate(
             ],
             "pqbtc": vector["expected_signature_sha256"],
         },
-        "lineage_limit": manifest["sources"]["mldsa_native"]["lineage_limit"],
+        "lineage": {
+            "mldsa_native": manifest["sources"]["mldsa_native"]["lineage_limit"],
+            "libcrux": manifest["sources"]["libcrux"]["independence_assessment"],
+        },
         "block_space_model": block_space_model(profile, manifest["system_cost_model"]),
         "benchmark": benchmark,
     }
@@ -1402,6 +1764,18 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=optional_path("OPENSSL_SOURCE_DIR"),
         help="path to the pinned OpenSSL source checkout",
+    )
+    parser.add_argument(
+        "--libcrux-source",
+        type=Path,
+        default=optional_path("LIBCRUX_SOURCE_DIR"),
+        help="path to the full-history pinned celabshq/libcrux checkout",
+    )
+    parser.add_argument(
+        "--libcrux-crate",
+        type=Path,
+        default=optional_path("LIBCRUX_CRATE_PATH"),
+        help="path to the pinned libcrux-ml-dsa 0.0.10 crate archive",
     )
     parser.add_argument(
         "--fips204",
@@ -1435,7 +1809,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sanitizers",
         action="store_true",
-        help="also build and exercise both adapters with ASan and UBSan",
+        help="also build and exercise both portable-C adapters with ASan and UBSan",
     )
     return parser.parse_args()
 
@@ -1459,6 +1833,8 @@ def main() -> int:
         acvp_server = require_path(args.acvp_server, "--acvp-server")
         mldsa_native = require_path(args.mldsa_native, "--mldsa-native")
         openssl_source = require_path(args.openssl_source, "--openssl-source")
+        libcrux_source = require_path(args.libcrux_source, "--libcrux-source")
+        libcrux_crate = require_path(args.libcrux_crate, "--libcrux-crate")
         fips204 = require_path(args.fips204, "--fips204")
         fips204_updates = require_path(args.fips204_updates, "--fips204-updates")
         section6_guidance = require_path(
@@ -1482,28 +1858,50 @@ def main() -> int:
         require_mldsa_native_source(
             mldsa_native, sources["mldsa_native"]["commit"]
         )
+        require_libcrux_source(libcrux_source, sources["libcrux"])
 
         with tempfile.TemporaryDirectory(prefix="pqbtc-ml-dsa-") as temporary:
             build_dir = Path(temporary)
+            libcrux_crate_dir = prepare_libcrux_crate(
+                build_dir, libcrux_crate, sources["libcrux"]
+            )
+            libcrux_upstream_report = run_libcrux_security_regressions(
+                build_dir, libcrux_crate_dir
+            )
             oracles = {
-                "openssl": compile_openssl_oracle(
-                    build_dir, sources["openssl"]["version"]
+                "openssl": Oracle(
+                    compile_openssl_oracle(
+                        build_dir, sources["openssl"]["version"]
+                    )
                 ),
-                "mldsa_native": compile_mldsa_native_oracle(
-                    build_dir, mldsa_native, sources["mldsa_native"]["commit"]
+                "mldsa_native": Oracle(
+                    compile_mldsa_native_oracle(
+                        build_dir, mldsa_native, sources["mldsa_native"]["commit"]
+                    )
+                ),
+                "libcrux": Oracle(
+                    compile_libcrux_oracle(build_dir, libcrux_crate_dir),
+                    derives_public_key=False,
+                    sign_requires_public_key=True,
                 ),
             }
             sanitized_report = None
             if args.sanitizers:
                 sanitized_oracles = {
-                    "openssl": compile_openssl_oracle(
-                        build_dir, sources["openssl"]["version"], sanitized=True
+                    "openssl": Oracle(
+                        compile_openssl_oracle(
+                            build_dir,
+                            sources["openssl"]["version"],
+                            sanitized=True,
+                        )
                     ),
-                    "mldsa_native": compile_mldsa_native_oracle(
-                        build_dir,
-                        mldsa_native,
-                        sources["mldsa_native"]["commit"],
-                        sanitized=True,
+                    "mldsa_native": Oracle(
+                        compile_mldsa_native_oracle(
+                            build_dir,
+                            mldsa_native,
+                            sources["mldsa_native"]["commit"],
+                            sanitized=True,
+                        )
                     ),
                 }
                 sanitized_report = evaluate_sanitized_smoke(
@@ -1517,6 +1915,7 @@ def main() -> int:
                 source_cases,
                 args.benchmark_iterations,
                 sanitized_report,
+                libcrux_upstream_report,
             )
         print(json.dumps(report, indent=2, sort_keys=True))
         return 0

--- a/contrib/ml-dsa-ref/libcrux_oracle.rs
+++ b/contrib/ml-dsa-ref/libcrux_oracle.rs
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+use libcrux_ml_dsa::ml_dsa_44::{
+    portable, MLDSA44Signature, MLDSA44SigningKey, MLDSA44VerificationKey,
+};
+use std::env;
+use std::fs::File;
+use std::io::Read;
+use std::process::ExitCode;
+use std::time::Instant;
+
+const KEYGEN_SEED_SIZE: usize = 32;
+const PRIVATE_KEY_SIZE: usize = 2560;
+const PUBLIC_KEY_SIZE: usize = 1312;
+const RANDOMIZER_SIZE: usize = 32;
+const SIGNATURE_SIZE: usize = 2420;
+
+fn decode_hex(value: &str) -> Result<Vec<u8>, String> {
+    if !value.len().is_multiple_of(2) {
+        return Err("hex input has odd length".to_owned());
+    }
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let text = std::str::from_utf8(pair).map_err(|_| "hex input is not ASCII")?;
+            u8::from_str_radix(text, 16).map_err(|_| "hex input contains a non-hex digit")
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(str::to_owned)
+}
+
+fn decode_array<const SIZE: usize>(value: &str, label: &str) -> Result<[u8; SIZE], String> {
+    let decoded = decode_hex(value)?;
+    decoded
+        .try_into()
+        .map_err(|_| format!("{label} must be {SIZE} bytes"))
+}
+
+fn print_hex(name: &str, value: &[u8]) {
+    print!("{name}=");
+    for byte in value {
+        print!("{byte:02x}");
+    }
+    println!();
+}
+
+fn randomizer() -> Result<[u8; RANDOMIZER_SIZE], String> {
+    let mut output = [0u8; RANDOMIZER_SIZE];
+    File::open("/dev/urandom")
+        .and_then(|mut source| source.read_exact(&mut output))
+        .map_err(|error| format!("randomizer generation failed: {error}"))?;
+    Ok(output)
+}
+
+fn run_keygen(seed_hex: &str) -> Result<(), String> {
+    let seed = decode_array::<KEYGEN_SEED_SIZE>(seed_hex, "key-generation seed")?;
+    let started = Instant::now();
+    let key_pair = portable::generate_key_pair(seed);
+    let keygen_ns = started.elapsed().as_nanos();
+
+    print_hex("pk", key_pair.verification_key.as_ref());
+    print_hex("sk", key_pair.signing_key.as_ref());
+    println!("keygen_ns={keygen_ns}");
+    Ok(())
+}
+
+fn run_sign(
+    private_key_hex: &str,
+    message_hex: &str,
+    context_hex: &str,
+    public_key_hex: &str,
+    fixed_randomizer_hex: Option<&str>,
+    randomized: bool,
+) -> Result<(), String> {
+    let private_key = MLDSA44SigningKey::new(decode_array::<PRIVATE_KEY_SIZE>(
+        private_key_hex,
+        "private key",
+    )?);
+    let public_key = MLDSA44VerificationKey::new(decode_array::<PUBLIC_KEY_SIZE>(
+        public_key_hex,
+        "public key",
+    )?);
+    let message = decode_hex(message_hex)?;
+    let context = decode_hex(context_hex)?;
+    if context.len() > 255 {
+        return Err("context must not exceed 255 bytes".to_owned());
+    }
+    let signing_randomizer = match (fixed_randomizer_hex, randomized) {
+        (Some(_), true) => return Err("fixed and random signing modes conflict".to_owned()),
+        (Some(value), false) => decode_array::<RANDOMIZER_SIZE>(value, "randomizer")?,
+        (None, true) => randomizer()?,
+        (None, false) => [0u8; RANDOMIZER_SIZE],
+    };
+
+    let sign_started = Instant::now();
+    let signature = portable::sign(&private_key, &message, &context, signing_randomizer)
+        .map_err(|error| format!("signing failed: {error:?}"))?;
+    let sign_ns = sign_started.elapsed().as_nanos();
+    let verify_started = Instant::now();
+    portable::verify(&public_key, &message, &context, &signature)
+        .map_err(|error| format!("generated signature did not verify: {error:?}"))?;
+    let verify_ns = verify_started.elapsed().as_nanos();
+
+    print_hex("signature", signature.as_ref());
+    println!("verified=1");
+    println!("sign_ns={sign_ns}");
+    println!("verify_ns={verify_ns}");
+    Ok(())
+}
+
+fn run_verify(
+    public_key_hex: &str,
+    message_hex: &str,
+    context_hex: &str,
+    signature_hex: &str,
+) -> Result<(), String> {
+    let public_key = MLDSA44VerificationKey::new(decode_array::<PUBLIC_KEY_SIZE>(
+        public_key_hex,
+        "public key",
+    )?);
+    let message = decode_hex(message_hex)?;
+    let context = decode_hex(context_hex)?;
+    if context.len() > 255 {
+        return Err("context must not exceed 255 bytes".to_owned());
+    }
+    let signature_bytes = decode_hex(signature_hex)?;
+    if signature_bytes.len() != SIGNATURE_SIZE {
+        println!("verified=0");
+        println!("verify_ns=0");
+        return Ok(());
+    }
+    let signature = MLDSA44Signature::new(
+        signature_bytes
+            .try_into()
+            .map_err(|_| "signature must be 2420 bytes")?,
+    );
+
+    let verify_started = Instant::now();
+    let verified = portable::verify(&public_key, &message, &context, &signature).is_ok();
+    let verify_ns = verify_started.elapsed().as_nanos();
+    println!("verified={}", u8::from(verified));
+    println!("verify_ns={verify_ns}");
+    Ok(())
+}
+
+fn usage(program: &str) {
+    eprintln!("usage: {program} keygen <seed-hex>");
+    eprintln!("       {program} sign <sk-hex> <message-hex> <context-hex> <pk-hex>");
+    eprintln!("       {program} sign-randomized <sk-hex> <message-hex> <context-hex> <pk-hex>");
+    eprintln!(
+        "       {program} sign-with-randomizer <sk-hex> <message-hex> <context-hex> <randomizer-hex> <pk-hex>"
+    );
+    eprintln!("       {program} verify <pk-hex> <message-hex> <context-hex> <signature-hex>");
+}
+
+fn main() -> ExitCode {
+    let arguments: Vec<String> = env::args().collect();
+    let result = match arguments.as_slice() {
+        [_, command, seed] if command == "keygen" => run_keygen(seed),
+        [_, command, private_key, message, context, public_key] if command == "sign" => {
+            run_sign(private_key, message, context, public_key, None, false)
+        }
+        [_, command, private_key, message, context, public_key] if command == "sign-randomized" => {
+            run_sign(private_key, message, context, public_key, None, true)
+        }
+        [_, command, private_key, message, context, randomizer, public_key]
+            if command == "sign-with-randomizer" =>
+        {
+            run_sign(
+                private_key,
+                message,
+                context,
+                public_key,
+                Some(randomizer),
+                false,
+            )
+        }
+        [_, command, public_key, message, context, signature] if command == "verify" => {
+            run_verify(public_key, message, context, signature)
+        }
+        _ => {
+            usage(arguments.first().map_or("libcrux_oracle", String::as_str));
+            return ExitCode::from(2);
+        }
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("libcrux_oracle: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/contrib/ml-dsa-ref/vectors.json
+++ b/contrib/ml-dsa-ref/vectors.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "profile": {
     "name": "ML-DSA-44",
     "standard": "FIPS 204",
@@ -97,6 +97,40 @@
       "license_expression": "Apache-2.0 OR ISC OR MIT",
       "role": "portable-C prototype oracle; not vendored or linked into the node",
       "lineage_limit": "mldsa-native is forked from the pq-crystals reference implementation; agreement with OpenSSL is strong differential evidence but not independent cryptographic review"
+    },
+    "libcrux": {
+      "repository": "https://github.com/celabshq/libcrux",
+      "commit": "c5fb80f37530ee9b2df9501ae5ff8cb4a973a4bd",
+      "tag": "libcrux-ml-dsa-v0.0.10",
+      "tag_object": "255922337dee37aa32b21dbed27785f535de0336",
+      "version": "0.0.10",
+      "published": "2026-07-16",
+      "git_tree": "0044b70c4675ba97623c9105387f592e038e837d",
+      "initial_implementation_commit": "3f14979a2b30c43572bd81fae64cc4743943b5da",
+      "crate_url": "https://static.crates.io/crates/libcrux-ml-dsa/libcrux-ml-dsa-0.0.10.crate",
+      "crate_sha256": "783ebed7cb27de6d44ef2aa662648d1a0869694f2f754f2f1ed45e959ef3b48e",
+      "license_expression": "Apache-2.0",
+      "implementation": "portable Rust ML-DSA-44 path",
+      "role": "research-only independent implementation oracle; neither vendored nor linked into the node",
+      "verification_scope": "portable and AVX2 field arithmetic, NTT polynomial arithmetic, and serialization are formally verified; the complete high-level implementation, compiler output, and side-channel behavior are not",
+      "independence_assessment": {
+        "outcome": "separate_implementation_lineage_with_reference_influence",
+        "normal_pqclean_or_pq_crystals_dependency": false,
+        "basis": "direct Rust implementation history begins at the pinned May 2024 commit; the resolved normal dependency graph does not include PQClean, pq-crystals, mldsa-native, or pqcrypto-mldsa",
+        "limit": "unit-test outputs and selected sampling/optimization comments cite PQ-Crystals; this is independent implementation evidence, not independent design, external cryptographic review, or production approval"
+      },
+      "fixed_advisories": {
+        "RUSTSEC-2026-0076": {
+          "ghsa": "GHSA-xrf2-5r3p-5wgj",
+          "fixed_in": "0.0.8",
+          "upstream_test": "bad_hint_out_of_bounds"
+        },
+        "RUSTSEC-2026-0077": {
+          "ghsa": "GHSA-cp57-fq8g-qh6v",
+          "fixed_in": "0.0.8",
+          "upstream_test": "mask_exceeds_norm"
+        }
+      }
     }
   },
   "vectors": {

--- a/docs/ML_DSA_44_REFERENCE.md
+++ b/docs/ML_DSA_44_REFERENCE.md
@@ -1,8 +1,8 @@
 # ML-DSA-44 Reference Comparator
 
 ## Status: REFERENCE ONLY - NOT CONSENSUS
-## Spec-ID: ML-DSA-44-REFERENCE-v1
-## Updated: 2026-07-18
+## Spec-ID: ML-DSA-44-REFERENCE-v2
+## Updated: 2026-07-19
 ## Consensus-Relevant: NO
 
 ## Decision Boundary
@@ -76,6 +76,13 @@ streaming design must specify and validate the `mu` trust boundary separately.
   `aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f`
 - `mldsa-native` `v1.0.0-beta2` commit
   `9b0ee84f4cf399043eca59eca4e5f8531ca1d61b`
+- `libcrux-ml-dsa` `v0.0.10` commit
+  `c5fb80f37530ee9b2df9501ae5ff8cb4a973a4bd`, annotated tag object
+  `255922337dee37aa32b21dbed27785f535de0336`, and ML-DSA subtree
+  `0044b70c4675ba97623c9105387f592e038e837d`
+- crates.io archive
+  `libcrux-ml-dsa-0.0.10.crate`, SHA256
+  `783ebed7cb27de6d44ef2aa662648d1a0869694f2f754f2f1ed45e959ef3b48e`
 - one repo-defined 32-byte sighash/context interoperability vector
 
 Representative signature hashes are:
@@ -86,24 +93,40 @@ Representative signature hashes are:
 | NIST randomized siggen group 13 case 181 | `8a17b6ff3f9633cd3c7cd0687d6384408e145bfd3725f6c57a8a2727f50ec989` |
 | PQBTC prototype deterministic signature | `98094b39d9ae1ad76fc734f9e0199ad37315dd4eb7a22f29561582239f64e131` |
 
-The driver builds two adapters in a temporary directory. OpenSSL imports the
+The driver builds three adapters in temporary directories. OpenSSL imports the
 expanded private key and derives its public key through the provider; it does
 not assume the public key is a suffix of the ML-DSA private key.
-`mldsa-native` uses `mldsa_pk_from_sk` and the exact FIPS prefix. Both reproduce
-all selected NIST bytes, derive the same keys, cross-verify every generated
-signature, and agree byte-for-byte when given the same explicit `rnd`.
+`mldsa-native` uses `mldsa_pk_from_sk` and the exact FIPS prefix. The libcrux
+adapter uses its portable Rust ML-DSA-44 path. Its public API does not derive a
+verification key from an imported expanded signing key, so the driver first
+requires OpenSSL and `mldsa-native` to agree on that key and then supplies it
+to libcrux for signing self-verification. All three reproduce the selected
+NIST bytes, cross-verify every generated signature, and agree byte-for-byte
+when given the same explicit `rnd`.
 
-Each native randomized API is also exercised twice. All four signatures are
-distinct and accepted by both verifiers. Deterministic signing is retained for
+Each randomized API is exercised twice. All six signatures are distinct and
+accepted by all three verifiers. Deterministic signing is retained for
 reproducible evidence only; any production proposal must preserve the hedged
 randomized posture and define entropy-failure behavior. The research-only
-`mldsa-native` adapter obtains those test bytes from POSIX `/dev/urandom`; that
-wrapper is not a node entropy design and limits the full harness to macOS/Linux.
+`mldsa-native` and libcrux adapters obtain their test bytes from POSIX
+`/dev/urandom`; those wrappers are not a node entropy design and limit the full
+harness to macOS/Linux.
 
 `mldsa-native` is a fork of the `pq-crystals` reference implementation. It is a
 separate portable-C code path from OpenSSL, so agreement is meaningful
 differential evidence. Its ancestry still limits independence, and this result
 must not be described as independent cryptographic review.
+
+libcrux has a separate direct-Rust implementation history beginning at the
+pinned May 2024 commit, and its normal crate dependency graph does not include
+PQClean, `pq-crystals`, `mldsa-native`, or `pqcrypto-mldsa`. Its unit-test
+outputs and selected sampling/optimization comments cite PQ-Crystals. The
+frozen assessment is
+`separate_implementation_lineage_with_reference_influence`: this is independent
+implementation evidence, not independent design, external cryptographic
+review, or production approval. The harness also reruns the upstream
+regressions for `RUSTSEC-2026-0076` and `RUSTSEC-2026-0077` and adds two
+ML-DSA-44 malformed-hint rejections, including the old out-of-bounds shape.
 
 Run:
 
@@ -113,6 +136,8 @@ python3 contrib/ml-dsa-ref/compare_oracles.py \
   --acvp-server /path/to/pinned/ACVP-Server \
   --openssl-source /path/to/pinned/openssl \
   --mldsa-native /path/to/pinned/mldsa-native \
+  --libcrux-source /path/to/full-history/pinned/libcrux \
+  --libcrux-crate /path/to/libcrux-ml-dsa-0.0.10.crate \
   --fips204 /path/to/NIST.FIPS.204.pdf \
   --fips204-updates /path/to/fips-204-potential-updates.xlsx \
   --fips204-section6-guidance /path/to/fips204-sec6-03192025.pdf \
@@ -120,23 +145,27 @@ python3 contrib/ml-dsa-ref/compare_oracles.py \
   --sanitizers
 ```
 
-The full run requires clean source checkouts at the exact pinned commits. The
+The full run requires clean source checkouts at the exact pinned commits, a
+full-history libcrux checkout for its ancestry check, the exact pinned libcrux
+crate archive, and Rust/Cargo access to the crate's locked dependencies. The
 installed OpenSSL CLI and `pkg-config` library must both report 3.6.3. The
-adapter links that installed library; the source checkout establishes review
-provenance and is not compiled by the harness.
+OpenSSL adapter links that installed library; its source checkout establishes
+review provenance and is not compiled by the harness.
 
 ## Prototype Measurements
 
-Local arm64 macOS measurement on 2026-07-18, using OpenSSL 3.6.3 and the pinned
-portable-C oracle compiled with `-O2`. Values are medians of ten repetitions
-of the fixed PQBTC vector and are directional, not release envelopes. They
-time the adapter's cryptographic calls and exclude compilation, process
-startup, cross-verification, and OpenSSL context initialization.
+Local arm64 macOS measurement on 2026-07-19, using OpenSSL 3.6.3, the pinned
+portable-C oracle compiled with `-O2`, and the pinned portable-Rust libcrux
+oracle compiled in release mode. Values are medians of ten repetitions of the
+fixed PQBTC vector and are directional, not release envelopes. They time the
+adapter's cryptographic calls and exclude compilation, process startup,
+cross-verification, and OpenSSL context initialization.
 
 | Oracle | Keygen | Deterministic sign | Deterministic verify | Randomized sign | Randomized verify |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| OpenSSL 3.6.3 | 0.099 ms | 0.157 ms | 0.092 ms | 0.752 ms | 0.052 ms |
-| `mldsa-native` | 0.029 ms | 0.102 ms | 0.029 ms | 0.324 ms | 0.029 ms |
+| OpenSSL 3.6.3 | 0.151 ms | 0.353 ms | 0.137 ms | 0.609 ms | 0.086 ms |
+| `mldsa-native` | 0.031 ms | 0.165 ms | 0.065 ms | 0.237 ms | 0.030 ms |
+| libcrux 0.0.10 | 0.096 ms | 0.197 ms | 0.068 ms | 0.219 ms | 0.030 ms |
 
 The timing spread between deterministic and randomized calls includes random
 generation and variable rejection-sampling work. Supported-platform,
@@ -174,31 +203,36 @@ required before selection.
 Established:
 
 1. the exact final-standard ML-DSA-44 external/pure profile is frozen
-2. all 70 applicable selected-profile ACVP cases pass both codebases
+2. all 70 applicable selected-profile ACVP cases pass all three codebases
 3. deterministic and fixed-randomizer key/signature outputs agree byte-for-byte
-4. native randomized outputs are distinct and cross-verify in both directions
+4. randomized outputs are distinct and cross-verify across all three oracles
 5. empty/maximum context, malformed lengths, and 12 cryptographic mutations
    have explicit outcomes
-6. both adapters pass the bounded ASan/UBSan exercise
-7. the candidate has a reproducible ten-run performance and raw-payload model
+6. both portable-C adapters pass the bounded ASan/UBSan exercise
+7. the pinned libcrux release passes both disclosed advisory regressions and
+   the two repo-level malformed-hint rejections without panic
+8. a separate implementation lineage agrees with the full comparator contract
+9. the candidate has a reproducible ten-run performance and raw-payload model
 
 Not established:
 
 1. a production-quality consensus implementation
-2. fully independent implementation ancestry or external cryptographic review
+2. independent design or external cryptographic review
 3. constant-time signing, adequate secret erasure, or fault-attack resistance
-4. exhaustive fuzzing or sanitizer coverage of the linked OpenSSL library
+4. exhaustive fuzzing or sanitizer coverage of the linked OpenSSL and Rust
+   libraries
 5. acceptable wallet, descriptor, PSBT, hardware-signer, fee, or block behavior
 6. an activation, migration, public-key commitment, or algorithm-agility design
 
 ## Next Gate
 
-Produce a measured candidate-selection memo comparing this baseline with
-`SLH_DSA_SHA2_128S_REFERENCE.md`. The memo must evaluate security assumptions,
-implementation maturity and lineage, key/signature economics, signer and
-verifier behavior, wallet/backup impact, and reviewability. It may select a
-candidate for a separate engineering proposal or retain `HOLD`.
+Package this frozen profile, provenance record, complete three-oracle report,
+and remaining-risk statement for external cryptographic review. That review
+must cover the selected mode, randomization, rejection sampling, malformed
+keys and hints, side channels, fault behavior, secret erasure, and key
+derivation. Supported-platform and worst-case system measurements remain a
+separate gate after review intake.
 
 No candidate enters `src/crypto`, Script, wallet activation, or the `ALG_ID`
-registry before that selection, an explicit consensus design, and external
-cryptographic review.
+registry before external review, worst-case measurement, and a later explicit
+consensus design.

--- a/docs/PQSIG_CANDIDATE_SELECTION.md
+++ b/docs/PQSIG_CANDIDATE_SELECTION.md
@@ -3,6 +3,7 @@
 ## Status: ML_DSA_44_ENGINEERING_CANDIDATE - RELEASE_HOLD
 ## Spec-ID: PQSIG-CANDIDATE-SELECTION-v1
 ## Decided: 2026-07-18
+## Evidence-Updated: 2026-07-19
 ## Consensus-Relevant: NO
 
 ## Decision
@@ -143,15 +144,23 @@ worst-case, adversarial-input, and full-block measurements remain required.
 
 - The SLH-DSA harness compares OpenSSL with an independently developed
   portable implementation.
-- The ML-DSA harness compares separate codebases, but `mldsa-native` descends
-  from the `pq-crystals` reference implementation. Its agreement with OpenSSL
-  is strong differential evidence, not fully independent implementation
-  evidence or external review.
+- The ML-DSA harness now compares OpenSSL, `mldsa-native`, and libcrux.
+  `mldsa-native` descends from the `pq-crystals` reference implementation.
+  libcrux has a separate direct-Rust implementation history and no normal
+  PQClean, `pq-crystals`, `mldsa-native`, or `pqcrypto-mldsa` dependency,
+  while its tests and selected implementation comments disclose PQ-Crystals
+  influence.
+- The frozen libcrux assessment is
+  `separate_implementation_lineage_with_reference_influence`. Complete
+  three-oracle byte agreement and cross-verification close the independent
+  implementation evidence gate, but do not constitute independent design or
+  external cryptographic review.
 - Both candidates require a production implementation selected for auditability
   rather than a host OpenSSL consensus dependency.
 
-SLH-DSA therefore leads on current implementation-independence evidence.
-ML-DSA does not advance to consensus work until that gap is closed.
+ML-DSA still does not advance to consensus work. The next gate is external
+specialist review, followed by supported-platform and worst-case system
+measurements.
 
 ### Signing, Entropy, And Side Channels
 
@@ -206,15 +215,13 @@ ML-DSA-44 is selected for engineering work because:
 5. the remaining ML-DSA risks are concrete gates that can be tested and
    reviewed before consensus integration
 
-SLH-DSA-SHA2-128s remains the fallback because its hash-based assumptions,
-compact keys, and stronger current implementation-independence evidence are
-valuable if ML-DSA fails review. Its signature size and signing cost make it a
-weaker first engineering fit for PQBTC.
+SLH-DSA-SHA2-128s remains the fallback because its hash-based assumptions and
+compact keys are valuable if ML-DSA fails review. Its signature size and
+signing cost make it a weaker first engineering fit for PQBTC.
 
 Selecting a primary engineering candidate is preferable to an undirected
-`HOLD`: it focuses independent implementation, audit, benchmarking, and
-protocol-design work. Production nevertheless remains on `HOLD` until all
-readiness gates pass.
+`HOLD`: it focuses external review, benchmarking, and protocol-design work.
+Production nevertheless remains on `HOLD` until all readiness gates pass.
 
 ## Rejection And Fallback Criteria
 
@@ -231,19 +238,30 @@ if any of these occur:
 5. no strict transaction, wallet, backup, and hardware-signer design can meet
    the project's usability and resource constraints
 
+## Independent Implementation Evidence
+
+Completed on 2026-07-19:
+
+1. pin libcrux 0.0.10 source, tag, subtree, initial implementation commit, and
+   exact crates.io archive
+2. require all 70 selected-profile ACVP cases, exact signature-byte agreement,
+   randomized cross-verification, malformed-input rejection, and the repo
+   vector to pass OpenSSL, `mldsa-native`, and libcrux
+3. rerun the two disclosed libcrux advisory regressions and two ML-DSA-44
+   malformed-hint rejection cases without panic
+4. record the qualified lineage assessment rather than claiming independent
+   design or external review
+
 ## Next Gates
 
-The next work is evidence acquisition, not node integration:
+The next work remains evidence acquisition, not node integration:
 
-1. add a genuinely independent ML-DSA implementation that does not descend
-   from the same reference lineage and require exact-vector and
-   cross-verification agreement
-2. obtain external cryptographic review covering the selected mode,
+1. obtain external cryptographic review covering the selected mode,
    randomization, rejection sampling, side channels, fault behavior, secret
    erasure, and key derivation
-3. measure supported-platform and worst-case signer, verifier, malformed-input,
+2. measure supported-platform and worst-case signer, verifier, malformed-input,
    multi-input transaction, and full-block costs
-4. only after those gates, write a separate consensus-design specification for
+3. only after those gates, write a separate consensus-design specification for
    canonical key commitment, reveal, context, sighash, Script limits, policy,
    activation, and algorithm binding
 

--- a/docs/PQSIG_PRODUCTION_READINESS.md
+++ b/docs/PQSIG_PRODUCTION_READINESS.md
@@ -3,6 +3,7 @@
 ## Status: RELEASE_HOLD
 ## Spec-ID: PQSIG-PRODUCTION-READINESS-v1
 ## Decided: 2026-07-18
+## Evidence-Updated: 2026-07-19
 ## Consensus-Relevant: NO
 
 ## Decision
@@ -105,9 +106,12 @@ block-space, bandwidth, signer, and hardware-wallet costs. FIPS 204 adds
 structured-lattice assumptions and much larger public keys, but offers a much
 smaller combined payload and substantially faster signing. The isolated
 ML-DSA-44 comparator now passes its complete selected-profile ACVP and
-two-codebase differential contract, but its portable oracle descends from the
-`pq-crystals` reference implementation and does not replace independent
-cryptographic review.
+three-codebase differential contract. `mldsa-native` descends from the
+`pq-crystals` reference implementation. The added libcrux portable-Rust oracle
+has separate implementation history with disclosed PQ-Crystals influence and
+no normal reference-code dependency. This closes the independent
+implementation evidence gate, but does not replace independent cryptographic
+review.
 
 `PQSIG_CANDIDATE_SELECTION.md` selects `ML-DSA-44` as the primary engineering
 candidate because its raw key-plus-signature payload, signing latency, and
@@ -125,22 +129,26 @@ selected for activation by this record.
    green. Do not assign an active `ALG_ID` or connect it to Script yet.
 2. Maintain the isolated FIPS 204 `ML-DSA-44` comparator in
    `ML_DSA_44_REFERENCE.md`. Its 70-case ACVP, randomized interoperability,
-   mutation, sanitizer, timing, and raw-payload evidence is green. Preserve the
-   recorded implementation-lineage limitation.
+   mutation, sanitizer, disclosed-advisory regression, timing, and raw-payload
+   evidence is green across OpenSSL, `mldsa-native`, and libcrux. Preserve the
+   qualified `separate_implementation_lineage_with_reference_influence`
+   assessment.
 3. Use the OpenSSL 3.6.3 runtime and pinned source checkout only as a prototype
    and differential-test oracle. Do not introduce a host OpenSSL dependency
    into consensus verification.
-4. Obtain a second independent implementation or vector source for every
-   candidate. A repo-local signer and repo-local verifier are not independent
-   evidence.
+4. Preserve a second independent implementation or vector source for every
+   candidate. The ML-DSA comparator now satisfies this implementation-evidence
+   requirement through libcrux; that evidence is not independent design or
+   external review. A repo-local signer and repo-local verifier would not be
+   independent evidence.
 5. Monitor SP 800-230, but do not activate a draft profile. Reassess only after
    a final publication and an explicit one-key-per-output usage-limit design.
 6. Retire rc2 or replace it with a ground-up, exact construction. Do not patch
    isolated symptoms while retaining the current security claims.
 7. Apply the measured decision in `PQSIG_CANDIDATE_SELECTION.md`: advance
-   `ML-DSA-44` only through independent implementation evidence, external
-   cryptographic review, and worst-case system measurements. Preserve
-   `SLH-DSA-SHA2-128s` as the fallback and keep production on `HOLD`.
+   `ML-DSA-44` only through external cryptographic review and worst-case system
+   measurements now that its independent implementation evidence is complete.
+   Preserve `SLH-DSA-SHA2-128s` as the fallback and keep production on `HOLD`.
 
 ## Required Gates Before Consensus Integration
 
@@ -163,6 +171,11 @@ of these are satisfied:
 10. independent cryptographic review and consensus-code audit
 11. public testnet soak with no real-value representation
 12. a new, explicit production go/no-go record that removes this hold
+
+For ML-DSA-44, gate 4 is now complete at the isolated comparator level. Gate 5
+has bounded evidence but remains open for exhaustive fuzzing and resource
+exhaustion. The other integration, system, review, soak, and release gates
+remain open. No completion recorded here changes the consensus accepted set.
 
 ## Hold Exit Criteria
 

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: RESEARCH-INDEX-v1
-## Updated: 2026-07-18
+## Updated: 2026-07-19
 ## Consensus-Relevant: NO
 
 ## Purpose
@@ -22,10 +22,12 @@ answer specific classes of questions instead of listing every file in `docs/`.
   and randomized interoperability, malformed-input and sanitizer evidence, and
   timings without changing consensus behavior.
 - An equivalent isolated FIPS 204 `ML-DSA-44` comparator now provides all 70
-  applicable external/pure ACVP cases, exact and randomized differential
-  evidence, malformed-input and sanitizer coverage, timings, and a raw-payload
-  cost model. Its documented implementation-lineage limitation keeps external
-  cryptographic review as an unsatisfied gate.
+  applicable external/pure ACVP cases across OpenSSL, `mldsa-native`, and
+  libcrux, exact and randomized differential evidence, malformed-input,
+  disclosed-advisory regression and sanitizer coverage, timings, and a
+  raw-payload cost model. The qualified libcrux lineage result closes the
+  independent implementation evidence gate while keeping external
+  cryptographic review unsatisfied.
 - `PQSIG_CANDIDATE_SELECTION.md` selects `ML-DSA-44` as the primary
   engineering candidate, retains `SLH-DSA-SHA2-128s` as the conservative
   fallback, and preserves the production release hold. No consensus or wallet
@@ -88,8 +90,9 @@ answer specific classes of questions instead of listing every file in `docs/`.
   Isolated standards-conformance and measurement baseline for the first final-
   standard candidate.
 - [ML_DSA_44_REFERENCE.md](ML_DSA_44_REFERENCE.md)
-  Isolated FIPS 204 comparator, provenance record, and measured implementation
-  baseline for the second final-standard candidate.
+  Isolated FIPS 204 three-oracle comparator, qualified implementation-lineage
+  record, disclosed-advisory regressions, and measured baseline for the second
+  final-standard candidate.
 - [PQSIG_INTERNALS.md](PQSIG_INTERNALS.md)
   Best internal explainer for how the signature system is assembled.
 - [PQSIG_WIRE_FORMAT.md](PQSIG_WIRE_FORMAT.md)

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-07-18
+## Updated: 2026-07-19
 ## Current Phase: Phase 1 - Cryptographic Production Hold
 
 ## Purpose
@@ -58,13 +58,15 @@ baseline remains `pq_required: 121`, `pq_backlog: 0`, `legacy_only: 14`, and
 The isolated `ML-DSA-44` comparator is recorded in
 `ML_DSA_44_REFERENCE.md`. It pins FIPS 204, NIST's potential-updates and
 Section 6 guidance artifacts, all 70 applicable external/pure ACVP cases,
-OpenSSL 3.6.3, and `mldsa-native` `v1.0.0-beta2`. The two codebases agree on
-all official and repo-defined exact outputs, cross-verify native randomized
-signatures, reject the bounded malformed/mutated corpus, and pass the adapter
-ASan/UBSan tranche. Ten-run arm64 timings and a raw-payload cost model are
-recorded. `mldsa-native` descends from the `pq-crystals` reference
-implementation, so the result is differential evidence rather than independent
-cryptographic review.
+OpenSSL 3.6.3, `mldsa-native` `v1.0.0-beta2`, and libcrux 0.0.10. The three
+codebases agree on all official and repo-defined exact outputs, cross-verify
+randomized signatures, and reject the bounded malformed/mutated corpus. The
+two portable-C adapters pass the ASan/UBSan tranche, while the exact libcrux
+release passes both disclosed advisory regressions and repo-level malformed-
+hint checks without panic. Ten-run arm64 timings and a raw-payload cost model
+are recorded. The qualified libcrux result closes the independent
+implementation evidence gate but is not independent design, external
+cryptographic review, or production approval.
 
 The measured decision in `PQSIG_CANDIDATE_SELECTION.md` selects FIPS 204
 `ML-DSA-44` as the primary engineering candidate and retains FIPS 205
@@ -72,10 +74,10 @@ The measured decision in `PQSIG_CANDIDATE_SELECTION.md` selects FIPS 204
 `HOLD`; no consensus integration is authorized by the selection or either
 green reference harness.
 
-The next bounded cryptographic work is to obtain a genuinely independent
-ML-DSA implementation and external cryptographic review, then close
-supported-platform and worst-case system measurements. A consensus-design
-specification follows only after those gates.
+The next bounded cryptographic work is an external-review package for the
+frozen ML-DSA-44 profile and its three-oracle evidence. Supported-platform and
+worst-case system measurements remain the following separate gate. A
+consensus-design specification follows only after both gates.
 
 Keep the live `pq_required` gate aligned with the repo as it exists today. PR
 `#163` closed the initial inventory tranche at `pq_required: 120`,
@@ -167,10 +169,11 @@ Cryptography implementation lane:
    - retain the completed FIPS 204 `ML-DSA-44` comparator baseline
    - apply `ML_DSA_44_ENGINEERING_CANDIDATE` as an evidence priority, not
      production approval
-   - close the documented implementation-lineage limit with a genuinely
-     independent implementation
-   - require external cryptographic review and supported-platform worst-case
-     measurements before consensus-design work
+   - retain the completed three-oracle independent implementation evidence and
+     its qualified reference-influence disclosure
+   - obtain external cryptographic review as the next bounded gate
+   - require supported-platform worst-case measurements before
+     consensus-design work
    - do not allocate or activate an `ALG_ID` in the evidence slices
 
 ## Current Queue
@@ -191,9 +194,10 @@ Cryptography implementation lane:
 2. `HOLD`: do not infer another promotion from queue order. Require a fresh
    risk decision before changing another policy class.
 3. Cryptographic production remains on `HOLD` while `ML-DSA-44` advances only
-   as the selected engineering candidate. The next gates are independent
-   implementation evidence, external cryptographic review, and worst-case
-   system measurements; Script and wallet integration remain out of scope.
+   as the selected engineering candidate. Independent implementation evidence
+   is complete; the next gates are external cryptographic review and
+   worst-case system measurements. Script and wallet integration remain out of
+   scope.
 
 
 ## Historical Queue Ledger
@@ -1687,6 +1691,14 @@ Aineko must ask before:
 Entries below are dated decision snapshots. Use Current Follow-On Candidates
 above as the controlling live next-PR handoff when these older notes disagree.
 
+- 2026-07-19: The isolated ML-DSA-44 comparator added pinned libcrux 0.0.10 as
+  a third oracle. All 70 selected-profile ACVP cases, exact bytes, randomized
+  cross-verification, bounded malformed inputs, the two disclosed libcrux
+  advisory regressions, and repo-defined malformed-hint cases pass. The frozen
+  assessment is `separate_implementation_lineage_with_reference_influence`:
+  independent implementation evidence is complete, while independent design,
+  external cryptographic review, production implementation quality, and
+  consensus approval remain unestablished.
 - 2026-07-18: The measured final-standard comparison selected FIPS 204
   `ML-DSA-44` as `ML_DSA_44_ENGINEERING_CANDIDATE`, retained FIPS 205
   `SLH-DSA-SHA2-128s` as the conservative fallback, and kept production on
@@ -2616,11 +2628,11 @@ above as the controlling live next-PR handoff when these older notes disagree.
 - There is no active inventory blocker. The selected configuration-namespace
   gap is promoted, its platform default-datadir namespace is asserted, and no
   suites remain in `pq_backlog`.
-- Production cryptography remains blocked on independent ML-DSA implementation
-  evidence, external cryptographic review, constant-time and secret-erasure
-  analysis, supported-platform and worst-case validation cost, and a separate
-  consensus-design specification. Engineering-candidate selection closes none
-  of those gates.
+- Production cryptography remains blocked on external cryptographic review,
+  constant-time and secret-erasure analysis, supported-platform and worst-case
+  validation cost, and a separate consensus-design specification. The
+  independent ML-DSA implementation evidence gate is complete; it closes none
+  of these remaining gates.
 - A further promotion requires a newly reviewed PQ confidence gap with a named
   owner, open tracking issue, bounded contract, targeted test, and acceptable
   CI cost. Until another selection exists, `HOLD` is the intended baseline


### PR DESCRIPTION
## Summary

- pin libcrux ML-DSA 0.0.10 by source commit, annotated tag, subtree, first implementation commit, and exact crate SHA256
- add a portable Rust oracle and require complete three-oracle ACVP, byte-agreement, randomized interoperability, malformed-input, and advisory-regression evidence
- record the qualified `separate_implementation_lineage_with_reference_influence` result and advance the next gate to external cryptographic review

Production remains on `RELEASE_HOLD`. This PR changes no node dependency, consensus or Script rule, wallet path, `ALG_ID`, or functional-suite inventory class.

## Validation

- `git diff --check`
- `python3 ci/test/check_ci_inventory.py`
- `python3 -m unittest discover -s ci/test -p "test_*dsa_reference.py"` (17 passed)
- `python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only`
- `python3 contrib/ml-dsa-ref/compare_oracles.py --manifest-only`
- `rustfmt --check contrib/ml-dsa-ref/libcrux_oracle.rs`
- full pinned ML-DSA comparator with ten benchmark iterations and C-adapter ASan/UBSan: PASS (70 ACVP cases, six randomized rounds, 34 malformed-input rejects, both disclosed libcrux advisory regressions, and two ML-DSA-44 malformed-hint rejects without panic)