### PR TITLE
Sustain retained ML-DSA differential fuzzing

### DIFF
--- a/.github/workflows/ml-dsa-44-review-reproduction.yml
+++ b/.github/workflows/ml-dsa-44-review-reproduction.yml
@@ -8,9 +8,16 @@ on:
       - "contrib/ml-dsa-engineering/**"
       - "ci/test/test_ml_dsa_reference.py"
       - "ci/test/test_ml_dsa_differential_fuzz.py"
+  schedule:
+    - cron: "43 5 * * 3"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -28,6 +35,21 @@ jobs:
       LIBCRUX_DISABLE_SIMD256: "1"
 
     steps:
+      - name: Initialize failure evidence
+        env:
+          CONTEXT: ${{ runner.temp }}/ml-dsa-44-review-run-context.txt
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "event_name=$GITHUB_EVENT_NAME"
+            echo "github_ref=$GITHUB_REF"
+            echo "github_sha=$GITHUB_SHA"
+            echo "expected_checkout_head=$EXPECTED_HEAD"
+            echo "github_run_id=$GITHUB_RUN_ID"
+            echo "github_run_attempt=$GITHUB_RUN_ATTEMPT"
+          } > "$CONTEXT"
+
       - name: Checkout PQBTC review head
         timeout-minutes: 5
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -49,8 +71,13 @@ jobs:
 
       - name: Validate frozen repository inputs
         timeout-minutes: 10
+        env:
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euxo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+          repository_status="$(git status --porcelain --untracked-files=all)"
+          test -z "$repository_status"
           test "$(rustc --version | cut -d ' ' -f 2)" = "1.89.0"
           git diff --exit-code "$BASELINE" -- \
             contrib/ml-dsa-ref ci/test/test_ml_dsa_reference.py \
@@ -63,6 +90,243 @@ jobs:
           rustfmt --check \
             contrib/ml-dsa-engineering/pqbtc_mldsa44_libcrux_verify.rs
           python3 -m unittest ci.test.test_ml_dsa_differential_fuzz
