### PR TITLE
research: admit portable ML-DSA prototype backend

### DIFF
--- a/ci/test/test_ml_dsa_backend_admission.py
+++ b/ci/test/test_ml_dsa_backend_admission.py
@@ -1,0 +1,118 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINEERING_DIR = REPO_ROOT / "contrib" / "ml-dsa-engineering"
+ADMISSION_PATH = ENGINEERING_DIR / "backend_admission.json"
+REFERENCE_PATH = REPO_ROOT / "contrib" / "ml-dsa-ref" / "vectors.json"
+DECISION_PATH = REPO_ROOT / "docs" / "ML_DSA_44_BACKEND_ADMISSION.md"
+
+
+class MLDSABackendAdmissionTests(unittest.TestCase):
+    def setUp(self):
+        self.admission = json.loads(ADMISSION_PATH.read_text(encoding="utf8"))
+        self.reference = json.loads(REFERENCE_PATH.read_text(encoding="utf8"))
+
+    def test_decision_is_prototype_only(self):
+        decision = self.admission["decision"]
+        self.assertEqual(
+            decision["id"], "MLDSA_NATIVE_PORTABLE_C_ISOLATED_PROTOTYPE"
+        )
+        self.assertEqual(decision["production_backend"], "NONE")
+        self.assertTrue(decision["release_hold"])
+        self.assertEqual(
+            set(decision["prohibited_integrations"]),
+            {
+                "node",
+                "wallet",
+                "script",
+                "consensus",
+                "alg_id",
+                "functional_suite_inventory",
+            },
+        )
+
+    def test_profile_matches_frozen_reference(self):
+        profile = self.admission["profile"]
+        reference = self.reference["profile"]
+        for key in (
+            "name",
+            "standard",
+            "signature_interface",
+            "message_mode",
+            "public_key_bytes",
+            "private_key_bytes",
+            "signature_bytes",
+            "randomizer_bytes",
+        ):
+            self.assertEqual(profile[key], reference[key])
+        self.assertEqual(profile["production_signing"], "hedged_randomized_only")
+
+    def test_candidate_pins_match_reference_evidence(self):
+        assessments = self.admission["candidate_assessments"]
+        sources = self.reference["sources"]
+        expected = {
+            "openssl_3_6_3": sources["openssl"]["commit"],
+            "mldsa_native_portable_c": sources["mldsa_native"]["commit"],
+            "libcrux_ml_dsa_0_0_10_portable": sources["libcrux"]["commit"],
+        }
+        self.assertEqual(
+            {name: candidate["source_commit"] for name, candidate in assessments.items()},
+            expected,
+        )
+        for candidate in assessments.values():
+            self.assertRegex(candidate["source_tree"], r"^[0-9a-f]{40}$")
+            self.assertEqual(candidate["conformance"], "PASS")
+
+    def test_exactly_one_isolated_prototype_is_admitted(self):
+        assessments = self.admission["candidate_assessments"]
+        admitted = [
+            name
+            for name, candidate in assessments.items()
+            if candidate["outcome"] == "ISOLATED_PROTOTYPE_ADMITTED"
+        ]
+        self.assertEqual(admitted, ["mldsa_native_portable_c"])
+        self.assertEqual(assessments["openssl_3_6_3"]["outcome"], "ORACLE_ONLY")
+        self.assertEqual(
+            assessments["libcrux_ml_dsa_0_0_10_portable"]["outcome"],
+            "ORACLE_ONLY",
+        )
+
+    def test_prototype_build_contract_hides_test_and_deterministic_apis(self):
+        build = self.admission["admitted_prototype"]["build_contract"]
+        self.assertEqual(build["language"], "portable_c")
+        self.assertEqual(build["translation_units"], 1)
+        self.assertEqual(build["parameter_set"], 44)
+        self.assertFalse(build["native_arithmetic_backend"])
+        self.assertFalse(build["native_fips202_backend"])
+        self.assertEqual(build["external_api_qualifier"], "static")
+        self.assertFalse(build["supercop_aliases"])
+        self.assertEqual(build["max_signing_attempts"], 814)
+        self.assertEqual(build["randomized_entry_point"], "mldsa_signature")
+        self.assertFalse(build["deterministic_entry_points_exported"])
+        self.assertTrue(build["custom_randombytes_inside_wrapper_module"])
+        self.assertTrue(build["custom_zeroize_required"])
+        self.assertTrue(build["self_verify_before_release"])
+
+    def test_all_release_gates_remain_open(self):
+        gates = self.admission["open_gates"]
+        self.assertEqual(
+            {gate["tracking_issue"] for gate in gates},
+            {181, 184, 185, 186, 187, 188, 189, 190},
+        )
+        self.assertNotIn("CLOSED", {gate["status"] for gate in gates})
+
+    def test_normative_document_records_same_disposition(self):
+        decision = DECISION_PATH.read_text(encoding="utf8")
+        self.assertIn("MLDSA_NATIVE_PORTABLE_C_ISOLATED_PROTOTYPE", decision)
+        self.assertIn("production backend remains `NONE`", decision)
+        self.assertIn("OpenSSL 3.6.3", decision)
+        self.assertIn("mldsa-native", decision)
+        self.assertIn("libcrux", decision)
+        self.assertIn("RELEASE_HOLD", decision)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -16,12 +16,20 @@ future production signer can be proposed:
 - the local randomizer buffer is overwritten on every return path.
 
 The module deliberately uses opaque key handles and a backend protocol. It
