### PR TITLE
test: add three-way ML-DSA verifier fuzzing

### DIFF
--- a/.github/workflows/ml-dsa-44-review-reproduction.yml
+++ b/.github/workflows/ml-dsa-44-review-reproduction.yml
@@ -5,7 +5,9 @@ on:
     paths:
       - ".github/workflows/ml-dsa-44-review-reproduction.yml"
       - "contrib/ml-dsa-ref/**"
+      - "contrib/ml-dsa-engineering/**"
       - "ci/test/test_ml_dsa_reference.py"
+      - "ci/test/test_ml_dsa_differential_fuzz.py"
   workflow_dispatch:
 
 permissions:
@@ -15,7 +17,7 @@ jobs:
   reproduce:
     name: Reproduce pinned three-oracle evidence
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 150
     env:
       BASELINE: 6ffd47881fc2071724fa6e31fb3cf9557a64b467
       OPENSSL_COMMIT: aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f
@@ -25,6 +27,7 @@ jobs:
 
     steps:
       - name: Checkout PQBTC review head
+        timeout-minutes: 5
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
@@ -32,23 +35,35 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install build dependencies
+        timeout-minutes: 20
         run: |
           set -euxo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential ca-certificates curl git perl pkg-config python3
+            build-essential ca-certificates clang curl git perl pkg-config python3
+          rustup toolchain install 1.89.0 \
+            --profile minimal --component rustfmt --no-self-update
+          echo "RUSTUP_TOOLCHAIN=1.89.0" >> "$GITHUB_ENV"
 
       - name: Validate frozen repository inputs
+        timeout-minutes: 10
         run: |
           set -euxo pipefail
+          test "$(rustc --version | cut -d ' ' -f 2)" = "1.89.0"
           git diff --exit-code "$BASELINE" -- \
             contrib/ml-dsa-ref ci/test/test_ml_dsa_reference.py \
             ':(exclude)contrib/ml-dsa-ref/README.md' \
             ':(exclude)contrib/ml-dsa-ref/wolfram/**'
           python3 contrib/ml-dsa-ref/compare_oracles.py --manifest-only
           python3 -m unittest ci.test.test_ml_dsa_reference
+          python3 contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py \
+            --manifest-only
+          rustfmt --check \
+            contrib/ml-dsa-engineering/pqbtc_mldsa44_libcrux_verify.rs
+          python3 -m unittest ci.test.test_ml_dsa_differential_fuzz
 
       - name: Fetch pinned standards artifacts and upstream sources
+        timeout-minutes: 15
         run: |
           set -euxo pipefail
           mkdir -p "$RUNNER_TEMP/ml-dsa-review/artifacts"
@@ -77,6 +92,7 @@ jobs:
           git -C libcrux checkout --detach "$LIBCRUX_COMMIT"
 
       - name: Build pinned OpenSSL 3.6.3 out of tree
+        timeout-minutes: 25
         run: |
           set -euxo pipefail
           REVIEW_ROOT="$RUNNER_TEMP/ml-dsa-review"
@@ -95,13 +111,17 @@ jobs:
           {
             echo "PKG_CONFIG_PATH=$OPENSSL_PREFIX/lib64/pkgconfig:$OPENSSL_PREFIX/lib/pkgconfig"
             echo "LD_LIBRARY_PATH=$OPENSSL_PREFIX/lib64:$OPENSSL_PREFIX/lib"
+            echo "OPENSSL_CONF=/dev/null"
           } >> "$GITHUB_ENV"
 
       - name: Run complete pinned comparator
+        timeout-minutes: 60
         run: |
           set -euxo pipefail
           REVIEW_ROOT="$RUNNER_TEMP/ml-dsa-review"
           REPORT="$GITHUB_WORKSPACE/ml-dsa-44-review-run.json"
+          FUZZ_REPORT="$GITHUB_WORKSPACE/ml-dsa-44-differential-fuzz-run.json"
+          DIFFERENTIAL_EVIDENCE="$GITHUB_WORKSPACE/ml-dsa-44-differential-fuzz"
 
           {
             echo "pqbtc_commit=$(git rev-parse HEAD)"
@@ -113,10 +133,12 @@ jobs:
             echo "cc=$({ cc --version || true; } | head -n 1)"
             echo "rustc=$(rustc --version)"
             echo "cargo=$(cargo --version)"
+            echo "rustfmt=$(rustfmt --version)"
             echo "openssl=$(openssl version)"
             echo "python=$(python3 --version)"
           } | tee ml-dsa-44-review-toolchain.txt
 
+          set +e
           python3 contrib/ml-dsa-ref/compare_oracles.py \
             --acvp-server "$REVIEW_ROOT/acvp-server" \
             --openssl-source "$REVIEW_ROOT/openssl" \
@@ -128,11 +150,80 @@ jobs:
             --fips204-section6-guidance "$REVIEW_ROOT/artifacts/fips204-sec6-03192025.pdf" \
             --benchmark-iterations 10 \
             --sanitizers > "$REPORT"
+          REVIEW_EXIT=$?
+          set -e
+          if [[ ! -s "$REPORT" ]]; then
+            printf '{"status":"FAIL","processing_error":"comparator produced no JSON report"}\n' \
+              > "$REPORT"
+          fi
+          (
+            cd "$GITHUB_WORKSPACE"
+            sha256sum ml-dsa-44-review-run.json | tee ml-dsa-44-review-run.sha256
+          )
+          if (( REVIEW_EXIT != 0 )); then
+            exit "$REVIEW_EXIT"
+          fi
 
-          sha256sum "$REPORT" | tee ml-dsa-44-review-run.sha256
-          python3 - <<'PY'
+          set +e
+          FUZZ_CC=clang \
+            python3 contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py \
+              --openssl-source "$REVIEW_ROOT/openssl" \
+              --libcrux-source "$REVIEW_ROOT/libcrux" \
+              --libcrux-crate "$REVIEW_ROOT/artifacts/libcrux-ml-dsa-0.0.10.crate" \
+              --output-dir "$DIFFERENTIAL_EVIDENCE" \
+              --seconds 60 \
+              --seed 188 \
+              > "$FUZZ_REPORT"
+          FUZZ_EXIT=$?
+          set -e
+
+          if [[ ! -s "$FUZZ_REPORT" ]]; then
+            printf '{"status":"fail","processing_error":"driver produced no JSON report"}\n' \
+              > "$FUZZ_REPORT"
+          fi
+          (
+            cd "$GITHUB_WORKSPACE"
+            sha256sum ml-dsa-44-differential-fuzz-run.json | \
+              tee ml-dsa-44-differential-fuzz-run.sha256
+          )
+          EVIDENCE_EXIT=0
+          if [[ -f "$DIFFERENTIAL_EVIDENCE/SHA256SUMS" ]]; then
+            if ! (
+              cd "$DIFFERENTIAL_EVIDENCE"
+              sha256sum --check SHA256SUMS
+            ); then
+              EVIDENCE_EXIT=1
+            fi
+          else
+            EVIDENCE_EXIT=1
+          fi
+          if (( FUZZ_EXIT != 0 )); then
+            python3 - <<'PY'
           import json
           from pathlib import Path
+
+          report = json.loads(
+              Path("ml-dsa-44-differential-fuzz-run.json").read_text()
+          )
+          assert report["status"] == "fail"
+          campaign = Path("ml-dsa-44-differential-fuzz/campaign.json")
+          if campaign.is_file():
+              retained = json.loads(campaign.read_text())
+              assert retained["status"] == "fail"
+              assert retained["processing_error"] or retained["return_code"] != 0
+          print("ML-DSA-44 differential failure evidence retained")
+          PY
+            exit "$FUZZ_EXIT"
+          fi
+          if (( EVIDENCE_EXIT != 0 )); then
+            exit "$EVIDENCE_EXIT"
+          fi
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+          import subprocess
 
           report = json.loads(Path("ml-dsa-44-review-run.json").read_text())
           assert report["status"] == "PASS"
@@ -148,11 +239,131 @@ jobs:
               "nist_randomized": "8a17b6ff3f9633cd3c7cd0687d6384408e145bfd3725f6c57a8a2727f50ec989",
               "pqbtc": "98094b39d9ae1ad76fc734f9e0199ad37315dd4eb7a22f29561582239f64e131",
           }