+
+      - name: Stage failure evidence
+        env:
+          CONTEXT: ${{ runner.temp }}/ml-dsa-44-review-run-context.txt
+        run: |
+          set -euo pipefail
+          cp "$CONTEXT" ml-dsa-44-review-run-context.txt
+
+      - name: Restore prior minimized differential corpus
+        id: retained
+        timeout-minutes: 10
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRIOR_DIR: ${{ runner.temp }}/ml-dsa-44-prior-review
+          PROVENANCE: ml-dsa-44-differential-retained-corpus.txt
+        run: |
+          set -euo pipefail
+          {
+            echo "event_name=$GITHUB_EVENT_NAME"
+            echo "restore_policy=latest_successful_main_run"
+          } > "$PROVENANCE"
+
+          if [[ "$GITHUB_EVENT_NAME" != "schedule" && \
+                "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
+            echo "state=not_requested_for_pull_request_smoke" >> "$PROVENANCE"
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "state=long_campaign_requires_main" >> "$PROVENANCE"
+            exit 1
+          fi
+
+          previous_run_record="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow ml-dsa-44-review-reproduction.yml \
+              --branch main \
+              --status success \
+              --limit 20 \
+              --json databaseId,attempt,createdAt,headSha \
+              --jq 'sort_by([.createdAt, .databaseId]) | reverse | .[0] | select(.) | [.databaseId, .attempt, .headSha] | @tsv'
+          )"
+          if [[ -z "$previous_run_record" ]]; then
+            echo "state=no_prior_successful_main_run" >> "$PROVENANCE"
+            exit 1
+          fi
+
+          IFS=$'\t' read -r previous_run previous_attempt previous_head \
+            <<< "$previous_run_record"
+          [[ "$previous_run" =~ ^[0-9]+$ ]]
+          [[ "$previous_attempt" =~ ^[0-9]+$ ]]
+          [[ "$previous_head" =~ ^[0-9a-f]{40}$ ]]
+          git merge-base --is-ancestor "$previous_head" HEAD
+          artifact_name="ml-dsa-44-review-evidence-$previous_head"
+          mkdir -p "$PRIOR_DIR"
+          gh run download "$previous_run" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$artifact_name" \
+            --dir "$PRIOR_DIR"
+
+          prior_evidence="$PRIOR_DIR/ml-dsa-44-differential-fuzz"
+          test -f "$prior_evidence/SHA256SUMS"
+          prior_symlink="$(find "$prior_evidence" -type l -print -quit)"
+          test -z "$prior_symlink"
+
+          seed_dir="$prior_evidence/minimized-corpus"
+          test -d "$seed_dir"
+          test ! -L "$seed_dir"
+          seed_dir_relative="${seed_dir#"$PRIOR_DIR"/}"
+          test "$seed_dir_relative" = \
+            "ml-dsa-44-differential-fuzz/minimized-corpus"
+          seed_count=0
+          seed_total_bytes=0
+          while IFS= read -r -d '' seed; do
+            seed_count=$((seed_count + 1))
+            if (( seed_count > 4096 )); then
+              echo "state=minimized_corpus_file_count_exceeded" \
+                >> "$PROVENANCE"
+              exit 1
+            fi
+            if [[ ! -f "$seed" || -L "$seed" ]]; then
+              echo "state=non_regular_or_nested_minimized_corpus" \
+                >> "$PROVENANCE"
+              exit 1
+            fi
+            seed_bytes="$(stat --format=%s -- "$seed")"
+            [[ "$seed_bytes" =~ ^[0-9]+$ ]]
+            if (( seed_bytes > 8096 )); then
+              echo "state=minimized_corpus_input_size_exceeded" \
+                >> "$PROVENANCE"
+              exit 1
+            fi
+            seed_total_bytes=$((seed_total_bytes + seed_bytes))
+            if (( seed_total_bytes > 33554432 )); then
+              echo "state=minimized_corpus_total_size_exceeded" \
+                >> "$PROVENANCE"
+              exit 1
+            fi
+          done < <(
+            find "$seed_dir" -mindepth 1 -maxdepth 1 -print0
+          )
+          if (( seed_count < 1 )); then
+            echo "state=empty_minimized_corpus" >> "$PROVENANCE"
+            exit 1
+          fi
+          nested_seed_entry="$(find "$seed_dir" -mindepth 2 -print -quit)"
+          if [[ -n "$nested_seed_entry" ]]; then
+            echo "state=non_regular_or_nested_minimized_corpus" >> "$PROVENANCE"
+            exit 1
+          fi
+          (
+            cd "$prior_evidence"
+            sha256sum --check SHA256SUMS
+          )
+          python3 - "$prior_evidence/campaign.json" "$seed_dir" \
+            "$previous_head" >> "$PROVENANCE" <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+          import sys
+
+          campaign_path = Path(sys.argv[1])
+          seed_dir = Path(sys.argv[2])
+          expected_head = sys.argv[3]
+          campaign = json.loads(campaign_path.read_text(encoding="utf8"))
+          digest = hashlib.sha256()
+          file_count = 0
+          total_bytes = 0
+          for path in sorted(item for item in seed_dir.rglob("*") if item.is_file()):
+              relative = path.relative_to(seed_dir).as_posix()
+              data = path.read_bytes()
+              file_digest = hashlib.sha256(data).hexdigest()
+              digest.update(f"{relative}\0{len(data)}\0{file_digest}\n".encode())
+              file_count += 1
+              total_bytes += len(data)
+          actual_summary = {
+              "file_count": file_count,
+              "total_bytes": total_bytes,
+              "aggregate_sha256": digest.hexdigest(),
+          }
+          assert campaign["status"] == "pass"
+          assert campaign["return_code"] == 0
+          assert campaign["repository_commit"] == expected_head
+          assert campaign["repository_dirty"] is False
+          assert campaign["minimized_corpus"] == actual_summary
+          assert actual_summary["file_count"] > 0
+          print(f"source_campaign_repository_commit={expected_head}")
+          print(f"source_campaign_minimized_file_count={file_count}")
+          print(f"source_campaign_minimized_total_bytes={total_bytes}")
+          print(
+              "source_campaign_minimized_aggregate_sha256="
+              f"{actual_summary['aggregate_sha256']}"
+          )
+          PY
+          source_evidence_sha256="$(
+            sha256sum "$prior_evidence/SHA256SUMS" | cut -d ' ' -f 1
+          )"
+          [[ "$source_evidence_sha256" =~ ^[0-9a-f]{64}$ ]]
+
+          {
+            echo "state=restored"
+            echo "source_run_id=$previous_run"
+            echo "source_run_attempt=$previous_attempt"
+            echo "source_head_sha=$previous_head"
+            echo "source_artifact=$artifact_name"
+            echo "seed_directory=$seed_dir_relative"
+            echo "restored_seed_file_count=$seed_count"
+            echo "source_evidence_sha256=$source_evidence_sha256"
+          } >> "$PROVENANCE"
+          {
+            echo "restored=true"
+            echo "seed_dir=$seed_dir"
+            echo "source_run_id=$previous_run"
+            echo "source_run_attempt=$previous_attempt"
+            echo "source_head_sha=$previous_head"
+            echo "source_artifact=$artifact_name"
+            echo "restored_seed_file_count=$seed_count"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Select bounded differential campaign
+        env:
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          RETAINED_CORPUS_RESTORED: ${{ steps.retained.outputs.restored }}
+          RETAINED_SOURCE_RUN_ID: ${{ steps.retained.outputs.source_run_id }}
+          RETAINED_SOURCE_RUN_ATTEMPT: ${{ steps.retained.outputs.source_run_attempt }}
+          RETAINED_SOURCE_HEAD_SHA: ${{ steps.retained.outputs.source_head_sha }}
+          RETAINED_SOURCE_ARTIFACT: ${{ steps.retained.outputs.source_artifact }}
+          RETAINED_SEED_FILE_COUNT: ${{ steps.retained.outputs.restored_seed_file_count }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" || \
+                "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            campaign_seconds=1800
+            campaign_seed="$(python3 - <<'PY'
+          import os
+
+          run_id = int(os.environ["GITHUB_RUN_ID"])
+          run_attempt = int(os.environ["GITHUB_RUN_ATTEMPT"])
+          print(((run_id + run_attempt - 1) % 0xFFFFFFFF) + 1)
+          PY
+          )"
+          else
+            campaign_seconds=60
+            campaign_seed=188
+          fi
+          if [[ "$campaign_seconds" == "1800" ]]; then
+            test "$RETAINED_CORPUS_RESTORED" = "true"
+            test "$GITHUB_REF" = "refs/heads/main"
+          else
+            test "$RETAINED_CORPUS_RESTORED" = "false"
+          fi
+          [[ "$campaign_seconds" =~ ^(60|1800)$ ]]
+          [[ "$campaign_seed" =~ ^[0-9]+$ ]]
+          (( campaign_seed >= 1 && campaign_seed <= 4294967295 ))
+          checkout_head="$(git rev-parse HEAD)"
+          test "$checkout_head" = "$EXPECTED_HEAD"
+          {
+            echo "DIFFERENTIAL_CAMPAIGN_SECONDS=$campaign_seconds"
+            echo "DIFFERENTIAL_CAMPAIGN_SEED=$campaign_seed"
+          } >> "$GITHUB_ENV"
+          {
+            echo "event_name=$GITHUB_EVENT_NAME"
+            echo "github_sha=$GITHUB_SHA"
+            echo "expected_checkout_head=$EXPECTED_HEAD"
+            echo "checkout_head=$checkout_head"
+            echo "github_run_id=$GITHUB_RUN_ID"
+            echo "github_run_attempt=$GITHUB_RUN_ATTEMPT"
+            echo "campaign_seconds=$campaign_seconds"
+            echo "campaign_seed=$campaign_seed"
+            echo "retained_corpus_restored=${RETAINED_CORPUS_RESTORED:-false}"
+            echo "retained_source_run_id=$RETAINED_SOURCE_RUN_ID"
+            echo "retained_source_run_attempt=$RETAINED_SOURCE_RUN_ATTEMPT"
+            echo "retained_source_head_sha=$RETAINED_SOURCE_HEAD_SHA"
+            echo "retained_source_artifact=$RETAINED_SOURCE_ARTIFACT"
+            echo "retained_seed_file_count=$RETAINED_SEED_FILE_COUNT"
+          } > ml-dsa-44-differential-campaign-parameters.txt
 
       - name: Fetch pinned standards artifacts and upstream sources
         timeout-minutes: 15
@@ -93,6 +357,17 @@ jobs:
           git clone https://github.com/celabshq/libcrux.git libcrux
           git -C libcrux checkout --detach "$LIBCRUX_COMMIT"
 
+          test "$(git -C acvp-server rev-parse HEAD)" = "$ACVP_COMMIT"
+          test "$(git -C openssl rev-parse HEAD)" = "$OPENSSL_COMMIT"
+          test "$(git -C mldsa-native rev-parse HEAD)" = "$MLDSA_NATIVE_COMMIT"
+          test "$(git -C libcrux rev-parse HEAD)" = "$LIBCRUX_COMMIT"
+          for source in acvp-server openssl mldsa-native libcrux; do
+            source_status="$(
+              git -C "$source" status --porcelain --untracked-files=all
+            )"
+            test -z "$source_status"
+          done
+
       - name: Build pinned OpenSSL 3.6.3 out of tree
         timeout-minutes: 25
         run: |