-does not select or vendor a cryptographic backend, provide consensus code, or
-claim that Python buffer clearing establishes production secret erasure.
-Test-only entropy injection is private to the executable contract tests.
-The private backend protocol is a model seam, not a production FFI or evidence
-that randomness generation and `ML-DSA.Sign_internal` already share a reviewed
+does not vendor a cryptographic backend, provide consensus code, or claim that
+Python buffer clearing establishes production secret erasure. Test-only
+entropy injection is private to the executable contract tests. The private
+backend protocol is a model seam, not a production FFI or evidence that
+randomness generation and `ML-DSA.Sign_internal` already share a reviewed
 cryptographic-module boundary.
 
-The normative requirements, lifecycle limits, and backend admission criteria
-are in `docs/ML_DSA_44_HEDGED_SIGNING_CONTRACT.md`.
+`backend_admission.json` records the bounded backend decision. It admits the
+pinned `mldsa-native` portable-C path for a separate isolated wrapper prototype
+only. The production backend remains unset, OpenSSL and libcrux remain oracles,
+and every production gate remains open. The manifest also freezes the proposed
+single-translation-unit, static-symbol, portable-C build contract so a later
+prototype cannot silently expose deterministic or test entry points.
+
+The normative requirements and lifecycle limits are in
+`docs/ML_DSA_44_HEDGED_SIGNING_CONTRACT.md`. The admission disposition and
+candidate comparison are in `docs/ML_DSA_44_BACKEND_ADMISSION.md`.

