### PR TITLE
ci: audit isolated ML-DSA wrapper with static tools

### DIFF
--- a/.github/workflows/ml-dsa-44-wrapper-prototype.yml
+++ b/.github/workflows/ml-dsa-44-wrapper-prototype.yml
@@ -4,12 +4,18 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ml-dsa-44-wrapper-prototype.yml"
+      - "ci/test/00_setup_env_native_tidy.sh"
+      - "ci/test/01_base_install.sh"
+      - "ci/test/03_test_script.sh"
       - "ci/test/test_ml_dsa_wrapper_prototype.py"
+      - "contrib/devtools/bitcoin-tidy/**"
+      - "contrib/devtools/iwyu/bitcoin.core.imp"
       - "contrib/ml-dsa-engineering/**"
       - "contrib/ml-dsa-ref/vectors.json"
       - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
       - "docs/ML_DSA_44_HEDGED_SIGNING_CONTRACT.md"
       - "docs/ML_DSA_44_WRAPPER_PROTOTYPE.md"
+      - "src/.clang-tidy"
   workflow_dispatch:
 
 permissions:
@@ -32,7 +38,47 @@ jobs:
         env:
           CC: ${{ matrix.compiler }}
         run: |
+          python3 -m unittest \
+            ci.test.test_ml_dsa_wrapper_prototype.MlDsaWrapperPrototypeTest.test_static_analysis_plan_is_pinned \
+            ci.test.test_ml_dsa_wrapper_prototype.MlDsaWrapperPrototypeTest.test_static_analysis_plan_matches_wrapper_build_variants
           python3 contrib/ml-dsa-engineering/run_wrapper_tests.py
           python3 contrib/ml-dsa-engineering/run_wrapper_tests.py --sanitizers
           python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --manifest-only
           python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py
+
+  static-analysis:
+    name: Isolated wrapper (clang-tidy 20 + scoped IWYU)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      DANGER_CI_ON_HOST_FOLDERS: 1
+      FILE_ENV: './ci/test/00_setup_env_native_tidy.sh'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Configure environment
+        uses: ./.github/actions/configure-environment
+
+      - name: Restore caches
+        uses: ./.github/actions/restore-caches
+
+      - name: Configure Docker
+        uses: ./.github/actions/configure-docker
+        with:
+          cache-provider: gha
+
+      - name: Run versioned static analysis
+        run: ./ci/test_run_all.sh
+
+      - name: Upload static-analysis evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ml-dsa-44-wrapper-static-analysis-${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.BASE_BUILD_DIR }}/ml-dsa-44-wrapper-static-analysis
+          if-no-files-found: warn
+          retention-days: 90
+          compression-level: 9

--- a/.github/workflows/promotion-matrix.yml
+++ b/.github/workflows/promotion-matrix.yml
@@ -608,5 +608,15 @@ jobs:
       - name: CI script
         run: ./ci/test_run_all.sh
 
+      - name: Upload ML-DSA-44 wrapper static-analysis evidence
+        if: ${{ always() && matrix.name == 'tidy' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ml-dsa-44-wrapper-static-analysis-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.BASE_BUILD_DIR }}/ml-dsa-44-wrapper-static-analysis
+          if-no-files-found: warn
+          retention-days: 90
+          compression-level: 9
+
       - name: Save caches
         uses: ./.github/actions/save-caches

--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -9,6 +9,8 @@ export LC_ALL=C.UTF-8
 export CI_IMAGE_NAME_TAG="mirror.gcr.io/ubuntu:24.04"
 export CONTAINER_NAME=ci_native_tidy
 export TIDY_LLVM_V="20"
+# Pin the matching IWYU source instead of resolving the mutable clang_20 branch.
+export IWYU_COMMIT="6e08906c66b3009f2d590e4bd40d60fa303bf803"
 export APT_LLVM_V="${TIDY_LLVM_V}"
 export PACKAGES="clang-${TIDY_LLVM_V} libclang-${TIDY_LLVM_V}-dev llvm-${TIDY_LLVM_V}-dev libomp-${TIDY_LLVM_V}-dev clang-tidy-${TIDY_LLVM_V} jq libevent-dev libboost-dev libzmq3-dev systemtap-sdt-dev qt6-base-dev qt6-tools-dev qt6-l10n-tools libqrencode-dev libsqlite3-dev libcapnp-dev capnproto"
 export NO_DEPENDS=1

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -79,7 +79,12 @@ if [[ -n "${USE_INSTRUMENTED_LIBCPP}" ]]; then
 fi
 
 if [[ "${RUN_TIDY}" == "true" ]]; then
-  ${CI_RETRY_EXE} git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_"${TIDY_LLVM_V}" /include-what-you-use
+  test -n "${IWYU_COMMIT}"
+  git init /include-what-you-use
+  git -C /include-what-you-use remote add origin https://github.com/include-what-you-use/include-what-you-use
+  ${CI_RETRY_EXE} git -C /include-what-you-use fetch --depth=1 origin "${IWYU_COMMIT}"
+  git -C /include-what-you-use checkout --detach FETCH_HEAD
+  test "$(git -C /include-what-you-use rev-parse HEAD)" = "${IWYU_COMMIT}"
   cmake -B /iwyu-build/ -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-"${TIDY_LLVM_V}" -S /include-what-you-use
   make -C /iwyu-build/ install "$MAKEJOBS"
 fi

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -329,6 +329,9 @@ if [ "${RUN_TIDY}" = "true" ]; then
   fi
 
   cd "${BASE_ROOT_DIR}"
+  python3 "${BASE_ROOT_DIR}/contrib/ml-dsa-engineering/run_static_analysis.py" \
+    --output-dir "${BASE_BUILD_DIR}/ml-dsa-44-wrapper-static-analysis"
+
   python3 "/include-what-you-use/iwyu_tool.py" \
            -p "${BASE_BUILD_DIR}" "${MAKEJOBS}" \
            -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="${BASE_ROOT_DIR}/contrib/devtools/iwyu/bitcoin.core.imp" \
@@ -337,10 +340,6 @@ if [ "${RUN_TIDY}" = "true" ]; then
   cd "${BASE_ROOT_DIR}/src"
   python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out
   git --no-pager diff
-
-  cd "${BASE_ROOT_DIR}"
-  python3 "${BASE_ROOT_DIR}/contrib/ml-dsa-engineering/run_static_analysis.py" \
-    --output-dir "${BASE_BUILD_DIR}/ml-dsa-44-wrapper-static-analysis"
 fi
 
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -337,6 +337,10 @@ if [ "${RUN_TIDY}" = "true" ]; then
   cd "${BASE_ROOT_DIR}/src"
   python3 "/include-what-you-use/fix_includes.py" --nosafe_headers < /tmp/iwyu_ci.out
   git --no-pager diff