@@ -117,7 +392,11 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Run complete pinned comparator
-        timeout-minutes: 60
+        timeout-minutes: 75
+        env:
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          RETAINED_CORPUS_RESTORED: ${{ steps.retained.outputs.restored }}
+          RETAINED_SEED_DIR: ${{ steps.retained.outputs.seed_dir }}
         run: |
           set -euxo pipefail
           REVIEW_ROOT="$RUNNER_TEMP/ml-dsa-review"
@@ -166,16 +445,32 @@ jobs:
             exit "$REVIEW_EXIT"
           fi
 
+          fuzz_args=(
+            --openssl-source "$REVIEW_ROOT/openssl"
+            --libcrux-source "$REVIEW_ROOT/libcrux"
+            --libcrux-crate "$REVIEW_ROOT/artifacts/libcrux-ml-dsa-0.0.10.crate"
+            --output-dir "$DIFFERENTIAL_EVIDENCE"
+          )
+          if [[ "$DIFFERENTIAL_CAMPAIGN_SECONDS" == "1800" ]]; then
+            fuzz_args+=(--seconds 1800 --seed "$DIFFERENTIAL_CAMPAIGN_SEED")
+          else
+            test "$DIFFERENTIAL_CAMPAIGN_SECONDS" = "60"
+            test "$DIFFERENTIAL_CAMPAIGN_SEED" = "188"
+            fuzz_args+=(--seconds 60 --seed 188)
+          fi
+          if [[ "$RETAINED_CORPUS_RESTORED" == "true" ]]; then
+            test "$DIFFERENTIAL_CAMPAIGN_SECONDS" = "1800"
+            test -n "$RETAINED_SEED_DIR"
+            test -d "$RETAINED_SEED_DIR"
+            fuzz_args+=(--seed-corpus "$RETAINED_SEED_DIR")
+          else
+            test -z "$RETAINED_SEED_DIR"
+          fi
+
           set +e
           FUZZ_CC=clang \
             python3 contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py \
-              --openssl-source "$REVIEW_ROOT/openssl" \
-              --libcrux-source "$REVIEW_ROOT/libcrux" \
-              --libcrux-crate "$REVIEW_ROOT/artifacts/libcrux-ml-dsa-0.0.10.crate" \
-              --output-dir "$DIFFERENTIAL_EVIDENCE" \
-              --seconds 60 \
-              --seed 188 \
-              > "$FUZZ_REPORT"
+              "${fuzz_args[@]}" > "$FUZZ_REPORT"
           FUZZ_EXIT=$?
           set -e
 
@@ -220,6 +515,8 @@ jobs:
           if (( EVIDENCE_EXIT != 0 )); then
             exit "$EVIDENCE_EXIT"
           fi
+          git diff --exit-code
+          git diff --cached --exit-code
           python3 - <<'PY'
           import hashlib
           import json
@@ -259,30 +556,62 @@ jobs:
           fuzz_report = json.loads(
               Path("ml-dsa-44-differential-fuzz-run.json").read_text()
           )
+          expected_seconds = int(os.environ["DIFFERENTIAL_CAMPAIGN_SECONDS"])
+          expected_seed = int(os.environ["DIFFERENTIAL_CAMPAIGN_SEED"])
+          retained_corpus_restored = (
+              os.environ.get("RETAINED_CORPUS_RESTORED") == "true"
+          )
+          assert expected_seconds in (60, 1800)
+          assert 1 <= expected_seed <= 0xFFFFFFFF
+          if expected_seconds == 60:
+              assert os.environ["GITHUB_EVENT_NAME"] == "pull_request"
+              assert expected_seed == 188
+          else:
+              assert os.environ["GITHUB_EVENT_NAME"] in {
+                  "schedule",
+                  "workflow_dispatch",
+              }
+              assert os.environ["GITHUB_REF"] == "refs/heads/main"
           assert fuzz_report["status"] == "pass"
           assert fuzz_report["return_code"] == 0
           assert fuzz_report["sanitizer"] == "address-undefined"
           assert fuzz_report["coverage_enabled"] is True
-          assert fuzz_report["campaign_limit"] == {"runs": None, "seconds": 60}
-          assert fuzz_report["seed"] == 188
-          assert fuzz_report["seconds"] == 60
+          assert fuzz_report["campaign_limit"] == {
+              "runs": None,
+              "seconds": expected_seconds,
+          }
+          assert fuzz_report["seed"] == expected_seed
+          assert fuzz_report["seconds"] == expected_seconds
           checkout_head = subprocess.check_output(
               ["git", "rev-parse", "HEAD"], text=True
           ).strip()
+          assert checkout_head == os.environ["EXPECTED_HEAD"]
           assert fuzz_report["repository_commit"] == checkout_head
           assert fuzz_report["repository_dirty"] is False
           assert fuzz_report["crash_artifacts"]["file_count"] == 0
+          if retained_corpus_restored:
+              assert fuzz_report["imported_retained_seeds"] > 0
+          else:
+              assert fuzz_report["imported_retained_seeds"] == 0
           assert fuzz_report["source_corpus"]["total_cases"] == 207
           assert fuzz_report["working_corpus"]["file_count"] > 0
           assert fuzz_report["minimized_corpus"]["file_count"] > 0
           assert fuzz_report["last_progress_line"]
           assert fuzz_report["final_stats"]
-          assert fuzz_report["executed_units"] > 207
-          assert 59 <= fuzz_report["fuzzer_duration_seconds"] <= 95
+          if expected_seconds == 1800:
+              assert retained_corpus_restored
+              assert fuzz_report["executed_units"] >= 500_000
+              assert 1799 <= fuzz_report["fuzzer_duration_seconds"] <= 1835
+          else:
+              assert fuzz_report["executed_units"] > 207
+              assert 59 <= fuzz_report["fuzzer_duration_seconds"] <= 95
+          assert fuzz_report["fuzzer_duration_seconds"] <= expected_seconds + 35
 
           differential = fuzz_report["differential_oracles"]
           assert differential["fuzzer_binary_sha256"]
+          assert differential["wrapper"]["commit"] == os.environ["MLDSA_NATIVE_COMMIT"]
           assert differential["wrapper"]["source_capsule_sha256"]