--- a/contrib/ml-dsa-engineering/backend_admission.json
+++ b/contrib/ml-dsa-engineering/backend_admission.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": 1,
+  "decision": {
+    "id": "MLDSA_NATIVE_PORTABLE_C_ISOLATED_PROTOTYPE",
+    "decided": "2026-07-19",
+    "production_backend": "NONE",
+    "release_hold": true,
+    "authorized_scope": [
+      "research_wrapper_design",
+      "contrib_only_prototype",
+      "ci_contract_tests",
+      "documentation"
+    ],
+    "prohibited_integrations": [
+      "node",
+      "wallet",
+      "script",
+      "consensus",
+      "alg_id",
+      "functional_suite_inventory"
+    ]
+  },
+  "profile": {
+    "name": "ML-DSA-44",
+    "standard": "FIPS 204",
+    "signature_interface": "external",
+    "message_mode": "pure",
+    "public_key_bytes": 1312,
+    "private_key_bytes": 2560,
+    "signature_bytes": 2420,
+    "randomizer_bytes": 32,
+    "production_signing": "hedged_randomized_only"
+  },
+  "standards_refresh": {
+    "checked": "2026-07-19",
+    "fips_204_status": "FINAL_WITH_POTENTIAL_UPDATES",
+    "potential_updates_are_official_changes": false,
+    "selected_profile_conflict_found": false
+  },
+  "admitted_prototype": {
+    "backend": "mldsa_native_portable_c",
+    "source": {
+      "repository": "https://github.com/pq-code-package/mldsa-native",
+      "tag": "v1.0.0-beta2",
+      "commit": "9b0ee84f4cf399043eca59eca4e5f8531ca1d61b",
+      "git_tree": "c73c7029182122fce2f2dd8ac544ae990abd74a2",
+      "license_expression": "Apache-2.0 OR ISC OR MIT"
+    },
+    "upstream_status": {
+      "release_label": "second_beta",
+      "latest_tag_found_on_refresh": true,
+      "upstream_portable_c_assessment": "production_ready_with_documented_verification_limits",
+      "pqbtc_assessment": "isolated_prototype_only",
+      "repin_before_production_review": true
+    },
+    "build_contract": {
+      "language": "portable_c",
+      "translation_units": 1,
+      "parameter_set": 44,
+      "native_arithmetic_backend": false,
+      "native_fips202_backend": false,
+      "external_api_qualifier": "static",
+      "supercop_aliases": false,
+      "max_signing_attempts": 814,
+      "randomized_entry_point": "mldsa_signature",
+      "deterministic_entry_points_exported": false,
+      "custom_randombytes_inside_wrapper_module": true,
+      "custom_zeroize_required": true,
+      "self_verify_before_release": true
+    }
+  },
+  "candidate_assessments": {
+    "openssl_3_6_3": {
+      "source_commit": "aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f",
+      "source_tree": "a8a306c000bc2426afd3264b2c41bc7223728475",
+      "license_expression": "Apache-2.0",
+      "conformance": "PASS",
+      "entropy_boundary": "INTERNAL_DRBG_WITH_PUBLIC_TEST_AND_DETERMINISTIC_CONTROLS",
+      "secret_erasure": "PARTIAL_SOURCE_EVIDENCE",
+      "side_channel_posture": "NO_PQBTC_BINARY_EVIDENCE",
+      "build_fit": "NEW_FULL_PROVIDER_DEPENDENCY",
+      "outcome": "ORACLE_ONLY"
+    },
+    "mldsa_native_portable_c": {
+      "source_commit": "9b0ee84f4cf399043eca59eca4e5f8531ca1d61b",
+      "source_tree": "c73c7029182122fce2f2dd8ac544ae990abd74a2",
+      "license_expression": "Apache-2.0 OR ISC OR MIT",
+      "conformance": "PASS",
+      "entropy_boundary": "INTEGRATOR_HOOK_CALLED_BY_RANDOMIZED_ENTRY_POINT",
+      "secret_erasure": "STRONG_INTERNAL_SOURCE_EVIDENCE_WITH_COMPILER_COPY_LIMIT",
+      "side_channel_posture": "UPSTREAM_SOURCE_AND_DYNAMIC_EVIDENCE_REQUIRES_PQBTC_BINARY_VALIDATION",
+      "build_fit": "PORTABLE_C_SINGLE_TRANSLATION_UNIT",
+      "outcome": "ISOLATED_PROTOTYPE_ADMITTED"
+    },
+    "libcrux_ml_dsa_0_0_10_portable": {
+      "source_commit": "c5fb80f37530ee9b2df9501ae5ff8cb4a973a4bd",
+      "source_tree": "0044b70c4675ba97623c9105387f592e038e837d",
+      "license_expression": "Apache-2.0",
+      "conformance": "PASS",
+      "entropy_boundary": "CALLER_SUPPLIED_RANDOMIZER",
+      "secret_erasure": "CLONABLE_KEY_WITHOUT_ZEROIZING_DROP",
+      "side_channel_posture": "PARTIAL_FORMAL_SCOPE_WITHOUT_PQBTC_BINARY_EVIDENCE",
+      "build_fit": "NEW_RUST_1_89_AND_FFI_BOUNDARY",
+      "outcome": "ORACLE_ONLY"
+    }
+  },
+  "open_gates": [
+    {
+      "id": "entropy_and_failure_binding",
+      "status": "PARTIAL_DESIGN_ONLY",
+      "tracking_issue": 184
+    },
+    {
+      "id": "supported_platform_side_channel",
+      "status": "OPEN",
+      "tracking_issue": 185
+    },
+    {
+      "id": "fault_resistance",
+      "status": "OPEN",
+      "tracking_issue": 186
+    },
+    {
+      "id": "secret_lifecycle_and_erasure",
+      "status": "OPEN",
+      "tracking_issue": 187
+    },
+    {
+      "id": "structure_aware_fuzzing_and_resources",
+      "status": "OPEN",
+      "tracking_issue": 188
+    },
+    {
+      "id": "backend_advisory_and_sbom_refresh",
+      "status": "OPEN",
+      "tracking_issue": 189
+    },
+    {
+      "id": "wallet_and_key_format",
+      "status": "OPEN",
+      "tracking_issue": 190
+    },
+    {
+      "id": "independent_human_review",
+      "status": "OPEN",
+      "tracking_issue": 181
+    }
+  ]
+}