+          fuzz_report = json.loads(
+              Path("ml-dsa-44-differential-fuzz-run.json").read_text()
+          )
+          assert fuzz_report["status"] == "pass"
+          assert fuzz_report["return_code"] == 0
+          assert fuzz_report["sanitizer"] == "address-undefined"
+          assert fuzz_report["coverage_enabled"] is True
+          assert fuzz_report["campaign_limit"] == {"runs": None, "seconds": 60}
+          assert fuzz_report["seed"] == 188
+          assert fuzz_report["seconds"] == 60
+          checkout_head = subprocess.check_output(
+              ["git", "rev-parse", "HEAD"], text=True
+          ).strip()
+          assert fuzz_report["repository_commit"] == checkout_head
+          assert fuzz_report["repository_dirty"] is False
+          assert fuzz_report["crash_artifacts"]["file_count"] == 0
+          assert fuzz_report["source_corpus"]["total_cases"] == 207
+          assert fuzz_report["working_corpus"]["file_count"] > 0
+          assert fuzz_report["minimized_corpus"]["file_count"] > 0
+          assert fuzz_report["last_progress_line"]
+          assert fuzz_report["final_stats"]
+          assert fuzz_report["executed_units"] > 207
+          assert 59 <= fuzz_report["fuzzer_duration_seconds"] <= 95
+
+          differential = fuzz_report["differential_oracles"]
+          assert differential["fuzzer_binary_sha256"]
+          assert differential["wrapper"]["source_capsule_sha256"]
+          assert differential["openssl"]["bridge_source_sha256"]
+          openssl_runtime = differential["openssl"]["runtime"]
+          openssl_prefix = (
+              Path(os.environ["RUNNER_TEMP"])
+              / "ml-dsa-review"
+              / "openssl-install"
+          ).resolve()
+          libcrypto = Path(openssl_runtime["libcrypto_path"]).resolve()
+          assert openssl_runtime["pkg_config_version"] == "3.6.3"
+          assert Path(openssl_runtime["pkg_config_prefix"]).resolve() == openssl_prefix
+          assert openssl_runtime["libcrypto_resolution"] == "linked-dependency"
+          assert libcrypto.is_relative_to(openssl_prefix)
+          assert openssl_runtime["libcrypto_sha256"]
+          assert openssl_runtime["openssl_conf"] == "/dev/null"
+          assert "OpenSSL Default Provider" in openssl_runtime["provider_inventory"]
+          assert "version: 3.6.3" in openssl_runtime["provider_inventory"]
+          assert differential["libcrux"]["bridge_source_sha256"]
+          assert differential["libcrux"]["rlib_sha256"]
+          assert differential["libcrux"]["bridge_binary_sha256"]
+          smoke = differential["exact_replay"]
+          assert smoke["status"] == "pass"
+          assert smoke["case_count"] == 5
+          assert smoke["expected_accept_count"] == 2
+          assert smoke["expected_reject_count"] == 3
+          assert smoke["binary_sha256"]
+          assert all(
+              case["status"] == "pass" and case["return_code"] == 0
+              for case in smoke["cases"]
+          )
+          assert {case["name"] for case in smoke["cases"]} == {
+              "valid_frozen_vector",
+              "valid_empty_message_context",
+              "reject_ctilde_bit_flip",
+              "reject_hint_counter_overflow",
+              "reject_null_signature",
+          }
+          assert {
+              case["name"]: (case["expected"], case["frame_sha256"])
+              for case in smoke["cases"]
+          } == {
+              "valid_frozen_vector": (
+                  "accept",
+                  "1f1400abcc4219a5bb48c05e7f35525a9c98861f7b14fe8cfd8653dd52ca001d",
+              ),
+              "valid_empty_message_context": (
+                  "accept",
+                  "34335fc41196fad28e8970efd5386acfd0ad7aa0d1bebca6b8d6237ef97b44c4",
+              ),
+              "reject_ctilde_bit_flip": (
+                  "reject",
+                  "dd431b2d49e7ebf65bd4d6d6d14ec56e7d9bd433a9602e9aedb51218c267655f",
+              ),
+              "reject_hint_counter_overflow": (
+                  "reject",
+                  "f9ab7ac3eb9ff8a2a278abc63ed58955f939b2e281555177ad9dcaf4aab0741f",
+              ),
+              "reject_null_signature": (
+                  "reject",
+                  "ccd69d2b0691117dafce3ccaa79096cf13ce86d96fa153d21878eec5830aaaa7",
+              ),
+          }
+
+          evidence = Path("ml-dsa-44-differential-fuzz")
+          campaign_path = evidence / "campaign.json"
+          assert campaign_path.is_file()
+          assert (evidence / "coverage.json").is_file()
+          assert (evidence / "coverage.txt").is_file()
+          assert (evidence / "differential-smoke.log").is_file()
+          assert (evidence / "SHA256SUMS").is_file()
+          assert fuzz_report["evidence_sha256"] == hashlib.sha256(
+              (evidence / "SHA256SUMS").read_bytes()
+          ).hexdigest()
+          campaign = json.loads(campaign_path.read_text())
+          for key in (
+              "status",
+              "return_code",
+              "repository_commit",
+              "repository_dirty",
+              "sanitizer",
+              "coverage_enabled",
+              "campaign_limit",
+              "source_corpus",
+              "working_corpus",
+              "minimized_corpus",
+              "crash_artifacts",
+              "last_progress_line",
+              "final_stats",
+              "executed_units",
+              "fuzzer_duration_seconds",
+              "differential_oracles",
+          ):
+              assert fuzz_report[key] == campaign[key]
           print("ML-DSA-44 review invariants verified")
           PY
 
       - name: Upload review evidence
         if: always()
+        timeout-minutes: 10
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ml-dsa-44-review-evidence-${{ github.event.pull_request.head.sha || github.sha }}
@@ -160,5 +371,8 @@ jobs:
             ml-dsa-44-review-run.json
             ml-dsa-44-review-run.sha256
             ml-dsa-44-review-toolchain.txt
-          if-no-files-found: warn
+            ml-dsa-44-differential-fuzz-run.json
+            ml-dsa-44-differential-fuzz-run.sha256
+            ml-dsa-44-differential-fuzz/
+          if-no-files-found: error
           retention-days: 90

