### PR TITLE
ci: add sustained ML-DSA-44 verifier fuzzing

### DIFF
--- a/.github/workflows/ml-dsa-44-sustained-fuzz.yml
+++ b/.github/workflows/ml-dsa-44-sustained-fuzz.yml
@@ -1,0 +1,170 @@
+name: ML-DSA-44 sustained verifier fuzzing
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ml-dsa-44-sustained-fuzz.yml"
+      - "ci/test/test_ml_dsa_sustained_fuzz.py"
+      - "contrib/ml-dsa-engineering/**"
+      - "contrib/ml-dsa-ref/vectors.json"
+      - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
+      - "docs/ML_DSA_44_WRAPPER_PROTOTYPE.md"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ml-dsa-44-sustained-fuzz.yml"
+      - "ci/test/test_ml_dsa_sustained_fuzz.py"
+      - "contrib/ml-dsa-engineering/**"
+      - "contrib/ml-dsa-ref/vectors.json"
+      - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
+      - "docs/ML_DSA_44_WRAPPER_PROTOTYPE.md"
+  schedule:
+    - cron: '17 4 * * 3'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  verifier-fuzz:
+    name: Strict verifier (${{ matrix.label }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ASan + UBSan
+            sanitizer: address-undefined
+            coverage: 'true'
+            artifact: asan-ubsan
+          - label: MSan
+            sanitizer: memory
+            coverage: 'false'
+            artifact: msan
+    env:
+      CC: clang
+      OUTPUT_DIR: ${{ runner.temp }}/ml-dsa-44-fuzz-output
+      PRIOR_DIR: ${{ runner.temp }}/ml-dsa-44-prior
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Verify toolchain
+        run: |
+          set -euxo pipefail
+          clang --version
+          llvm-profdata --version
+          llvm-cov --version
+          python3 --version
+
+      - name: Restore latest retained corpus
+        id: retained
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_NAME: ml-dsa-44-sustained-${{ matrix.artifact }}
+        run: |
+          set -euo pipefail
+          previous_run_and_attempt="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow ml-dsa-44-sustained-fuzz.yml \
+              --branch main \
+              --status success \
+              --limit 1 \
+              --json databaseId,attempt \
+              --jq '.[0] | select(.) | [.databaseId, .attempt] | @tsv'
+          )"
+          if [[ -z "$previous_run_and_attempt" ]]; then
+            echo "No prior successful sustained campaign is available"
+            exit 0
+          fi
+          read -r previous_run previous_attempt <<< "$previous_run_and_attempt"
+          artifact_name="$ARTIFACT_NAME-$previous_run-$previous_attempt"
+          mkdir -p "$PRIOR_DIR"
+          if ! gh run download "$previous_run" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$artifact_name" \
+            --dir "$PRIOR_DIR"; then
+            echo "::warning title=Corpus restore unavailable::Could not download $artifact_name"
+            exit 0
+          fi
+          seed_dir="$(find "$PRIOR_DIR" -type d -name minimized-corpus -print -quit)"
+          if [[ -n "$seed_dir" ]]; then
+            echo "seed_dir=$seed_dir" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run bounded sustained campaign
+        env:
+          SANITIZER: ${{ matrix.sanitizer }}
+          COVERAGE: ${{ matrix.coverage }}
+          RETAINED_SEED_DIR: ${{ steps.retained.outputs.seed_dir }}
+        run: |
+          set -euxo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            campaign_seconds=1800
+            campaign_seed="$GITHUB_RUN_NUMBER"
+          else
+            campaign_seconds=60
+            campaign_seed=188
+          fi
+          args=(
+            --sanitizers
+            --sanitizer "$SANITIZER"
+            --seconds "$campaign_seconds"
+            --seed "$campaign_seed"
+            --output-dir "$OUTPUT_DIR"
+          )
+          if [[ -n "$RETAINED_SEED_DIR" ]]; then
+            args+=(--seed-corpus "$RETAINED_SEED_DIR")
+          fi
+          if [[ "$COVERAGE" == "true" ]]; then
+            args+=(--coverage)
+          fi
+          python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py "${args[@]}"
+
+      - name: Verify campaign evidence
+        if: success()
+        env:
+          EXPECTED_SANITIZER: ${{ matrix.sanitizer }}
+          COVERAGE: ${{ matrix.coverage }}
+        run: |
+          python3 - "$OUTPUT_DIR" "$EXPECTED_SANITIZER" "$COVERAGE" <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          output = Path(sys.argv[1])
+          report = json.loads((output / "campaign.json").read_text(encoding="utf8"))
+          assert report["schema_version"] == 1
+          assert report["status"] == "pass"
+          assert report["sanitizer"] == sys.argv[2]
+          assert report["coverage_enabled"] is (sys.argv[3] == "true")
+          assert report["minimized_corpus"]["file_count"] > 0
+          assert report["crash_artifacts"]["file_count"] == 0
+          assert (output / "SHA256SUMS").is_file()
+          if report["coverage_enabled"]:
+              assert (output / "coverage.txt").is_file()
+              assert (output / "coverage.json").is_file()
+          print(json.dumps(report, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload retained corpus and evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ml-dsa-44-sustained-${{ matrix.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.OUTPUT_DIR }}
+          if-no-files-found: warn
+          retention-days: 90
+          compression-level: 9

--- a/.github/workflows/ml-dsa-44-sustained-fuzz.yml
+++ b/.github/workflows/ml-dsa-44-sustained-fuzz.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload retained corpus and evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ml-dsa-44-sustained-${{ matrix.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/ml-dsa-44-fuzz-output

--- a/.github/workflows/ml-dsa-44-sustained-fuzz.yml
+++ b/.github/workflows/ml-dsa-44-sustained-fuzz.yml
@@ -61,8 +61,8 @@ jobs:
         run: |
           set -euxo pipefail
           clang --version
-          llvm-profdata --version
-          llvm-cov --version
+          llvm-profdata-18 --version
+          llvm-cov-18 --version
           python3 --version
 
       - name: Restore latest retained corpus

--- a/.github/workflows/ml-dsa-44-sustained-fuzz.yml
+++ b/.github/workflows/ml-dsa-44-sustained-fuzz.yml
@@ -50,8 +50,6 @@ jobs:
             artifact: msan
     env:
       CC: clang
-      OUTPUT_DIR: ${{ runner.temp }}/ml-dsa-44-fuzz-output
-      PRIOR_DIR: ${{ runner.temp }}/ml-dsa-44-prior
 
     steps:
       - name: Checkout
@@ -73,6 +71,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ARTIFACT_NAME: ml-dsa-44-sustained-${{ matrix.artifact }}
+          PRIOR_DIR: ${{ runner.temp }}/ml-dsa-44-prior
         run: |
           set -euo pipefail
           previous_run_and_attempt="$(
@@ -109,6 +108,7 @@ jobs:
           SANITIZER: ${{ matrix.sanitizer }}
           COVERAGE: ${{ matrix.coverage }}
           RETAINED_SEED_DIR: ${{ steps.retained.outputs.seed_dir }}
+          OUTPUT_DIR: ${{ runner.temp }}/ml-dsa-44-fuzz-output
         run: |
           set -euxo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
@@ -138,6 +138,7 @@ jobs:
         env:
           EXPECTED_SANITIZER: ${{ matrix.sanitizer }}
           COVERAGE: ${{ matrix.coverage }}
+          OUTPUT_DIR: ${{ runner.temp }}/ml-dsa-44-fuzz-output
         run: |
           python3 - "$OUTPUT_DIR" "$EXPECTED_SANITIZER" "$COVERAGE" <<'PY'
           import json
@@ -164,7 +165,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ml-dsa-44-sustained-${{ matrix.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ env.OUTPUT_DIR }}
+          path: ${{ runner.temp }}/ml-dsa-44-fuzz-output
           if-no-files-found: warn
           retention-days: 90
           compression-level: 9

--- a/.github/workflows/ml-dsa-44-wrapper-prototype.yml
+++ b/.github/workflows/ml-dsa-44-wrapper-prototype.yml
@@ -36,9 +36,3 @@ jobs:
           python3 contrib/ml-dsa-engineering/run_wrapper_tests.py --sanitizers
           python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --manifest-only
           python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py
-
-      - name: Fuzz strict verifier with ASan and UBSan
-        if: matrix.compiler == 'clang'
-        env:
-          CC: clang
-        run: python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --sanitizers --runs 10000

--- a/ci/test/test_ml_dsa_sustained_fuzz.py
+++ b/ci/test/test_ml_dsa_sustained_fuzz.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINEERING_DIR = REPO_ROOT / "contrib" / "ml-dsa-engineering"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-sustained-fuzz.yml"
+ADMISSION = ENGINEERING_DIR / "backend_admission.json"
+
+sys.path.insert(0, str(ENGINEERING_DIR))
+SPEC = importlib.util.spec_from_file_location(
+    "run_verifier_fuzz",
+    ENGINEERING_DIR / "run_verifier_fuzz.py",
+)
+assert SPEC is not None and SPEC.loader is not None
+verifier_fuzz = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = verifier_fuzz
+SPEC.loader.exec_module(verifier_fuzz)
+
+
+class MlDsaSustainedFuzzTest(unittest.TestCase):
+    def test_machine_readable_gate_remains_open(self):
+        admission = json.loads(ADMISSION.read_text(encoding="utf8"))
+        gate = next(
+            item
+            for item in admission["open_gates"]
+            if item["id"] == "structure_aware_fuzzing_and_resources"
+        )
+        self.assertEqual(gate["tracking_issue"], 188)
+        self.assertEqual(
+            gate["status"],
+            "SUSTAINED_SANITIZER_EVIDENCE_GATE_OPEN",
+        )
+        self.assertTrue(admission["decision"]["release_hold"])
+        self.assertEqual(admission["decision"]["production_backend"], "NONE")
+
+    def test_workflow_freezes_bounded_campaign_contract(self):
+        workflow = WORKFLOW.read_text(encoding="utf8")
+        for required in (
+            "schedule:",
+            "cron: '17 4 * * 3'",
+            "actions: read",
+            "contents: read",
+            "timeout-minutes: 45",
+            "sanitizer: address-undefined",
+            "sanitizer: memory",
+            "campaign_seconds=1800",
+            "campaign_seconds=60",
+            'campaign_seed="$GITHUB_RUN_NUMBER"',
+            "campaign_seed=188",
+            "group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}",
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            "--seed-corpus",
+            "--coverage",
+            "--json databaseId,attempt",
+            '--name "$artifact_name"',
+            "if: always()",
+            "retention-days: 90",
+            "github.run_id",
+            "github.run_attempt",
+            "coverage.json",
+        ):
+            self.assertIn(required, workflow)
+        self.assertIn(
+            "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd",
+            workflow,
+        )
+        self.assertIn(
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+            workflow,
+        )
+
+    def test_retained_corpus_import_is_bounded_and_content_addressed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            seed = b"retained seed"
+            (source / "seed.bin").write_bytes(seed)
+            (source / "ignored-directory").mkdir()
+
+            imported = verifier_fuzz.import_seed_corpus(source, destination)
+
+            digest = hashlib.sha256(seed).hexdigest()
+            self.assertEqual(imported, 1)
+            self.assertEqual(
+                (destination / f"retained_{digest}.bin").read_bytes(),
+                seed,
+            )
+            self.assertEqual(verifier_fuzz.import_seed_corpus(source, destination), 0)
+
+            (source / "oversized.bin").write_bytes(
+                bytes(verifier_fuzz.MAX_FRAME_BYTES + 1)
+            )
+            with self.assertRaises(verifier_fuzz.FuzzHarnessError):
+                verifier_fuzz.import_seed_corpus(source, destination)
+
+    def test_sanitizer_compile_contracts_are_distinct(self):
+        contracts = (
+            (
+                "address-undefined",
+                True,
+                {"-fsanitize=fuzzer,address,undefined", "-fprofile-instr-generate"},
+                {"-fsanitize=fuzzer,memory", "-fsanitize-memory-track-origins=2"},
+            ),
+            (
+                "memory",
+                False,
+                {"-fsanitize=fuzzer,memory", "-fsanitize-memory-track-origins=2", "-pie"},
+                {"-fsanitize=fuzzer,address,undefined", "-fprofile-instr-generate"},
+            ),
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            for sanitizer, coverage, required, prohibited in contracts:
+                with self.subTest(sanitizer=sanitizer):
+                    with mock.patch.object(verifier_fuzz.wrapper, "run") as run:
+                        verifier_fuzz.compile_fuzzer(
+                            "clang",
+                            Path(temporary),
+                            sanitizer=sanitizer,
+                            coverage=coverage,
+                        )
+                    command = set(run.call_args.args[0])
+                    self.assertTrue(required <= command)
+                    self.assertTrue(prohibited.isdisjoint(command))
+
+    def test_empty_minimized_corpus_is_a_campaign_failure(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            corpus = root / "corpus"
+            corpus.mkdir()
+            (corpus / "seed").write_bytes(b"seed")
+            completed = subprocess.CompletedProcess(
+                args=["fuzzer"], returncode=0, stdout="", stderr=""
+            )
+            with mock.patch.object(
+                verifier_fuzz.subprocess,
+                "run",
+                return_value=completed,
+            ):
+                with self.assertRaisesRegex(
+                    verifier_fuzz.FuzzHarnessError,
+                    "empty corpus",
+                ):
+                    verifier_fuzz.minimize_corpus(
+                        Path("fuzzer"),
+                        corpus,
+                        root / "minimized",
+                        root / "minimization.log",
+                        sanitizer="address-undefined",
+                        profile_pattern=None,
+                    )
+
+    def test_wall_clock_timeout_preserves_campaign_log(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            corpus = root / "corpus"
+            crashes = root / "crashes"
+            corpus.mkdir()
+            crashes.mkdir()
+            timeout = subprocess.TimeoutExpired(
+                cmd=["fuzzer"],
+                timeout=31,
+                output=b"partial stdout",
+                stderr=b"partial stderr",
+            )
+            with mock.patch.object(
+                verifier_fuzz.subprocess,
+                "run",
+                side_effect=timeout,
+            ):
+                completed = verifier_fuzz.run_fuzzer(
+                    Path("fuzzer"),
+                    corpus,
+                    crashes,
+                    root / "fuzzer.log",
+                    runs=None,
+                    seconds=1,
+                    sanitizer="address-undefined",
+                    profile_pattern=None,
+                    seed=188,
+                )
+
+            self.assertEqual(completed.returncode, 124)
+            log = (root / "fuzzer.log").read_text(encoding="utf8")
+            self.assertIn("partial stdout", log)
+            self.assertIn("partial stderr", log)
+            self.assertIn("31-second wall-clock limit", log)
+
+    def test_crash_minimization_timeout_retains_original(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            crashes = output / "crashes"
+            crashes.mkdir()
+            artifact = crashes / "crash-example"
+            artifact.write_bytes(b"crash")
+            timeout = subprocess.TimeoutExpired(
+                cmd=["fuzzer"],
+                timeout=verifier_fuzz.CRASH_MINIMIZATION_TIMEOUT_SECONDS,
+                output=b"partial minimizer output",
+                stderr=b"",
+            )
+            with mock.patch.object(
+                verifier_fuzz.subprocess,
+                "run",
+                side_effect=timeout,
+            ):
+                records = verifier_fuzz.minimize_crash_artifacts(
+                    Path("fuzzer"),
+                    crashes,
+                    output,
+                    sanitizer="address-undefined",
+                    seed=188,
+                )
+
+            self.assertTrue(artifact.is_file())
+            self.assertEqual(len(records), 1)
+            self.assertTrue(records[0]["timed_out"])
+            self.assertEqual(records[0]["return_code"], 124)
+            self.assertIn(
+                "partial minimizer output",
+                (output / "crash-minimization.log").read_text(encoding="utf8"),
+            )
+
+    def test_evidence_hashes_cover_nested_outputs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            nested = output / "minimized-corpus"
+            nested.mkdir()
+            (output / "campaign.json").write_text("{}\n", encoding="utf8")
+            (nested / "seed").write_bytes(b"seed")
+
+            verifier_fuzz.write_evidence_hashes(output)
+
+            sums = (output / "SHA256SUMS").read_text(encoding="utf8")
+            self.assertIn("campaign.json", sums)
+            self.assertIn("minimized-corpus/seed", sums)
+            self.assertNotIn("SHA256SUMS  SHA256SUMS", sums)
+
+    def test_failure_report_retains_actionable_metadata(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            for name in ("corpus", "crashes", "minimized-corpus"):
+                (output / name).mkdir()
+            (output / "corpus" / "seed").write_bytes(b"seed")
+            completed = subprocess.CompletedProcess(
+                args=["fuzzer"],
+                returncode=1,
+                stdout="",
+                stderr="#1 DONE\nstat::number_of_executed_units: 1\n",
+            )
+
+            verifier_fuzz.write_campaign_report(
+                output,
+                compiler=sys.executable,
+                sanitizer="address-undefined",
+                coverage=False,
+                runs=None,
+                seconds=60,
+                imported_seeds=0,
+                source_summary={"total_cases": 207},
+                started_at="2026-07-20T00:00:00+00:00",
+                duration_seconds=1.25,
+                seed=188,
+                completed=completed,
+                processing_error="corpus minimization failed",
+                crash_minimization=[],
+            )
+
+            report = json.loads(
+                (output / "campaign.json").read_text(encoding="utf8")
+            )
+            self.assertEqual(report["status"], "fail")
+            self.assertEqual(report["return_code"], 1)
+            self.assertEqual(report["processing_error"], "corpus minimization failed")
+            self.assertEqual(report["resource_limits"]["seed"], 188)
+            self.assertIn("source_capsule_sha256", report["source_files"])
+            self.assertEqual(report["last_progress_line"], "#1 DONE")
+            self.assertEqual(report["final_stats"], ["stat::number_of_executed_units: 1"])
+
+    def test_campaign_options_require_sanitizers_and_nonzero_seed(self):
+        runner = ENGINEERING_DIR / "run_verifier_fuzz.py"
+        for arguments, message in (
+            (["--seconds", "1"], "fuzz campaign options require --sanitizers"),
+            (["--sanitizers", "--seed", "0"], "--seed must be a nonzero"),
+        ):
+            completed = subprocess.run(
+                [sys.executable, str(runner), *arguments],
+                cwd=REPO_ROOT,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 1)
+            self.assertIn(message, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/test/test_ml_dsa_sustained_fuzz.py
+++ b/ci/test/test_ml_dsa_sustained_fuzz.py
@@ -78,7 +78,7 @@ class MlDsaSustainedFuzzTest(unittest.TestCase):
             workflow,
         )
         self.assertIn(
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+            "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
             workflow,
         )
 

--- a/ci/test/test_ml_dsa_sustained_fuzz.py
+++ b/ci/test/test_ml_dsa_sustained_fuzz.py
@@ -138,6 +138,34 @@ class MlDsaSustainedFuzzTest(unittest.TestCase):
                     self.assertTrue(required <= command)
                     self.assertTrue(prohibited.isdisjoint(command))
 
+    def test_compiler_tool_uses_matching_versioned_fallback(self):
+        completed = (
+            subprocess.CompletedProcess(
+                args=["clang", "--print-prog-name=llvm-profdata"],
+                returncode=0,
+                stdout="llvm-profdata\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["clang", "--version"],
+                returncode=0,
+                stdout="Ubuntu clang version 18.1.3\n",
+                stderr="",
+            ),
+        )
+
+        def resolve(candidate):
+            return "/usr/bin/llvm-profdata-18" if candidate == "llvm-profdata-18" else None
+
+        with mock.patch.object(
+            verifier_fuzz.subprocess,
+            "run",
+            side_effect=completed,
+        ), mock.patch.object(verifier_fuzz.shutil, "which", side_effect=resolve):
+            tool = verifier_fuzz.compiler_tool("clang", "llvm-profdata")
+
+        self.assertEqual(tool, "/usr/bin/llvm-profdata-18")
+
     def test_empty_minimized_corpus_is_a_campaign_failure(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/contrib/ml-dsa-engineering/backend_admission.json
+++ b/contrib/ml-dsa-engineering/backend_admission.json
@@ -154,7 +154,7 @@
     },
     {
       "id": "structure_aware_fuzzing_and_resources",
-      "status": "BOUNDED_FAILURE_HARNESS_ONLY_OPEN",
+      "status": "SUSTAINED_SANITIZER_EVIDENCE_GATE_OPEN",
       "tracking_issue": 188
     },
     {

--- a/contrib/ml-dsa-engineering/run_verifier_fuzz.py
+++ b/contrib/ml-dsa-engineering/run_verifier_fuzz.py
@@ -904,11 +904,24 @@ def compiler_tool(compiler: str, tool: str) -> str:
         stderr=subprocess.DEVNULL,
         text=True,
     )
-    candidate = completed.stdout.strip()
-    resolved = shutil.which(candidate) if candidate else None
-    if completed.returncode != 0 or resolved is None:
-        raise FuzzHarnessError(f"matching {tool} is unavailable for {compiler}")
-    return resolved
+    printed_candidate = completed.stdout.strip()
+    compiler_version = compiler_identity(compiler)
+    version_match = re.search(r"\bclang version (\d+)", compiler_version)
+    candidates = []
+    if printed_candidate and printed_candidate != tool:
+        candidates.append(printed_candidate)
+    if version_match:
+        candidates.append(f"{tool}-{version_match.group(1)}")
+    if printed_candidate:
+        candidates.append(printed_candidate)
+    candidates.append(tool)
+    for candidate in dict.fromkeys(candidates):
+        resolved = shutil.which(candidate)
+        if resolved is not None:
+            return resolved
+    raise FuzzHarnessError(
+        f"matching {tool} is unavailable for {compiler} ({compiler_version})"
+    )
 
 
 def coverage_tool_identities(compiler: str) -> dict:

--- a/contrib/ml-dsa-engineering/run_verifier_fuzz.py
+++ b/contrib/ml-dsa-engineering/run_verifier_fuzz.py
@@ -6,15 +6,19 @@
 import argparse
 import ctypes
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import hashlib
 import json
 import os
 from pathlib import Path
+import platform
 import re
 import shutil
 import struct
+import subprocess
 import sys
 import tempfile
+import time
 
 import run_wrapper_tests as wrapper
 
@@ -61,6 +65,16 @@ RESULT_NAMES = {
     ERR_INVALID_ARGUMENT: "invalid_argument",
     ERR_VERIFY: "verify_rejection",
 }
+SANITIZERS = {
+    "address-undefined": "fuzzer,address,undefined",
+    "memory": "fuzzer,memory",
+}
+CAMPAIGN_SCHEMA_VERSION = 1
+MAX_RETAINED_CORPUS_FILES = 4096
+MAX_RETAINED_CORPUS_BYTES = 32 * 1024 * 1024
+CAMPAIGN_TIMEOUT_ALLOWANCE_SECONDS = 30
+CORPUS_MINIMIZATION_TIMEOUT_SECONDS = 150
+CRASH_MINIMIZATION_TIMEOUT_SECONDS = 75
 
 
 class FuzzHarnessError(RuntimeError):
@@ -534,12 +548,102 @@ def corpus_filename(case: CorpusCase) -> str:
 
 
 def materialize_corpus(directory: Path, cases: list[CorpusCase]) -> None:
-    directory.mkdir()
+    directory.mkdir(parents=True, exist_ok=True)
     for case in cases:
         (directory / corpus_filename(case)).write_bytes(case.frame)
 
 
-def compile_fuzzer(compiler: str, build_dir: Path) -> Path:
+def import_seed_corpus(source: Path, destination: Path) -> int:
+    if not source.is_dir():
+        raise FuzzHarnessError(f"seed corpus is not a directory: {source}")
+    imported = 0
+    total_bytes = 0
+    candidates = [
+        path for path in sorted(source.iterdir()) if not path.is_symlink() and path.is_file()
+    ]
+    if len(candidates) > MAX_RETAINED_CORPUS_FILES:
+        raise FuzzHarnessError("retained corpus exceeds the file-count bound")
+    for path in candidates:
+        size = path.stat().st_size
+        if size > MAX_FRAME_BYTES:
+            raise FuzzHarnessError(f"retained corpus input exceeds fuzz bound: {path}")
+        total_bytes += size
+        if total_bytes > MAX_RETAINED_CORPUS_BYTES:
+            raise FuzzHarnessError("retained corpus exceeds the aggregate byte bound")
+        data = path.read_bytes()
+        if len(data) != size:
+            raise FuzzHarnessError(f"retained corpus input changed during import: {path}")
+        digest = hashlib.sha256(data).hexdigest()
+        target = destination / f"retained_{digest}.bin"
+        if not target.exists():
+            target.write_bytes(data)
+            imported += 1
+    return imported
+
+
+def directory_summary(directory: Path) -> dict:
+    digest = hashlib.sha256()
+    file_count = 0
+    total_bytes = 0
+    if directory.is_dir():
+        for path in sorted(item for item in directory.rglob("*") if item.is_file()):
+            relative = path.relative_to(directory).as_posix()
+            data = path.read_bytes()
+            file_digest = hashlib.sha256(data).hexdigest()
+            digest.update(f"{relative}\0{len(data)}\0{file_digest}\n".encode())
+            file_count += 1
+            total_bytes += len(data)
+    return {
+        "file_count": file_count,
+        "total_bytes": total_bytes,
+        "aggregate_sha256": digest.hexdigest(),
+    }
+
+
+def compiler_identity(compiler: str) -> str:
+    completed = subprocess.run(
+        [compiler, "--version"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return completed.stdout.splitlines()[0] if completed.stdout else compiler
+
+
+def repository_commit() -> str:
+    github_sha = os.environ.get("GITHUB_SHA")
+    if github_sha:
+        return github_sha
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else "unknown"
+
+
+def repository_dirty() -> bool | None:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=REPO_ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return bool(completed.stdout) if completed.returncode == 0 else None
+
+
+def compile_fuzzer(
+    compiler: str,
+    build_dir: Path,
+    sanitizer: str,
+    coverage: bool,
+) -> Path:
     output = build_dir / "pqbtc_mldsa44_verify_fuzz"
     command = wrapper.common_flags(compiler)
     command.extend(
@@ -548,7 +652,15 @@ def compile_fuzzer(compiler: str, build_dir: Path) -> Path:
             "-g",
             "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
-            "-fsanitize=fuzzer,address,undefined",
+            f"-fsanitize={SANITIZERS[sanitizer]}",
+        ]
+    )
+    if sanitizer == "memory":
+        command.extend(["-fsanitize-memory-track-origins=2", "-fPIE", "-pie"])
+    if coverage:
+        command.extend(["-fprofile-instr-generate", "-fcoverage-mapping"])
+    command.extend(
+        [
             str(wrapper.WRAPPER_SOURCE),
             str(FUZZ_SOURCE),
             "-o",
@@ -559,26 +671,382 @@ def compile_fuzzer(compiler: str, build_dir: Path) -> Path:
     return output
 
 
-def run_fuzzer(executable: Path, corpus_dir: Path, artifact_dir: Path, runs: int) -> None:
+def captured_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf8", errors="replace")
+    return value
+
+
+def run_fuzzer(
+    executable: Path,
+    corpus_dir: Path,
+    artifact_dir: Path,
+    log_path: Path,
+    runs: int | None,
+    seconds: int | None,
+    sanitizer: str,
+    profile_pattern: Path | None,
+    seed: int,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
-    env["ASAN_OPTIONS"] = "detect_leaks=0" if sys.platform == "darwin" else "detect_leaks=1"
+    if sanitizer == "address-undefined":
+        env["ASAN_OPTIONS"] = (
+            "detect_leaks=0" if sys.platform == "darwin" else "detect_leaks=1"
+        )
     env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
-    wrapper.run(
-        [
+    if sanitizer == "memory":
+        env["MSAN_OPTIONS"] = "halt_on_error=1:print_stats=1"
+    if profile_pattern is not None:
+        env["LLVM_PROFILE_FILE"] = str(profile_pattern)
+    limit = f"-max_total_time={seconds}" if seconds is not None else f"-runs={runs}"
+    command = [
+        str(executable),
+        str(corpus_dir),
+        f"-artifact_prefix={artifact_dir}{os.sep}",
+        f"-max_len={MAX_FRAME_BYTES}",
+        limit,
+        f"-seed={seed}",
+        "-timeout=5",
+        "-rss_limit_mb=1024",
+        "-malloc_limit_mb=256",
+        "-use_value_profile=1",
+        "-print_final_stats=1",
+    ]
+    wall_timeout = (
+        seconds + CAMPAIGN_TIMEOUT_ALLOWANCE_SECONDS
+        if seconds is not None
+        else None
+    )
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            timeout=wall_timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        completed = subprocess.CompletedProcess(
+            args=command,
+            returncode=124,
+            stdout=captured_output(error.stdout),
+            stderr=(
+                captured_output(error.stderr)
+                + f"\ncampaign exceeded the {wall_timeout}-second wall-clock limit\n"
+            ),
+        )
+    log_path.write_text(
+        f"command: {' '.join(command)}\n\nstdout:\n{completed.stdout}\n\nstderr:\n{completed.stderr}",
+        encoding="utf8",
+    )
+    return completed
+
+
+def minimize_corpus(
+    executable: Path,
+    corpus_dir: Path,
+    destination: Path,
+    log_path: Path,
+    sanitizer: str,
+    profile_pattern: Path | None,
+) -> None:
+    destination.mkdir()
+    env = os.environ.copy()
+    if sanitizer == "address-undefined":
+        env["ASAN_OPTIONS"] = (
+            "detect_leaks=0" if sys.platform == "darwin" else "detect_leaks=1"
+        )
+    env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
+    if sanitizer == "memory":
+        env["MSAN_OPTIONS"] = "halt_on_error=1:print_stats=1"
+    if profile_pattern is not None:
+        env["LLVM_PROFILE_FILE"] = str(profile_pattern)
+    command = [
+        str(executable),
+        "-merge=1",
+        str(destination),
+        str(corpus_dir),
+        f"-max_len={MAX_FRAME_BYTES}",
+        "-timeout=5",
+        "-rss_limit_mb=1024",
+        "-malloc_limit_mb=256",
+        "-max_total_time=120",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            timeout=CORPUS_MINIMIZATION_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as error:
+        log_path.write_text(
+            f"command: {' '.join(command)}\n\nstdout:\n"
+            f"{captured_output(error.stdout)}\n\nstderr:\n"
+            f"{captured_output(error.stderr)}\ncorpus minimization exceeded the "
+            f"{CORPUS_MINIMIZATION_TIMEOUT_SECONDS}-second wall-clock limit\n",
+            encoding="utf8",
+        )
+        raise FuzzHarnessError(
+            "corpus minimization exceeded its wall-clock limit"
+        ) from error
+    log_path.write_text(
+        f"command: {' '.join(command)}\n\nstdout:\n{completed.stdout}\n\n"
+        f"stderr:\n{completed.stderr}",
+        encoding="utf8",
+    )
+    if completed.returncode != 0:
+        raise FuzzHarnessError(f"corpus minimization failed ({completed.returncode})")
+    if directory_summary(destination)["file_count"] == 0:
+        raise FuzzHarnessError("corpus minimization produced an empty corpus")
+
+
+def minimize_crash_artifacts(
+    executable: Path,
+    artifact_dir: Path,
+    output_dir: Path,
+    sanitizer: str,
+    seed: int,
+) -> list[dict]:
+    artifacts = sorted(path for path in artifact_dir.iterdir() if path.is_file())
+    if not artifacts:
+        return []
+    destination = output_dir / "minimized-crashes"
+    destination.mkdir()
+    env = os.environ.copy()
+    if sanitizer == "address-undefined":
+        env["ASAN_OPTIONS"] = (
+            "detect_leaks=0" if sys.platform == "darwin" else "detect_leaks=1"
+        )
+    env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
+    if sanitizer == "memory":
+        env["MSAN_OPTIONS"] = "halt_on_error=1:print_stats=1"
+    records = []
+    log_parts = []
+    for artifact in artifacts[:4]:
+        minimized = destination / artifact.name
+        command = [
             str(executable),
-            str(corpus_dir),
-            f"-artifact_prefix={artifact_dir}{os.sep}",
+            "-minimize_crash=1",
+            f"-exact_artifact_path={minimized}",
+            "-max_total_time=60",
             f"-max_len={MAX_FRAME_BYTES}",
-            f"-runs={runs}",
-            "-seed=188",
+            f"-seed={seed}",
             "-timeout=5",
             "-rss_limit_mb=1024",
             "-malloc_limit_mb=256",
-            "-use_value_profile=1",
-            "-print_final_stats=1",
-        ],
-        env=env,
+            str(artifact),
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                timeout=CRASH_MINIMIZATION_TIMEOUT_SECONDS,
+            )
+            return_code = completed.returncode
+            timed_out = False
+            error_message = None
+            log_parts.append(
+                f"command: {' '.join(command)}\nstdout:\n{completed.stdout}\n"
+                f"stderr:\n{completed.stderr}\n"
+            )
+        except subprocess.TimeoutExpired as error:
+            return_code = 124
+            timed_out = True
+            error_message = (
+                "crash minimization exceeded the "
+                f"{CRASH_MINIMIZATION_TIMEOUT_SECONDS}-second wall-clock limit"
+            )
+            log_parts.append(
+                f"command: {' '.join(command)}\nstdout:\n"
+                f"{captured_output(error.stdout)}\nstderr:\n"
+                f"{captured_output(error.stderr)}\nerror: {error_message}\n"
+            )
+        except OSError as error:
+            return_code = None
+            timed_out = False
+            error_message = str(error)
+            log_parts.append(f"command: {' '.join(command)}\nerror: {error}\n")
+        records.append(
+            {
+                "original": artifact.name,
+                "original_sha256": sha256_file(artifact),
+                "return_code": return_code,
+                "timed_out": timed_out,
+                "error": error_message,
+                "minimized": minimized.name if minimized.is_file() else None,
+                "minimized_sha256": sha256_file(minimized) if minimized.is_file() else None,
+            }
+        )
+    (output_dir / "crash-minimization.log").write_text(
+        "\n".join(log_parts),
+        encoding="utf8",
     )
+    return records
+
+
+def compiler_tool(compiler: str, tool: str) -> str:
+    completed = subprocess.run(
+        [compiler, f"--print-prog-name={tool}"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    candidate = completed.stdout.strip()
+    resolved = shutil.which(candidate) if candidate else None
+    if completed.returncode != 0 or resolved is None:
+        raise FuzzHarnessError(f"matching {tool} is unavailable for {compiler}")
+    return resolved
+
+
+def coverage_tool_identities(compiler: str) -> dict:
+    identities = {}
+    for tool in ("llvm-profdata", "llvm-cov"):
+        try:
+            path = compiler_tool(compiler, tool)
+            identities[tool] = {
+                "path": path,
+                "version": compiler_identity(path),
+            }
+        except (FuzzHarnessError, OSError) as error:
+            identities[tool] = {"error": str(error)}
+    return identities
+
+
+def write_coverage_report(compiler: str, executable: Path, output_dir: Path) -> None:
+    profiles = sorted(output_dir.glob("coverage-*.profraw"))
+    if not profiles:
+        raise FuzzHarnessError("LLVM coverage profiles are unavailable")
+    llvm_profdata = compiler_tool(compiler, "llvm-profdata")
+    llvm_cov = compiler_tool(compiler, "llvm-cov")
+    merged = output_dir / "coverage.profdata"
+    wrapper.run([llvm_profdata, "merge", "-sparse", *map(str, profiles), "-o", str(merged)])
+    report = wrapper.run(
+        [
+            llvm_cov,
+            "report",
+            str(executable),
+            f"-instr-profile={merged}",
+        ]
+    )
+    (output_dir / "coverage.txt").write_text(report, encoding="utf8")
+    exported = wrapper.run(
+        [
+            llvm_cov,
+            "export",
+            "-summary-only",
+            str(executable),
+            f"-instr-profile={merged}",
+        ]
+    )
+    parsed = json.loads(exported)
+    (output_dir / "coverage.json").write_text(
+        json.dumps(parsed, indent=2, sort_keys=True) + "\n",
+        encoding="utf8",
+    )
+
+
+def write_campaign_report(
+    output_dir: Path,
+    *,
+    compiler: str,
+    sanitizer: str,
+    coverage: bool,
+    runs: int | None,
+    seconds: int | None,
+    imported_seeds: int,
+    source_summary: dict,
+    started_at: str,
+    duration_seconds: float,
+    seed: int,
+    completed: subprocess.CompletedProcess[str],
+    processing_error: str | None,
+    crash_minimization: list[dict],
+) -> None:
+    progress_lines = [
+        line.strip()
+        for line in completed.stderr.splitlines()
+        if re.match(r"^#\d+", line.strip())
+    ]
+    final_stats = [
+        line.strip()
+        for line in completed.stderr.splitlines()
+        if line.strip().startswith("stat::")
+    ]
+    report = {
+        "schema_version": CAMPAIGN_SCHEMA_VERSION,
+        "status": (
+            "pass" if completed.returncode == 0 and processing_error is None else "fail"
+        ),
+        "return_code": completed.returncode,
+        "processing_error": processing_error,
+        "repository_commit": repository_commit(),
+        "repository_dirty": repository_dirty(),
+        "started_at": started_at,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "duration_seconds": round(duration_seconds, 3),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "compiler": compiler_identity(compiler),
+        "coverage_tools": coverage_tool_identities(compiler) if coverage else None,
+        "sanitizer": sanitizer,
+        "coverage_enabled": coverage,
+        "campaign_limit": {"runs": runs, "seconds": seconds},
+        "resource_limits": {
+            "max_frame_bytes": MAX_FRAME_BYTES,
+            "input_timeout_seconds": 5,
+            "rss_limit_mb": 1024,
+            "malloc_limit_mb": 256,
+            "seed": seed,
+        },
+        "imported_retained_seeds": imported_seeds,
+        "source_corpus": source_summary,
+        "source_files": {
+            "wrapper_sha256": sha256_file(wrapper.WRAPPER_SOURCE),
+            "fuzz_target_sha256": sha256_file(FUZZ_SOURCE),
+            "corpus_manifest_sha256": sha256_file(CORPUS_MANIFEST),
+            "wycheproof_vectors_sha256": sha256_file(WYCHEPROOF_VECTORS),
+            "source_manifest_sha256": sha256_file(wrapper.SOURCE_MANIFEST),
+            "source_capsule_sha256": json.loads(
+                wrapper.SOURCE_MANIFEST.read_text(encoding="utf8")
+            )["capsule_hash"]["value"],
+        },
+        "working_corpus": directory_summary(output_dir / "corpus"),
+        "minimized_corpus": directory_summary(output_dir / "minimized-corpus"),
+        "crash_artifacts": directory_summary(output_dir / "crashes"),
+        "minimized_crash_artifacts": directory_summary(
+            output_dir / "minimized-crashes"
+        ),
+        "crash_minimization": crash_minimization,
+        "last_progress_line": progress_lines[-1] if progress_lines else None,
+        "final_stats": final_stats,
+    }
+    (output_dir / "campaign.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf8",
+    )
+
+
+def write_evidence_hashes(output_dir: Path) -> None:
+    lines = []
+    for path in sorted(item for item in output_dir.rglob("*") if item.is_file()):
+        if path.name == "SHA256SUMS":
+            continue
+        relative = path.relative_to(output_dir).as_posix()
+        lines.append(f"{sha256_file(path)}  {relative}\n")
+    (output_dir / "SHA256SUMS").write_text("".join(lines), encoding="utf8")
 
 
 def main() -> int:
@@ -587,11 +1055,42 @@ def main() -> int:
     )
     parser.add_argument("--manifest-only", action="store_true")
     parser.add_argument("--sanitizers", action="store_true")
-    parser.add_argument("--runs", type=int, default=1000)
+    parser.add_argument(
+        "--sanitizer",
+        choices=sorted(SANITIZERS),
+        default="address-undefined",
+    )
+    parser.add_argument("--runs", type=int)
+    parser.add_argument("--seconds", type=int)
+    parser.add_argument("--seed", type=int, default=188)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--seed-corpus", type=Path)
+    parser.add_argument("--coverage", action="store_true")
     args = parser.parse_args()
-    if args.runs < 1:
+    if args.runs is not None and args.seconds is not None:
+        raise FuzzHarnessError("--runs and --seconds are mutually exclusive")
+    if args.runs is not None and args.runs < 1:
         raise FuzzHarnessError("--runs must be positive")
+    if args.seconds is not None and args.seconds < 1:
+        raise FuzzHarnessError("--seconds must be positive")
+    if not 1 <= args.seed <= 0xFFFFFFFF:
+        raise FuzzHarnessError("--seed must be a nonzero unsigned 32-bit integer")
+    if args.coverage and not args.sanitizers:
+        raise FuzzHarnessError("--coverage requires --sanitizers")
+    if args.coverage and args.sanitizer == "memory":
+        raise FuzzHarnessError("coverage is collected only in the address-undefined campaign")
+    if not args.sanitizers and (
+        args.runs is not None
+        or args.seconds is not None
+        or args.output_dir is not None
+        or args.seed_corpus is not None
+        or args.coverage
+        or args.sanitizer != "address-undefined"
+        or args.seed != 188
+    ):
+        raise FuzzHarnessError("fuzz campaign options require --sanitizers")
 
+    wrapper.validate_source_capsule()
     wycheproof = validate_wycheproof_source()
     if args.manifest_only:
         manifest = json.loads(CORPUS_MANIFEST.read_text(encoding="utf8"))
@@ -605,6 +1104,11 @@ def main() -> int:
     compiler = os.environ.get("CC", "cc")
     if shutil.which(compiler) is None:
         raise FuzzHarnessError(f"C compiler not found: {compiler}")
+    if args.sanitizers and args.sanitizer == "memory":
+        if not sys.platform.startswith("linux"):
+            raise FuzzHarnessError("MemorySanitizer campaigns require Linux")
+        if "clang" not in compiler_identity(compiler).lower():
+            raise FuzzHarnessError("MemorySanitizer campaigns require Clang")
     with tempfile.TemporaryDirectory(prefix="pqbtc-mldsa44-verifier-fuzz-") as temporary:
         build_dir = Path(temporary)
         production_library = wrapper.compile_shared(compiler, build_dir, testing=False)
@@ -613,14 +1117,118 @@ def main() -> int:
         summary = validate_corpus_manifest(cases)
         replay_corpus(production_library, cases)
         if args.sanitizers:
-            corpus_dir = build_dir / "corpus"
-            artifact_dir = build_dir / "artifacts"
+            runs = args.runs if args.runs is not None else (None if args.seconds else 1000)
+            if args.output_dir is None:
+                output_dir = build_dir / "campaign"
+            else:
+                output_dir = args.output_dir.resolve()
+                if output_dir.exists():
+                    if not output_dir.is_dir():
+                        raise FuzzHarnessError(
+                            f"output directory path is not a directory: {output_dir}"
+                        )
+                    if any(output_dir.iterdir()):
+                        raise FuzzHarnessError(
+                            f"output directory is not empty: {output_dir}"
+                        )
+            output_dir.mkdir(parents=True, exist_ok=True)
+            corpus_dir = output_dir / "corpus"
+            artifact_dir = output_dir / "crashes"
             artifact_dir.mkdir()
             materialize_corpus(corpus_dir, cases)
-            fuzzer = compile_fuzzer(compiler, build_dir)
-            run_fuzzer(fuzzer, corpus_dir, artifact_dir, args.runs)
+            imported_seeds = 0
+            if args.seed_corpus is not None:
+                imported_seeds = import_seed_corpus(args.seed_corpus.resolve(), corpus_dir)
+            started_at = datetime.now(timezone.utc).isoformat()
+            monotonic_start = time.monotonic()
+            completed = subprocess.CompletedProcess([], 1, "", "campaign did not start")
+            processing_error = None
+            crash_minimization = []
+            try:
+                fuzzer = compile_fuzzer(
+                    compiler,
+                    build_dir,
+                    sanitizer=args.sanitizer,
+                    coverage=args.coverage,
+                )
+                profile_pattern = (
+                    output_dir / "coverage-%p.profraw" if args.coverage else None
+                )
+                completed = run_fuzzer(
+                    fuzzer,
+                    corpus_dir,
+                    artifact_dir,
+                    output_dir / "fuzzer.log",
+                    runs=runs,
+                    seconds=args.seconds,
+                    sanitizer=args.sanitizer,
+                    profile_pattern=profile_pattern,
+                    seed=args.seed,
+                )
+                if completed.returncode == 0:
+                    merge_profile = (
+                        output_dir / "coverage-merge-%p.profraw"
+                        if args.coverage
+                        else None
+                    )
+                    minimize_corpus(
+                        fuzzer,
+                        corpus_dir,
+                        output_dir / "minimized-corpus",
+                        output_dir / "corpus-minimization.log",
+                        sanitizer=args.sanitizer,
+                        profile_pattern=merge_profile,
+                    )
+                    if args.coverage:
+                        write_coverage_report(compiler, fuzzer, output_dir)
+                else:
+                    crash_minimization = minimize_crash_artifacts(
+                        fuzzer,
+                        artifact_dir,
+                        output_dir,
+                        sanitizer=args.sanitizer,
+                        seed=args.seed,
+                    )
+            except (FuzzHarnessError, wrapper.HarnessError, OSError, ValueError) as error:
+                processing_error = str(error)
+            finally:
+                write_campaign_report(
+                    output_dir,
+                    compiler=compiler,
+                    sanitizer=args.sanitizer,
+                    coverage=args.coverage,
+                    runs=runs,
+                    seconds=args.seconds,
+                    imported_seeds=imported_seeds,
+                    source_summary=summary,
+                    started_at=started_at,
+                    duration_seconds=time.monotonic() - monotonic_start,
+                    seed=args.seed,
+                    completed=completed,
+                    processing_error=processing_error,
+                    crash_minimization=crash_minimization,
+                )
+                write_evidence_hashes(output_dir)
+            if processing_error is not None:
+                evidence = (
+                    f"evidence retained in {output_dir}"
+                    if args.output_dir is not None
+                    else "temporary evidence discarded; pass --output-dir to retain it"
+                )
+                raise FuzzHarnessError(
+                    f"campaign processing failed; {evidence}: {processing_error}"
+                )
+            if completed.returncode != 0:
+                evidence = (
+                    f"evidence retained in {output_dir}"
+                    if args.output_dir is not None
+                    else "temporary evidence discarded; pass --output-dir to retain it"
+                )
+                raise FuzzHarnessError(
+                    f"fuzzer failed ({completed.returncode}); {evidence}"
+                )
 
-    mode = "sanitized fuzz" if args.sanitizers else "deterministic replay"
+    mode = f"{args.sanitizer} fuzz" if args.sanitizers else "deterministic replay"
     print(
         f"ML-DSA-44 verifier {mode} passed: {summary['total_cases']} cases, "
         f"{summary['expected_counts']['ok']} accepted"

--- a/docs/ML_DSA_44_BACKEND_ADMISSION.md
+++ b/docs/ML_DSA_44_BACKEND_ADMISSION.md
@@ -159,7 +159,7 @@ Prototype admission closes no production finding:
 | Supported-platform side channels | #185 | open |
 | Fault model and injected faults | #186 | open |
 | End-to-end secret erasure | #187 | source cleanup and sanitizer evidence only; compiler/caller/platform boundary open |
-| Structure-aware fuzzing and resource limits | #188 | pinned Wycheproof replay and bounded structure-aware ASan/UBSan fuzzing; sustained campaigns and production resource limits open |
+| Structure-aware fuzzing and resource limits | #188 | pinned Wycheproof replay plus scheduled structure-aware ASan/UBSan and MSan campaigns with retained evidence; differential/back-end coverage, advisory ingestion, adapter fuzzing, adversarial resource tests, broader platforms, and production limits open |
 | Backend advisories, SBOM, and reproducible build | #189 | pinned network-free source capsule only; SBOM, reproducibility, and monitoring open |
 | Wallet and key format | #190 | open |
 | Independent human cryptographic review | #181 | open |

--- a/docs/ML_DSA_44_WRAPPER_PROTOTYPE.md
+++ b/docs/ML_DSA_44_WRAPPER_PROTOTYPE.md
@@ -118,7 +118,14 @@ python3 contrib/ml-dsa-engineering/run_wrapper_tests.py --sanitizers
 python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --manifest-only
 python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py
 CC=clang python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --sanitizers --runs 10000
+CC=clang python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py \
+  --sanitizers --sanitizer address-undefined --seconds 1800 \
+  --coverage --output-dir /tmp/ml-dsa-44-asan
+CC=clang python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py \
+  --sanitizers --sanitizer memory --seconds 1800 \
+  --output-dir /tmp/ml-dsa-44-msan
 python3 -m unittest ci.test.test_ml_dsa_wrapper_prototype
+python3 -m unittest ci.test.test_ml_dsa_sustained_fuzz
 ```
 
 The verifier harness deterministically regenerates and replays 207 bounded
@@ -127,10 +134,28 @@ and 27 project cases covering commitment, `z`, hint, public-key, message,
 context, length, and null-pointer boundaries. The frozen manifest records 202
 unique frames and their expected strict-wrapper result classes. Its custom
 libFuzzer mutator preserves the frame format while targeting those same
-ML-DSA-44 fields. CI runs replay with GCC and Clang and a 10,000-execution
-ASan/UBSan campaign with Clang. The 4,096-byte message cap, five-second input
-timeout, 1 GiB RSS cap, and 256 MiB allocation cap are fuzz-campaign bounds,
-not production protocol limits or exhaustive resource proofs.
+ML-DSA-44 fields. CI runs replay with GCC and Clang; the dedicated workflow
+runs the bounded sanitizer campaigns described below. The 4,096-byte message
+cap, five-second input timeout, 1 GiB RSS cap, and 256 MiB allocation cap are
+fuzz-campaign bounds, not production protocol limits or exhaustive resource
+proofs.
+
+The dedicated sustained-fuzzing workflow runs separate Linux Clang
+ASan/UBSan and MSan jobs. Pull requests and pushes use 60-second smoke
+campaigns; the weekly schedule and manual dispatch use 1,800-second campaigns.
+Each run retains the complete log, machine-readable campaign metadata,
+content-addressed SHA256 provenance, crash inputs, best-effort minimized crash
+inputs, and a coverage-minimized corpus for 90 days. ASan/UBSan also emits
+text and JSON LLVM source-coverage summaries.
+Scheduled and manual runs may seed from the most recent successful retained
+corpus; imported files are bounded to the 8,096-byte frame limit and renamed
+by content hash. Scheduled and manual campaigns use a varying recorded seed;
+pull-request and push smokes retain seed 188 for exact repeatability. MSan
+instruments the complete portable backend translation unit, but system-library
+coverage still depends on LLVM interceptors and is not an all-code proof. A
+retained crash is evidence to investigate, not an
+automatically trusted regression vector: promotion into a checked-in corpus
+still requires review.
 
 ## Residual Boundary
 
@@ -146,8 +171,11 @@ This prototype advances engineering evidence but closes no production gate:
 - issue `#187`: explicit source cleanup and sanitizer evidence do not prove
   erasure of compiler copies, registers, caller-owned keys, or crash artifacts;
 - issue `#188`: deterministic Wycheproof replay and bounded structure-aware
-  ASan/UBSan fuzzing are now implemented, but sustained multi-platform fuzzing,
-  retained regression artifacts, and production resource limits remain open;
+  ASan/UBSan and MSan campaigns with retained evidence are now implemented,
+  but multi-backend differential and adapter fuzzing, automatic advisory-case
+  ingestion, Rust coverage if a Rust backend is admitted, broader platforms,
+  minimum coverage goals, reviewed regression-vector promotion, and stack,
+  worst-case, and adversarial-batch resource limits remain open;
 - issue `#189`: the source capsule and network-free build are partial evidence,
   not an SBOM, reproducibility campaign, or ongoing advisory process;
 - issue `#190`: key ownership, formats, backup, PSBT, and hardware-wallet


### PR DESCRIPTION
## Summary

- add a dedicated Linux Clang matrix with 60-second PR/push smokes and weekly/manual 1,800-second ASan+UBSan and MSan campaigns
- retain bounded, minimized corpora plus campaign metadata, logs, source coverage, hashes, seeds, toolchains, and original/minimized crash artifacts for 90 days
- restore the exact latest successful main-branch corpus attempt for long campaigns, with content and aggregate bounds
- add aggregate wall-clock limits and failure-path evidence handling without changing the production backend, RELEASE_HOLD, wallet, Script, consensus, or ALG_ID surfaces
- record this partial progress while leaving the remaining #188 differential, adapter, advisory-ingestion, platform, coverage-goal, and adversarial-resource work open

## Validation

- python3 -m py_compile contrib/ml-dsa-engineering/run_verifier_fuzz.py ci/test/test_ml_dsa_sustained_fuzz.py
- python3 -m unittest ci.test.test_ml_dsa_sustained_fuzz ci.test.test_ml_dsa_wrapper_prototype ci.test.test_ml_dsa_backend_admission (24 passed)
- python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --manifest-only
- python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py (207 cases, 81 accepted)
- python3 ci/test/check_ci_inventory.py
- python3 test/lint/lint-files.py
- Ruby YAML parse and git diff --check

The actual libFuzzer sanitizer/linker matrix is Linux-specific and is delegated to this PRs GitHub Actions run.