--- a/docs/ML_DSA_44_BACKEND_ADMISSION.md
+++ b/docs/ML_DSA_44_BACKEND_ADMISSION.md
@@ -1,0 +1,178 @@
+# ML-DSA-44 Backend Admission
+
+## Status: ISOLATED_PROTOTYPE_ADMITTED - RELEASE_HOLD
+## Spec-ID: ML-DSA-44-BACKEND-ADMISSION-v1
+## Decided: 2026-07-19
+## Evidence-Updated: 2026-07-19
+## Consensus-Relevant: NO
+
+## Decision
+
+The explicit disposition is:
+
+> **`MLDSA_NATIVE_PORTABLE_C_ISOLATED_PROTOTYPE`**
+
+The pinned `mldsa-native` `v1.0.0-beta2` portable-C path may be used in a
+separate `contrib/` prototype to implement and test the project-owned
+hedged-signing wrapper. The production backend remains `NONE`, and
+`RELEASE_HOLD` remains in force.
+
+This decision does not vendor or link a backend. It authorizes one bounded
+prototype lane only. It does not authorize node, wallet, Script, consensus,
+`ALG_ID`, or functional-suite inventory changes. OpenSSL 3.6.3 and libcrux
+0.0.10 remain comparator oracles, not production dependencies.
+
+The machine-readable disposition is
+`contrib/ml-dsa-engineering/backend_admission.json`. CI checks that its source
+pins match the frozen comparator and that no production backend or closed
+release gate is recorded.
+
+## Selection Boundary
+
+Algorithm conformance is not the differentiator in this decision. All three
+pinned implementations pass the frozen ML-DSA-44 comparator. Backend admission
+also requires a reviewable entropy boundary, secret lifetime, production/test
+API separation, toolchain fit, advisory posture, and reproducible source pin.
+
+| Gate | OpenSSL 3.6.3 | mldsa-native beta2 portable C | libcrux 0.0.10 portable |
+| --- | --- | --- | --- |
+| Exact FIPS 204 evidence | Pass | Pass | Pass |
+| Hedged entropy boundary | Internal OpenSSL DRBG, but deterministic and test-entropy controls are public parameters | High-level randomized API calls an integrator-owned `mld_randombytes` hook and propagates RNG failure | Signing API requires the caller to supply the 32-byte randomizer |
+| Secret cleanup | Randomizer and signing temporaries are cleansed in the reviewed source; provider and caller key lifetimes remain unreviewed | Signing allocations and randomizer are zeroized; upstream explicitly warns that compiler-created copies remain possible | Signing-key wrapper is clonable raw bytes without an evident zeroizing `Drop` |
+| Side-channel evidence | No supported PQBTC binary evidence | Portable C uses constant-time patterns and upstream dynamic checks; CBMC covers memory/type/selected-UB properties, not compiled timing | Formal scope covers selected arithmetic, NTT, and serialization; not the complete implementation or compiled timing |
+| Build fit | Would add a full provider dependency to a node that does not otherwise link OpenSSL | Portable C, minimal dependencies, single-compilation-unit support, and static API qualification fit a narrow C/C++ wrapper | Would add Rust 1.89, Cargo dependency resolution, and a new FFI boundary |
+| Lifecycle | Stable 3.6 series, broad maintenance surface | Latest tagged release found on 2026-07-19; substantial post-tag API churn requires a later re-pin | Fresh 0.0.10 release with four prior ML-DSA advisories fixed by version |
+| License | Apache-2.0 | Apache-2.0 OR ISC OR MIT | Apache-2.0 |
+| Disposition | `ORACLE_ONLY` | `ISOLATED_PROTOTYPE_ADMITTED` | `ORACLE_ONLY` |
+
+These are source and integration assessments, not claims that an upstream
+project is insecure. The selected prototype path remains unapproved for
+production until PQBTC validates the exact wrapper binary and closes the
+project gates below.
+
+## Candidate Findings
+
+### OpenSSL 3.6.3
+
+OpenSSL's ML-DSA provider generates per-message randomness through its private
+DRBG, returns failure when generation fails, and cleanses its local randomizer.
+It also exposes `deterministic` and `test-entropy` signature parameters. A
+PQBTC wrapper could suppress those controls, but the resulting dependency
+would include a large provider and configuration surface that the node does
+not otherwise require. Provider selection, dynamic configuration, key object
+lifetime, and the exact module boundary would all need separate review.
+
+OpenSSL remains the strongest general-purpose differential oracle in this
+repository. It is not the narrowest production integration.
+
+### mldsa-native v1.0.0-beta2 portable C
+
+The high-level `mldsa_signature` entry point implements randomized signing,
+calls the integrator-provided random-byte hook, returns `MLD_ERR_RNG_FAIL` on
+failure, clears signing temporaries, and supports an explicit rejection-loop
+bound. The source can be compiled as one C translation unit and can mark all
+upstream public entry points `static`, allowing a project wrapper to export
+only its hedged operation.
+
+The upstream release describes the portable C backend as production-ready
+within its documented verification scope. PQBTC does not adopt that conclusion
+for its own product: the exact integration, compiler output, operating-system
+RBG adapters, caller-owned key memory, failure paths, and supported platforms
+have not been reviewed. The source descends from the PQ-Crystals reference
+implementation, so this admission also does not add independent design review.
+
+The beta tag was still the newest tagged release on the evidence date, while
+the default branch had substantial API and proof work after the tag. The
+prototype therefore stays pinned to the comparator commit. Any later production
+proposal must select a then-current tagged source, explain every change from
+this pin, and rerun the complete evidence package.
+
+### libcrux-ml-dsa 0.0.10 portable Rust
+
+libcrux provides valuable separate-lineage interoperability evidence and
+formally verified components. Its current signing API accepts randomizer bytes
+from the caller, its signing-key wrapper is clonable, and the reviewed type has
+no evident zeroizing destructor. A production wrapper would have to add an RNG
+and secret-owning boundary around the crate, then cross a new Rust/C++ FFI and
+toolchain boundary.
+
+RustSec records four prior `libcrux-ml-dsa` advisories. Version 0.0.10 is above
+the published fixed versions, and the frozen portable path passes the two
+repo-retained advisory regressions. This is useful evidence, not a reason to
+prefer a wider integration boundary for the first prototype.
+
+## Frozen Prototype Build Contract
+
+The next implementation slice must use the exact source pin in
+`backend_admission.json` and satisfy all of these conditions:
+
+1. compile only ML-DSA-44 and the portable C arithmetic/FIPS 202 paths;
+2. use one translation unit and mark upstream APIs `static`;
+3. disable SUPERCOP aliases and export only a project-owned hedged-signing
+   wrapper plus the strict verification operation needed for self-checking;
+4. set the signing-attempt bound to `814` and return no partial result when it
+   is exhausted;
+5. provide project-owned random-byte and zeroization hooks inside that same
+   compiled module;
+6. expose no caller-supplied `rnd`, deterministic mode, seed, ACVP operation,
+   or entropy callback from the production-shaped wrapper;
+7. self-verify every generated signature before release; and
+8. remain under `contrib/` with no node, wallet, Script, consensus, `ALG_ID`,
+   packaging, or inventory connection.
+
+The prototype must have two builds. The production-shaped build exports only
+the restricted wrapper. A separately named test build may expose deterministic
+or fixed-randomizer operations for official-vector testing. CI must inspect the
+production-shaped symbol table and fail if a deterministic or internal signing
+entry point is exported.
+
+## Gates That Remain Open
+
+Prototype admission closes no production finding:
+
+| Gate | Tracking | State after this decision |
+| --- | --- | --- |
+| Entropy and fail-closed binding | #184 | partial design only; no real wrapper or platform RBG test |
+| Supported-platform side channels | #185 | open |
+| Fault model and injected faults | #186 | open |
+| End-to-end secret erasure | #187 | open |
+| Structure-aware fuzzing and resource limits | #188 | open |
+| Backend advisories, SBOM, and reproducible build | #189 | open |
+| Wallet and key format | #190 | open |
+| Independent human cryptographic review | #181 | open |
+
+The current comparator, Wolfram arithmetic model, and this admission review are
+AI-assisted engineering evidence. None is the independent human review required
+by issue #181.
+
+## Validation
+
+Run the bounded decision checks with:
+
+```bash
+python3 -m unittest ci.test.test_ml_dsa_backend_admission
+python3 -m unittest ci.test.test_ml_dsa_hedged_signing_contract
+python3 -m unittest discover -s ci/test -p 'test_*dsa_reference.py'
+python3 contrib/ml-dsa-ref/compare_oracles.py --manifest-only
+python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only
+python3 ci/test/check_ci_inventory.py
+```
+
+No command above compiles or admits a production cryptographic backend.
+
+## Primary Sources
+
+- NIST FIPS 204 and potential-updates notice:
+  https://csrc.nist.gov/pubs/fips/204/final
+- OpenSSL 3.6 ML-DSA signature interface:
+  https://docs.openssl.org/3.6/man7/EVP_SIGNATURE-ML-DSA/
+- OpenSSL 3.6 release and vulnerability status:
+  https://www.openssl-library.org/news/openssl-3.6-notes/
+- mldsa-native beta2 release and verification scope:
+  https://github.com/pq-code-package/mldsa-native/releases/tag/v1.0.0-beta2
+- mldsa-native source and soundness record:
+  https://github.com/pq-code-package/mldsa-native
+- libcrux ML-DSA 0.0.10 source:
+  https://github.com/celabshq/libcrux/tree/libcrux-ml-dsa-v0.0.10/libcrux-ml-dsa
+- RustSec libcrux-ml-dsa advisory inventory:
+  https://rustsec.org/packages/libcrux-ml-dsa.html