--- a/ci/test/test_ml_dsa_differential_fuzz.py
+++ b/ci/test/test_ml_dsa_differential_fuzz.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+import importlib.util
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINEERING_DIR = REPO_ROOT / "contrib" / "ml-dsa-engineering"
+DRIVER = ENGINEERING_DIR / "run_differential_verifier_fuzz.py"
+FUZZ_SOURCE = ENGINEERING_DIR / "pqbtc_mldsa44_verify_fuzz.c"
+OPENSSL_BRIDGE = ENGINEERING_DIR / "pqbtc_mldsa44_openssl_verify.c"
+LIBCRUX_BRIDGE = ENGINEERING_DIR / "pqbtc_mldsa44_libcrux_verify.rs"
+REPLAY_SOURCE = ENGINEERING_DIR / "pqbtc_mldsa44_differential_replay.c"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-review-reproduction.yml"
+ADMISSION = ENGINEERING_DIR / "backend_admission.json"
+
+sys.path.insert(0, str(ENGINEERING_DIR))
+SPEC = importlib.util.spec_from_file_location("run_differential_verifier_fuzz", DRIVER)
+assert SPEC is not None and SPEC.loader is not None
+differential = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = differential
+SPEC.loader.exec_module(differential)
+
+
+class MlDsaDifferentialFuzzTest(unittest.TestCase):
+    def test_manifest_only_cli(self):
+        completed = subprocess.run(
+            [sys.executable, str(DRIVER), "--manifest-only"],
+            cwd=REPO_ROOT,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("wrapper + OpenSSL 3.6.3 + libcrux 0.0.10", completed.stdout)
+
+    def test_differential_compile_contract(self):
+        with tempfile.TemporaryDirectory() as temporary, mock.patch.object(
+            differential.verifier_fuzz.wrapper, "run"
+        ) as run:
+            differential.verifier_fuzz.compile_fuzzer(
+                "clang",
+                Path(temporary),
+                sanitizer="address-undefined",
+                coverage=True,
+                differential_sources=(OPENSSL_BRIDGE,),
+                differential_link_args=("libcrux.so", "-lcrypto"),
+            )
+
+        command = run.call_args.args[0]
+        self.assertIn("-DPQBTC_MLDSA44_DIFFERENTIAL=1", command)
+        self.assertIn(str(OPENSSL_BRIDGE), command)
+        self.assertIn("libcrux.so", command)
+        self.assertIn("-lcrypto", command)
+        self.assertIn("-fsanitize=fuzzer,address,undefined", command)
+
+    def test_external_bridges_are_binary_and_in_process(self):
+        openssl_source = OPENSSL_BRIDGE.read_text(encoding="utf8")
+        self.assertIn("EVP_PKEY_verify_message_init", openssl_source)
+        self.assertIn("EVP_PKEY_verify(", openssl_source)
+        self.assertIn("PQBTC_MLDSA44_ORACLE_ERROR", openssl_source)
+
+        libcrux_source = LIBCRUX_BRIDGE.read_text(encoding="utf8")
+        self.assertIn("portable::verify", libcrux_source)
+        self.assertIn('extern "C" fn pqbtc_mldsa44_libcrux_verify', libcrux_source)
+        self.assertNotIn("Command::", libcrux_source)
+
+        replay_source = REPLAY_SOURCE.read_text(encoding="utf8")
+        self.assertIn("LLVMFuzzerTestOneInput(input, input_size)", replay_source)
+        self.assertIn("PQBTC_MLDSA44_FUZZ_MAX_FRAME_BYTES 8096U", replay_source)
+
+    def test_evidence_inventory_covers_execution_inputs(self):
+        manifest = differential.reference.load_manifest()
+        inventory = differential.validate_local_inputs(manifest)
+        for path in (
+            DRIVER,
+            REPO_ROOT / "contrib" / "ml-dsa-ref" / "compare_oracles.py",
+            REPO_ROOT / "contrib" / "ml-dsa-ref" / "libcrux_oracle.rs",
+            FUZZ_SOURCE,
+            OPENSSL_BRIDGE,
+            LIBCRUX_BRIDGE,
+            REPLAY_SOURCE,
+            WORKFLOW,
+        ):
+            self.assertIn(str(path.relative_to(REPO_ROOT)), inventory)
+
+    def test_exact_replay_cases_match_frozen_frames(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            library = differential.verifier_fuzz.wrapper.compile_shared(
+                "cc", Path(temporary), testing=True
+            )
+            cases = {
+                case.name: case
+                for case in differential.verifier_fuzz.project_corpus(library)
+            }
+        actual = {
+            name: (
+                "accept"
+                if cases[name].expected == differential.verifier_fuzz.OK
+                else "reject",
+                hashlib.sha256(cases[name].frame).hexdigest(),
+            )
+            for name in differential.SMOKE_CASE_NAMES
+        }
+        self.assertEqual(
+            actual,
+            {
+                "valid_frozen_vector": (
+                    "accept",
+                    "1f1400abcc4219a5bb48c05e7f35525a9c98861f7b14fe8cfd8653dd52ca001d",
+                ),
+                "valid_empty_message_context": (
+                    "accept",
+                    "34335fc41196fad28e8970efd5386acfd0ad7aa0d1bebca6b8d6237ef97b44c4",
+                ),
+                "reject_ctilde_bit_flip": (
+                    "reject",
+                    "dd431b2d49e7ebf65bd4d6d6d14ec56e7d9bd433a9602e9aedb51218c267655f",
+                ),
+                "reject_hint_counter_overflow": (
+                    "reject",
+                    "f9ab7ac3eb9ff8a2a278abc63ed58955f939b2e281555177ad9dcaf4aab0741f",
+                ),
+                "reject_null_signature": (
+                    "reject",
+                    "ccd69d2b0691117dafce3ccaa79096cf13ce86d96fa153d21878eec5830aaaa7",
+                ),
+            },
+        )
+
+    def test_exact_replay_records_the_failing_named_case(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            library = differential.verifier_fuzz.wrapper.compile_shared(
+                "cc", root, testing=True
+            )
+            cases = differential.verifier_fuzz.project_corpus(library)
+            executable = root / "replay-stub"
+            executable.write_text(
+                "#!/bin/sh\n"
+                "case \"$1\" in\n"
+                "  *reject_ctilde_bit_flip) exit 7 ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n",
+                encoding="utf8",
+            )
+            executable.chmod(0o755)
+            output = root / "evidence"
+            output.mkdir()
+            records = differential.replay_differential_smoke(
+                executable, cases, output
+            )
+
+            failures = [record for record in records if record["status"] == "fail"]
+            self.assertEqual(len(failures), 1)
+            self.assertEqual(failures[0]["name"], "reject_ctilde_bit_flip")
+            self.assertEqual(failures[0]["return_code"], 7)
+            self.assertIn(
+                "case: reject_ctilde_bit_flip",
+                (output / "differential-smoke.log").read_text(encoding="utf8"),
+            )
+
+    def test_target_catches_acceptance_disagreement_and_oracle_error(self):
+        compiler = "cc"
+        stub_source = textwrap.dedent(
+            r"""
+            #include "pqbtc_mldsa44.h"
+            #include "pqbtc_mldsa44_differential.h"
+            #include <stdint.h>
+            #include <stdlib.h>
+
+            int wrapper_result;
+            int openssl_result;
+            int libcrux_result;
+
+            int pqbtc_mldsa44_verify_strict(
+                const uint8_t* signature, size_t signature_size,
+                const uint8_t* public_key, size_t public_key_size,
+                const uint8_t* message, size_t message_size,
+                const uint8_t* context, size_t context_size)
+            {
+                (void)signature; (void)signature_size;
+                (void)public_key; (void)public_key_size;
+                (void)message; (void)message_size;
+                (void)context; (void)context_size;
+                return wrapper_result;
+            }
+
+            int pqbtc_mldsa44_openssl_verify(
+                const uint8_t* signature, size_t signature_size,
+                const uint8_t* public_key, size_t public_key_size,
+                const uint8_t* message, size_t message_size,
+                const uint8_t* context, size_t context_size)
+            {
+                (void)signature; (void)signature_size;
+                (void)public_key; (void)public_key_size;
+                (void)message; (void)message_size;
+                (void)context; (void)context_size;
+                return openssl_result;
+            }
+
+            int pqbtc_mldsa44_libcrux_verify(
+                const uint8_t* signature, size_t signature_size,
+                const uint8_t* public_key, size_t public_key_size,
+                const uint8_t* message, size_t message_size,
+                const uint8_t* context, size_t context_size)
+            {
+                (void)signature; (void)signature_size;
+                (void)public_key; (void)public_key_size;
+                (void)message; (void)message_size;
+                (void)context; (void)context_size;
+                return libcrux_result;
+            }
+
+            size_t LLVMFuzzerMutate(
+                uint8_t* data, size_t size, size_t max_size)
+            {
+                (void)data; (void)max_size;
+                return size;
+            }
+
+            int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
+
+            int main(int argc, char** argv)
+            {
+                uint8_t frame[10 + 2420 + 1312] = {0};
+                if (argc != 4) return 2;
+                wrapper_result = atoi(argv[1]);
+                openssl_result = atoi(argv[2]);
+                libcrux_result = atoi(argv[3]);
+                frame[0] = 1;
+                frame[2] = 0x74;
+                frame[3] = 0x09;
+                frame[4] = 0x20;
+                frame[5] = 0x05;
+                return LLVMFuzzerTestOneInput(frame, sizeof(frame));
+            }
+            """
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            stub = root / "stub.c"
+            executable = root / "differential-contract"
+            stub.write_text(stub_source, encoding="utf8")
+            subprocess.run(
+                [
+                    compiler,
+                    "-std=c11",
+                    "-Wall",
+                    "-Wextra",
+                    "-Werror",
+                    "-DPQBTC_MLDSA44_DIFFERENTIAL=1",
+                    f"-I{ENGINEERING_DIR}",
+                    str(FUZZ_SOURCE),
+                    str(stub),
+                    "-o",
+                    str(executable),
+                ],
+                check=True,
+            )
+
+            for arguments in (("0", "1", "1"), ("-9", "0", "0")):
+                with self.subTest(arguments=arguments):
+                    completed = subprocess.run(
+                        [str(executable), *arguments],
+                        check=False,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    )
+                    self.assertEqual(completed.returncode, 0, completed.stderr)
+
+            disagreement = subprocess.run(
+                [str(executable), "0", "0", "0"],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            self.assertNotEqual(disagreement.returncode, 0)
+            self.assertIn("DIFFERENTIAL_DISAGREEMENT", disagreement.stderr)
+
+            oracle_error = subprocess.run(
+                [str(executable), "-9", "-1", "0"],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            self.assertNotEqual(oracle_error.returncode, 0)
+            self.assertIn("DIFFERENTIAL_ORACLE_ERROR", oracle_error.stderr)
+
+    def test_pinned_workflow_runs_and_retains_differential_evidence(self):
+        workflow = WORKFLOW.read_text(encoding="utf8")
+        for required in (
+            '"contrib/ml-dsa-engineering/**"',
+            "run_differential_verifier_fuzz.py",
+            "RUSTUP_TOOLCHAIN=1.89.0",
+            "FUZZ_CC=clang",
+            "--seconds 60",
+            "--seed 188",
+            "sha256sum --check SHA256SUMS",
+            'smoke["case_count"] == 5',
+            'fuzz_report["executed_units"] > 207',
+            'fuzz_report["fuzzer_duration_seconds"] <= 95',
+            'openssl_runtime["libcrypto_resolution"] == "linked-dependency"',
+            'openssl_runtime["openssl_conf"] == "/dev/null"',
+            "if-no-files-found: error",
+            "ml-dsa-44-differential-fuzz-run.json",
+            "ml-dsa-44-differential-fuzz-run.sha256",
+            "ml-dsa-44-differential-fuzz/",
+            "retention-days: 90",
+        ):
+            self.assertIn(required, workflow)
+
+    def test_release_hold_remains_unchanged(self):
+        admission = json.loads(ADMISSION.read_text(encoding="utf8"))
+        self.assertTrue(admission["decision"]["release_hold"])
+        self.assertEqual(admission["decision"]["production_backend"], "NONE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/test/test_ml_dsa_sustained_fuzz.py
+++ b/ci/test/test_ml_dsa_sustained_fuzz.py
@@ -41,7 +41,7 @@ class MlDsaSustainedFuzzTest(unittest.TestCase):
         self.assertEqual(gate["tracking_issue"], 188)
         self.assertEqual(
             gate["status"],
-            "SUSTAINED_SANITIZER_EVIDENCE_GATE_OPEN",
+            "DIFFERENTIAL_SANITIZER_EVIDENCE_RESOURCES_OPEN",
         )
         self.assertTrue(admission["decision"]["release_hold"])
         self.assertEqual(admission["decision"]["production_backend"], "NONE")

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -63,6 +63,12 @@ units and their wrapper headers. It intentionally does not propose edits for
 single-compilation-unit implementation and its nested `.c` files. Clang-tidy
 still parses that implementation as part of the wrapper translation unit, but
 the audit reports primary diagnostics only at first-party wrapper locations.
+The versioned static plan predates the differential adapters: it does not run
+clang-tidy/IWYU over the OpenSSL bridge, Rust bridge, exact-replay driver, or
+the differential-only target branch. The review-reproduction workflow instead
+compiles those C paths with fatal warnings and exercises them dynamically; the
+Rust bridge is checked separately with the pinned Rust 1.89.0 `rustfmt` and
+`rustc` toolchain.
 
 Each run retains the exact plan, resolved tool and source identities,
 per-command logs,
@@ -70,3 +76,27 @@ a machine-readable result, and `SHA256SUMS` in a commit-named workflow
 artifact. This is static source-analysis evidence only. It is not a proof of
 memory safety, constant-time behavior, secret erasure, or production fitness,
 and it does not alter the release hold.
+
+## Differential Verifier Fuzzing
+
+The pinned review-reproduction workflow runs a separate 60-second in-process
+differential campaign. Every parsed frame is evaluated by the admitted
+wrapper, OpenSSL 3.6.3's explicitly selected default provider in an isolated
+library context, and libcrux 0.0.10; an oracle setup error or
+accept/reject disagreement aborts through the normal libFuzzer crash path.
+Wrapper argument-error taxonomy remains a separate assertion, while the two
+external bridges normalize invalid shapes to rejection. The workflow records
+the upstream commits, crate and source hashes, bridge and binary hashes, the
+actual linked `libcrypto` path and hash, toolchains, minimized corpus, coverage,
+logs, and crash artifacts for 90 days. Before the timed campaign, a separate
+sanitized executable replays five named frozen accept/reject cases exactly once
+through the real wrapper/OpenSSL/libcrux target and records each frame hash.
+The upstream versions are pinned by the frozen reference manifest; the small
+first-party adapter sources are review inputs whose exact hashes are evidence,
+not a claim that the adapters themselves are independent implementations.
+
+This closes the former self-fulfilling `OK`/`ERR_VERIFY` oracle gap for that
+bounded Linux campaign. It is not long-duration or multi-platform
+differential evidence, and the prebuilt OpenSSL and Rust implementation bodies
+are not fully sanitizer-instrumented by the C fuzz build. It does not alter
+the release hold.

--- a/contrib/ml-dsa-engineering/backend_admission.json
+++ b/contrib/ml-dsa-engineering/backend_admission.json
@@ -154,7 +154,7 @@
     },
     {
       "id": "structure_aware_fuzzing_and_resources",
-      "status": "SUSTAINED_SANITIZER_EVIDENCE_GATE_OPEN",
+      "status": "DIFFERENTIAL_SANITIZER_EVIDENCE_RESOURCES_OPEN",
       "tracking_issue": 188
     },
     {

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_differential.h
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_differential.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+#ifndef BITCOIN_ML_DSA_ENGINEERING_PQBTC_MLDSA44_DIFFERENTIAL_H
+#define BITCOIN_ML_DSA_ENGINEERING_PQBTC_MLDSA44_DIFFERENTIAL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum pqbtc_mldsa44_oracle_result {
+    PQBTC_MLDSA44_ORACLE_ERROR = -1,
+    PQBTC_MLDSA44_ORACLE_REJECT = 0,
+    PQBTC_MLDSA44_ORACLE_ACCEPT = 1
+};
+
+int pqbtc_mldsa44_openssl_verify(
+    const uint8_t* signature,
+    size_t signature_size,
+    const uint8_t* public_key,
+    size_t public_key_size,
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size);
+
+int pqbtc_mldsa44_libcrux_verify(
+    const uint8_t* signature,
+    size_t signature_size,
+    const uint8_t* public_key,
+    size_t public_key_size,
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // BITCOIN_ML_DSA_ENGINEERING_PQBTC_MLDSA44_DIFFERENTIAL_H

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_differential_replay.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_differential_replay.c
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define PQBTC_MLDSA44_FUZZ_MAX_FRAME_BYTES 8096U
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
+
+size_t LLVMFuzzerMutate(uint8_t* data, size_t size, size_t max_size)
+{
+    (void)data;
+    (void)max_size;
+    return size;
+}
+
+static int ReplayFile(const char* program, const char* path)
+{
+    uint8_t input[PQBTC_MLDSA44_FUZZ_MAX_FRAME_BYTES + 1U];
+    FILE* stream;
+    size_t input_size;
+    int saved_errno;
+
+    errno = 0;
+    stream = fopen(path, "rb");
+    if (stream == NULL) {
+        saved_errno = errno;
+        fprintf(
+            stderr,
+            "%s: cannot open %s: %s\n",
+            program,
+            path,
+            strerror(saved_errno));
+        return 0;
+    }
+
+    errno = 0;
+    input_size = fread(input, 1, sizeof(input), stream);
+    if (ferror(stream)) {
+        saved_errno = errno;
+        if (saved_errno != 0) {
+            fprintf(
+                stderr,
+                "%s: cannot read %s: %s\n",
+                program,
+                path,
+                strerror(saved_errno));
+        } else {
+            fprintf(stderr, "%s: cannot read %s\n", program, path);
+        }
+        (void)fclose(stream);
+        return 0;
+    }
+    if (input_size > PQBTC_MLDSA44_FUZZ_MAX_FRAME_BYTES) {
+        fprintf(
+            stderr,
+            "%s: input exceeds %u bytes: %s\n",
+            program,
+            (unsigned int)PQBTC_MLDSA44_FUZZ_MAX_FRAME_BYTES,
+            path);
+        (void)fclose(stream);
+        return 0;
+    }
+    if (fclose(stream) != 0) {
+        saved_errno = errno;
+        fprintf(
+            stderr,
+            "%s: cannot close %s: %s\n",
+            program,
+            path,
+            strerror(saved_errno));
+        return 0;
+    }
+
+    if (LLVMFuzzerTestOneInput(input, input_size) != 0) {
+        fprintf(stderr, "%s: fuzz target returned a failure for %s\n", program, path);
+        return 0;
+    }
+    return 1;
+}
+
+int main(int argc, char** argv)
+{
+    int index;
+
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <fuzz-input> [<fuzz-input> ...]\n", argv[0]);
+        return 2;
+    }
+    for (index = 1; index < argc; ++index) {
+        if (!ReplayFile(argv[0], argv[index])) return 1;
+    }
+    printf("replayed %d ML-DSA-44 fuzz input(s)\n", argc - 1);
+    return 0;
+}

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_libcrux_verify.rs
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_libcrux_verify.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+use libcrux_ml_dsa::ml_dsa_44::{portable, MLDSA44Signature, MLDSA44VerificationKey};
+use std::slice;
+
+const ORACLE_REJECT: i32 = 0;
+const ORACLE_ACCEPT: i32 = 1;
+const PUBLIC_KEY_SIZE: usize = 1312;
+const SIGNATURE_SIZE: usize = 2420;
+const MAX_CONTEXT_SIZE: usize = 255;
+
+unsafe fn byte_slice<'a>(value: *const u8, size: usize) -> Option<&'a [u8]> {
+    if size == 0 {
+        Some(&[])
+    } else if value.is_null() {
+        None
+    } else {
+        Some(unsafe { slice::from_raw_parts(value, size) })
+    }
+}
+
+/// Return a normalized accept/reject result for one binary ML-DSA-44 tuple.
+///
+/// # Safety
+///
+/// Every non-null pointer must remain readable for its associated size for the
+/// duration of this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pqbtc_mldsa44_libcrux_verify(
+    signature: *const u8,
+    signature_size: usize,
+    public_key: *const u8,
+    public_key_size: usize,
+    message: *const u8,
+    message_size: usize,
+    context: *const u8,
+    context_size: usize,
+) -> i32 {
+    if signature.is_null()
+        || signature_size != SIGNATURE_SIZE
+        || public_key.is_null()
+        || public_key_size != PUBLIC_KEY_SIZE
+        || (message.is_null() && message_size != 0)
+        || (context.is_null() && context_size != 0)
+        || context_size > MAX_CONTEXT_SIZE
+    {
+        return ORACLE_REJECT;
+    }
+
+    let signature = match unsafe { byte_slice(signature, signature_size) }
+        .and_then(|value| <[u8; SIGNATURE_SIZE]>::try_from(value).ok())
+    {
+        Some(value) => MLDSA44Signature::new(value),
+        None => return ORACLE_REJECT,
+    };
+    let public_key = match unsafe { byte_slice(public_key, public_key_size) }
+        .and_then(|value| <[u8; PUBLIC_KEY_SIZE]>::try_from(value).ok())
+    {
+        Some(value) => MLDSA44VerificationKey::new(value),
+        None => return ORACLE_REJECT,
+    };
+    let message = match unsafe { byte_slice(message, message_size) } {
+        Some(value) => value,
+        None => return ORACLE_REJECT,
+    };
+    let context = match unsafe { byte_slice(context, context_size) } {
+        Some(value) => value,
+        None => return ORACLE_REJECT,
+    };
+
+    if portable::verify(&public_key, message, context, &signature).is_ok() {
+        ORACLE_ACCEPT
+    } else {
+        ORACLE_REJECT
+    }
+}

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_openssl_verify.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_openssl_verify.c
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+#include "pqbtc_mldsa44.h"
+#include "pqbtc_mldsa44_differential.h"
+
+#include <openssl/core_names.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/params.h>
+#include <openssl/provider.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define PQBTC_MLDSA44_OPENSSL_ALGORITHM "ML-DSA-44"
+#define PQBTC_MLDSA44_OPENSSL_PROPERTIES "provider=default"
+
+static int InvalidByteString(const uint8_t* value, size_t size)
+{
+    return size != 0 && value == NULL;
+}
+
+static int OracleError(const char* stage)
+{
+    unsigned long error_code = ERR_peek_last_error();
+
+    fprintf(
+        stderr,
+        "PQBTC_MLDSA44_OPENSSL_ORACLE_ERROR stage=%s code=%lu\n",
+        stage,
+        error_code);
+    fflush(stderr);
+    ERR_clear_error();
+    return PQBTC_MLDSA44_ORACLE_ERROR;
+}
+
+static EVP_PKEY* ImportPublicKey(
+    OSSL_LIB_CTX* library_context,
+    const uint8_t* public_key,
+    int* result)
+{
+    EVP_PKEY_CTX* context =
+        EVP_PKEY_CTX_new_from_name(
+            library_context,
+            PQBTC_MLDSA44_OPENSSL_ALGORITHM,
+            PQBTC_MLDSA44_OPENSSL_PROPERTIES);
+    EVP_PKEY* key = NULL;
+    OSSL_PARAM parameters[] = {
+        OSSL_PARAM_construct_octet_string(
+            OSSL_PKEY_PARAM_PUB_KEY,
+            (void*)public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES),
+        OSSL_PARAM_construct_end(),
+    };
+
+    if (context == NULL) {
+        *result = OracleError("public_key_context");
+    } else if (EVP_PKEY_fromdata_init(context) <= 0) {
+        *result = OracleError("public_key_import_init");
+    } else if (
+        EVP_PKEY_fromdata(context, &key, EVP_PKEY_PUBLIC_KEY, parameters) <= 0) {
+        *result = OracleError("public_key_import");
+    } else {
+        *result = PQBTC_MLDSA44_ORACLE_ACCEPT;
+    }
+    EVP_PKEY_CTX_free(context);
+    if (*result != PQBTC_MLDSA44_ORACLE_ACCEPT) EVP_PKEY_free(key);
+    return *result == PQBTC_MLDSA44_ORACLE_ACCEPT ? key : NULL;
+}
+
+int pqbtc_mldsa44_openssl_verify(
+    const uint8_t* signature,
+    size_t signature_size,
+    const uint8_t* public_key,
+    size_t public_key_size,
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size)
+{
+    static const uint8_t empty[1] = {0};
+    OSSL_LIB_CTX* library_context = NULL;
+    OSSL_PROVIDER* default_provider = NULL;
+    EVP_PKEY* key = NULL;
+    EVP_SIGNATURE* algorithm = NULL;
+    EVP_PKEY_CTX* verify_context = NULL;
+    OSSL_PARAM parameters[2];
+    int imported;
+    int result;
+    int verified;
+
+    if (signature == NULL || signature_size != PQBTC_MLDSA44_SIGNATURE_BYTES ||
+        public_key == NULL || public_key_size != PQBTC_MLDSA44_PUBLIC_KEY_BYTES ||
+        InvalidByteString(message, message_size) ||
+        InvalidByteString(context, context_size) ||
+        context_size > PQBTC_MLDSA44_MAX_CONTEXT_BYTES) {
+        return PQBTC_MLDSA44_ORACLE_REJECT;
+    }
+    if (message == NULL) message = empty;
+    if (context == NULL) context = empty;
+
+    ERR_clear_error();
+    library_context = OSSL_LIB_CTX_new();
+    if (library_context == NULL) return OracleError("library_context");
+    default_provider = OSSL_PROVIDER_load(library_context, "default");
+    if (default_provider == NULL) {
+        result = OracleError("default_provider_load");
+        goto cleanup;
+    }
+
+    key = ImportPublicKey(library_context, public_key, &imported);
+    if (key == NULL) {
+        result = imported;
+        goto cleanup;
+    }
+
+    algorithm = EVP_SIGNATURE_fetch(
+        library_context,
+        PQBTC_MLDSA44_OPENSSL_ALGORITHM,
+        PQBTC_MLDSA44_OPENSSL_PROPERTIES);
+    if (algorithm == NULL) {
+        result = OracleError("signature_fetch");
+        goto cleanup;
+    }
+    verify_context = EVP_PKEY_CTX_new_from_pkey(
+        library_context, key, PQBTC_MLDSA44_OPENSSL_PROPERTIES);
+    if (verify_context == NULL) {
+        result = OracleError("verify_context");
+        goto cleanup;
+    }
+    parameters[0] = OSSL_PARAM_construct_octet_string(
+        OSSL_SIGNATURE_PARAM_CONTEXT_STRING, (void*)context, context_size);
+    parameters[1] = OSSL_PARAM_construct_end();
+    if (EVP_PKEY_verify_message_init(verify_context, algorithm, parameters) <= 0) {
+        result = OracleError("verify_init");
+        goto cleanup;
+    }
+
+    verified = EVP_PKEY_verify(
+        verify_context, signature, signature_size, message, message_size);
+    if (verified < 0) {
+        result = OracleError("verify");
+        goto cleanup;
+    }
+    ERR_clear_error();
+    result = verified == 1 ? PQBTC_MLDSA44_ORACLE_ACCEPT :
+                             PQBTC_MLDSA44_ORACLE_REJECT;
+
+cleanup:
+    EVP_PKEY_CTX_free(verify_context);
+    EVP_SIGNATURE_free(algorithm);
+    EVP_PKEY_free(key);
+    if (default_provider != NULL) OSSL_PROVIDER_unload(default_provider);
+    OSSL_LIB_CTX_free(library_context);
+    return result;
+}

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_verify_fuzz.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_verify_fuzz.c
@@ -4,8 +4,15 @@
 
 #include "pqbtc_mldsa44.h"
 
+#ifdef PQBTC_MLDSA44_DIFFERENTIAL
+#include "pqbtc_mldsa44_differential.h"
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
+#ifdef PQBTC_MLDSA44_DIFFERENTIAL
+#include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 
@@ -96,11 +103,79 @@ static const uint8_t* MaybeNull(
     return (null_flags & null_flag) != 0 ? NULL : data + offset;
 }
 
+#ifdef PQBTC_MLDSA44_DIFFERENTIAL
+static void RequireDifferentialAgreement(
+    int wrapper_result,
+    const uint8_t* signature,
+    size_t signature_size,
+    const uint8_t* public_key,
+    size_t public_key_size,
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size)
+{
+    int wrapper_accept =
+        wrapper_result == PQBTC_MLDSA44_OK ? PQBTC_MLDSA44_ORACLE_ACCEPT :
+                                            PQBTC_MLDSA44_ORACLE_REJECT;
+    int openssl_accept = pqbtc_mldsa44_openssl_verify(
+        signature,
+        signature_size,
+        public_key,
+        public_key_size,
+        message,
+        message_size,
+        context,
+        context_size);
+    int libcrux_accept = pqbtc_mldsa44_libcrux_verify(
+        signature,
+        signature_size,
+        public_key,
+        public_key_size,
+        message,
+        message_size,
+        context,
+        context_size);
+
+    if ((openssl_accept != PQBTC_MLDSA44_ORACLE_REJECT &&
+         openssl_accept != PQBTC_MLDSA44_ORACLE_ACCEPT) ||
+        (libcrux_accept != PQBTC_MLDSA44_ORACLE_REJECT &&
+         libcrux_accept != PQBTC_MLDSA44_ORACLE_ACCEPT)) {
+        fprintf(
+            stderr,
+            "PQBTC_MLDSA44_DIFFERENTIAL_ORACLE_ERROR "
+            "wrapper=%d openssl=%d libcrux=%d\n",
+            wrapper_accept,
+            openssl_accept,
+            libcrux_accept);
+        fflush(stderr);
+        abort();
+    }
+    if (wrapper_accept != openssl_accept || wrapper_accept != libcrux_accept) {
+        fprintf(
+            stderr,
+            "PQBTC_MLDSA44_DIFFERENTIAL_DISAGREEMENT "
+            "wrapper=%d openssl=%d libcrux=%d\n",
+            wrapper_accept,
+            openssl_accept,
+            libcrux_accept);
+        fflush(stderr);
+        abort();
+    }
+}
+#endif
+
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     struct fuzz_frame frame;
     int expected_invalid_argument;
     int result;
+#ifdef PQBTC_MLDSA44_DIFFERENTIAL
+    const uint8_t* context;
+    const uint8_t* message;
+    const uint8_t* public_key;
+    const uint8_t* signature;
+#endif
 
     if (!ParseFrame(data, size, &frame)) return 0;
 
@@ -115,6 +190,38 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         ((frame.null_flags & PQBTC_MLDSA44_FUZZ_NULL_MESSAGE) != 0 &&
          frame.message_size != 0);
 
+#ifdef PQBTC_MLDSA44_DIFFERENTIAL
+    signature = MaybeNull(
+        data,
+        frame.signature_offset,
+        frame.null_flags,
+        PQBTC_MLDSA44_FUZZ_NULL_SIGNATURE);
+    public_key = MaybeNull(
+        data,
+        frame.public_key_offset,
+        frame.null_flags,
+        PQBTC_MLDSA44_FUZZ_NULL_PUBLIC_KEY);
+    message = MaybeNull(
+        data,
+        frame.message_offset,
+        frame.null_flags,
+        PQBTC_MLDSA44_FUZZ_NULL_MESSAGE);
+    context = MaybeNull(
+        data,
+        frame.context_offset,
+        frame.null_flags,
+        PQBTC_MLDSA44_FUZZ_NULL_CONTEXT);
+
+    result = pqbtc_mldsa44_verify_strict(
+        signature,
+        frame.signature_size,
+        public_key,
+        frame.public_key_size,
+        message,
+        frame.message_size,
+        context,
+        frame.context_size);
+#else
     result = pqbtc_mldsa44_verify_strict(
         MaybeNull(
             data,
@@ -140,12 +247,25 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
             frame.null_flags,
             PQBTC_MLDSA44_FUZZ_NULL_CONTEXT),
         frame.context_size);
+#endif
 
     if (expected_invalid_argument) {
         if (result != PQBTC_MLDSA44_ERR_INVALID_ARGUMENT) abort();
     } else if (result != PQBTC_MLDSA44_OK && result != PQBTC_MLDSA44_ERR_VERIFY) {
         abort();
     }
+#ifdef PQBTC_MLDSA44_DIFFERENTIAL
+    RequireDifferentialAgreement(
+        result,
+        signature,
+        frame.signature_size,
+        public_key,
+        frame.public_key_size,
+        message,
+        frame.message_size,
+        context,
+        frame.context_size);
+#endif
     return 0;
 }
 

--- a/contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py
+++ b/contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py
@@ -1,0 +1,777 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+"""Fuzz the isolated verifier against pinned OpenSSL and libcrux oracles."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+import run_verifier_fuzz as verifier_fuzz
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+REFERENCE_DIR = REPO_ROOT / "contrib" / "ml-dsa-ref"
+
+
+def load_reference_module():
+    spec = importlib.util.spec_from_file_location(
+        "compare_ml_dsa_oracles", REFERENCE_DIR / "compare_oracles.py"
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load the frozen ML-DSA comparator module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+reference = load_reference_module()
+
+
+OPENSSL_BRIDGE = HERE / "pqbtc_mldsa44_openssl_verify.c"
+LIBCRUX_BRIDGE = HERE / "pqbtc_mldsa44_libcrux_verify.rs"
+DIFFERENTIAL_HEADER = HERE / "pqbtc_mldsa44_differential.h"
+DIFFERENTIAL_REPLAY = HERE / "pqbtc_mldsa44_differential_replay.c"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-review-reproduction.yml"
+SANITIZER = "address-undefined"
+MAX_CAMPAIGN_SECONDS = 1800
+SMOKE_CASE_NAMES = (
+    "valid_frozen_vector",
+    "valid_empty_message_context",
+    "reject_ctilde_bit_flip",
+    "reject_hint_counter_overflow",
+    "reject_null_signature",
+)
+
+
+class DifferentialFuzzError(RuntimeError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def command_identity(command: str) -> str:
+    try:
+        completed = subprocess.run(
+            [command, "--version"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except OSError as error:
+        return f"unavailable: {error}"
+    return completed.stdout.splitlines()[0] if completed.stdout else command
+
+
+def validate_local_inputs(manifest: dict) -> dict:
+    expected_files = (
+        Path(__file__).resolve(),
+        REFERENCE_DIR / "compare_oracles.py",
+        REFERENCE_DIR / "libcrux_oracle.rs",
+        reference.MANIFEST_PATH,
+        DIFFERENTIAL_HEADER,
+        DIFFERENTIAL_REPLAY,
+        OPENSSL_BRIDGE,
+        LIBCRUX_BRIDGE,
+        HERE / "pqbtc_mldsa44.h",
+        HERE / "pqbtc_mldsa44_config.h",
+        verifier_fuzz.FUZZ_SOURCE,
+        verifier_fuzz.CORPUS_MANIFEST,
+        verifier_fuzz.WYCHEPROOF_SOURCE,
+        verifier_fuzz.WYCHEPROOF_LICENSE,
+        verifier_fuzz.WYCHEPROOF_VECTORS,
+        verifier_fuzz.wrapper.VECTORS,
+        verifier_fuzz.wrapper.SOURCE_MANIFEST,
+        verifier_fuzz.wrapper.WRAPPER_SOURCE,
+        HERE / "run_verifier_fuzz.py",
+        HERE / "run_wrapper_tests.py",
+        WORKFLOW,
+    )
+    missing = [str(path.relative_to(REPO_ROOT)) for path in expected_files if not path.is_file()]
+    if missing:
+        raise DifferentialFuzzError(f"missing differential fuzz inputs: {missing}")
+    if manifest["sources"]["openssl"]["version"] != "3.6.3":
+        raise DifferentialFuzzError("differential fuzzing requires OpenSSL 3.6.3")
+    if manifest["sources"]["libcrux"]["version"] != "0.0.10":
+        raise DifferentialFuzzError("differential fuzzing requires libcrux 0.0.10")
+    return {
+        str(path.relative_to(REPO_ROOT)): sha256_file(path) for path in expected_files
+    }
+
+
+def git_head() -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else "unknown"
+
+
+def git_input_status(source_hashes: dict) -> list[str] | None:
+    completed = subprocess.run(
+        [
+            "git",
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--",
+            *source_hashes,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.splitlines()
+
+
+def openssl_runtime_provenance(executable: Path) -> dict:
+    if sys.platform.startswith("linux"):
+        dependency_command = ["ldd", str(executable)]
+        dependency_pattern = re.compile(r"\blibcrypto\.so(?:\.\d+)*\s+=>\s+(\S+)")
+    elif sys.platform == "darwin":
+        dependency_command = ["otool", "-L", str(executable)]
+        dependency_pattern = re.compile(r"^\s*(\S*libcrypto[^\s]*\.dylib)", re.MULTILINE)
+    else:
+        raise DifferentialFuzzError(
+            "OpenSSL runtime provenance supports Linux and macOS only"
+        )
+
+    dependencies = reference.run(dependency_command).strip()
+    match = dependency_pattern.search(dependencies)
+    linked_path = Path(match.group(1)).resolve() if match is not None else None
+    libdir = Path(
+        reference.run(["pkg-config", "--variable=libdir", "openssl"]).strip()
+    ).resolve()
+    if linked_path is None or not linked_path.is_file():
+        raise DifferentialFuzzError(
+            "cannot resolve the linked OpenSSL libcrypto binary"
+        )
+    resolution = "linked-dependency"
+    try:
+        linked_path.relative_to(libdir)
+    except ValueError as error:
+        raise DifferentialFuzzError(
+            f"linked libcrypto is outside the pkg-config libdir: {linked_path}"
+        ) from error
+
+    return {
+        "cli_version_a": reference.run(["openssl", "version", "-a"]).strip(),
+        "provider_inventory": reference.run(
+            ["openssl", "list", "-providers", "-verbose"]
+        ).strip(),
+        "pkg_config_version": reference.run(
+            ["pkg-config", "--modversion", "openssl"]
+        ).strip(),
+        "pkg_config_prefix": reference.run(
+            ["pkg-config", "--variable=prefix", "openssl"]
+        ).strip(),
+        "pkg_config_libdir": str(libdir),
+        "dependency_command": dependency_command,
+        "dependency_report": dependencies,
+        "libcrypto_path": str(linked_path),
+        "libcrypto_resolution": resolution,
+        "libcrypto_sha256": sha256_file(linked_path),
+        "openssl_modules": os.environ.get("OPENSSL_MODULES"),
+        "openssl_conf": os.environ.get("OPENSSL_CONF"),
+    }
+
+
+def compile_libcrux_bridge(build_dir: Path, crate_dir: Path) -> tuple[Path, Path]:
+    reference.compile_libcrux_oracle(build_dir, crate_dir)
+    dependency_dir = build_dir / "libcrux-target" / "release" / "deps"
+    candidates = sorted(dependency_dir.glob("liblibcrux_ml_dsa-*.rlib"))
+    if len(candidates) != 1:
+        raise DifferentialFuzzError(
+            "expected exactly one release libcrux ML-DSA rlib, got "
+            f"{len(candidates)}"
+        )
+    rlib = candidates[0]
+    if sys.platform.startswith("linux"):
+        extension = ".so"
+    elif sys.platform == "darwin":
+        extension = ".dylib"
+    else:
+        raise DifferentialFuzzError(
+            "differential verifier fuzzing supports Linux and macOS only"
+        )
+    output = build_dir / f"libpqbtc_mldsa44_libcrux_verify{extension}"
+    reference.run(
+        [
+            "rustc",
+            "--edition=2021",
+            "--crate-type=cdylib",
+            "-C",
+            "opt-level=3",
+            "-C",
+            "panic=abort",
+            "-L",
+            f"dependency={dependency_dir}",
+            "--extern",
+            f"libcrux_ml_dsa={rlib}",
+            str(LIBCRUX_BRIDGE),
+            "-o",
+            str(output),
+        ]
+    )
+    if not output.is_file():
+        raise DifferentialFuzzError(
+            "rustc did not produce the libcrux differential bridge"
+        )
+    return output, rlib
+
+
+def differential_link_args(
+    libcrux_bridge: Path, expected_openssl_version: str
+) -> tuple[str, ...]:
+    reference.openssl_version(expected_openssl_version)
+    openssl_flags = shlex.split(
+        reference.run(["pkg-config", "--cflags", "--libs", "openssl"])
+    )
+    return (
+        str(libcrux_bridge),
+        f"-Wl,-rpath,{libcrux_bridge.parent}",
+        *openssl_flags,
+    )
+
+
+def compile_differential_targets(
+    build_dir: Path,
+    libcrux_bridge: Path,
+    expected_openssl_version: str,
+) -> tuple[Path, Path, str]:
+    compiler = os.environ.get("FUZZ_CC", "clang")
+    if shutil.which(compiler) is None:
+        raise DifferentialFuzzError(f"differential fuzz compiler not found: {compiler}")
+    link_args = differential_link_args(libcrux_bridge, expected_openssl_version)
+    try:
+        fuzzer = verifier_fuzz.compile_fuzzer(
+            compiler,
+            build_dir,
+            sanitizer=SANITIZER,
+            coverage=True,
+            differential_sources=(OPENSSL_BRIDGE,),
+            differential_link_args=link_args,
+        )
+        replay = build_dir / "pqbtc_mldsa44_differential_replay"
+        replay_command = verifier_fuzz.wrapper.common_flags(compiler)
+        replay_command.extend(
+            [
+                "-O1",
+                "-g",
+                "-fno-omit-frame-pointer",
+                "-fno-sanitize-recover=all",
+                "-fsanitize=address,undefined",
+                "-fprofile-instr-generate",
+                "-fcoverage-mapping",
+                "-DPQBTC_MLDSA44_DIFFERENTIAL=1",
+                str(verifier_fuzz.wrapper.WRAPPER_SOURCE),
+                str(verifier_fuzz.FUZZ_SOURCE),
+                str(OPENSSL_BRIDGE),
+                str(DIFFERENTIAL_REPLAY),
+                "-o",
+                str(replay),
+                *link_args,
+            ]
+        )
+        verifier_fuzz.wrapper.run(replay_command)
+    except (
+        OSError,
+        verifier_fuzz.FuzzHarnessError,
+        verifier_fuzz.wrapper.HarnessError,
+    ) as error:
+        raise DifferentialFuzzError(
+            f"differential target compilation failed: {error}"
+        ) from error
+    return fuzzer, replay, compiler
+
+
+def replay_differential_smoke(
+    executable: Path,
+    cases: list[verifier_fuzz.CorpusCase],
+    output_dir: Path,
+) -> list[dict]:
+    selected_by_name = {case.name: case for case in cases if case.source == "project"}
+    if set(SMOKE_CASE_NAMES) - selected_by_name.keys():
+        raise DifferentialFuzzError("differential smoke corpus is incomplete")
+    smoke_dir = output_dir / "differential-smoke-inputs"
+    smoke_dir.mkdir()
+    records = []
+    log_parts = []
+    env = os.environ.copy()
+    env["ASAN_OPTIONS"] = (
+        "detect_leaks=0" if sys.platform == "darwin" else "detect_leaks=1"
+    )
+    env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
+    env["LLVM_PROFILE_FILE"] = str(output_dir / "coverage-replay-%p.profraw")
+    for index, name in enumerate(SMOKE_CASE_NAMES):
+        case = selected_by_name[name]
+        path = smoke_dir / f"{index:02d}-{name}"
+        path.write_bytes(case.frame)
+        record = {
+            "name": name,
+            "source": case.source,
+            "frame_sha256": hashlib.sha256(case.frame).hexdigest(),
+            "expected": "accept" if case.expected == verifier_fuzz.OK else "reject",
+        }
+        command = [str(executable), str(path)]
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+            record["return_code"] = completed.returncode
+            record["status"] = "pass" if completed.returncode == 0 else "fail"
+            record["error"] = None
+            stdout = completed.stdout
+            stderr = completed.stderr
+        except subprocess.TimeoutExpired as error:
+            record["return_code"] = 124
+            record["status"] = "fail"
+            record["error"] = "exact replay exceeded 30 seconds"
+            stdout = verifier_fuzz.captured_output(error.stdout)
+            stderr = verifier_fuzz.captured_output(error.stderr)
+        records.append(record)
+        log_parts.append(
+            f"case: {name}\ncommand: {shlex.join(command)}\n"
+            f"status: {record['status']}\nreturn_code: {record['return_code']}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}\n"
+        )
+    (output_dir / "differential-smoke.log").write_text(
+        "\n".join(log_parts),
+        encoding="utf8",
+    )
+    return records
+
+
+def add_differential_metadata(
+    output_dir: Path,
+    manifest: dict,
+    source_hashes: dict,
+    source_manifest: dict,
+    fuzzer: Path | None,
+    replay: Path | None,
+    libcrux_bridge: Path | None,
+    libcrux_rlib: Path | None,
+    crate_dir: Path | None,
+    openssl_runtime: dict | None,
+    smoke_records: list[dict],
+    input_status: list[str] | None,
+    fuzzer_duration_seconds: float | None,
+) -> dict:
+    campaign_path = output_dir / "campaign.json"
+    campaign = json.loads(campaign_path.read_text(encoding="utf8"))
+    executed_units = None
+    for line in campaign["final_stats"]:
+        match = re.fullmatch(r"stat::number_of_executed_units:\s*(\d+)", line)
+        if match is not None:
+            executed_units = int(match.group(1))
+            break
+    campaign["repository_commit"] = git_head()
+    campaign["github_sha"] = os.environ.get("GITHUB_SHA")
+    campaign["repository_dirty"] = (
+        None if input_status is None else bool(input_status)
+    )
+    campaign["repository_input_status_porcelain"] = input_status
+    campaign["executed_units"] = executed_units
+    campaign["fuzzer_duration_seconds"] = (
+        round(fuzzer_duration_seconds, 3)
+        if fuzzer_duration_seconds is not None
+        else None
+    )
+    campaign["differential_oracles"] = {
+        "comparison": "accept/reject equality for every parsed fuzz frame",
+        "wrapper": {
+            "implementation": "vendored mldsa-native through pqbtc_mldsa44_verify_strict",
+            "commit": source_manifest.get("commit"),
+            "source_capsule_sha256": source_manifest.get("capsule_hash", {}).get(
+                "value"
+            ),
+        },
+        "openssl": {
+            "version": manifest["sources"]["openssl"]["version"],
+            "commit": manifest["sources"]["openssl"]["commit"],
+            "bridge_source_sha256": sha256_file(OPENSSL_BRIDGE),
+            "runtime": openssl_runtime,
+        },
+        "libcrux": {
+            "version": manifest["sources"]["libcrux"]["version"],
+            "commit": manifest["sources"]["libcrux"]["commit"],
+            "crate_sha256": manifest["sources"]["libcrux"]["crate_sha256"],
+            "bridge_source_sha256": sha256_file(LIBCRUX_BRIDGE),
+            "cargo_lock_sha256": (
+                sha256_file(crate_dir / "Cargo.lock")
+                if crate_dir is not None and (crate_dir / "Cargo.lock").is_file()
+                else None
+            ),
+            "rlib_sha256": (
+                sha256_file(libcrux_rlib)
+                if libcrux_rlib is not None and libcrux_rlib.is_file()
+                else None
+            ),
+            "bridge_binary_sha256": (
+                sha256_file(libcrux_bridge)
+                if libcrux_bridge is not None and libcrux_bridge.is_file()
+                else None
+            ),
+        },
+        "source_files": source_hashes,
+        "fuzzer_binary_sha256": (
+            sha256_file(fuzzer) if fuzzer is not None and fuzzer.is_file() else None
+        ),
+        "exact_replay": {
+            "status": (
+                "pass"
+                if len(smoke_records) == len(SMOKE_CASE_NAMES)
+                and all(record["status"] == "pass" for record in smoke_records)
+                else ("fail" if smoke_records else "not_run")
+            ),
+            "case_count": len(smoke_records),
+            "expected_accept_count": sum(
+                record["expected"] == "accept" for record in smoke_records
+            ),
+            "expected_reject_count": sum(
+                record["expected"] == "reject" for record in smoke_records
+            ),
+            "cases": smoke_records,
+            "binary_sha256": (
+                sha256_file(replay)
+                if replay is not None and replay.is_file()
+                else None
+            ),
+        },
+        "coverage_scope": {
+            "instrumented": [
+                "pqbtc_mldsa44 wrapper and vendored portable C backend",
+                "differential fuzz target and exact replay driver",
+                "OpenSSL C adapter",
+            ],
+            "not_instrumented": [
+                "prebuilt OpenSSL provider implementation body",
+                "prebuilt libcrux Rust implementation body",
+            ],
+        },
+        "toolchain": {
+            "rustc": command_identity("rustc"),
+            "cargo": command_identity("cargo"),
+        },
+    }
+    campaign_path.write_text(
+        json.dumps(campaign, indent=2, sort_keys=True) + "\n", encoding="utf8"
+    )
+    verifier_fuzz.write_evidence_hashes(output_dir)
+    return campaign
+
+
+def run_campaign(
+    manifest: dict,
+    source_hashes: dict,
+    openssl_source: Path,
+    libcrux_source: Path,
+    libcrux_crate: Path,
+    output_dir: Path,
+    *,
+    seconds: int,
+    seed: int,
+) -> dict:
+    input_status = git_input_status(source_hashes)
+    output_dir = output_dir.resolve()
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise DifferentialFuzzError(f"output path is not a directory: {output_dir}")
+        if any(output_dir.iterdir()):
+            raise DifferentialFuzzError(f"output directory is not empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    corpus_dir = output_dir / "corpus"
+    artifact_dir = output_dir / "crashes"
+    artifact_dir.mkdir()
+
+    started_at = datetime.now(timezone.utc).isoformat()
+    monotonic_start = time.monotonic()
+    completed = subprocess.CompletedProcess([], 1, "", "campaign did not start")
+    processing_error = None
+    crash_minimization: list[dict] = []
+    source_summary: dict = {}
+    compiler = os.environ.get("FUZZ_CC", "clang")
+    fuzzer: Path | None = None
+    libcrux_bridge: Path | None = None
+    libcrux_rlib: Path | None = None
+    crate_dir: Path | None = None
+    replay: Path | None = None
+    openssl_runtime: dict | None = None
+    smoke_records: list[dict] = []
+    source_manifest: dict = {}
+    fuzzer_duration_seconds: float | None = None
+
+    with tempfile.TemporaryDirectory(prefix="pqbtc-mldsa44-differential-") as temporary:
+        build_dir = Path(temporary)
+        try:
+            source_manifest = verifier_fuzz.wrapper.validate_source_capsule()
+            wycheproof = verifier_fuzz.validate_wycheproof_source()
+            sources = manifest["sources"]
+            reference.require_openssl_source(
+                openssl_source, sources["openssl"]["commit"]
+            )
+            reference.require_libcrux_source(libcrux_source, sources["libcrux"])
+            reference.require_artifact(
+                libcrux_crate,
+                sources["libcrux"]["crate_sha256"],
+                "libcrux ML-DSA crate",
+            )
+            production_library = verifier_fuzz.wrapper.compile_shared(
+                compiler, build_dir, testing=False
+            )
+            test_library = verifier_fuzz.wrapper.compile_shared(
+                compiler, build_dir, testing=True
+            )
+            cases = verifier_fuzz.project_corpus(
+                test_library
+            ) + verifier_fuzz.wycheproof_corpus(wycheproof)
+            source_summary = verifier_fuzz.validate_corpus_manifest(cases)
+            verifier_fuzz.replay_corpus(production_library, cases)
+            verifier_fuzz.materialize_corpus(corpus_dir, cases)
+
+            crate_dir = reference.prepare_libcrux_crate(
+                build_dir, libcrux_crate, sources["libcrux"]
+            )
+            libcrux_bridge, libcrux_rlib = compile_libcrux_bridge(
+                build_dir, crate_dir
+            )
+            fuzzer, replay, compiler = compile_differential_targets(
+                build_dir, libcrux_bridge, sources["openssl"]["version"]
+            )
+            openssl_runtime = openssl_runtime_provenance(fuzzer)
+            smoke_records = replay_differential_smoke(
+                replay, cases, output_dir
+            )
+            failed_smoke_cases = [
+                record["name"]
+                for record in smoke_records
+                if record["status"] != "pass"
+            ]
+            if failed_smoke_cases:
+                raise DifferentialFuzzError(
+                    "exact differential smoke replay failed for: "
+                    + ", ".join(failed_smoke_cases)
+                )
+            fuzzer_started = time.monotonic()
+            completed = verifier_fuzz.run_fuzzer(
+                fuzzer,
+                corpus_dir,
+                artifact_dir,
+                output_dir / "fuzzer.log",
+                runs=None,
+                seconds=seconds,
+                sanitizer=SANITIZER,
+                profile_pattern=output_dir / "coverage-%p.profraw",
+                seed=seed,
+            )
+            fuzzer_duration_seconds = time.monotonic() - fuzzer_started
+            if completed.returncode == 0:
+                verifier_fuzz.minimize_corpus(
+                    fuzzer,
+                    corpus_dir,
+                    output_dir / "minimized-corpus",
+                    output_dir / "corpus-minimization.log",
+                    sanitizer=SANITIZER,
+                    profile_pattern=output_dir / "coverage-merge-%p.profraw",
+                )
+                verifier_fuzz.write_coverage_report(compiler, fuzzer, output_dir)
+            else:
+                crash_minimization = verifier_fuzz.minimize_crash_artifacts(
+                    fuzzer,
+                    artifact_dir,
+                    output_dir,
+                    sanitizer=SANITIZER,
+                    seed=seed,
+                )
+        except (
+            DifferentialFuzzError,
+            KeyError,
+            OSError,
+            ValueError,
+            reference.ReferenceError,
+            verifier_fuzz.FuzzHarnessError,
+            verifier_fuzz.wrapper.HarnessError,
+        ) as error:
+            processing_error = str(error)
+        finally:
+            verifier_fuzz.write_campaign_report(
+                output_dir,
+                compiler=compiler,
+                sanitizer=SANITIZER,
+                coverage=True,
+                runs=None,
+                seconds=seconds,
+                imported_seeds=0,
+                source_summary=source_summary,
+                started_at=started_at,
+                duration_seconds=time.monotonic() - monotonic_start,
+                seed=seed,
+                completed=completed,
+                processing_error=processing_error,
+                crash_minimization=crash_minimization,
+            )
+            campaign = add_differential_metadata(
+                output_dir,
+                manifest,
+                source_hashes,
+                source_manifest,
+                fuzzer,
+                replay,
+                libcrux_bridge,
+                libcrux_rlib,
+                crate_dir,
+                openssl_runtime,
+                smoke_records,
+                input_status,
+                fuzzer_duration_seconds,
+            )
+
+    if processing_error is not None:
+        raise DifferentialFuzzError(
+            f"campaign processing failed; evidence retained in {output_dir}: "
+            f"{processing_error}"
+        )
+    if completed.returncode != 0:
+        raise DifferentialFuzzError(
+            f"fuzzer failed ({completed.returncode}); evidence retained in {output_dir}"
+        )
+    return {
+        "status": campaign["status"],
+        "return_code": campaign["return_code"],
+        "sanitizer": campaign["sanitizer"],
+        "coverage_enabled": campaign["coverage_enabled"],
+        "campaign_limit": campaign["campaign_limit"],
+        "repository_commit": campaign["repository_commit"],
+        "repository_dirty": campaign["repository_dirty"],
+        "seed": seed,
+        "seconds": seconds,
+        "source_corpus": campaign["source_corpus"],
+        "working_corpus": campaign["working_corpus"],
+        "minimized_corpus": campaign["minimized_corpus"],
+        "crash_artifacts": campaign["crash_artifacts"],
+        "last_progress_line": campaign["last_progress_line"],
+        "final_stats": campaign["final_stats"],
+        "executed_units": campaign["executed_units"],
+        "fuzzer_duration_seconds": campaign["fuzzer_duration_seconds"],
+        "differential_oracles": campaign["differential_oracles"],
+        "evidence_sha256": sha256_file(output_dir / "SHA256SUMS"),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest-only", action="store_true")
+    parser.add_argument("--openssl-source", type=Path)
+    parser.add_argument("--libcrux-source", type=Path)
+    parser.add_argument("--libcrux-crate", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--seconds", type=int, default=60)
+    parser.add_argument("--seed", type=int, default=188)
+    return parser.parse_args()
+
+
+def require_path(value: Path | None, option: str) -> Path:
+    if value is None:
+        raise DifferentialFuzzError(f"{option} is required")
+    return value.resolve()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifest = reference.load_manifest()
+        source_hashes = validate_local_inputs(manifest)
+        verifier_fuzz.wrapper.validate_source_capsule()
+        verifier_fuzz.validate_wycheproof_source()
+        if args.manifest_only:
+            print(
+                "ML-DSA-44 differential verifier fuzz inputs OK: "
+                "wrapper + OpenSSL 3.6.3 + libcrux 0.0.10"
+            )
+            return 0
+        if not 1 <= args.seconds <= MAX_CAMPAIGN_SECONDS:
+            raise DifferentialFuzzError(
+                f"--seconds must be between 1 and {MAX_CAMPAIGN_SECONDS}"
+            )
+        if not 1 <= args.seed <= 0xFFFFFFFF:
+            raise DifferentialFuzzError(
+                "--seed must be a nonzero unsigned 32-bit integer"
+            )
+        report = run_campaign(
+            manifest,
+            source_hashes,
+            require_path(args.openssl_source, "--openssl-source"),
+            require_path(args.libcrux_source, "--libcrux-source"),
+            require_path(args.libcrux_crate, "--libcrux-crate"),
+            require_path(args.output_dir, "--output-dir"),
+            seconds=args.seconds,
+            seed=args.seed,
+        )
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    except (
+        DifferentialFuzzError,
+        OSError,
+        KeyError,
+        ValueError,
+        reference.ReferenceError,
+        verifier_fuzz.FuzzHarnessError,
+        verifier_fuzz.wrapper.HarnessError,
+    ) as error:
+        if args.output_dir is not None:
+            campaign_path = args.output_dir.resolve() / "campaign.json"
+            if campaign_path.is_file():
+                campaign = json.loads(campaign_path.read_text(encoding="utf8"))
+                print(
+                    json.dumps(
+                        {
+                            "status": campaign.get("status", "fail"),
+                            "return_code": campaign.get("return_code"),
+                            "processing_error": campaign.get("processing_error"),
+                            "repository_commit": campaign.get("repository_commit"),
+                            "evidence_directory": str(args.output_dir.resolve()),
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    )
+                )
+        print(f"differential verifier fuzz: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/ml-dsa-engineering/run_verifier_fuzz.py
+++ b/contrib/ml-dsa-engineering/run_verifier_fuzz.py
@@ -643,8 +643,17 @@ def compile_fuzzer(
     build_dir: Path,
     sanitizer: str,
     coverage: bool,
+    *,
+    differential_sources: tuple[Path, ...] = (),
+    differential_link_args: tuple[str, ...] = (),
 ) -> Path:
-    output = build_dir / "pqbtc_mldsa44_verify_fuzz"
+    differential = bool(differential_sources or differential_link_args)
+    output_name = (
+        "pqbtc_mldsa44_differential_verify_fuzz"
+        if differential
+        else "pqbtc_mldsa44_verify_fuzz"
+    )
+    output = build_dir / output_name
     command = wrapper.common_flags(compiler)
     command.extend(
         [
@@ -659,12 +668,16 @@ def compile_fuzzer(
         command.extend(["-fsanitize-memory-track-origins=2", "-fPIE", "-pie"])
     if coverage:
         command.extend(["-fprofile-instr-generate", "-fcoverage-mapping"])
+    if differential:
+        command.append("-DPQBTC_MLDSA44_DIFFERENTIAL=1")
     command.extend(
         [
             str(wrapper.WRAPPER_SOURCE),
             str(FUZZ_SOURCE),
+            *map(str, differential_sources),
             "-o",
             str(output),
+            *differential_link_args,
         ]
     )
     wrapper.run(command)

--- a/docs/ML_DSA_44_WRAPPER_PROTOTYPE.md
+++ b/docs/ML_DSA_44_WRAPPER_PROTOTYPE.md
@@ -124,8 +124,11 @@ CC=clang python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py \
 CC=clang python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py \
   --sanitizers --sanitizer memory --seconds 1800 \
   --output-dir /tmp/ml-dsa-44-msan
+python3 contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py \
+  --manifest-only
 python3 -m unittest ci.test.test_ml_dsa_wrapper_prototype
 python3 -m unittest ci.test.test_ml_dsa_sustained_fuzz
+python3 -m unittest ci.test.test_ml_dsa_differential_fuzz
 ```
 
 The verifier harness deterministically regenerates and replays 207 bounded
@@ -157,6 +160,25 @@ retained crash is evidence to investigate, not an
 automatically trusted regression vector: promotion into a checked-in corpus
 still requires review.
 
+The pinned review-reproduction workflow adds a 60-second Linux Clang
+ASan/UBSan differential campaign. Its fuzz target calls the isolated wrapper,
+OpenSSL 3.6.3's explicitly selected default provider in a separate library
+context, and libcrux 0.0.10 in-process for every parsed frame and aborts
+on any setup error or accept/reject disagreement. The wrapper's exact
+invalid-argument taxonomy is still checked separately. The retained evidence
+records source and binary hashes, both external-oracle pins, the resolved
+`libcrypto` binary hash, coverage, minimized corpus, and crash artifacts. A
+separate sanitized replay executable first sends five named frozen valid,
+invalid, malformed, and null-argument frames through the same real three-way
+target exactly once. This prevents an always-accepting or
+always-rejecting well-shaped wrapper from passing that campaign merely because
+the result remained inside the wrapper's documented return-code set. It does
+not instrument the complete OpenSSL or Rust implementation bodies with the C
+sanitizers and is not long-duration or multi-platform differential evidence.
+The versioned clang-tidy/IWYU plan does not cover the differential-only branch
+or external adapter sources; those C sources are compiled with fatal warnings
+and exercised dynamically in the pinned review workflow instead.
+
 ## Residual Boundary
 
 This prototype advances engineering evidence but closes no production gate:
@@ -170,12 +192,13 @@ This prototype advances engineering evidence but closes no production gate:
   not a complete fault model;
 - issue `#187`: explicit source cleanup and sanitizer evidence do not prove
   erasure of compiler copies, registers, caller-owned keys, or crash artifacts;
-- issue `#188`: deterministic Wycheproof replay and bounded structure-aware
-  ASan/UBSan and MSan campaigns with retained evidence are now implemented,
-  but multi-backend differential and adapter fuzzing, automatic advisory-case
-  ingestion, Rust coverage if a Rust backend is admitted, broader platforms,
-  minimum coverage goals, reviewed regression-vector promotion, and stack,
-  worst-case, and adversarial-batch resource limits remain open;
+- issue `#188`: deterministic Wycheproof replay, bounded structure-aware
+  ASan/UBSan and MSan campaigns, and bounded three-backend differential
+  verifier fuzzing with retained evidence are now implemented, but stateful
+  signer fuzzing, long-duration and broader-platform differential campaigns,
+  automatic advisory-case ingestion, full Rust sanitizer coverage, minimum
+  coverage goals, reviewed regression-vector promotion, and stack, worst-case,
+  and adversarial-batch resource limits remain open;
 - issue `#189`: the source capsule and network-free build are partial evidence,
   not an SBOM, reproducibility campaign, or ongoing advisory process;
 - issue `#190`: key ownership, formats, backup, PSBT, and hardware-wallet


### PR DESCRIPTION
## Summary

- compare every parsed verifier frame in-process across the admitted wrapper, pinned OpenSSL 3.6.3 default provider, and pinned libcrux 0.0.10
- replay five frozen accept/reject cases exactly once through the real three-backend target before timed fuzzing
- retain source, binary, loaded-libcrypto, corpus, coverage, crash, and checksum evidence from a 60-second Linux ASan/UBSan campaign
- keep production backend NONE and the release hold enabled

## Local validation

- 63 ML-DSA unit and contract tests passed
- all 207 generated and Wycheproof frames passed the isolated-provider three-way replay
- strict C syntax, Rust formatting, Python lint, frozen comparator, workflow YAML/shell/Python, sanitized wrapper, and deterministic verifier replay checks passed

## Remaining scope

The pinned Linux campaign must complete in CI. Long-duration and broader-platform differential campaigns, stateful signer fuzzing, full Rust sanitizer coverage, and resource-envelope limits remain open.