+          assert differential["openssl"]["commit"] == os.environ["OPENSSL_COMMIT"]
           assert differential["openssl"]["bridge_source_sha256"]
           openssl_runtime = differential["openssl"]["runtime"]
           openssl_prefix = (
@@ -299,6 +628,7 @@ jobs:
           assert openssl_runtime["openssl_conf"] == "/dev/null"
           assert "OpenSSL Default Provider" in openssl_runtime["provider_inventory"]
           assert "version: 3.6.3" in openssl_runtime["provider_inventory"]
+          assert differential["libcrux"]["commit"] == os.environ["LIBCRUX_COMMIT"]
           assert differential["libcrux"]["bridge_source_sha256"]
           assert differential["libcrux"]["rlib_sha256"]
           assert differential["libcrux"]["bridge_binary_sha256"]
@@ -351,11 +681,14 @@ jobs:
           assert (evidence / "coverage.json").is_file()
           assert (evidence / "coverage.txt").is_file()
           assert (evidence / "differential-smoke.log").is_file()
+          assert (evidence / "fuzzer.log").is_file()
           assert (evidence / "SHA256SUMS").is_file()
           assert fuzz_report["evidence_sha256"] == hashlib.sha256(
               (evidence / "SHA256SUMS").read_bytes()
           ).hexdigest()
           campaign = json.loads(campaign_path.read_text())
+          assert campaign["minimized_crash_artifacts"]["file_count"] == 0
+          assert campaign["crash_minimization"] == []
           for key in (
               "status",
               "return_code",
@@ -372,11 +705,88 @@ jobs:
               "final_stats",
               "executed_units",
               "fuzzer_duration_seconds",
+              "imported_retained_seeds",
               "differential_oracles",
           ):
               assert fuzz_report[key] == campaign[key]
+
+          fuzzer_log = (evidence / "fuzzer.log").read_text(
+              encoding="utf8", errors="replace"
+          )
+          for prohibited in (
+              "PQBTC_MLDSA44_DIFFERENTIAL_ORACLE_ERROR",
+              "PQBTC_MLDSA44_DIFFERENTIAL_DISAGREEMENT",
+              "ERROR: AddressSanitizer",
+              "SUMMARY: AddressSanitizer",
+              "SUMMARY: UndefinedBehaviorSanitizer",
+              "runtime error:",
+          ):
+              assert prohibited not in fuzzer_log
+
+          coverage = json.loads((evidence / "coverage.json").read_text())
+          assert coverage["type"] == "llvm.coverage.json.export"
+          assert len(coverage["data"]) == 1
+          coverage_files = coverage["data"][0]["files"]
+
+          def source_summary(filename):
+              matches = [
+                  record
+                  for record in coverage_files
+                  if Path(record["filename"]).name == filename
+              ]
+              assert len(matches) == 1, (filename, len(matches))
+              return matches[0]["summary"]
+
+          def checked_percent(summary, metric, floor):
+              value = summary[metric]
+              count = value["count"]
+              covered = value["covered"]
+              assert type(count) is int and type(covered) is int
+              assert count > 0
+              assert 0 <= covered <= count
+              computed = 100.0 * covered / count
+              assert abs(computed - float(value["percent"])) <= 0.01
+              assert computed + 1e-12 >= floor, (metric, computed, floor)
+              return {
+                  "count": count,
+                  "covered": covered,
+                  "percent": round(computed, 6),
+                  "required_percent": floor,
+              }
+
+          target = source_summary("pqbtc_mldsa44_verify_fuzz.c")
+          openssl_bridge = source_summary("pqbtc_mldsa44_openssl_verify.c")
+          coverage_floor_evidence = {
+              "schema_version": 1,
+              "campaign_seconds": expected_seconds,
+              "target": {
+                  "functions": checked_percent(target, "functions", 100.0),
+                  "lines": checked_percent(target, "lines", 89.0),
+                  "branches": checked_percent(target, "branches", 85.0),
+              },
+              "openssl_bridge": {
+                  "functions": checked_percent(
+                      openssl_bridge, "functions", 75.0
+                  ),
+                  "lines": checked_percent(openssl_bridge, "lines", 71.0),
+                  "branches": checked_percent(
+                      openssl_bridge, "branches", 74.0
+                  ),
+              },
+          }
+          Path("ml-dsa-44-differential-coverage-floors.json").write_text(
+              json.dumps(coverage_floor_evidence, indent=2, sort_keys=True) + "\n",
+              encoding="utf8",
+          )
           print("ML-DSA-44 review invariants verified")
           PY
+          sha256sum \
+            ml-dsa-44-review-run-context.txt \
+            ml-dsa-44-differential-campaign-parameters.txt \
+            ml-dsa-44-differential-retained-corpus.txt \
+            ml-dsa-44-differential-coverage-floors.json | \
+            tee ml-dsa-44-differential-supplemental.sha256
+          sha256sum --check ml-dsa-44-differential-supplemental.sha256
 
       - name: Upload review evidence
         if: always()
@@ -385,11 +795,26 @@ jobs:
         with:
           name: ml-dsa-44-review-evidence-${{ github.event.pull_request.head.sha || github.sha }}
           path: |
+            ml-dsa-44-review-run-context.txt
             ml-dsa-44-review-run.json
             ml-dsa-44-review-run.sha256
             ml-dsa-44-review-toolchain.txt
             ml-dsa-44-differential-fuzz-run.json
             ml-dsa-44-differential-fuzz-run.sha256
+            ml-dsa-44-differential-campaign-parameters.txt
+            ml-dsa-44-differential-retained-corpus.txt
+            ml-dsa-44-differential-coverage-floors.json
+            ml-dsa-44-differential-supplemental.sha256
             ml-dsa-44-differential-fuzz/
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload checkout-failure context
+        if: failure() && hashFiles('ml-dsa-44-review-run-context.txt') == ''
+        timeout-minutes: 5
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ml-dsa-44-review-failure-context-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ml-dsa-44-review-run-context.txt
           if-no-files-found: error
           retention-days: 90

--- a/ci/test/test_ml_dsa_differential_fuzz.py
+++ b/ci/test/test_ml_dsa_differential_fuzz.py
@@ -6,6 +6,7 @@
 import importlib.util
 import hashlib
 import json
+from contextlib import ExitStack
 from pathlib import Path
 import subprocess
 import sys
@@ -95,6 +96,260 @@ class MlDsaDifferentialFuzzTest(unittest.TestCase):
             WORKFLOW,
         ):
             self.assertIn(str(path.relative_to(REPO_ROOT)), inventory)