--- a/docs/ML_DSA_44_HEDGED_SIGNING_CONTRACT.md
+++ b/docs/ML_DSA_44_HEDGED_SIGNING_CONTRACT.md
@@ -20,6 +20,12 @@ concurrency behavior testable, but it is not a cryptographic implementation.
 It is not linked into the node, wallet, Script, or an `ALG_ID`, and it does not
 close issue `#184` or remove `RELEASE_HOLD`.
 
+`ML_DSA_44_BACKEND_ADMISSION.md` admits the pinned `mldsa-native` portable-C
+path for a separate isolated wrapper prototype. That decision supplies a
+bounded implementation target for this contract, not a production backend.
+The production backend remains `NONE`, and all platform, lifecycle, review,
+and release gates remain open.
+
 ## Standards Basis
 
 FIPS 204 makes hedged signing the default and permits deterministic signing as
@@ -82,6 +88,14 @@ production FFI. In a real binding, entropy acquisition and
 boundary. Passing `rnd` across an opaque provider, process, device, or FFI
 boundary does not satisfy this contract unless that complete boundary is
 specified and shown to meet FIPS 204.
+
+For the admitted isolated prototype, the intended module is one portable-C
+translation unit containing the project wrapper, project random-byte and
+zeroization hooks, and the pinned `mldsa-native` source. All upstream entry
+points are `static`; only the project hedged-signing wrapper and strict
+verification surface may be exported. A separately named test build may expose
+fixed-randomizer operations for official vectors, but those symbols may not
+appear in the production-shaped prototype.
 
 ## Entropy Contract
 