+
+  cd "${BASE_ROOT_DIR}"
+  python3 "${BASE_ROOT_DIR}/contrib/ml-dsa-engineering/run_static_analysis.py" \
+    --output-dir "${BASE_BUILD_DIR}/ml-dsa-44-wrapper-static-analysis"
 fi
 
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then

--- a/ci/test/test_ml_dsa_wrapper_prototype.py
+++ b/ci/test/test_ml_dsa_wrapper_prototype.py
@@ -16,6 +16,19 @@ SOURCE_MANIFEST = ENGINEERING_DIR / "vendor" / "mldsa-native" / "SOURCE.json"
 ADMISSION = ENGINEERING_DIR / "backend_admission.json"
 PROTOTYPE_DOCUMENT = REPO_ROOT / "docs" / "ML_DSA_44_WRAPPER_PROTOTYPE.md"
 FUZZ_MANIFEST = ENGINEERING_DIR / "verifier_fuzz_corpus.json"
+STATIC_ANALYSIS = ENGINEERING_DIR / "run_static_analysis.py"
+
+
+def load_static_analysis_plan() -> dict:
+    completed = subprocess.run(
+        [sys.executable, str(STATIC_ANALYSIS), "--plan-only"],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return json.loads(completed.stdout)
 
 
 class MlDsaWrapperPrototypeTest(unittest.TestCase):
@@ -101,6 +114,134 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
             cwd=REPO_ROOT,
             check=True,
         )
+
+    def test_static_analysis_plan_is_pinned(self):
+        plan = load_static_analysis_plan()
+        self.assertEqual(plan["schema_version"], 1)
+        self.assertEqual(plan["expected_llvm_major"], 20)
+        self.assertEqual(
+            plan["tools"]["iwyu"]["source_commit"],
+            "6e08906c66b3009f2d590e4bd40d60fa303bf803",
+        )
+        self.assertEqual(
+            plan["tools"]["iwyu"]["source_dir"], "/include-what-you-use"
+        )
+        self.assertTrue(plan["scope"]["isolated_wrapper_only"])
+        self.assertTrue(plan["scope"]["clang_tidy_wrapper_implementation"])
+        self.assertFalse(plan["scope"]["iwyu_wrapper_implementation"])
+        self.assertTrue(
+            plan["scope"]["iwyu_first_party_leaf_units_and_headers"]
+        )
+        self.assertFalse(plan["scope"]["production_integration"])
+        self.assertTrue(plan["scope"]["release_hold_unchanged"])
+        self.assertTrue(
+            plan["source_capsule"]["verified_against_checked_in_files"]
+        )
+        self.assertEqual(
+            plan["reporting_boundary"]["vendor_root"],
+            "contrib/ml-dsa-engineering/vendor",
+        )
+        self.assertTrue(
+            plan["reporting_boundary"]["vendor_files_are_never_main_inputs"]
+        )
+        for evidence_source in (
+            ".github/workflows/ml-dsa-44-wrapper-prototype.yml",
+            ".github/workflows/promotion-matrix.yml",
+            "ci/test/00_setup_env_native_tidy.sh",
+            "ci/test/01_base_install.sh",
+            "ci/test/03_test_script.sh",
+            "ci/test/test_ml_dsa_wrapper_prototype.py",
+            "contrib/ml-dsa-engineering/README.md",
+        ):
+            self.assertRegex(
+                plan["source_files"][evidence_source], r"^[0-9a-f]{64}$"
+            )
+
+        checks = plan["checks"]
+        counts = {
+            kind: sum(check["kind"] == kind for check in checks)
+            for kind in (
+                "clang-tidy",
+                "iwyu",
+                "header-self-containment",
+            )
+        }
+        self.assertEqual(
+            counts,
+            {
+                "clang-tidy": 4,
+                "iwyu": 2,
+                "header-self-containment": 2,
+            },
+        )
+        for check in checks:
+            self.assertNotIn("/vendor/", check["input"])
+            if check["kind"] == "clang-tidy":
+                self.assertIn(
+                    "--exclude-header-filter="
+                    + plan["reporting_boundary"]["vendor_header_exclude"],
+                    check["command"],
+                )
+                self.assertIn("--warnings-as-errors=*", check["command"])
+            if check["kind"] == "iwyu":
+                self.assertNotEqual(
+                    check["input"],
+                    "contrib/ml-dsa-engineering/pqbtc_mldsa44.c",
+                )
+                self.assertIn("--error=1", check["command"])
+                self.assertTrue(check["check_also"])
+                self.assertFalse(
+                    any("/vendor/" in path for path in check["check_also"])
+                )
+
+    def test_static_analysis_plan_matches_wrapper_build_variants(self):
+        plan = load_static_analysis_plan()
+        self.assertEqual(plan["tools"]["clang"]["command"], "clang-20")
+        self.assertEqual(
+            plan["tools"]["clang-tidy"]["command"], "clang-tidy-20"
+        )
+        self.assertEqual(
+            plan["tools"]["iwyu"]["command"], "include-what-you-use"
+        )
+
+        checks = {check["id"]: check for check in plan["checks"]}
+        expected_ids = {
+            "clang-tidy-wrapper-production",
+            "clang-tidy-wrapper-testing",
+            "clang-tidy-smoke-testing",
+            "clang-tidy-verifier-fuzz",
+            "iwyu-smoke-testing",
+            "iwyu-verifier-fuzz",
+            "header-self-contained-production",
+            "header-self-contained-testing",
+        }
+        self.assertEqual(set(checks), expected_ids)
+        for check in checks.values():
+            self.assertIn("-std=c11", check["command"])
+
+        testing_define = "-DPQBTC_MLDSA44_TESTING=1"
+        self.assertNotIn(
+            testing_define, checks["clang-tidy-wrapper-production"]["command"]
+        )
+        self.assertIn(
+            testing_define, checks["clang-tidy-wrapper-testing"]["command"]
+        )
+        self.assertIn(testing_define, checks["clang-tidy-smoke-testing"]["command"])
+        self.assertIn(testing_define, checks["iwyu-smoke-testing"]["command"])
+        self.assertIn("-pthread", checks["clang-tidy-smoke-testing"]["command"])
+        self.assertIn("-pthread", checks["iwyu-smoke-testing"]["command"])
+        self.assertNotIn(
+            testing_define, checks["clang-tidy-verifier-fuzz"]["command"]
+        )
+        self.assertNotIn(testing_define, checks["iwyu-verifier-fuzz"]["command"])
+
+        for check_id in (
+            "header-self-contained-production",
+            "header-self-contained-testing",
+        ):
+            self.assertIn("-x", checks[check_id]["command"])
+            self.assertIn("c-header", checks[check_id]["command"])
+            self.assertIn("-fsyntax-only", checks[check_id]["command"])
 
 
 if __name__ == "__main__":