+
+    def test_seed_corpus_cli_preserves_the_60_second_default(self):
+        with mock.patch.object(
+            sys,
+            "argv",
+            [str(DRIVER), "--seed-corpus", "retained-corpus"],
+        ):
+            args = differential.parse_args()
+
+        self.assertEqual(args.seconds, 60)
+        self.assertEqual(args.seed, 188)
+        self.assertEqual(args.seed_corpus, Path("retained-corpus"))
+
+    def test_retained_seed_import_is_bounded_deduplicated_and_content_addressed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            arbitrary_seed = b"not a decoded verifier frame"
+            second_seed = bytes(range(32))
+            (destination / "project_existing.bin").write_bytes(arbitrary_seed)
+            (source / "first").write_bytes(arbitrary_seed)
+            (source / "duplicate").write_bytes(arbitrary_seed)
+            (source / "second").write_bytes(second_seed)
+
+            imported = differential.import_seed_corpus(source, destination)
+
+            self.assertEqual(imported, 1)
+            arbitrary_digest = hashlib.sha256(arbitrary_seed).hexdigest()
+            self.assertFalse(
+                (destination / f"retained_{arbitrary_digest}.bin").exists()
+            )
+            second_digest = hashlib.sha256(second_seed).hexdigest()
+            self.assertEqual(
+                (destination / f"retained_{second_digest}.bin").read_bytes(),
+                second_seed,
+            )
+            self.assertEqual(
+                differential.import_seed_corpus(source, destination),
+                0,
+            )
+
+    def test_retained_seed_import_rejects_unsafe_container_entries(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+
+            source = root / "nested-source"
+            destination = root / "nested-destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "valid-first").write_bytes(b"seed")
+            (source / "nested").mkdir()
+            with self.assertRaisesRegex(
+                differential.DifferentialFuzzError,
+                "not a regular file",
+            ):
+                differential.import_seed_corpus(source, destination)
+            self.assertEqual(list(destination.iterdir()), [])
+
+            source = root / "symlink-source"
+            destination = root / "symlink-destination"
+            source.mkdir()
+            destination.mkdir()
+            target = root / "symlink-target"
+            target.write_bytes(b"seed")
+            (source / "linked").symlink_to(target)
+            with self.assertRaisesRegex(
+                differential.DifferentialFuzzError,
+                "must not be a symlink",
+            ):
+                differential.import_seed_corpus(source, destination)
+
+            source_link = root / "source-link"
+            source_link.symlink_to(source, target_is_directory=True)
+            with self.assertRaisesRegex(
+                differential.DifferentialFuzzError,
+                "seed corpus must not be a symlink",
+            ):
+                differential.import_seed_corpus(source_link, destination)
+
+    def test_retained_seed_import_enforces_each_resource_bound(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "oversized").write_bytes(
+                bytes(differential.verifier_fuzz.MAX_FRAME_BYTES + 1)
+            )
+            with self.assertRaisesRegex(
+                differential.DifferentialFuzzError,
+                "exceeds fuzz bound",
+            ):
+                differential.import_seed_corpus(source, destination)
+
+            (source / "oversized").unlink()
+            (source / "one").write_bytes(b"1")
+            (source / "two").write_bytes(b"2")
+            with mock.patch.object(
+                differential.verifier_fuzz,
+                "MAX_RETAINED_CORPUS_FILES",
+                1,
+            ), self.assertRaisesRegex(
+                differential.DifferentialFuzzError,
+                "file-count bound",
+            ):
+                differential.import_seed_corpus(source, destination)
+
+            with mock.patch.object(
+                differential.verifier_fuzz,
+                "MAX_RETAINED_CORPUS_BYTES",
+                1,
+            ), self.assertRaisesRegex(
+                differential.DifferentialFuzzError,
+                "aggregate byte bound",
+            ):
+                differential.import_seed_corpus(source, destination)
+
+    def test_campaign_propagates_the_exact_imported_seed_count(self):
+        completed = subprocess.CompletedProcess(
+            args=["fuzzer"],
+            returncode=0,
+            stdout="",
+            stderr="stat::number_of_executed_units: 123\n",
+        )
+        smoke_records = [
+            {
+                "name": name,
+                "status": "pass",
+                "expected": "accept" if index == 0 else "reject",
+            }
+            for index, name in enumerate(differential.SMOKE_CASE_NAMES)
+        ]
+        manifest = {
+            "sources": {
+                "openssl": {"version": "3.6.3", "commit": "openssl-commit"},
+                "libcrux": {
+                    "version": "0.0.10",
+                    "commit": "libcrux-commit",
+                    "crate_sha256": "crate-sha256",
+                },
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            retained = root / "retained"
+            retained.mkdir()
+            (retained / "one").write_bytes(b"arbitrary retained seed")
+            fuzz = differential.verifier_fuzz
+            wrapper = fuzz.wrapper
+            reference = differential.reference
+            patch_specs = (
+                (differential, "git_input_status", []),
+                (
+                    differential,
+                    "compile_libcrux_bridge",
+                    (root / "bridge", root / "rlib"),
+                ),
+                (
+                    differential,
+                    "compile_differential_targets",
+                    (root / "fuzzer", root / "replay", "clang"),
+                ),
+                (differential, "openssl_runtime_provenance", {}),
+                (differential, "replay_differential_smoke", smoke_records),
+                (differential, "command_identity", "tool test"),
+                (reference, "require_openssl_source", None),
+                (reference, "require_libcrux_source", None),
+                (reference, "require_artifact", None),
+                (reference, "prepare_libcrux_crate", root),
+                (wrapper, "validate_source_capsule", {}),
+                (wrapper, "compile_shared", root / "mock-library"),
+                (fuzz, "validate_wycheproof_source", {}),
+                (fuzz, "project_corpus", []),
+                (fuzz, "wycheproof_corpus", []),
+                (fuzz, "validate_corpus_manifest", {}),
+                (fuzz, "replay_corpus", None),
+                (fuzz, "run_fuzzer", completed),
+                (fuzz, "minimize_corpus", None),
+                (fuzz, "write_coverage_report", None),
+                (fuzz, "compiler_identity", "clang test"),
+                (fuzz, "coverage_tool_identities", {}),
+            )
+            with ExitStack() as stack:
+                for target, attribute, return_value in patch_specs:
+                    stack.enter_context(
+                        mock.patch.object(
+                            target,
+                            attribute,
+                            return_value=return_value,
+                        )
+                    )
+                report = differential.run_campaign(
+                    manifest,
+                    {},
+                    root / "openssl",
+                    root / "libcrux",
+                    root / "libcrux.crate",
+                    root / "output",
+                    seconds=1,
+                    seed=7,
+                    seed_corpus=retained,
+                )
+                with mock.patch.object(
+                    differential,
+                    "import_seed_corpus",
+                    return_value=0,
+                ), self.assertRaisesRegex(
+                    differential.DifferentialFuzzError,
+                    "contributed no novel inputs",
+                ):
+                    differential.run_campaign(
+                        manifest,
+                        {},
+                        root / "openssl",
+                        root / "libcrux",
+                        root / "libcrux.crate",
+                        root / "zero-novel-output",
+                        seconds=1,
+                        seed=7,
+                        seed_corpus=retained,
+                    )
+                baseline_report = differential.run_campaign(
+                    manifest,
+                    {},
+                    root / "openssl",
+                    root / "libcrux",
+                    root / "libcrux.crate",
+                    root / "baseline-output",
+                    seconds=1,
+                    seed=7,
+                )
+
+            campaign = json.loads(
+                (root / "output" / "campaign.json").read_text(encoding="utf8")
+            )
+            self.assertEqual(campaign["imported_retained_seeds"], 1)
+            self.assertEqual(report["imported_retained_seeds"], 1)
+            self.assertEqual(baseline_report["imported_retained_seeds"], 0)
+            zero_novel = json.loads(
+                (root / "zero-novel-output" / "campaign.json").read_text(
+                    encoding="utf8"
+                )
+            )
+            self.assertEqual(zero_novel["imported_retained_seeds"], 0)
+            self.assertEqual(
+                zero_novel["processing_error"],
+                "retained seed corpus contributed no novel inputs",
+            )
+            self.assertEqual(zero_novel["final_stats"], [])
 
     def test_exact_replay_cases_match_frozen_frames(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -306,15 +561,22 @@ class MlDsaDifferentialFuzzTest(unittest.TestCase):
         workflow = WORKFLOW.read_text(encoding="utf8")
         for required in (
             '"contrib/ml-dsa-engineering/**"',
+            'cron: "43 5 * * 3"',
+            "actions: read",
             "run_differential_verifier_fuzz.py",
             "RUSTUP_TOOLCHAIN=1.89.0",
             "FUZZ_CC=clang",
             "--seconds 60",
             "--seed 188",
+            "--seconds 1800",
             "sha256sum --check SHA256SUMS",
             'smoke["case_count"] == 5',
             'fuzz_report["executed_units"] > 207',
-            'fuzz_report["fuzzer_duration_seconds"] <= 95',
+            'fuzz_report["executed_units"] >= 500_000',
+            'fuzz_report["fuzzer_duration_seconds"]',
+            "expected_seconds + 35",
+            "--seed-corpus",
+            'fuzz_report["imported_retained_seeds"] > 0',
             'openssl_runtime["libcrypto_resolution"] == "linked-dependency"',
             'openssl_runtime["openssl_conf"] == "/dev/null"',
             "if-no-files-found: error",
@@ -322,6 +584,43 @@ class MlDsaDifferentialFuzzTest(unittest.TestCase):
             "ml-dsa-44-differential-fuzz-run.sha256",
             "ml-dsa-44-differential-fuzz/",
             "retention-days: 90",
+        ):
+            self.assertIn(required, workflow)
+
+    def test_long_workflow_fails_closed_on_retained_corpus_and_coverage(self):
+        workflow = WORKFLOW.read_text(encoding="utf8")
+        for required in (
+            "restore_policy=latest_successful_main_run",
+            "--branch main",
+            "--status success",
+            "--json databaseId,attempt,createdAt,headSha",
+            "git merge-base --is-ancestor",
+            "prior_symlink=",
+            'sha256sum --check SHA256SUMS',
+            "seed_count > 4096",
+            "seed_bytes > 8096",
+            "seed_total_bytes > 33554432",
+            'campaign["repository_commit"] == expected_head',
+            'campaign["repository_dirty"] is False',
+            'campaign["minimized_corpus"] == actual_summary',
+            'test "$RETAINED_CORPUS_RESTORED" = "true"',
+            'test "$GITHUB_REF" = "refs/heads/main"',
+            'fuzz_report["imported_retained_seeds"] > 0',
+            '1799 <= fuzz_report["fuzzer_duration_seconds"] <= 1835',
+            '"PQBTC_MLDSA44_DIFFERENTIAL_ORACLE_ERROR"',
+            '"PQBTC_MLDSA44_DIFFERENTIAL_DISAGREEMENT"',
+            'source_summary("pqbtc_mldsa44_verify_fuzz.c")',
+            'source_summary("pqbtc_mldsa44_openssl_verify.c")',
+            'checked_percent(target, "functions", 100.0)',
+            'checked_percent(target, "lines", 89.0)',
+            'checked_percent(target, "branches", 85.0)',
+            'openssl_bridge, "functions", 75.0',
+            'checked_percent(openssl_bridge, "lines", 71.0)',
+            'openssl_bridge, "branches", 74.0',
+            'expected_checkout_head=$EXPECTED_HEAD',
+            '${{ runner.temp }}/ml-dsa-44-review-run-context.txt',
+            'ml-dsa-44-differential-coverage-floors.json',
+            'ml-dsa-44-differential-supplemental.sha256',
         ):
             self.assertIn(required, workflow)
 

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -180,11 +180,19 @@ review, close a production gate, or alter the release hold.
 
 ## Differential Verifier Fuzzing
 
-The pinned review-reproduction workflow runs a separate 60-second in-process
-differential campaign. Every parsed frame is evaluated by the admitted
+On pull requests, the pinned review-reproduction workflow runs a separate
+60-second in-process differential campaign. Scheduled and manually dispatched
+runs require the latest successful `main` minimized differential corpus and
+use a 1,800-second campaign; an unavailable or invalid prior artifact fails
+before the long campaign starts. The retained-corpus container is validated
+under explicit file-count, per-input, and aggregate-size bounds; symlinks,
+nested or special entries, and changing inputs fail closed. A successful
+restore must import at least one seed whose content is not already in the
+fixed source corpus. Every parsed frame is evaluated by the admitted
 wrapper, OpenSSL 3.6.3's explicitly selected default provider in an isolated
-library context, and libcrux 0.0.10; an oracle setup error or
-accept/reject disagreement aborts through the normal libFuzzer crash path.
+library context, and libcrux 0.0.10. An oracle setup error or accept/reject
+disagreement aborts through the normal
+libFuzzer crash path.
 Wrapper argument-error taxonomy remains a separate assertion, while the two
 external bridges normalize invalid shapes to rejection. The workflow records
 the upstream commits, crate and source hashes, bridge and binary hashes, the
@@ -196,8 +204,9 @@ The upstream versions are pinned by the frozen reference manifest; the small
 first-party adapter sources are review inputs whose exact hashes are evidence,
 not a claim that the adapters themselves are independent implementations.
 
-This closes the former self-fulfilling `OK`/`ERR_VERIFY` oracle gap for that
-bounded Linux campaign. It is not long-duration or multi-platform
+This closes the former self-fulfilling `OK`/`ERR_VERIFY` oracle gap for these
+bounded Linux campaigns. The configured long-duration path becomes evidence
+only after it succeeds on the exact merged commit; it is not multi-platform
 differential evidence, and the prebuilt OpenSSL and Rust implementation bodies
 are not fully sanitizer-instrumented by the C fuzz build. It does not alter
 the release hold.

--- a/contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py
+++ b/contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -376,6 +377,218 @@ def replay_differential_smoke(
     return records
 
 
+def filesystem_identity(status: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        status.st_dev,
+        status.st_ino,
+        status.st_mode,
+        status.st_size,
+        status.st_mtime_ns,
+    )
+
+
+def open_corpus_directory(path: Path, label: str) -> int:
+    try:
+        expected = path.lstat()
+    except FileNotFoundError as error:
+        raise DifferentialFuzzError(f"{label} does not exist: {path}") from error
+    if stat.S_ISLNK(expected.st_mode):
+        raise DifferentialFuzzError(f"{label} must not be a symlink: {path}")
+    if not stat.S_ISDIR(expected.st_mode):
+        raise DifferentialFuzzError(f"{label} is not a directory: {path}")
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise DifferentialFuzzError(f"cannot open {label}: {path}: {error}") from error
+    actual = os.fstat(descriptor)
+    if filesystem_identity(actual) != filesystem_identity(expected):
+        os.close(descriptor)
+        raise DifferentialFuzzError(f"{label} changed during import: {path}")
+    return descriptor
+
+
+def read_corpus_file(
+    directory_descriptor: int,
+    name: str,
+    display_path: Path,
+    label: str,
+) -> bytes:
+    try:
+        expected = os.stat(
+            name,
+            dir_fd=directory_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as error:
+        raise DifferentialFuzzError(
+            f"cannot inspect {label}: {display_path}: {error}"
+        ) from error
+    if stat.S_ISLNK(expected.st_mode):
+        raise DifferentialFuzzError(f"{label} must not be a symlink: {display_path}")
+    if not stat.S_ISREG(expected.st_mode):
+        raise DifferentialFuzzError(f"{label} is not a regular file: {display_path}")
+    if expected.st_size > verifier_fuzz.MAX_FRAME_BYTES:
+        raise DifferentialFuzzError(f"{label} exceeds fuzz bound: {display_path}")
+
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(name, flags, dir_fd=directory_descriptor)
+    except OSError as error:
+        raise DifferentialFuzzError(
+            f"cannot open {label}: {display_path}: {error}"
+        ) from error
+    try:
+        opened = os.fstat(descriptor)
+        if filesystem_identity(opened) != filesystem_identity(expected):
+            raise DifferentialFuzzError(
+                f"{label} changed during import: {display_path}"
+            )
+        remaining = verifier_fuzz.MAX_FRAME_BYTES + 1
+        chunks = []
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, 64 * 1024))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if len(data) > verifier_fuzz.MAX_FRAME_BYTES:
+        raise DifferentialFuzzError(f"{label} exceeds fuzz bound: {display_path}")
+    if (
+        filesystem_identity(after) != filesystem_identity(opened)
+        or len(data) != opened.st_size
+    ):
+        raise DifferentialFuzzError(f"{label} changed during import: {display_path}")
+    return data
+
+
+def import_seed_corpus(source: Path, destination: Path) -> int:
+    """Import a flat retained corpus without trusting its filesystem layout."""
+    source_descriptor = open_corpus_directory(source, "seed corpus")
+    try:
+        candidates = []
+        with os.scandir(source_descriptor) as entries:
+            for entry in entries:
+                candidates.append(entry.name)
+                if len(candidates) > verifier_fuzz.MAX_RETAINED_CORPUS_FILES:
+                    raise DifferentialFuzzError(
+                        "retained corpus exceeds the file-count bound"
+                    )
+        candidates.sort()
+
+        retained: dict[str, bytes] = {}
+        total_bytes = 0
+        for name in candidates:
+            path = source / name
+            data = read_corpus_file(
+                source_descriptor,
+                name,
+                path,
+                "retained corpus input",
+            )
+            total_bytes += len(data)
+            if total_bytes > verifier_fuzz.MAX_RETAINED_CORPUS_BYTES:
+                raise DifferentialFuzzError(
+                    "retained corpus exceeds the aggregate byte bound"
+                )
+            digest = hashlib.sha256(data).hexdigest()
+            previous = retained.setdefault(digest, data)
+            if previous != data:
+                raise DifferentialFuzzError(
+                    f"retained corpus SHA256 collision detected: {path}"
+                )
+    finally:
+        os.close(source_descriptor)
+
+    destination_status = destination.lstat()
+    if stat.S_ISLNK(destination_status.st_mode) or not stat.S_ISDIR(
+        destination_status.st_mode
+    ):
+        raise DifferentialFuzzError(
+            f"working corpus is not a regular directory: {destination}"
+        )
+
+    destination_contents: dict[str, bytes] = {}
+    for path in sorted(destination.iterdir(), key=lambda item: item.name):
+        before = path.lstat()
+        if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+            raise DifferentialFuzzError(
+                f"working corpus input is not a regular file: {path}"
+            )
+        if before.st_size > verifier_fuzz.MAX_FRAME_BYTES:
+            raise DifferentialFuzzError(
+                f"working corpus input exceeds fuzz bound: {path}"
+            )
+        data = path.read_bytes()
+        after = path.lstat()
+        identity_before = (
+            before.st_dev,
+            before.st_ino,
+            before.st_mode,
+            before.st_size,
+            before.st_mtime_ns,
+        )
+        identity_after = (
+            after.st_dev,
+            after.st_ino,
+            after.st_mode,
+            after.st_size,
+            after.st_mtime_ns,
+        )
+        if identity_after != identity_before or len(data) != before.st_size:
+            raise DifferentialFuzzError(
+                f"working corpus input changed during import: {path}"
+            )
+        digest = hashlib.sha256(data).hexdigest()
+        previous = destination_contents.setdefault(digest, data)
+        if previous != data:
+            raise DifferentialFuzzError(
+                f"working corpus SHA256 collision detected: {path}"
+            )
+
+    imported = 0
+    for digest, data in retained.items():
+        target = destination / f"retained_{digest}.bin"
+        if target.exists() or target.is_symlink():
+            target_status = target.lstat()
+            if stat.S_ISLNK(target_status.st_mode) or not stat.S_ISREG(
+                target_status.st_mode
+            ):
+                raise DifferentialFuzzError(
+                    f"retained corpus destination is not a regular file: {target}"
+                )
+            if target.read_bytes() != data:
+                raise DifferentialFuzzError(
+                    f"retained corpus destination hash collision: {target}"
+                )
+            continue
+        if digest in destination_contents:
+            if destination_contents[digest] != data:
+                raise DifferentialFuzzError(
+                    f"working corpus SHA256 collision detected: {target}"
+                )
+            continue
+        with target.open("xb") as output:
+            output.write(data)
+        if target.read_bytes() != data:
+            raise DifferentialFuzzError(
+                f"retained corpus destination changed during import: {target}"
+            )
+        destination_contents[digest] = data
+        imported += 1
+    return imported
+
+
 def add_differential_metadata(
     output_dir: Path,
     manifest: dict,
@@ -505,6 +718,7 @@ def run_campaign(
     *,
     seconds: int,
     seed: int,
+    seed_corpus: Path | None = None,
 ) -> dict:
     input_status = git_input_status(source_hashes)
     output_dir = output_dir.resolve()
@@ -534,6 +748,7 @@ def run_campaign(
     smoke_records: list[dict] = []
     source_manifest: dict = {}
     fuzzer_duration_seconds: float | None = None
+    imported_seeds = 0
 
     with tempfile.TemporaryDirectory(prefix="pqbtc-mldsa44-differential-") as temporary:
         build_dir = Path(temporary)
@@ -562,6 +777,12 @@ def run_campaign(
             source_summary = verifier_fuzz.validate_corpus_manifest(cases)
             verifier_fuzz.replay_corpus(production_library, cases)
             verifier_fuzz.materialize_corpus(corpus_dir, cases)
+            if seed_corpus is not None:
+                imported_seeds = import_seed_corpus(seed_corpus, corpus_dir)
+                if imported_seeds == 0:
+                    raise DifferentialFuzzError(
+                        "retained seed corpus contributed no novel inputs"
+                    )
 
             crate_dir = reference.prepare_libcrux_crate(
                 build_dir, libcrux_crate, sources["libcrux"]
@@ -635,7 +856,7 @@ def run_campaign(
                 coverage=True,
                 runs=None,
                 seconds=seconds,
-                imported_seeds=0,
+                imported_seeds=imported_seeds,
                 source_summary=source_summary,
                 started_at=started_at,
                 duration_seconds=time.monotonic() - monotonic_start,
@@ -679,6 +900,7 @@ def run_campaign(
         "repository_dirty": campaign["repository_dirty"],
         "seed": seed,
         "seconds": seconds,
+        "imported_retained_seeds": campaign["imported_retained_seeds"],
         "source_corpus": campaign["source_corpus"],
         "working_corpus": campaign["working_corpus"],
         "minimized_corpus": campaign["minimized_corpus"],
@@ -701,6 +923,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-dir", type=Path)
     parser.add_argument("--seconds", type=int, default=60)
     parser.add_argument("--seed", type=int, default=188)
+    parser.add_argument("--seed-corpus", type=Path)
     return parser.parse_args()
 
 
@@ -740,6 +963,7 @@ def main() -> int:
             require_path(args.output_dir, "--output-dir"),
             seconds=args.seconds,
             seed=args.seed,
+            seed_corpus=args.seed_corpus,
         )
         print(json.dumps(report, indent=2, sort_keys=True))
         return 0

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -145,7 +145,7 @@ artifacts, or production resource limits. Production remains `NONE` and
 `RELEASE_HOLD`; no consensus, wallet, Script, `ALG_ID`, or functional-suite
 inventory policy changed.
 
-The next seven bounded evidence tranches are also merged. PR `#198`
+The next eight bounded evidence tranches are also merged. PR `#198`
 (`f7b6f24936d1d0321ce33ca7245662db744348bc`) added sustained sanitizer
 campaigns; PR `#199` (`840dbffdf2fe29d87c0da2b6fe2a9147c35f4ee7`) hardened
 value-profile corpus minimization; PR `#200`
@@ -158,9 +158,15 @@ differential verifier campaign; PR `#203`
 (`257d3c1a8ee74cccbbb87d54880a7bde58c68f39`) reproduced all 200 upstream
 ML-DSA-44 CBMC proofs; and PR `#204`
 (`cb2c4b77ed534a7c342e95d764f2fb998bd702aa`) added the fail-closed advisory,
-SBOM, full-lock, and portable-Miri ledger. These are isolated engineering
-evidence only. Production remains `NONE`, issue-owned gaps remain open, and
-the release hold is unchanged.
+SBOM, full-lock, and portable-Miri ledger. PR `#205` landed the live OpenSSL
+and `mldsa-native` advisory feeds at merge commit
+`9ca23911e7570cc550ea80f4d58159b5fe2de6e4`. Its merge commit completed
+`30/30` checks successfully, including Promotion Matrix run `29948058770`.
+Advisory-ledger run `29948058829` verified `41/41` retained checksums, 272
+OpenSSL records with all 37 reviewed 3.6 identifiers and zero affecting exact
+3.6.3, and zero published `mldsa-native` advisories. These are isolated
+engineering evidence only. Production remains `NONE`, issue-owned gaps remain
+open, and the release hold is unchanged.
 
 Keep the live `pq_required` gate aligned with the repo as it exists today. PR
 `#163` closed the initial inventory tranche at `pq_required: 120`,
@@ -225,16 +231,19 @@ tracked suites now have an explicit policy class and none remains in
 
 Preferred next owned tranche:
 
-1. Hold the reviewed post-promotion baseline
-   - Why next: the selected configuration-namespace gap and its platform
-     default-datadir follow-up are closed, all `276` tracked functional suites
-     retain explicit policy classes, and `pq_backlog` remains empty.
-   - `tool_bitcoin.py` remains deferred; its low runtime does not replace the
-     missing dedicated issue and cross-platform/optional-IPC boundary.
-   - `rpc_blockchain.py` remains rejected because its replacement-deployment
-     evidence duplicates an existing required gate.
-   - production release remains blocked independently of CI inventory status;
-     green rc2 tests are regression evidence, not cryptographic approval.
+1. Run the retained-corpus 1,800-second three-oracle differential campaign
+   under issue `#188`
+   - restore the prior minimized differential corpus and require a nonzero
+     imported-seed count before the campaign starts
+   - exercise OpenSSL, `mldsa-native`, and libcrux for the full 1,800 seconds
+     on exact merged `main`, with the varying seed recorded in the evidence
+   - require zero crashes, oracle errors, or disagreements, at least 500,000
+     executions, a nonempty minimized corpus, the defined coverage floors,
+     verified checksums, and retained evidence artifacts
+   - keep pull-request campaigns bounded at 60 seconds; use the scheduled or
+     manual promotion path for the 1,800-second campaign
+   - keep production at `NONE` and `RELEASE_HOLD`; this tranche authorizes no
+     consensus, wallet, Script, `ALG_ID`, or inventory-policy change
 
 Future selection boundary:
 


### PR DESCRIPTION
Summary

- Keep pull-request three-oracle fuzzing bounded at 60 seconds with seed 188.
- Require scheduled and manual main runs to restore verified prior minimized evidence and run for 1,800 seconds with a varying seed.
- Import retained inputs through bounded, no-follow, content-deduplicating reads and fail before fuzzing when no novel input remains.
- Enforce execution, duration, oracle, smoke-case, corpus, checksum, provenance, and per-file coverage gates with 90-day evidence.
- Record the merged PR 205 advisory-feed baseline and keep backend admission unchanged.

Validation

- 118 repository unit tests pass.
- 28 differential and sustained-fuzz tests pass.
- The prior exact-main artifact verifies: 132 retained files, 472,766 bytes, 72 novel imports.
- actionlint 1.7.12 with ShellCheck 0.11.0 passes.
- Ruff 0.5.5, Python compilation, workflow YAML, all Bash blocks, embedded Python, manifest-only validation, repository linters, and diff checks pass.

Scope

Refs #188. Production remains NONE and the release hold is unchanged. The configured 1,800-second path becomes evidence only after a successful post-merge dispatch on exact main.