@@ -186,17 +200,18 @@ They cover:
 
 ## Exit Criteria
 
-This contract can be bound to a real backend only in a separate proposal that:
+The isolated prototype may bind this contract only under
+`ML_DSA_44_BACKEND_ADMISSION.md`. A production proposal still must:
 
-1. freezes the backend, source revision, build, supported platforms, and secret
-   ownership types;
-2. keeps entropy generation and `ML-DSA.Sign_internal` in one reviewed module
-   and implements the production API without linking test/CAVP entry points;
-3. uses reviewed OS and hardware RBG adapters with injected failure coverage;
-4. demonstrates compiler-resistant cleanup across language and FFI boundaries;
-5. adds fork/process and supported VM-clone tests at the platform layer;
-6. passes side-channel, fault, fuzzing, advisory, and lifecycle gates; and
-7. receives re-review under issue `#181` against the exact implementation
+1. re-pin a then-current tagged backend, freeze the imported source and build,
+   and define supported platforms and secret ownership types;
+2. keep entropy generation and `ML-DSA.Sign_internal` in one reviewed module
+   and implement the production API without linking test/ACVP entry points;
+3. use reviewed OS and hardware RBG adapters with injected failure coverage;
+4. demonstrate compiler-resistant cleanup across language and FFI boundaries;
+5. add fork/process and supported VM-clone tests at the platform layer;
+6. pass side-channel, fault, fuzzing, advisory, and lifecycle gates; and
+7. receive re-review under issue `#181` against the exact implementation
    commit.
 
 Until then, this is a misuse-resistant design target only. It authorizes no

--- a/docs/PQSIG_PRODUCTION_READINESS.md
+++ b/docs/PQSIG_PRODUCTION_READINESS.md
@@ -26,6 +26,14 @@ supporting evidence, not the signed review of an independent human
 cryptographer required by issue `#181`. The project remains
 `AWAITING_EXTERNAL_REVIEW`, and this release hold remains in force.
 
+`ML_DSA_44_BACKEND_ADMISSION.md` now records the first backend decision:
+`MLDSA_NATIVE_PORTABLE_C_ISOLATED_PROTOTYPE`. The pinned `mldsa-native`
+portable-C path may be used only for a separate production-shaped wrapper
+prototype under `contrib/`. The production backend remains `NONE`; OpenSSL and
+libcrux remain oracles. This narrows the next experiment without satisfying a
+production gate or authorizing node, wallet, Script, consensus, or `ALG_ID`
+work.
+
 ## Evidence Classification
 
 ### Observed In The Repository
@@ -165,6 +173,11 @@ selected for activation by this record.
    evidence only. Do not close the finding until a selected backend implements
    the contract in a production build, platform RNG and lifecycle tests pass,
    and the exact implementation commit is re-reviewed.
+9. Apply `ML_DSA_44_BACKEND_ADMISSION.md` only to the next isolated prototype.
+   Use the exact pinned `mldsa-native` portable-C source, one translation unit,
+   hidden upstream symbols, project RNG and zeroization hooks, and a hedged-only
+   exported wrapper. Keep the production backend unset until the resulting
+   binary passes the open issues and independent review.
 
 ## Required Gates Before Consensus Integration
 
@@ -194,6 +207,9 @@ exhaustion. The AI-assisted review is merged with a
 `REMEDIATE_AND_REREVIEW` disposition and seven open Medium findings; the gate
 10 independent-human review has not occurred. The hedged-signing contract is
 partial design evidence for issue `#184`, not a production implementation.
+The backend-admission decision selects a portable-C isolated prototype target,
+not a production dependency; every gate recorded in its machine-readable
+manifest remains open.
 The other integration, system, review, soak, and release gates remain open. No
 completion recorded here changes the consensus accepted set.
 

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -41,8 +41,13 @@ answer specific classes of questions instead of listing every file in `docs/`.
 - `ML_DSA_44_HEDGED_SIGNING_CONTRACT.md` defines the first remediation design
   boundary: internally generated 32-byte `rnd`, hedged-only production API,
   fail-closed errors, serialized callers, self-verification, lifecycle limits,