--- a/ci/test/test_ml_dsa_wrapper_prototype.py
+++ b/ci/test/test_ml_dsa_wrapper_prototype.py
@@ -144,6 +144,19 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
         self.assertTrue(
             plan["reporting_boundary"]["vendor_files_are_never_main_inputs"]
         )
+        self.assertEqual(
+            plan["reporting_boundary"]["clang_tidy_local_suppression"],
+            {
+                "check": "clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling",
+                "annotation": "NOLINTNEXTLINE",
+                "occurrences": 13,
+                "expected_occurrences": 13,
+                "reason": (
+                    "C11 Annex K _s functions are optional and unavailable on "
+                    "the supported Linux toolchain"
+                ),
+            },
+        )
         for evidence_source in (
             ".github/workflows/ml-dsa-44-wrapper-prototype.yml",
             ".github/workflows/promotion-matrix.yml",
@@ -177,6 +190,10 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
         for check in checks:
             self.assertNotIn("/vendor/", check["input"])
             if check["kind"] == "clang-tidy":
+                self.assertIn(
+                    "--checks=clang-analyzer-*",
+                    check["command"],
+                )
                 self.assertIn(
                     "--exclude-header-filter="
                     + plan["reporting_boundary"]["vendor_header_exclude"],

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -52,6 +52,10 @@ versions and binary hashes. IWYU is built from exact source commit
 `6e08906c66b3009f2d590e4bd40d60fa303bf803`. The audit runs clang-tidy over
 the production wrapper, test wrapper, smoke harness, and verifier fuzz target,
 then checks both public headers for C11 self-containment.
+The optional Annex-K `_s` functions recommended by one analyzer check are
+unavailable on the supported Linux toolchain. That checker remains enabled and
+fatal for new call sites; the 13 reviewed portable API calls use localized,
+inventory-checked `NOLINTNEXTLINE` annotations.
 
 IWYU is enforced only on the first-party smoke and verifier-fuzz translation
 units and their wrapper headers. It intentionally does not propose edits for

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -42,3 +42,27 @@ The normative requirements and lifecycle limits are in
 candidate comparison are in `docs/ML_DSA_44_BACKEND_ADMISSION.md`.
 The implemented evidence and remaining boundaries are in
 `docs/ML_DSA_44_WRAPPER_PROTOTYPE.md`.
+
+## Versioned Static-Analysis Audit
+
+`run_static_analysis.py` defines the isolated wrapper's versioned
+clang-tidy/IWYU boundary. The wrapper workflow and the Promotion Matrix tidy
+lane constrain LLVM/clang-tidy to major version 20 and record the exact tool
+versions and binary hashes. IWYU is built from exact source commit
+`6e08906c66b3009f2d590e4bd40d60fa303bf803`. The audit runs clang-tidy over
+the production wrapper, test wrapper, smoke harness, and verifier fuzz target,
+then checks both public headers for C11 self-containment.
+
+IWYU is enforced only on the first-party smoke and verifier-fuzz translation
+units and their wrapper headers. It intentionally does not propose edits for
+`pqbtc_mldsa44.c`, because that file includes the pinned upstream
+single-compilation-unit implementation and its nested `.c` files. Clang-tidy
+still parses that implementation as part of the wrapper translation unit, but
+the audit reports primary diagnostics only at first-party wrapper locations.
+
+Each run retains the exact plan, resolved tool and source identities,
+per-command logs,
+a machine-readable result, and `SHA256SUMS` in a commit-named workflow
+artifact. This is static source-analysis evidence only. It is not a proof of
+memory safety, constant-time behavior, secret erasure, or production fitness,
+and it does not alter the release hold.

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44.c
@@ -106,6 +106,7 @@ static int FillEntropy(uint8_t* output, size_t requested, size_t* received)
         return -1;
     }
     *received = g_test_entropy_size;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     if (*received <= requested) memcpy(output, g_test_entropy, *received);
     return 0;
 #elif defined(_WIN32)
@@ -164,6 +165,7 @@ static int pqbtc_mldsa44_randombytes(uint8_t* ptr, size_t len)
         return -1;
     }
 
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     memcpy(g_last_randomizer_digest, digest, sizeof(digest));
     g_has_last_randomizer_digest = 1;
     pqbtc_mldsa44_zeroize(digest, sizeof(digest));
@@ -281,6 +283,7 @@ int pqbtc_mldsa44_sign_hedged(
         goto cleanup;
     }
 
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     memcpy(signature, candidate, sizeof(candidate));
     result = PQBTC_MLDSA44_OK;
 
@@ -349,6 +352,7 @@ int pqbtc_mldsa44_test_set_entropy(int mode, const uint8_t* bytes, size_t report
     }
     LockSigningModule();
     pqbtc_mldsa44_zeroize(g_test_entropy, sizeof(g_test_entropy));
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     if (reported_size != 0) memcpy(g_test_entropy, bytes, reported_size);
     g_test_entropy_size = reported_size;
     g_test_entropy_mode = mode;
