### PR TITLE
preserve fuzzer value-profile corpus features

### DIFF
--- a/ci/test/test_ml_dsa_sustained_fuzz.py
+++ b/ci/test/test_ml_dsa_sustained_fuzz.py
@@ -193,6 +193,40 @@ class MlDsaSustainedFuzzTest(unittest.TestCase):
                         profile_pattern=None,
                     )
 
+    def test_corpus_minimization_preserves_value_profile_features(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            corpus = root / "corpus"
+            corpus.mkdir()
+            (corpus / "seed").write_bytes(b"seed")
+
+            def run(command, **_kwargs):
+                (root / "minimized" / "seed").write_bytes(b"seed")
+                return subprocess.CompletedProcess(
+                    args=command,
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                )
+
+            with mock.patch.object(
+                verifier_fuzz.subprocess,
+                "run",
+                side_effect=run,
+            ) as run_mock:
+                verifier_fuzz.minimize_corpus(
+                    Path("fuzzer"),
+                    corpus,
+                    root / "minimized",
+                    root / "minimization.log",
+                    sanitizer="address-undefined",
+                    profile_pattern=None,
+                )
+
+            command = run_mock.call_args.args[0]
+            self.assertIn("-merge=1", command)
+            self.assertEqual(command.count("-use_value_profile=1"), 1)
+
     def test_wall_clock_timeout_preserves_campaign_log(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/contrib/ml-dsa-engineering/run_verifier_fuzz.py
+++ b/contrib/ml-dsa-engineering/run_verifier_fuzz.py
@@ -768,6 +768,7 @@ def minimize_corpus(
     command = [
         str(executable),
         "-merge=1",
+        "-use_value_profile=1",
         str(destination),
         str(corpus_dir),
         f"-max_len={MAX_FRAME_BYTES}",


### PR DESCRIPTION
## Issue

PR #198 enabled libFuzzer value profiling during sustained verifier campaigns, but its corpus-minimization merge did not enable the same feature set. This follows up the unresolved review at https://github.com/scottdhughes/quantum-proof-bitcoin/pull/198#discussion_r3618121118 and advances #188.

The mismatch could discard retained inputs whose only novel signal is value-profile coverage. That weakens the seed corpus restored by later scheduled or manually dispatched campaigns. It does not affect production node, wallet, Script, consensus, or verification behavior; the impact is limited to fuzzing evidence quality.

## Root cause

`run_fuzzer()` passed `-use_value_profile=1`, while `minimize_corpus()` invoked libFuzzer merge mode without that option. Merge therefore evaluated corpus usefulness with a narrower feature set than the campaign that discovered the inputs.

## Fix

- pass `-use_value_profile=1` to corpus minimization alongside `-merge=1`
- add a regression test that exercises a successful merge and requires exactly one value-profile flag in the subprocess command

No workflow, production backend, release-hold, wallet, Script, consensus, or `ALG_ID` surface changes.

## Validation

- `python3 -m unittest ci.test.test_ml_dsa_sustained_fuzz.MlDsaSustainedFuzzTest.test_corpus_minimization_preserves_value_profile_features` (1 passed)
- `python3 -m unittest ci.test.test_ml_dsa_sustained_fuzz ci.test.test_ml_dsa_wrapper_prototype ci.test.test_ml_dsa_backend_admission` (26 passed)
- `python3 -m py_compile contrib/ml-dsa-engineering/run_verifier_fuzz.py ci/test/test_ml_dsa_sustained_fuzz.py`
- `python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --manifest-only` (180 pinned Wycheproof cases)
- `python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py` (207 cases, 81 accepted)
- `python3 ci/test/check_ci_inventory.py`
- `python3 test/lint/lint-files.py`
- `git diff --check`

An attempted local Clang sanitizer smoke could not link because the installed macOS Command Line Tools do not provide `libclang_rt.fuzzer_osx.a`. The repository's Linux sanitizer jobs remain the authoritative real-libFuzzer validation.