-  and explicit rollback residual risk. Its executable model is not a selected
-  backend or production implementation, so issue `#184` remains open.
+  and explicit rollback residual risk. Its executable model is not the
+  admitted backend wrapper or a production implementation, so issue `#184`
+  remains open.
+- `ML_DSA_44_BACKEND_ADMISSION.md` admits the pinned `mldsa-native` portable-C
+  path for an isolated wrapper prototype. The production backend remains
+  `NONE`; OpenSSL and libcrux remain oracles, every release gate remains open,
+  and no node or consensus integration is authorized.
 - No PDF papers are currently checked into this repo.
 - Delving Bitcoin now provides concrete adjacent research references that are
   directly relevant to Track A, especially around SHRINCS / SHRIMPS and
@@ -114,6 +119,9 @@ answer specific classes of questions instead of listing every file in `docs/`.
 - [ML_DSA_44_HEDGED_SIGNING_CONTRACT.md](ML_DSA_44_HEDGED_SIGNING_CONTRACT.md)
   Project-owned hedged-signing entropy, failure, concurrency, and lifecycle
   contract for the bounded issue `#184` remediation lane.
+- [ML_DSA_44_BACKEND_ADMISSION.md](ML_DSA_44_BACKEND_ADMISSION.md)
+  Pinned three-candidate backend comparison and the portable-C isolated
+  prototype admission, with an explicit `NONE` production backend.
 - [ML_DSA_44_WOLFRAM_ORACLE.md](ML_DSA_44_WOLFRAM_ORACLE.md)
   Supplemental exact-arithmetic cross-check for bounded FIPS 204 algebra,
   encoding boundaries, and malformed hint rejection. It is not another native

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -23,8 +23,8 @@ controlling evidence and replacement-gate record.
 
 The current implementation lane is isolated standards and remediation
 evidence. The FIPS 205 `SLH-DSA-SHA2-128s` prototype, FIPS 204 `ML-DSA-44`
-comparator, and hedged-signing contract are all kept outside inventory policy,
-`ALG_ID`, Script, wallet, and consensus changes.
+comparator, hedged-signing contract, and backend-admission record are all kept
+outside inventory policy, `ALG_ID`, Script, wallet, and consensus changes.
 
 The first isolated reference slice is recorded in
 `SLH_DSA_SHA2_128S_REFERENCE.md`. It pins NIST ACVP and portable-C source
@@ -94,6 +94,21 @@ implementation. Issue `#184` remains open pending backend binding, production
 build isolation, supported-platform tests, secret-lifecycle evidence, and
 re-review. No `ALG_ID`, Script, node, wallet, or inventory policy class changes
 in this lane.
+
+PR `#192` landed that contract and its executable model at merge commit
+`896cd74735029f2918d65bbf554fb046c59f7cc2`. Its duplicate push and
+pull-request CI/Gatekeeper workflows completed all `8/8` checks successfully.
+Post-merge Promotion Matrix run `29705831229` completed `21/21` jobs
+successfully, and the merge commit completed all `26/26` checks successfully.
+Issue `#184` remains open because this was design evidence, not a production
+backend binding.
+
+`ML_DSA_44_BACKEND_ADMISSION.md` now records the next bounded decision:
+`MLDSA_NATIVE_PORTABLE_C_ISOLATED_PROTOTYPE`. The pinned `mldsa-native`
+portable-C path is admitted only for a separate production-shaped wrapper
+prototype. The production backend remains `NONE`; OpenSSL and libcrux remain
+oracles, every release gate remains open, and no node, wallet, Script,
+consensus, `ALG_ID`, or inventory policy change is authorized.
 
 Keep the live `pq_required` gate aligned with the repo as it exists today. PR
 `#163` closed the initial inventory tranche at `pq_required: 120`,
@@ -190,9 +205,12 @@ Cryptography implementation lane:
    - retain PR `#183` as supporting AI-assisted review evidence with
      `REMEDIATE_AND_REREVIEW`; do not treat it as the independent-human gate
    - use issues `#184` through `#190` as the bounded remediation ledger
-   - advance issue `#184` first through
-     `ML_DSA_44_HEDGED_SIGNING_CONTRACT.md`, without claiming the executable
-     model is a production backend or closes the finding
+   - retain PR `#192` and `ML_DSA_44_HEDGED_SIGNING_CONTRACT.md` as partial
+     design evidence for issue `#184`; the finding remains open
+   - apply `MLDSA_NATIVE_PORTABLE_C_ISOLATED_PROTOTYPE` as a bounded wrapper
+     target, not production backend approval
+   - keep OpenSSL and libcrux as comparator oracles and keep the production
+     backend at `NONE`
    - obtain a qualifying independent-human re-review against exact remediation
      commits before any gate disposition changes
    - require supported-platform worst-case measurements before
