### PR TITLE
research: add exact ML-DSA-44 Wolfram model

### DIFF
--- a/contrib/ml-dsa-ref/README.md
+++ b/contrib/ml-dsa-ref/README.md
@@ -73,3 +73,13 @@ All three adapters reject any signature whose decoded length is not exactly
 `mldsa-native`, and libcrux are prototype oracles only; passing this harness
 neither makes one a node dependency nor approves ML-DSA-44 for consensus
 integration.
+
+## Supplemental Exact Model
+
+`wolfram/` contains a separately transcribed exact-integer model for bounded
+FIPS 204 algebra and hint-encoding rules. Its NTT is checked against both the
+defining transform equation and direct negacyclic multiplication, while its
+boundary tests exercise decomposition, hints, strict hint decoding, and
+Montgomery reduction. This is specification-level supplemental evidence, not a
+fourth implementation oracle, native side-channel evidence, external review,
+or production approval.

--- a/contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wl
+++ b/contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wl
@@ -1,0 +1,297 @@
+BeginPackage["MLDSA44ExactOracle`"];
+
+MLDSA44Parameters::usage =
+  "MLDSA44Parameters[] returns the exact FIPS 204 ML-DSA-44 constants used by this model.";
+MLDSA44CenteredMod::usage =
+  "MLDSA44CenteredMod[x, m] returns the representative r with -Ceiling[m/2] < r <= Floor[m/2].";
+MLDSA44BitReverse8::usage =
+  "MLDSA44BitReverse8[i] reverses the eight bits of an integer from 0 through 255.";
+MLDSA44ZetaTable::usage =
+  "MLDSA44ZetaTable[] returns the 255 FIPS 204 NTT twiddle factors.";
+MLDSA44NTT::usage =
+  "MLDSA44NTT[p] applies FIPS 204 Algorithm 41 to a 256-coefficient polynomial.";
+MLDSA44DirectNTT::usage =
+  "MLDSA44DirectNTT[p] evaluates the defining FIPS 204 NTT equation directly.";
+MLDSA44InverseNTT::usage =
+  "MLDSA44InverseNTT[w] applies FIPS 204 Algorithm 42.";
+MLDSA44PointwiseMultiply::usage =
+  "MLDSA44PointwiseMultiply[a, b] multiplies two NTT representations coefficient-wise.";
+MLDSA44NegacyclicMultiply::usage =
+  "MLDSA44NegacyclicMultiply[a, b] multiplies in Z_q[X]/(X^256 + 1) by direct convolution.";
+MLDSA44Power2Round::usage =
+  "MLDSA44Power2Round[r] applies FIPS 204 Algorithm 35 for d = 13.";
+MLDSA44Decompose::usage =
+  "MLDSA44Decompose[r] applies FIPS 204 Algorithm 36 for ML-DSA-44.";
+MLDSA44HighBits::usage =
+  "MLDSA44HighBits[r] returns the high part from MLDSA44Decompose[r].";
+MLDSA44LowBits::usage =
+  "MLDSA44LowBits[r] returns the low part from MLDSA44Decompose[r].";
+MLDSA44MakeHint::usage =
+  "MLDSA44MakeHint[z, r] applies FIPS 204 Algorithm 39.";
+MLDSA44UseHint::usage =
+  "MLDSA44UseHint[h, r] applies FIPS 204 Algorithm 40.";
+MLDSA44HintBitPack::usage =
+  "MLDSA44HintBitPack[h] applies FIPS 204 Algorithm 20 to four binary polynomials.";
+MLDSA44HintBitUnpack::usage =
+  "MLDSA44HintBitUnpack[y] applies the strict FIPS 204 Algorithm 21 decoder or returns $Failed.";
+MLDSA44MontgomeryReduce::usage =
+  "MLDSA44MontgomeryReduce[a] applies FIPS 204 Algorithm 49 using exact integers.";
+
+Begin["`Private`"];
+
+$q = 8380417;
+$n = 256;
+$d = 13;
+$zeta = 1753;
+$k = 4;
+$l = 4;
+$eta = 2;
+$tau = 39;
+$beta = 78;
+$gamma1 = 2^17;
+$gamma2 = Quotient[$q - 1, 88];
+$omega = 80;
+$alpha = 2 $gamma2;
+$highModulus = Quotient[$q - 1, $alpha];
+$inverseN = 8347681;
+$montgomeryQInverse = 58728449;
+$montgomeryRadix = 2^32;
+
+MLDSA44Parameters[] := <|
+  "name" -> "ML-DSA-44",
+  "q" -> $q,
+  "n" -> $n,
+  "d" -> $d,
+  "zeta" -> $zeta,
+  "k" -> $k,
+  "l" -> $l,
+  "eta" -> $eta,
+  "tau" -> $tau,
+  "beta" -> $beta,
+  "gamma1" -> $gamma1,
+  "gamma2" -> $gamma2,
+  "omega" -> $omega,
+  "alpha" -> $alpha,
+  "high_modulus" -> $highModulus,
+  "inverse_n" -> $inverseN,
+  "montgomery_q_inverse" -> $montgomeryQInverse,
+  "public_key_bytes" -> 1312,
+  "private_key_bytes" -> 2560,
+  "signature_bytes" -> 2420
+|>;
+
+MLDSA44CenteredMod[x_Integer, modulus_Integer?Positive] :=
+  Mod[x + Ceiling[modulus/2] - 1, modulus] - Ceiling[modulus/2] + 1;
+MLDSA44CenteredMod[___] := $Failed;
+
+MLDSA44BitReverse8[i_Integer] /; 0 <= i < 256 :=
+  FromDigits[Reverse[IntegerDigits[i, 2, 8]], 2];
+MLDSA44BitReverse8[___] := $Failed;
+
+$zetaTable = Table[
+  PowerMod[$zeta, MLDSA44BitReverse8[m], $q],
+  {m, 1, $n - 1}
+];
+
+MLDSA44ZetaTable[] := $zetaTable;
+
+validPolynomialQ[p_] :=
+  ListQ[p] && Length[p] == $n && VectorQ[p, IntegerQ];
+
+validHintQ[h_] :=
+  MatrixQ[h, Function[x, x === 0 || x === 1]] &&
+    Dimensions[h] == {$k, $n};
+
+validByteVectorQ[y_] :=
+  VectorQ[y, Function[x, IntegerQ[x] && 0 <= x <= 255]];
+
+MLDSA44NTT[p_?validPolynomialQ] := Module[
+  {w = Mod[p, $q], m = 0, length = 128, start, j, z, u, v, t},
+  While[length >= 1,
+    start = 0;
+    While[start < $n,
+      m = m + 1;
+      z = $zetaTable[[m]];
+      Do[
+        u = w[[j + 1]];
+        v = w[[j + length + 1]];
+        t = Mod[z v, $q];
+        w[[j + 1]] = Mod[u + t, $q];
+        w[[j + length + 1]] = Mod[u - t, $q],
+        {j, start, start + length - 1}
+      ];
+      start = start + 2 length;
+    ];
+    length = Quotient[length, 2];
+  ];
+  w
+];
+MLDSA44NTT[___] := $Failed;
+
+MLDSA44DirectNTT[p_?validPolynomialQ] := Module[
+  {coefficients = Reverse[Mod[p, $q]], root},
+  Table[
+    root = PowerMod[$zeta, 2 MLDSA44BitReverse8[i] + 1, $q];
+    Fold[
+      Function[{accumulator, coefficient},
+        Mod[accumulator root + coefficient, $q]
+      ],
+      0,
+      coefficients
+    ],
+    {i, 0, $n - 1}
+  ]
+];
+MLDSA44DirectNTT[___] := $Failed;
+
+MLDSA44InverseNTT[input_?validPolynomialQ] := Module[
+  {w = Mod[input, $q], m = 256, length = 1, start, j, z, u, v},
+  While[length < $n,
+    start = 0;
+    While[start < $n,
+      m = m - 1;
+      z = Mod[-$zetaTable[[m]], $q];
+      Do[
+        u = w[[j + 1]];
+        v = w[[j + length + 1]];
+        w[[j + 1]] = Mod[u + v, $q];
+        w[[j + length + 1]] = Mod[z (u - v), $q],
+        {j, start, start + length - 1}
+      ];
+      start = start + 2 length;
+    ];
+    length = 2 length;
+  ];
+  Mod[$inverseN w, $q]
+];
+MLDSA44InverseNTT[___] := $Failed;
+
+MLDSA44PointwiseMultiply[a_?validPolynomialQ, b_?validPolynomialQ] :=
+  Mod[a b, $q];
+MLDSA44PointwiseMultiply[___] := $Failed;
+
+MLDSA44NegacyclicMultiply[a_?validPolynomialQ, b_?validPolynomialQ] := Module[
+  {result = ConstantArray[0, $n], i, j, index, term},
+  Do[
+    index = i + j;
+    term = a[[i + 1]] b[[j + 1]];
+    If[index < $n,
+      result[[index + 1]] = result[[index + 1]] + term,
+      result[[index - $n + 1]] = result[[index - $n + 1]] - term
+    ],
+    {i, 0, $n - 1},
+    {j, 0, $n - 1}
+  ];
+  Mod[result, $q]
+];
+MLDSA44NegacyclicMultiply[___] := $Failed;
+
+MLDSA44Power2Round[r_Integer] := Module[{rPositive, r0},
+  rPositive = Mod[r, $q];
+  r0 = MLDSA44CenteredMod[rPositive, 2^$d];
+  {Quotient[rPositive - r0, 2^$d], r0}
+];
+MLDSA44Power2Round[___] := $Failed;
+
+MLDSA44Decompose[r_Integer] := Module[{rPositive, r0},
+  rPositive = Mod[r, $q];
+  r0 = MLDSA44CenteredMod[rPositive, $alpha];
+  If[rPositive - r0 == $q - 1,
+    {0, r0 - 1},
+    {Quotient[rPositive - r0, $alpha], r0}
+  ]
+];
+MLDSA44Decompose[___] := $Failed;
+
+MLDSA44HighBits[r_Integer] := First[MLDSA44Decompose[r]];
+MLDSA44HighBits[___] := $Failed;
+
+MLDSA44LowBits[r_Integer] := Last[MLDSA44Decompose[r]];
+MLDSA44LowBits[___] := $Failed;
+
+MLDSA44MakeHint[z_Integer, r_Integer] :=
+  Boole[MLDSA44HighBits[r] != MLDSA44HighBits[r + z]];
+MLDSA44MakeHint[___] := $Failed;
+
+MLDSA44UseHint[h_Integer, r_Integer] /; h === 0 || h === 1 := Module[
+  {decomposition, r1, r0},
+  decomposition = MLDSA44Decompose[r];
+  r1 = First[decomposition];
+  r0 = Last[decomposition];
+  If[h == 0,
+    r1,
+    If[r0 > 0,
+      Mod[r1 + 1, $highModulus],
+      Mod[r1 - 1, $highModulus]
+    ]
+  ]
+];
+MLDSA44UseHint[___] := $Failed;
+
+MLDSA44HintBitPack[h_?validHintQ] := If[
+  Total[Flatten[h]] > $omega,
+  $Failed,
+  Module[
+    {encoded = ConstantArray[0, $omega + $k], index = 0, positions, i, position},
+    Do[
+      positions = Flatten[Position[h[[i]], 1]] - 1;
+      Do[
+        position = positions[[j]];
+        encoded[[index + 1]] = position;
+        index = index + 1,
+        {j, Length[positions]}
+      ];
+      encoded[[$omega + i]] = index,
+      {i, 1, $k}
+    ];
+    encoded
+  ]
+];
+MLDSA44HintBitPack[___] := $Failed;
+
+MLDSA44HintBitUnpack[encoded_List] := Catch[
+  Module[
+    {h, index = 0, count, segment, i, j},
+    If[Length[encoded] != $omega + $k || !validByteVectorQ[encoded],
+      Throw[$Failed, hintDecodeFailure]
+    ];
+    h = ConstantArray[0, {$k, $n}];
+    Do[
+      count = encoded[[$omega + i]];
+      If[count < index || count > $omega,
+        Throw[$Failed, hintDecodeFailure]
+      ];
+      segment = If[count > index,
+        Take[encoded, {index + 1, count}],
+        {}
+      ];
+      If[
+        Length[segment] > 1 &&
+          !TrueQ[And @@ Thread[Rest[segment] > Most[segment]]],
+        Throw[$Failed, hintDecodeFailure]
+      ];
+      Do[
+        h[[i, segment[[j]] + 1]] = 1,
+        {j, Length[segment]}
+      ];
+      index = count,
+      {i, 1, $k}
+    ];
+    If[
+      index < $omega && AnyTrue[Take[encoded, {index + 1, $omega}], # != 0 &],
+      Throw[$Failed, hintDecodeFailure]
+    ];
+    h
+  ],
+  hintDecodeFailure
+];
+MLDSA44HintBitUnpack[___] := $Failed;
+
+MLDSA44MontgomeryReduce[a_Integer] /; Abs[a] <= 2^31 $q := Module[{t},
+  t = MLDSA44CenteredMod[a $montgomeryQInverse, $montgomeryRadix];
+  Quotient[a - t $q, $montgomeryRadix]
+];
+MLDSA44MontgomeryReduce[___] := $Failed;
+
+End[];
+EndPackage[];

--- a/contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wlt
+++ b/contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wlt
@@ -1,0 +1,235 @@
+oracleDirectory = DirectoryName[$InputFileName];
+If[!NameQ["MLDSA44ExactOracle`MLDSA44Parameters"],
+  Get[FileNameJoin[{oracleDirectory, "MLDSA44ExactOracle.wl"}]]
+];
+
+parameters = MLDSA44Parameters[];
+q = parameters["q"];
+n = parameters["n"];
+d = parameters["d"];
+zeta = parameters["zeta"];
+gamma2 = parameters["gamma2"];
+alpha = parameters["alpha"];
+omega = parameters["omega"];
+
+polynomialA = Table[Mod[j^3 + 7 j + 11, q], {j, 0, n - 1}];
+polynomialB = Table[Mod[5 j^2 + 3 j + 19, q], {j, 0, n - 1}];
+
+boundaryResidues = DeleteDuplicates[Mod[
+  Flatten[Table[
+    k alpha + delta,
+    {k, 0, Quotient[q - 1, alpha]},
+    {delta, {
+      -gamma2 - 1, -gamma2, -gamma2 + 1, -1, 0, 1,
+      gamma2 - 1, gamma2, gamma2 + 1
+    }}
+  ]],
+  q
+]];
+
+hintOffsets = {-gamma2 + 1, -1, 0, 1, gamma2 - 1};
+
+validHint = ConstantArray[0, {parameters["k"], n}];
+Scan[(validHint[[1, # + 1]] = 1) &, {0, 3, 255}];
+Scan[(validHint[[2, # + 1]] = 1) &, {1, 2}];
+Scan[(validHint[[3, # + 1]] = 1) &, {42}];
+Scan[(validHint[[4, # + 1]] = 1) &, {7, 9, 10, 200}];
+packedHint = MLDSA44HintBitPack[validHint];
+
+VerificationTest[
+  Lookup[
+    parameters,
+    {
+      "q", "n", "d", "zeta", "k", "l", "eta", "tau", "beta",
+      "gamma1", "gamma2", "omega", "alpha", "high_modulus",
+      "inverse_n", "montgomery_q_inverse", "public_key_bytes",
+      "private_key_bytes", "signature_bytes"
+    }
+  ],
+  {
+    8380417, 256, 13, 1753, 4, 4, 2, 39, 78, 131072, 95232, 80,
+    190464, 44, 8347681, 58728449, 1312, 2560, 2420
+  },
+  TestID -> "FIPS 204 ML-DSA-44 constants"
+]
+
+VerificationTest[
+  {
+    PrimeQ[q],
+    Mod[q - 1, 512],
+    PowerMod[zeta, 256, q],
+    PowerMod[zeta, 512, q],
+    Mod[n parameters["inverse_n"], q],
+    Mod[q parameters["montgomery_q_inverse"], 2^32]
+  },
+  {True, 0, q - 1, 1, 1, 1},
+  TestID -> "Prime field, primitive root, inverse, and Montgomery facts"
+]
+
+VerificationTest[
+  Take[MLDSA44ZetaTable[], 15],
+  {
+    4808194, 3765607, 3761513, 5178923, 5496691,
+    5234739, 5178987, 7778734, 3542485, 2682288,
+    2129892, 3764867, 7375178, 557458, 7159240
+  },
+  TestID -> "Appendix B leading zeta values"
+]
+
+VerificationTest[
+  MLDSA44NTT[polynomialA],
+  MLDSA44DirectNTT[polynomialA],
+  TestID -> "Algorithm 41 agrees with the defining NTT equation"
+]
+
+VerificationTest[
+  MLDSA44InverseNTT[MLDSA44NTT[polynomialA]],
+  polynomialA,
+  TestID -> "Algorithms 41 and 42 round trip a dense polynomial"
+]
+
+VerificationTest[
+  MLDSA44InverseNTT[
+    MLDSA44PointwiseMultiply[
+      MLDSA44NTT[polynomialA],
+      MLDSA44NTT[polynomialB]
+    ]
+  ],
+  MLDSA44NegacyclicMultiply[polynomialA, polynomialB],
+  TestID -> "NTT pointwise product equals direct negacyclic convolution"
+]
+
+VerificationTest[
+  {
+    MLDSA44CenteredMod[-5, 10],
+    MLDSA44CenteredMod[5, 10],
+    MLDSA44CenteredMod[6, 10],
+    MLDSA44CenteredMod[-4, 10]
+  },
+  {5, 5, -4, -4},
+  TestID -> "Centered reduction uses the FIPS half-open interval"
+]
+
+VerificationTest[
+  And @@ Table[
+    With[{parts = MLDSA44Power2Round[r]},
+      Mod[First[parts] 2^d + Last[parts], q] == Mod[r, q] &&
+        -2^(d - 1) < Last[parts] <= 2^(d - 1) &&
+        0 <= First[parts] <= 1023
+    ],
+    {r, boundaryResidues}
+  ],
+  True,
+  TestID -> "Power2Round reconstructs boundary residues within exact bounds"
+]
+
+VerificationTest[
+  MLDSA44Decompose /@ {
+    0,
+    gamma2,
+    gamma2 + 1,
+    q - gamma2 - 1,
+    q - gamma2,
+    q - 1
+  },
+  {
+    {0, 0},
+    {0, gamma2},
+    {1, -gamma2 + 1},
+    {43, gamma2},
+    {0, -gamma2},
+    {0, -1}
+  },
+  TestID -> "Decompose handles the q minus one special boundary"
+]
+
+VerificationTest[
+  And @@ Table[
+    With[{parts = MLDSA44Decompose[r]},
+      Mod[First[parts] alpha + Last[parts], q] == Mod[r, q] &&
+        0 <= First[parts] < parameters["high_modulus"] &&
+        -gamma2 <= Last[parts] <= gamma2
+    ],
+    {r, boundaryResidues}
+  ],
+  True,
+  TestID -> "Decompose reconstructs boundary residues within exact bounds"
+]
+
+VerificationTest[
+  And @@ Flatten[Table[
+    MLDSA44UseHint[MLDSA44MakeHint[z, r], r] == MLDSA44HighBits[r + z],
+    {r, boundaryResidues},
+    {z, hintOffsets}
+  ]],
+  True,
+  TestID -> "MakeHint and UseHint agree across 1335 boundary cases"
+]
+
+VerificationTest[
+  MLDSA44HintBitUnpack[packedHint],
+  validHint,
+  TestID -> "HintBitPack and HintBitUnpack strict round trip"
+]
+
+VerificationTest[
+  Module[{malformed = packedHint},
+    malformed[[2]] = malformed[[1]];
+    MLDSA44HintBitUnpack[malformed]
+  ],
+  $Failed,
+  TestID -> "HintBitUnpack rejects repeated positions"
+]
+
+VerificationTest[
+  Module[{malformed = packedHint},
+    malformed[[omega + 2]] = malformed[[omega + 1]] - 1;
+    MLDSA44HintBitUnpack[malformed]
+  ],
+  $Failed,
+  TestID -> "HintBitUnpack rejects decreasing cumulative counts"
+]
+
+VerificationTest[
+  Module[{malformed = packedHint},
+    malformed[[omega + 1]] = omega + 1;
+    MLDSA44HintBitUnpack[malformed]
+  ],
+  $Failed,
+  TestID -> "HintBitUnpack rejects cumulative counts above omega"
+]
+
+VerificationTest[
+  Module[{malformed = packedHint, used = packedHint[[omega + parameters["k"]]]},
+    malformed[[used + 1]] = 1;
+    MLDSA44HintBitUnpack[malformed]
+  ],
+  $Failed,
+  TestID -> "HintBitUnpack rejects nonzero padding"
+]
+
+VerificationTest[
+  And @@ Table[
+    With[{reduced = MLDSA44MontgomeryReduce[a]},
+      IntegerQ[reduced] &&
+        Mod[reduced 2^32 - a, q] == 0 &&
+        Abs[reduced] <= q
+    ],
+    {a, {
+      -2^31 q, -2^31 q + 1, -q^2, -q, -1, 0,
+      1, q, q^2, 2^31 q - 1, 2^31 q
+    }}
+  ],
+  True,
+  TestID -> "MontgomeryReduce boundary congruence and output bound"
+]
+
+VerificationTest[
+  {
+    MLDSA44NTT[ConstantArray[0, n - 1]],
+    MLDSA44HintBitUnpack[ConstantArray[0, omega + parameters["k"] - 1]],
+    MLDSA44MontgomeryReduce[2^31 q + 1]
+  },
+  {$Failed, $Failed, $Failed},
+  TestID -> "Model rejects values outside its bounded contracts"
+]

--- a/contrib/ml-dsa-ref/wolfram/README.md
+++ b/contrib/ml-dsa-ref/wolfram/README.md
@@ -1,0 +1,60 @@
+# ML-DSA-44 Exact Wolfram Model
+
+This directory contains an independently transcribed, exact-integer model of
+selected FIPS 204 operations for the `ML-DSA-44` parameter set. It supplements
+the native three-oracle comparator; it is not a fourth implementation oracle.
+
+## Covered Operations
+
+- centered reduction and eight-bit reversal
+- FIPS 204 Algorithms 41 and 42, checked against the defining NTT equation
+- pointwise NTT multiplication, checked against direct multiplication in
+  `Z_q[X]/(X^256 + 1)`
+- Algorithms 35 through 40 for rounding, decomposition, and hints
+- strict Algorithm 20 and 21 hint packing and malformed-encoding rejection
+- Algorithm 49 Montgomery reduction
+- the exact `ML-DSA-44` constants and leading Appendix B twiddle factors
+
+The tests use arbitrary-precision integer arithmetic. They include explicit
+boundary corpora rather than machine-integer approximations.
+
+## Run
+
+From a Wolfram Language kernel:
+
+```wolfram
+TestReport[
+  "contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wlt"
+]
+```
+
+Codex can run the same file through the Wolfram MCP `TestReport` tool. A local
+Wolfram desktop activation is not required for that MCP execution path. The
+MCP runner does not preserve sibling-file loading, so create a transient test
+bundle containing the exact package followed by the test file:
+
+```bash
+awk 'BEGIN { print "Quiet[Remove[\"MLDSA44ExactOracle`*\"]];" } { print }' \
+  contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wl \
+  contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wlt \
+  > /private/tmp/MLDSA44ExactOracle.bundled.wlt
+```
+
+Pass that transient `.wlt` path to the MCP `TestReport` tool. The bundle is a
+transport artifact only and must not be committed as a separate source of
+truth.
+
+## Evidence Boundary
+
+The model is a specification-level cross-check. It does not implement SHAKE,
+sampling, key generation, signing, or verification. It is not constant-time,
+does not model native overflow or memory behavior, and provides no side-channel
+or secret-erasure evidence. It is not linked into PQBTC, does not define
+consensus behavior, and does not authorize an `ALG_ID`, wallet integration, or
+production release.
+
+The controlling source is the final NIST FIPS 204 PDF pinned in
+`../vectors.json` with SHA256
+`57239b9f84c03227eda3ca0991204dc7764c79af9ce2e6824eda774918d46b6b`.
+Potential corrections remain separately pinned and do not silently alter this
+model.

--- a/docs/ML_DSA_44_WOLFRAM_ORACLE.md
+++ b/docs/ML_DSA_44_WOLFRAM_ORACLE.md
@@ -1,0 +1,66 @@
+# ML-DSA-44 Wolfram Exact-Model Evidence
+
+## Status: SUPPLEMENTAL EVIDENCE
+## Spec-ID: ML-DSA-44-WOLFRAM-EXACT-v1
+## Updated: 2026-07-19
+## Consensus-Relevant: NO
+
+## Decision
+
+Use Wolfram Language as an independent exact-arithmetic cross-check for the
+bounded algebra and encoding rules in FIPS 204. Do not count it as a fourth
+cryptographic implementation or as satisfaction of the external-review gate.
+
+## Evidence Added
+
+The model and tests in `contrib/ml-dsa-ref/wolfram/` cover:
+
+- Algorithms 41 and 42 against both the defining transform equation and direct
+  negacyclic polynomial multiplication;
+- the exact centered-reduction, `Power2Round`, `Decompose`, `HighBits`,
+  `LowBits`, `MakeHint`, and `UseHint` boundaries;
+- strict hint encoding and rejection of repeated positions, decreasing or
+  oversized cumulative counts, and nonzero padding;
+- Montgomery reduction congruence at its stated input boundaries; and
+- independent constants, field facts, inverse facts, and Appendix B twiddle
+  factors.
+
+The deterministic test polynomials and boundary corpora are generated inside
+the test file. Constants are transcribed into the model from FIPS 204 rather
+than derived from the repository manifest. The existing Python reference tests
+separately enforce the corresponding `vectors.json` profile values.
+
+## Reproduction
+
+Run the Wolfram test file with a fresh kernel:
+
+```wolfram
+TestReport[
+  "contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wlt"
+]
+```
+
+For MCP execution, mechanically concatenate the package and test file because
+the service does not preserve sibling-file loading:
+
+```bash
+awk 'BEGIN { print "Quiet[Remove[\"MLDSA44ExactOracle`*\"]];" } { print }' \
+  contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wl \
+  contrib/ml-dsa-ref/wolfram/MLDSA44ExactOracle.wlt \
+  > /private/tmp/MLDSA44ExactOracle.bundled.wlt
+```
+
+Pass the transient bundle to MCP `TestReport`; do not commit it. On 2026-07-19,
+Wolfram Language `15.0.0 for Mac OS X ARM (64-bit)` passed all 18 tests through
+the MCP managed kernel. MCP `CodeInspector` also reported no issues at
+confidence `0.75` with formatting and scoping findings excluded. A separate
+fresh test kernel could not be started, so the successful report used the
+managed kernel after explicitly removing the package context and loading the
+exact package content into the bundle.
+
+## Limits
+
+This evidence does not cover SHAKE, sampling, key generation, signing,
+verification, native integer overflow, memory safety, constant-time behavior,
+side channels, fault injection, or secret erasure. The production hold and the
+external cryptographic review requirement remain unchanged.

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -100,6 +100,10 @@ answer specific classes of questions instead of listing every file in `docs/`.
 - [ML_DSA_44_EXTERNAL_REVIEW.md](ML_DSA_44_EXTERNAL_REVIEW.md)
   Frozen external-review input and acceptance contract for the selected
   engineering candidate; issue `#181` tracks the still-open review gate.
+- [ML_DSA_44_WOLFRAM_ORACLE.md](ML_DSA_44_WOLFRAM_ORACLE.md)
+  Supplemental exact-arithmetic cross-check for bounded FIPS 204 algebra,
+  encoding boundaries, and malformed hint rejection. It is not another native
+  implementation oracle and does not satisfy the external-review gate.
 - [PQSIG_INTERNALS.md](PQSIG_INTERNALS.md)
   Best internal explainer for how the signature system is assembled.
 - [PQSIG_WIRE_FORMAT.md](PQSIG_WIRE_FORMAT.md)


### PR DESCRIPTION
## Summary
- add an independently transcribed exact-integer Wolfram model for bounded FIPS 204 ML-DSA-44 operations
- add 18 verification tests covering NTT equivalence and inversion, negacyclic multiplication, rounding/decomposition boundaries, strict hint decoding, and Montgomery reduction
- document reproducibility, evidence scope, and the MCP bundle transport boundary
- index the supplemental evidence without changing the frozen three-oracle comparator baseline

## Validation
- Wolfram MCP `TestReport`: 18/18 passed after explicitly clearing the package context
- Wolfram MCP `CodeInspector`: no findings in either Wolfram file at confidence 0.75, excluding formatting and scoping
- `python3 -m unittest discover -s ci/test -p 'test_ml_dsa_reference.py'`: 9/9 passed
- `python3 ci/test/check_ci_inventory.py`: passed
- `git diff --check`: passed

## Boundary
This is specification-level supplemental evidence only. It does not add a fourth native implementation oracle, change consensus or wallet behavior, allocate an `ALG_ID`, establish constant-time or memory-safety properties, satisfy external cryptographic review, or lift the production hold. Issue #181 remains open.