@@ -439,6 +443,7 @@ int pqbtc_mldsa44_test_sign_fixed_randomizer(
     pqbtc_mldsa44_zeroize(signature, PQBTC_MLDSA44_SIGNATURE_BYTES);
     prefix[0] = 0;
     prefix[1] = (uint8_t)context_size;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     if (context_size != 0) memcpy(prefix + 2, context, context_size);
 
     LockSigningModule();
@@ -453,6 +458,7 @@ int pqbtc_mldsa44_test_sign_fixed_randomizer(
         secret_key,
         0);
     if (backend_result == 0 && candidate_size == PQBTC_MLDSA44_SIGNATURE_BYTES) {
+        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
         memcpy(signature, candidate, sizeof(candidate));
         result = PQBTC_MLDSA44_OK;
     } else if (backend_result == PQBTC_MLDSA44_UPSTREAM_ERR_SIGN_ATTEMPTS_EXHAUSTED) {

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_smoke.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_smoke.c
@@ -2,19 +2,26 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/license/mit.
 
+#include "pqbtc_mldsa44.h"
 #include "pqbtc_mldsa44_test.h"
 
 #include <pthread.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define CHECK(condition)                                              \
-    do {                                                              \
-        if (!(condition)) {                                           \
-            fprintf(stderr, "wrapper smoke failure at line %d: %s\n", \
-                    __LINE__, #condition);                            \
-            return 1;                                                 \
-        }                                                             \
+static int ReportFailure(int line, const char* condition)
+{
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+    fprintf(stderr, "wrapper smoke failure at line %d: %s\n", line, condition);
+    return 1;
+}
+
+#define CHECK(condition)                               \
+    do {                                               \
+        if (!(condition)) {                            \
+            return ReportFailure(__LINE__, #condition); \
+        }                                              \
     } while (0)
 
 static const uint8_t TEST_SEED[32] = {
@@ -116,6 +123,7 @@ int main(void)
     pqbtc_mldsa44_test_reset();
     CHECK(pqbtc_mldsa44_test_keypair_from_seed(public_key, secret_key, TEST_SEED) ==
           PQBTC_MLDSA44_OK);
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     memcpy(secret_key_copy, secret_key, sizeof(secret_key_copy));
     CHECK(pqbtc_mldsa44_sign_hedged(
               secret_key,
@@ -298,6 +306,7 @@ int main(void)
 
         pqbtc_mldsa44_test_reset();
         CHECK(SetFixedEntropy(randomizer, sizeof(randomizer)) == PQBTC_MLDSA44_OK);
+        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
         memset(cases, 0, sizeof(cases));
         for (i = 0; i < 2; ++i) {
             cases[i].secret_key = secret_key;

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_test.h
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_test.h
@@ -7,6 +7,9 @@
 
 #include <pqbtc_mldsa44.h>
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_verify_fuzz.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_verify_fuzz.c
@@ -181,6 +181,7 @@ static size_t ResizeField(
     size_t i;
 
     if (new_size > max_size) return size;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     memmove(data + offset + new_length, data + tail_offset, tail_size);
     for (i = old_length; i < new_length; ++i) {
         data[offset + i] = (uint8_t)NextRandom(state);
@@ -239,6 +240,7 @@ size_t LLVMFuzzerCustomMutator(
     case 3:
         if (frame.signature_size == PQBTC_MLDSA44_SIGNATURE_BYTES) {
             hints = signature + PQBTC_MLDSA44_HINT_OFFSET;
+            // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
             memset(hints, 0, PQBTC_MLDSA44_HINT_INDICES + PQBTC_MLDSA44_HINT_COUNTERS);
             hints[0] = 2U;
             hints[1] = 1U;
@@ -251,6 +253,7 @@ size_t LLVMFuzzerCustomMutator(
     case 4:
         if (frame.signature_size == PQBTC_MLDSA44_SIGNATURE_BYTES) {
             hints = signature + PQBTC_MLDSA44_HINT_OFFSET;
+            // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
             memset(hints, 0, PQBTC_MLDSA44_HINT_INDICES + PQBTC_MLDSA44_HINT_COUNTERS);
             hints[0] = 1U;
             hints[1] = 1U;
@@ -263,6 +266,7 @@ size_t LLVMFuzzerCustomMutator(
     case 5:
         if (frame.signature_size == PQBTC_MLDSA44_SIGNATURE_BYTES) {
             hints = signature + PQBTC_MLDSA44_HINT_OFFSET;
+            // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
             memset(hints, 0, PQBTC_MLDSA44_HINT_INDICES + PQBTC_MLDSA44_HINT_COUNTERS);
             hints[0] = 1U;
         }

--- a/contrib/ml-dsa-engineering/run_static_analysis.py
+++ b/contrib/ml-dsa-engineering/run_static_analysis.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+"""Run versioned static analysis over the isolated ML-DSA-44 wrapper."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import run_wrapper_tests as wrapper_contract
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+ENGINEERING_ROOT = "contrib/ml-dsa-engineering"
+VENDOR_ROOT = f"{ENGINEERING_ROOT}/vendor"
+WRAPPER_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44.c"
+SMOKE_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_smoke.c"
+FUZZ_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_verify_fuzz.c"
+PUBLIC_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44.h"
+TEST_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_test.h"
+CONFIG_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_config.h"
+SOURCE_MANIFEST = f"{VENDOR_ROOT}/mldsa-native/SOURCE.json"
+TIDY_CONFIG = "src/.clang-tidy"
+IWYU_MAPPING = "contrib/devtools/iwyu/bitcoin.core.imp"
+EXPECTED_LLVM_MAJOR = 20
+EXPECTED_IWYU_COMMIT = "6e08906c66b3009f2d590e4bd40d60fa303bf803"
+
+FIRST_PARTY_HEADER_FILTER = (
+    r"(^|.*/)contrib/ml-dsa-engineering/pqbtc_mldsa44[^/]*\.h$"
+)
+VENDOR_HEADER_EXCLUDE = r"(^|.*/)contrib/ml-dsa-engineering/vendor/"
+
+COMMON_C_FLAGS = [
+    "-std=c11",
+    "-Wall",
+    "-Wextra",
+    "-Werror",
+    "-Wno-unused-function",
+    "-Wno-unknown-pragmas",
+    "-fvisibility=hidden",
+    f"-I{ENGINEERING_ROOT}",
+]
+
+EVIDENCE_SOURCES = [
+    ".github/workflows/ml-dsa-44-wrapper-prototype.yml",
+    ".github/workflows/promotion-matrix.yml",
+    "ci/test/00_setup_env_native_tidy.sh",
+    "ci/test/01_base_install.sh",
+    "ci/test/03_test_script.sh",
+    "ci/test/test_ml_dsa_wrapper_prototype.py",
+    "contrib/ml-dsa-engineering/README.md",
+    "contrib/ml-dsa-engineering/run_static_analysis.py",
+    "contrib/ml-dsa-engineering/run_wrapper_tests.py",
+    WRAPPER_SOURCE,
+    SMOKE_SOURCE,
+    FUZZ_SOURCE,
+    PUBLIC_HEADER,
+    TEST_HEADER,
+    CONFIG_HEADER,
+    SOURCE_MANIFEST,
+    TIDY_CONFIG,
+    IWYU_MAPPING,
+]
+
+
+class AuditError(RuntimeError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def json_text(value: object) -> str:
+    return json.dumps(value, indent=2, sort_keys=True) + "\n"
+
+
+def source_hashes() -> dict[str, str]:
+    hashes = {}
+    for relative in EVIDENCE_SOURCES:
+        path = REPO_ROOT / relative
+        if not path.is_file():
+            raise AuditError(f"required audit input is missing: {relative}")
+        hashes[relative] = sha256_file(path)
+    return hashes
+
+
+def tidy_command(
+    clang_tidy: str,
+    plugin: str,
+    source: str,
+    extra_flags: list[str] | None = None,
+) -> list[str]:
+    return [
+        clang_tidy,
+        "--quiet",
+        f"--load={plugin}",
+        f"--config-file={TIDY_CONFIG}",
+        "--checks=clang-analyzer-*",
+        "--warnings-as-errors=*",
+        f"--header-filter={FIRST_PARTY_HEADER_FILTER}",
+        f"--exclude-header-filter={VENDOR_HEADER_EXCLUDE}",
+        source,
+        "--",
+        *COMMON_C_FLAGS,
+        *(extra_flags or []),
+    ]
+
+
+def iwyu_command(
+    iwyu: str,
+    source: str,
+    check_also: list[str],
+    extra_flags: list[str] | None = None,
+) -> list[str]:
+    command = [
+        iwyu,
+        "-Xiwyu",
+        "--error=1",
+        "-Xiwyu",
+        f"--mapping_file={IWYU_MAPPING}",
+        "-Xiwyu",
+        "--max_line_length=160",
+    ]
+    for header in check_also:
+        command.extend(["-Xiwyu", f"--check_also={header}"])
+    command.extend([*COMMON_C_FLAGS, *(extra_flags or []), source])
+    return command
+
+
+def header_command(clang: str, header: str) -> list[str]:
+    return [
+        clang,
+        *COMMON_C_FLAGS,
+        "-x",
+        "c-header",
+        "-fsyntax-only",
+        header,
+    ]
+
+
+def build_plan(
+    clang: str,
+    clang_tidy: str,
+    iwyu: str,
+    iwyu_source_dir: str,
+    plugin: str,
+) -> dict[str, object]:
+    checks = [
+        {
+            "id": "clang-tidy-wrapper-production",
+            "kind": "clang-tidy",
+            "input": WRAPPER_SOURCE,
+            "variant": "production",
+            "command": tidy_command(clang_tidy, plugin, WRAPPER_SOURCE),
+        },
+        {
+            "id": "clang-tidy-wrapper-testing",
+            "kind": "clang-tidy",
+            "input": WRAPPER_SOURCE,
+            "variant": "testing",
+            "command": tidy_command(
+                clang_tidy,
+                plugin,
+                WRAPPER_SOURCE,
+                ["-DPQBTC_MLDSA44_TESTING=1"],
+            ),
+        },
+        {
+            "id": "clang-tidy-smoke-testing",
+            "kind": "clang-tidy",
+            "input": SMOKE_SOURCE,
+            "variant": "testing",
+            "command": tidy_command(
+                clang_tidy,
+                plugin,
+                SMOKE_SOURCE,
+                ["-DPQBTC_MLDSA44_TESTING=1", "-pthread"],
+            ),
+        },
+        {
+            "id": "clang-tidy-verifier-fuzz",
+            "kind": "clang-tidy",
+            "input": FUZZ_SOURCE,
+            "variant": "production-api",
+            "command": tidy_command(clang_tidy, plugin, FUZZ_SOURCE),
+        },
+        {
+            "id": "iwyu-smoke-testing",
+            "kind": "iwyu",
+            "input": SMOKE_SOURCE,
+            "variant": "testing",
+            "check_also": [PUBLIC_HEADER, TEST_HEADER],
+            "command": iwyu_command(
+                iwyu,
+                SMOKE_SOURCE,
+                [PUBLIC_HEADER, TEST_HEADER],
+                ["-DPQBTC_MLDSA44_TESTING=1", "-pthread"],
+            ),
+        },
+        {
+            "id": "iwyu-verifier-fuzz",
+            "kind": "iwyu",
+            "input": FUZZ_SOURCE,
+            "variant": "production-api",
+            "check_also": [PUBLIC_HEADER],
+            "command": iwyu_command(iwyu, FUZZ_SOURCE, [PUBLIC_HEADER]),
+        },
+        {
+            "id": "header-self-contained-production",
+            "kind": "header-self-containment",
+            "input": PUBLIC_HEADER,
+            "variant": "production",
+            "command": header_command(clang, PUBLIC_HEADER),
+        },
+        {
+            "id": "header-self-contained-testing",
+            "kind": "header-self-containment",
+            "input": TEST_HEADER,
+            "variant": "testing",
+            "command": header_command(clang, TEST_HEADER),
+        },
+    ]
+    manifest = wrapper_contract.validate_source_capsule()
+    plan: dict[str, object] = {
+        "schema_version": 1,
+        "audit": "ml-dsa-44-isolated-wrapper-static-analysis",
+        "expected_llvm_major": EXPECTED_LLVM_MAJOR,
+        "scope": {
+            "isolated_wrapper_only": True,
+            "clang_tidy_wrapper_implementation": True,
+            "iwyu_wrapper_implementation": False,
+            "iwyu_first_party_leaf_units_and_headers": True,
+            "production_integration": False,
+            "release_hold_unchanged": True,
+        },
+        "tools": {
+            "clang": {"command": clang, "required_llvm_major": EXPECTED_LLVM_MAJOR},
+            "clang-tidy": {
+                "command": clang_tidy,
+                "plugin": plugin,
+                "required_llvm_major": EXPECTED_LLVM_MAJOR,
+            },
+            "iwyu": {
+                "command": iwyu,
+                "required_llvm_major": EXPECTED_LLVM_MAJOR,
+                "source_dir": iwyu_source_dir,
+                "source_commit": EXPECTED_IWYU_COMMIT,
+            },
+        },
+        "reporting_boundary": {
+            "first_party_root": ENGINEERING_ROOT,
+            "first_party_header_filter": FIRST_PARTY_HEADER_FILTER,
+            "vendor_root": VENDOR_ROOT,
+            "vendor_header_exclude": VENDOR_HEADER_EXCLUDE,
+            "vendor_may_be_parsed_for_translation_unit_semantics": True,
+            "vendor_files_are_never_main_inputs": True,
+            "iwyu_excludes_single_compilation_unit_aggregator": WRAPPER_SOURCE,
+        },
+        "source_capsule": {
+            "commit": manifest["commit"],
+            "capsule_sha256": manifest["capsule_hash"]["value"],
+            "manifest_sha256": sha256_file(REPO_ROOT / SOURCE_MANIFEST),
+            "verified_against_checked_in_files": True,
+        },
+        "source_files": source_hashes(),
+        "checks": checks,
+    }
+    validate_plan(plan)
+    return plan
+
+
+def validate_plan(plan: dict[str, object]) -> None:
+    checks = plan.get("checks")
+    if not isinstance(checks, list):
+        raise AuditError("static-analysis plan has no check list")
+
+    expected_counts = {
+        "clang-tidy": 4,
+        "iwyu": 2,
+        "header-self-containment": 2,
+    }
+    counts = {kind: 0 for kind in expected_counts}
+    seen_ids = set()
+    for raw_check in checks:
+        if not isinstance(raw_check, dict):
+            raise AuditError("static-analysis check is not an object")
+        check_id = raw_check.get("id")
+        kind = raw_check.get("kind")
+        source = raw_check.get("input")
+        command = raw_check.get("command")
+        if not isinstance(check_id, str) or not check_id:
+            raise AuditError("static-analysis check has no id")
+        if check_id in seen_ids:
+            raise AuditError(f"duplicate static-analysis check id: {check_id}")
+        seen_ids.add(check_id)
+        if kind not in counts:
+            raise AuditError(f"unknown static-analysis check kind: {kind}")
+        counts[kind] += 1
+        if not isinstance(source, str) or source.startswith(f"{VENDOR_ROOT}/"):
+            raise AuditError(f"vendored file selected as main input: {source}")
+        if not isinstance(command, list) or not all(
+            isinstance(argument, str) for argument in command
+        ):
+            raise AuditError(f"invalid command for {check_id}")
+        if "-std=c11" not in command:
+            raise AuditError(f"{check_id} does not use the C11 wrapper contract")
+
+        if kind == "clang-tidy":
+            required = {
+                f"--header-filter={FIRST_PARTY_HEADER_FILTER}",
+                f"--exclude-header-filter={VENDOR_HEADER_EXCLUDE}",
+                "--warnings-as-errors=*",
+            }
+            if not required.issubset(command):
+                raise AuditError(f"{check_id} lacks the reporting boundary")
+        if kind == "iwyu":
+            if source == WRAPPER_SOURCE:
+                raise AuditError("IWYU must not analyze the vendored SCU aggregator")
+            if "--error=1" not in command:
+                raise AuditError(f"{check_id} is not enforcing IWYU findings")
+            check_also = raw_check.get("check_also")
+            if not isinstance(check_also, list) or not check_also:
+                raise AuditError(f"{check_id} has no first-party header coverage")
+            for path in check_also:
+                if not isinstance(path, str) or not path.startswith(
+                    f"{ENGINEERING_ROOT}/pqbtc_mldsa44"
+                ):
+                    raise AuditError(f"{check_id} has an invalid check_also path: {path}")
+                if path.startswith(f"{VENDOR_ROOT}/"):
+                    raise AuditError(f"{check_id} selects a vendored check_also path")
+
+    if counts != expected_counts:
+        raise AuditError(
+            f"unexpected static-analysis check counts: {counts}, expected {expected_counts}"
+        )
+
+    tools = plan.get("tools")
+    if not isinstance(tools, dict) or not isinstance(tools.get("iwyu"), dict):
+        raise AuditError("static-analysis plan has no IWYU tool contract")
+    if tools["iwyu"].get("source_commit") != EXPECTED_IWYU_COMMIT:
+        raise AuditError("static-analysis plan does not pin the expected IWYU commit")
+
+
+def resolve_tool(command: str) -> str | None:
+    resolved = shutil.which(command)
+    if resolved is not None:
+        return str(Path(resolved).resolve())
+    candidate = Path(command)
+    if candidate.is_file():
+        return str(candidate.resolve())
+    return None
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf8",
+        errors="replace",
+    )
+
+
+def write_log(
+    path: Path,
+    command: list[str],
+    return_code: int,
+    stdout: str,
+    stderr: str,
+) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                f"command: {shlex.join(command)}",
+                f"cwd: {REPO_ROOT}",
+                f"return_code: {return_code}",
+                "stdout:",
+                stdout.rstrip(),
+                "stderr:",
+                stderr.rstrip(),
+                "",
+            ]
+        ),
+        encoding="utf8",
+    )
+
+
+def prepare_output_dir(output_dir: Path) -> Path:
+    resolved = output_dir.resolve()
+    if resolved.exists():
+        if not resolved.is_dir():
+            raise AuditError(f"output path is not a directory: {resolved}")
+        if any(resolved.iterdir()):
+            raise AuditError(f"output directory is not empty: {resolved}")
+    else:
+        resolved.mkdir(parents=True)
+    (resolved / "logs").mkdir()
+    return resolved
+
+
+def version_matches_llvm_20(output: str) -> bool:
+    return re.search(
+        rf"\b(?:clang|LLVM)(?:\s+version)?\s+{EXPECTED_LLVM_MAJOR}(?:\.|\b)",
+        output,
+        flags=re.IGNORECASE,
+    ) is not None
+
+
+def repository_state() -> dict[str, object]:
+    commit = run_command(["git", "rev-parse", "HEAD"])
+    status = run_command(["git", "status", "--porcelain", "--untracked-files=no"])
+    return {
+        "commit": commit.stdout.strip() if commit.returncode == 0 else "unknown",
+        "tracked_worktree_dirty": bool(status.stdout.strip())
+        if status.returncode == 0
+        else None,
+    }
+
+
+def write_evidence_hashes(output_dir: Path) -> None:
+    lines = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_file() and path.name != "SHA256SUMS":
+            relative = path.relative_to(output_dir).as_posix()
+            lines.append(f"{sha256_file(path)}  {relative}\n")
+    (output_dir / "SHA256SUMS").write_text("".join(lines), encoding="utf8")
+
+
+def execute_audit(plan: dict[str, object], requested_output_dir: Path) -> int:
+    output_dir = prepare_output_dir(requested_output_dir)
+    plan_path = output_dir / "static-analysis-plan.json"
+    plan_path.write_text(json_text(plan), encoding="utf8")
+
+    report: dict[str, object] = {
+        "schema_version": 1,
+        "audit": plan["audit"],
+        "status": "failed",
+        "repository": repository_state(),
+        "plan_sha256": sha256_file(plan_path),
+        "tools": {},
+        "checks": [],
+        "errors": [],
+    }
+    errors = report["errors"]
+    tool_results = report["tools"]
+    assert isinstance(errors, list)
+    assert isinstance(tool_results, dict)
+
+    plan_tools = plan["tools"]
+    assert isinstance(plan_tools, dict)
+    resolved_tools: dict[str, str] = {}
+    for tool_name in ("clang", "clang-tidy", "iwyu"):
+        tool = plan_tools[tool_name]
+        assert isinstance(tool, dict)
+        configured = tool["command"]
+        assert isinstance(configured, str)
+        resolved = resolve_tool(configured)
+        log_relative = f"logs/tool-{tool_name}-version.log"
+        log_path = output_dir / log_relative
+        if resolved is None:
+            message = f"required tool is unavailable: {configured}"
+            write_log(log_path, [configured, "--version"], 127, "", message)
+            tool_results[tool_name] = {
+                "configured_command": configured,
+                "status": "failed",
+                "error": message,
+                "log": log_relative,
+            }
+            errors.append(message)
+            continue
+
+        completed = run_command([resolved, "--version"])
+        version_output = "\n".join(
+            part for part in (completed.stdout.strip(), completed.stderr.strip()) if part
+        )
+        write_log(
+            log_path,
+            [resolved, "--version"],
+            completed.returncode,
+            completed.stdout,
+            completed.stderr,
+        )
+        valid_version = completed.returncode == 0 and version_matches_llvm_20(
+            version_output
+        )
+        status = "passed" if valid_version else "failed"
+        tool_results[tool_name] = {
+            "configured_command": configured,
+            "resolved_command": resolved,
+            "status": status,
+            "version": version_output,
+            "sha256": sha256_file(Path(resolved)),
+            "log": log_relative,
+        }
+        if valid_version:
+            resolved_tools[tool_name] = resolved
+        else:
+            message = (
+                f"{tool_name} is not a successful LLVM {EXPECTED_LLVM_MAJOR} tool: "
+                f"{version_output or 'no version output'}"
+            )
+            errors.append(message)
+
+    iwyu_tool = plan_tools["iwyu"]
+    assert isinstance(iwyu_tool, dict)
+    iwyu_source_dir = Path(str(iwyu_tool["source_dir"]))
+    if not iwyu_source_dir.is_absolute():
+        iwyu_source_dir = REPO_ROOT / iwyu_source_dir
+    iwyu_source_dir = iwyu_source_dir.resolve()
+    source_command = [
+        "git",
+        "-C",
+        str(iwyu_source_dir),
+        "rev-parse",
+        "HEAD",
+    ]
+    source_completed = run_command(source_command)
+    source_commit = source_completed.stdout.strip()
+    source_log_relative = "logs/tool-iwyu-source.log"
+    write_log(
+        output_dir / source_log_relative,
+        source_command,
+        source_completed.returncode,
+        source_completed.stdout,
+        source_completed.stderr,
+    )
+    source_valid = (
+        source_completed.returncode == 0 and source_commit == EXPECTED_IWYU_COMMIT
+    )
+    iwyu_result = tool_results.get("iwyu")
+    assert isinstance(iwyu_result, dict)
+    iwyu_result.update(
+        {
+            "source_dir": str(iwyu_source_dir),
+            "source_commit": source_commit or None,
+            "expected_source_commit": EXPECTED_IWYU_COMMIT,
+            "source_status": "passed" if source_valid else "failed",
+            "source_log": source_log_relative,
+        }
+    )
+    if not source_valid:
+        resolved_tools.pop("iwyu", None)
+        message = (
+            f"IWYU source checkout mismatch: expected {EXPECTED_IWYU_COMMIT}, "
+            f"got {source_commit or 'unavailable'} from {iwyu_source_dir}"
+        )
+        errors.append(message)
+
+    tidy_tool = plan_tools["clang-tidy"]
+    assert isinstance(tidy_tool, dict)
+    plugin = Path(str(tidy_tool["plugin"]))
+    if not plugin.is_absolute():
+        plugin = REPO_ROOT / plugin
+    plugin = plugin.resolve()
+    plugin_available = plugin.is_file()
+    tool_results["bitcoin-tidy-plugin"] = {
+        "path": str(plugin),
+        "status": "passed" if plugin_available else "failed",
+        "sha256": sha256_file(plugin) if plugin_available else None,
+    }
+    if not plugin_available:
+        errors.append(f"bitcoin-tidy plugin is unavailable: {plugin}")
+
+    check_results = report["checks"]
+    assert isinstance(check_results, list)
+    plan_checks = plan["checks"]
+    assert isinstance(plan_checks, list)
+    tool_for_kind = {
+        "clang-tidy": "clang-tidy",
+        "iwyu": "iwyu",
+        "header-self-containment": "clang",
+    }
+    for raw_check in plan_checks:
+        assert isinstance(raw_check, dict)
+        check_id = str(raw_check["id"])
+        kind = str(raw_check["kind"])
+        command = list(raw_check["command"])
+        tool_name = tool_for_kind[kind]
+        log_relative = f"logs/{check_id}.log"
+        log_path = output_dir / log_relative
+        skip_reason = None
+        if tool_name not in resolved_tools:
+            skip_reason = f"{tool_name} did not pass version validation"
+        elif kind == "clang-tidy" and not plugin_available:
+            skip_reason = "bitcoin-tidy plugin is unavailable"
+
+        if skip_reason is not None:
+            write_log(log_path, command, 125, "", f"skipped: {skip_reason}")
+            check_results.append(
+                {
+                    "id": check_id,
+                    "kind": kind,
+                    "input": raw_check["input"],
+                    "status": "skipped",
+                    "reason": skip_reason,
+                    "log": log_relative,
+                }
+            )
+            continue
+
+        command[0] = resolved_tools[tool_name]
+        if kind == "clang-tidy":
+            command = [
+                f"--load={plugin}" if argument.startswith("--load=") else argument
+                for argument in command
+            ]
+        completed = run_command(command)
+        write_log(
+            log_path,
+            command,
+            completed.returncode,
+            completed.stdout,
+            completed.stderr,
+        )
+        status = "passed" if completed.returncode == 0 else "failed"
+        check_results.append(
+            {
+                "id": check_id,
+                "kind": kind,
+                "input": raw_check["input"],
+                "status": status,
+                "return_code": completed.returncode,
+                "log": log_relative,
+            }
+        )
+        if completed.returncode != 0:
+            errors.append(f"{check_id} failed with return code {completed.returncode}")
+
+    report["status"] = "passed" if not errors else "failed"
+    report_path = output_dir / "static-analysis-report.json"
+    report_path.write_text(json_text(report), encoding="utf8")
+    write_evidence_hashes(output_dir)
+
+    if report["status"] == "passed":
+        print(f"ML-DSA-44 static analysis passed; evidence: {output_dir}")
+        return 0
+    print(f"ML-DSA-44 static analysis failed; evidence: {output_dir}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit the isolated ML-DSA-44 wrapper with LLVM 20 tools"
+    )
+    parser.add_argument("--plan-only", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--clang", default="clang-20")
+    parser.add_argument("--clang-tidy", default="clang-tidy-20")
+    parser.add_argument("--iwyu", default="include-what-you-use")
+    parser.add_argument(
+        "--iwyu-source-dir",
+        default="/include-what-you-use",
+    )
+    parser.add_argument(
+        "--bitcoin-tidy-plugin",
+        default="/tidy-build/libbitcoin-tidy.so",
+    )
+    args = parser.parse_args()
+
+    plan = build_plan(
+        clang=args.clang,
+        clang_tidy=args.clang_tidy,
+        iwyu=args.iwyu,
+        iwyu_source_dir=args.iwyu_source_dir,
+        plugin=args.bitcoin_tidy_plugin,
+    )
+    if args.plan_only:
+        print(json_text(plan), end="")
+        return 0
+    if args.output_dir is None:
+        parser.error("--output-dir is required unless --plan-only is used")
+    return execute_audit(plan, args.output_dir)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (AuditError, OSError, ValueError) as error:
+        print(f"static analysis: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/contrib/ml-dsa-engineering/run_static_analysis.py
+++ b/contrib/ml-dsa-engineering/run_static_analysis.py
@@ -35,6 +35,11 @@ TIDY_CONFIG = "src/.clang-tidy"
 IWYU_MAPPING = "contrib/devtools/iwyu/bitcoin.core.imp"
 EXPECTED_LLVM_MAJOR = 20
 EXPECTED_IWYU_COMMIT = "6e08906c66b3009f2d590e4bd40d60fa303bf803"
+ANNEX_K_TIDY_CHECK = (
+    "clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling"
+)
+CLANG_TIDY_CHECKS = "clang-analyzer-*"
+EXPECTED_ANNEX_K_SUPPRESSIONS = 13
 
 FIRST_PARTY_HEADER_FILTER = (
     r"(^|.*/)contrib/ml-dsa-engineering/pqbtc_mldsa44[^/]*\.h$"
@@ -96,6 +101,14 @@ def source_hashes() -> dict[str, str]:
     return hashes
 
 
+def annex_k_suppression_count() -> int:
+    marker = f"NOLINTNEXTLINE({ANNEX_K_TIDY_CHECK})"
+    return sum(
+        (REPO_ROOT / relative).read_text(encoding="utf8").count(marker)
+        for relative in (WRAPPER_SOURCE, SMOKE_SOURCE, FUZZ_SOURCE)
+    )
+
+
 def tidy_command(
     clang_tidy: str,
     plugin: str,
@@ -107,7 +120,7 @@ def tidy_command(
         "--quiet",
         f"--load={plugin}",
         f"--config-file={TIDY_CONFIG}",
-        "--checks=clang-analyzer-*",
+        f"--checks={CLANG_TIDY_CHECKS}",
         "--warnings-as-errors=*",
         f"--header-filter={FIRST_PARTY_HEADER_FILTER}",
         f"--exclude-header-filter={VENDOR_HEADER_EXCLUDE}",
@@ -264,6 +277,17 @@ def build_plan(
             "first_party_header_filter": FIRST_PARTY_HEADER_FILTER,
             "vendor_root": VENDOR_ROOT,
             "vendor_header_exclude": VENDOR_HEADER_EXCLUDE,
+            "clang_tidy_check_expression": CLANG_TIDY_CHECKS,
+            "clang_tidy_local_suppression": {
+                "check": ANNEX_K_TIDY_CHECK,
+                "annotation": "NOLINTNEXTLINE",
+                "occurrences": annex_k_suppression_count(),
+                "expected_occurrences": EXPECTED_ANNEX_K_SUPPRESSIONS,
+                "reason": (
+                    "C11 Annex K _s functions are optional and unavailable on "
+                    "the supported Linux toolchain"
+                ),
+            },
             "vendor_may_be_parsed_for_translation_unit_semantics": True,
             "vendor_files_are_never_main_inputs": True,
             "iwyu_excludes_single_compilation_unit_aggregator": WRAPPER_SOURCE,
@@ -319,6 +343,7 @@ def validate_plan(plan: dict[str, object]) -> None:
 
         if kind == "clang-tidy":
             required = {
+                f"--checks={CLANG_TIDY_CHECKS}",
                 f"--header-filter={FIRST_PARTY_HEADER_FILTER}",
                 f"--exclude-header-filter={VENDOR_HEADER_EXCLUDE}",
                 "--warnings-as-errors=*",
@@ -351,6 +376,14 @@ def validate_plan(plan: dict[str, object]) -> None:
         raise AuditError("static-analysis plan has no IWYU tool contract")
     if tools["iwyu"].get("source_commit") != EXPECTED_IWYU_COMMIT:
         raise AuditError("static-analysis plan does not pin the expected IWYU commit")
+    suppression = plan["reporting_boundary"].get("clang_tidy_local_suppression")
+    if (
+        not isinstance(suppression, dict)
+        or suppression.get("occurrences") != EXPECTED_ANNEX_K_SUPPRESSIONS
+        or suppression.get("expected_occurrences")
+        != EXPECTED_ANNEX_K_SUPPRESSIONS
+    ):
+        raise AuditError("unexpected Annex-K clang-tidy suppression inventory")
 
 
 def resolve_tool(command: str) -> str | None:
@@ -424,11 +457,29 @@ def version_matches_llvm_20(output: str) -> bool:
 def repository_state() -> dict[str, object]:
     commit = run_command(["git", "rev-parse", "HEAD"])
     status = run_command(["git", "status", "--porcelain", "--untracked-files=no"])
+    tracked_changes = []
+    if status.returncode == 0:
+        for line in status.stdout.splitlines():
+            path = line[3:]
+            if " -> " in path:
+                path = path.rsplit(" -> ", maxsplit=1)[1]
+            tracked_changes.append(path)
+    audit_inputs = set(EVIDENCE_SOURCES)
+    dirty_audit_inputs = sorted(
+        path
+        for path in tracked_changes
+        if path in audit_inputs or path.startswith(f"{ENGINEERING_ROOT}/")
+    )
     return {
         "commit": commit.stdout.strip() if commit.returncode == 0 else "unknown",
-        "tracked_worktree_dirty": bool(status.stdout.strip())
+        "tracked_worktree_dirty": bool(tracked_changes)
         if status.returncode == 0
         else None,
+        "tracked_changes": sorted(tracked_changes),
+        "audit_input_dirty": bool(dirty_audit_inputs)
+        if status.returncode == 0
+        else None,
+        "dirty_audit_inputs": dirty_audit_inputs,
     }
 
 
@@ -446,11 +497,12 @@ def execute_audit(plan: dict[str, object], requested_output_dir: Path) -> int:
     plan_path = output_dir / "static-analysis-plan.json"
     plan_path.write_text(json_text(plan), encoding="utf8")
 
+    repository = repository_state()
     report: dict[str, object] = {
         "schema_version": 1,
         "audit": plan["audit"],
         "status": "failed",
-        "repository": repository_state(),
+        "repository": repository,
         "plan_sha256": sha256_file(plan_path),
         "tools": {},
         "checks": [],
@@ -460,6 +512,11 @@ def execute_audit(plan: dict[str, object], requested_output_dir: Path) -> int:
     tool_results = report["tools"]
     assert isinstance(errors, list)
     assert isinstance(tool_results, dict)
+    if repository["audit_input_dirty"] is not False:
+        errors.append(
+            "tracked audit inputs must be clean: "
+            + ", ".join(repository["dirty_audit_inputs"])
+        )
 
     plan_tools = plan["tools"]
     assert isinstance(plan_tools, dict)


### PR DESCRIPTION
## Summary

- add a versioned eight-check static-analysis plan for the isolated ML-DSA-44 wrapper
- run clang-tidy over production/test wrapper variants and enforce scoped IWYU over first-party leaf units and headers
- pin IWYU source, constrain LLVM to major version 20, and retain exact versions, binary hashes, command logs, JSON results, and SHA256SUMS
- preserve the production backend as NONE and leave the cryptographic release hold unchanged

## Local validation

- 8 wrapper-prototype unit tests passed
- CI inventory validation passed
- Python compilation, shell syntax, YAML parsing, file/UTF-8 lints, and diff checks passed
- local Clang header and leaf-translation-unit syntax checks passed

## Remaining validation

The authoritative LLVM 20 and pinned-IWYU execution runs in this pull request and publishes a commit-named evidence artifact.