@@ -219,11 +237,12 @@ Cryptography implementation lane:
 3. Cryptographic production remains on `HOLD` while `ML-DSA-44` advances only
    as the selected engineering candidate. Independent implementation evidence
    is complete; PR `#183` concluded `REMEDIATE_AND_REREVIEW`, and issues `#184`
-   through `#190` remain open. The issue `#184` hedged-signing contract is the
-   current bounded remediation lane, not production integration. Status remains
-   `AWAITING_EXTERNAL_REVIEW`; a qualifying independent-human re-review and
-   worst-case system measurements remain required. Script and wallet
-   integration remain out of scope.
+   through `#190` remain open. PR `#192` landed the issue `#184`
+   hedged-signing design contract. The current bounded lane admits only the
+   pinned `mldsa-native` portable-C path for an isolated wrapper prototype;
+   production remains `NONE`. Status remains `AWAITING_EXTERNAL_REVIEW`; a
+   qualifying independent-human re-review and worst-case system measurements
+   remain required. Script and wallet integration remain out of scope.
 
 
 ## Historical Queue Ledger
@@ -1717,6 +1736,18 @@ Aineko must ask before:
 Entries below are dated decision snapshots. Use Current Follow-On Candidates
 above as the controlling live next-PR handoff when these older notes disagree.
 
+- 2026-07-19: The backend comparison admitted the pinned `mldsa-native`
+  `v1.0.0-beta2` portable-C path as
+  `MLDSA_NATIVE_PORTABLE_C_ISOLATED_PROTOTYPE`. Its frozen next-slice contract
+  uses one translation unit, static upstream symbols, project RNG and
+  zeroization hooks, portable code only, a bounded signing loop, and mandatory
+  self-verification. The production backend remains `NONE`; OpenSSL and
+  libcrux remain oracles, and every release gate remains open.
+- 2026-07-19: PR `#192` landed the project-owned hedged-signing contract and
+  executable model at merge commit
+  `896cd74735029f2918d65bbf554fb046c59f7cc2`. Duplicate branch checks were
+  `8/8` green, post-merge Promotion Matrix run `29705831229` was `21/21`
+  green, and merge-commit checks were `26/26` green. Issue `#184` remains open.
 - 2026-07-19: PR `#183` landed the AI-assisted ML-DSA-44 technical assessment
   at merge commit `587371a818a1f5902f5ad977d9891b9d1bff0902`. Its disposition
   is `REMEDIATE_AND_REREVIEW`: no Critical or High issue was identified, seven
@@ -2672,7 +2703,8 @@ above as the controlling live next-PR handoff when these older notes disagree.
   constant-time and secret-erasure analysis, supported-platform and worst-case
   validation cost, and a separate consensus-design specification. The
   independent ML-DSA implementation evidence gate is complete; it closes none
-  of these remaining gates.
+  of these remaining gates. The portable-C isolated prototype admission also
+  closes none of them.
 - A further promotion requires a newly reviewed PQ confidence gap with a named
   owner, open tracking issue, bounded contract, targeted test, and acceptable
   CI cost. Until another selection exists, `HOLD` is the intended baseline


### PR DESCRIPTION
## Summary

- admit pinned mldsa-native v1.0.0-beta2 portable C for an isolated wrapper prototype only
- keep the production backend at NONE and preserve RELEASE_HOLD
- retain OpenSSL 3.6.3 and libcrux 0.0.10 as comparator oracles
- freeze the single-translation-unit, hidden-symbol, hedged-only build contract
- add machine-readable admission bookkeeping and CI drift checks
- update production-readiness, hedged-signing, research-index, and Track A handoff docs

## Scope boundary

No cryptographic source, node, wallet, Script, consensus, ALG_ID, packaging, or functional-suite inventory policy changes. Issues #181 and #184 through #190 remain open.

## Validation

- git diff --check
- python3 -m unittest ci.test.test_ml_dsa_backend_admission
- python3 -m unittest ci.test.test_ml_dsa_hedged_signing_contract
- python3 -m unittest discover -s ci/test -p "test_*dsa_reference.py"
- python3 -m unittest discover -s ci/test -p "test_*.py"
- python3 contrib/ml-dsa-ref/compare_oracles.py --manifest-only
- python3 contrib/slh-dsa-ref/compare_oracles.py --manifest-only
- python3 ci/test/check_ci_inventory.py

Inventory remains pq_required 121, pq_backlog 0, legacy_only 14, dual_profile 141.