### PR TITLE
Add stateful ML-DSA-44 signer fuzzing

### DIFF
--- a/.github/workflows/ml-dsa-44-sustained-fuzz.yml
+++ b/.github/workflows/ml-dsa-44-sustained-fuzz.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/ml-dsa-44-sustained-fuzz.yml"
       - "ci/test/test_ml_dsa_sustained_fuzz.py"
+      - "ci/test/test_ml_dsa_stateful_signer_fuzz.py"
       - "contrib/ml-dsa-engineering/**"
       - "contrib/ml-dsa-ref/vectors.json"
       - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
@@ -15,6 +16,7 @@ on:
     paths:
       - ".github/workflows/ml-dsa-44-sustained-fuzz.yml"
       - "ci/test/test_ml_dsa_sustained_fuzz.py"
+      - "ci/test/test_ml_dsa_stateful_signer_fuzz.py"
       - "contrib/ml-dsa-engineering/**"
       - "contrib/ml-dsa-ref/vectors.json"
       - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
@@ -166,6 +168,363 @@ jobs:
         with:
           name: ml-dsa-44-sustained-${{ matrix.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/ml-dsa-44-fuzz-output
+          if-no-files-found: warn
+          retention-days: 90
+          compression-level: 9
+
+  stateful-signer-fuzz:
+    name: Stateful signer (${{ matrix.label }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ASan + UBSan
+            sanitizer: address-undefined
+            coverage: 'true'
+            artifact: asan-ubsan
+          - label: MSan
+            sanitizer: memory
+            coverage: 'false'
+            artifact: msan
+    env:
+      CC: clang
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify toolchain and frozen signer corpus
+        run: |
+          set -euxo pipefail
+          clang --version
+          llvm-profdata-18 --version
+          llvm-cov-18 --version
+          python3 --version
+          python3 contrib/ml-dsa-engineering/run_stateful_signer_fuzz.py \
+            --manifest-only
+
+      - name: Restore latest retained signer corpus
+        id: retained
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_NAME: ml-dsa-44-stateful-signer-${{ matrix.artifact }}
+          PRIOR_DIR: ${{ runner.temp }}/ml-dsa-44-prior-stateful-signer
+          SANITIZER: ${{ matrix.sanitizer }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          previous_run_records="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow ml-dsa-44-sustained-fuzz.yml \
+              --branch main \
+              --status success \
+              --limit 10 \
+              --json databaseId,attempt,createdAt,headSha \
+              --jq 'sort_by([.createdAt, .databaseId]) | reverse | .[] | [.databaseId, .attempt, .headSha] | @tsv'
+          )"
+          while read -r previous_run previous_attempt previous_head; do
+            if [[ -z "$previous_run" || -z "$previous_attempt" || -z "$previous_head" ]]; then
+              continue
+            fi
+            [[ "$previous_run" =~ ^[0-9]+$ ]]
+            [[ "$previous_attempt" =~ ^[0-9]+$ ]]
+            [[ "$previous_head" =~ ^[0-9a-f]{40}$ ]]
+            git merge-base --is-ancestor "$previous_head" HEAD
+            artifact_name="$ARTIFACT_NAME-$previous_run-$previous_attempt"
+            candidate_dir="$PRIOR_DIR/$previous_run-$previous_attempt"
+            mkdir -p "$candidate_dir"
+            if gh run download "$previous_run" \
+              --repo "$GITHUB_REPOSITORY" \
+              --name "$artifact_name" \
+              --dir "$candidate_dir"; then
+              validation_json="$PRIOR_DIR/validation-$previous_run-$previous_attempt.json"
+              python3 contrib/ml-dsa-engineering/run_stateful_signer_fuzz.py \
+                --validate-retained-evidence "$candidate_dir" \
+                --expected-retained-head "$previous_head" \
+                --expected-retained-sanitizer "$SANITIZER" \
+                > "$validation_json"
+              source_evidence_sha256="$(
+                jq -er '.source_evidence_sha256' "$validation_json"
+              )"
+              restored_seed_file_count="$(
+                jq -er '.restored_seed_file_count' "$validation_json"
+              )"
+              restored_seed_total_bytes="$(
+                jq -er '.restored_seed_total_bytes' "$validation_json"
+              )"
+              restored_seed_aggregate_sha256="$(
+                jq -er '.restored_seed_aggregate_sha256' "$validation_json"
+              )"
+              [[ "$source_evidence_sha256" =~ ^[0-9a-f]{64}$ ]]
+              [[ "$restored_seed_file_count" =~ ^[0-9]+$ ]]
+              [[ "$restored_seed_total_bytes" =~ ^[0-9]+$ ]]
+              [[ "$restored_seed_aggregate_sha256" =~ ^[0-9a-f]{64}$ ]]
+              (( restored_seed_file_count > 0 ))
+              {
+                echo "seed_dir=$candidate_dir/minimized-corpus"
+                echo "source_run=$previous_run"
+                echo "source_attempt=$previous_attempt"
+                echo "source_head=$previous_head"
+                echo "source_artifact=$artifact_name"
+                echo "source_evidence_sha256=$source_evidence_sha256"
+                echo "restored_seed_file_count=$restored_seed_file_count"
+                echo "restored_seed_total_bytes=$restored_seed_total_bytes"
+                echo "restored_seed_aggregate_sha256=$restored_seed_aggregate_sha256"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done <<< "$previous_run_records"
+          echo "No prior successful retained signer corpus is available"
+
+      - name: Run bounded stateful signer campaign
+        env:
+          SANITIZER: ${{ matrix.sanitizer }}
+          COVERAGE: ${{ matrix.coverage }}
+          RETAINED_SEED_DIR: ${{ steps.retained.outputs.seed_dir }}
+          RETAINED_SOURCE_RUN: ${{ steps.retained.outputs.source_run }}
+          RETAINED_SOURCE_ATTEMPT: ${{ steps.retained.outputs.source_attempt }}
+          RETAINED_SOURCE_HEAD: ${{ steps.retained.outputs.source_head }}
+          RETAINED_SOURCE_ARTIFACT: ${{ steps.retained.outputs.source_artifact }}
+          RETAINED_SOURCE_EVIDENCE_SHA256: ${{ steps.retained.outputs.source_evidence_sha256 }}
+          RETAINED_SOURCE_SEED_COUNT: ${{ steps.retained.outputs.restored_seed_file_count }}
+          RETAINED_SOURCE_SEED_BYTES: ${{ steps.retained.outputs.restored_seed_total_bytes }}
+          RETAINED_SOURCE_SEED_AGGREGATE_SHA256: ${{ steps.retained.outputs.restored_seed_aggregate_sha256 }}
+          OUTPUT_DIR: ${{ runner.temp }}/ml-dsa-44-stateful-signer-output
+        run: |
+          set -euxo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            campaign_seconds=1800
+            campaign_seed="$GITHUB_RUN_NUMBER"
+          else
+            campaign_seconds=60
+            campaign_seed=188
+          fi
+          args=(
+            --sanitizers
+            --sanitizer "$SANITIZER"
+            --seconds "$campaign_seconds"
+            --seed "$campaign_seed"
+            --output-dir "$OUTPUT_DIR"
+          )
+          if [[ -n "$RETAINED_SEED_DIR" ]]; then
+            args+=(--seed-corpus "$RETAINED_SEED_DIR")
+          fi
+          if [[ "$COVERAGE" == "true" ]]; then
+            args+=(--coverage)
+          fi
+          python3 contrib/ml-dsa-engineering/run_stateful_signer_fuzz.py \
+            "${args[@]}"
+
+      - name: Verify stateful signer evidence
+        if: success()
+        env:
+          EXPECTED_SANITIZER: ${{ matrix.sanitizer }}
+          COVERAGE: ${{ matrix.coverage }}
+          EXPECTED_COMMIT: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RETAINED_SEED_DIR: ${{ steps.retained.outputs.seed_dir }}
+          RETAINED_SOURCE_RUN: ${{ steps.retained.outputs.source_run }}
+          RETAINED_SOURCE_ATTEMPT: ${{ steps.retained.outputs.source_attempt }}
+          RETAINED_SOURCE_HEAD: ${{ steps.retained.outputs.source_head }}
+          RETAINED_SOURCE_ARTIFACT: ${{ steps.retained.outputs.source_artifact }}
+          RETAINED_SOURCE_EVIDENCE_SHA256: ${{ steps.retained.outputs.source_evidence_sha256 }}
+          RETAINED_SOURCE_SEED_COUNT: ${{ steps.retained.outputs.restored_seed_file_count }}
+          RETAINED_SOURCE_SEED_BYTES: ${{ steps.retained.outputs.restored_seed_total_bytes }}
+          RETAINED_SOURCE_SEED_AGGREGATE_SHA256: ${{ steps.retained.outputs.restored_seed_aggregate_sha256 }}
+          OUTPUT_DIR: ${{ runner.temp }}/ml-dsa-44-stateful-signer-output
+        run: |
+          actual_head="$(git rev-parse HEAD)"
+          test "$actual_head" = "$EXPECTED_COMMIT"
+          python3 - "$OUTPUT_DIR" "$EXPECTED_SANITIZER" "$COVERAGE" \
+            "$EXPECTED_COMMIT" "$EVENT_NAME" "$RUN_NUMBER" \
+            "$RETAINED_SEED_DIR" <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+          import re
+          import sys
+
+          def named_file_summary(paths):
+              digest = hashlib.sha256()
+              contents = {}
+              total_bytes = 0
+              paths = sorted(paths, key=lambda path: path.name)
+              for path in paths:
+                  assert path.is_file() and not path.is_symlink()
+                  data = path.read_bytes()
+                  file_digest = hashlib.sha256(data).hexdigest()
+                  digest.update(
+                      f"{path.name}\0{len(data)}\0{file_digest}\n".encode()
+                  )
+                  previous = contents.setdefault(file_digest, data)
+                  assert previous == data
+                  total_bytes += len(data)
+              return {
+                  "file_count": len(paths),
+                  "total_bytes": total_bytes,
+                  "aggregate_sha256": digest.hexdigest(),
+              }, contents
+
+          def content_inventory_summary(contents):
+              digest = hashlib.sha256()
+              total_bytes = 0
+              for file_digest, data in sorted(contents.items()):
+                  digest.update(f"{len(data)}\0{file_digest}\n".encode())
+                  total_bytes += len(data)
+              return {
+                  "file_count": len(contents),
+                  "total_bytes": total_bytes,
+                  "aggregate_sha256": digest.hexdigest(),
+              }
+
+          output = Path(sys.argv[1])
+          report = json.loads((output / "campaign.json").read_text(encoding="utf8"))
+          long_run = sys.argv[5] in {"schedule", "workflow_dispatch"}
+          expected_seconds = 1800 if long_run else 60
+          expected_seed = int(sys.argv[6]) if long_run else 188
+          assert report["schema_version"] == 1
+          assert report["target"] == "ml-dsa-44-stateful-signer-seeded-keygen"
+          assert report["status"] == "pass"
+          assert report["return_code"] == 0
+          assert report["processing_error"] is None
+          assert report["sanitizer"] == sys.argv[2]
+          assert report["coverage_enabled"] is (sys.argv[3] == "true")
+          assert report["repository_commit"] == sys.argv[4]
+          assert report["repository_head"] == sys.argv[4]
+          assert report["repository_dirty"] is False
+          assert report["campaign_limit"] == {
+              "runs": None,
+              "seconds": expected_seconds,
+          }
+          assert report["resource_limits"]["seed"] == expected_seed
+          assert report["resource_limits"]["harness_frame_bytes"] == 4456
+          assert report["resource_limits"]["fuzzer_max_len_bytes"] == 4456
+          assert expected_seconds - 1 <= report["fuzzer_duration_seconds"]
+          assert report["fuzzer_duration_seconds"] <= expected_seconds + 35
+          assert report["source_corpus"]["total_cases"] == 31
+          assert report["source_corpus"]["unique_frames"] == 31
+          assert (
+              report["source_corpus"]["aggregate_sha256"]
+              == "9ee9c275e59e8a4d383bd474b080406b764aafd9b219dffb522d9ef4e73f05d1"
+          )
+          for field in (
+              "driver_sha256",
+              "verifier_fuzz_driver_sha256",
+              "wrapper_test_driver_sha256",
+          ):
+              assert re.fullmatch(r"[0-9a-f]{64}", report["source_files"][field])
+          assert report["deterministic_replay"]["status"] == "pass"
+          assert report["deterministic_replay"]["case_count"] == 31
+          assert all(
+              case["status"] == "pass"
+              for case in report["deterministic_replay"]["cases"]
+          )
+          assert report["executed_units"] is not None
+          assert report["executed_units"] > 31
+          assert report["minimized_corpus"]["file_count"] > 0
+          assert report["crash_artifacts"]["file_count"] == 0
+          assert (output / "SHA256SUMS").is_file()
+          retained_source = report["retained_corpus_source"]
+          if sys.argv[7]:
+              expected_source = {
+                  "run_id": os.environ["RETAINED_SOURCE_RUN"],
+                  "run_attempt": os.environ["RETAINED_SOURCE_ATTEMPT"],
+                  "head_sha": os.environ["RETAINED_SOURCE_HEAD"],
+                  "artifact": os.environ["RETAINED_SOURCE_ARTIFACT"],
+                  "evidence_sha256": os.environ[
+                      "RETAINED_SOURCE_EVIDENCE_SHA256"
+                  ],
+                  "restored_seed_file_count": int(
+                      os.environ["RETAINED_SOURCE_SEED_COUNT"]
+                  ),
+                  "restored_seed_total_bytes": int(
+                      os.environ["RETAINED_SOURCE_SEED_BYTES"]
+                  ),
+                  "restored_seed_aggregate_sha256": os.environ[
+                      "RETAINED_SOURCE_SEED_AGGREGATE_SHA256"
+                  ],
+              }
+              assert retained_source == expected_source
+              assert re.fullmatch(r"[0-9a-f]{40}", retained_source["head_sha"])
+              assert re.fullmatch(
+                  r"[0-9a-f]{64}", retained_source["evidence_sha256"]
+              )
+              assert re.fullmatch(
+                  r"[0-9a-f]{64}",
+                  retained_source["restored_seed_aggregate_sha256"],
+              )
+              expected_source_summary = {
+                  "file_count": retained_source["restored_seed_file_count"],
+                  "total_bytes": retained_source["restored_seed_total_bytes"],
+                  "aggregate_sha256": retained_source[
+                      "restored_seed_aggregate_sha256"
+                  ],
+              }
+              seed_dir = Path(sys.argv[7])
+              actual_source, source_contents = named_file_summary(
+                  seed_dir.iterdir()
+              )
+              retained_import = report["retained_corpus_import"]
+              assert retained_import["source_summary"] == expected_source_summary
+              assert retained_import["source_summary"] == actual_source
+              assert retained_import["unique_source_summary"] == (
+                  content_inventory_summary(source_contents)
+              )
+              imported_paths = list(
+                  (output / "corpus").glob("retained_*.bin")
+              )
+              _, imported_contents = named_file_summary(imported_paths)
+              for path in imported_paths:
+                  file_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  assert path.name == f"retained_{file_digest}.bin"
+              imported_summary = retained_import["imported_summary"]
+              assert imported_summary == content_inventory_summary(
+                  imported_contents
+              )
+              assert report["imported_retained_seeds"] == (
+                  imported_summary["file_count"]
+              )
+              assert 0 < report["imported_retained_seeds"]
+              assert (
+                  report["imported_retained_seeds"]
+                  <= retained_source["restored_seed_file_count"]
+              )
+          else:
+              assert retained_source == {
+                  "run_id": None,
+                  "run_attempt": None,
+                  "head_sha": None,
+                  "artifact": None,
+                  "evidence_sha256": None,
+                  "restored_seed_file_count": None,
+                  "restored_seed_total_bytes": None,
+                  "restored_seed_aggregate_sha256": None,
+              }
+              assert report["imported_retained_seeds"] == 0
+              assert report["retained_corpus_import"] is None
+          if report["coverage_enabled"]:
+              assert (output / "coverage.txt").is_file()
+              assert (output / "coverage.json").is_file()
+          print(json.dumps(report, indent=2, sort_keys=True))
+          PY
+          cd "$OUTPUT_DIR"
+          sha256sum --check SHA256SUMS
+
+      - name: Upload retained signer corpus and evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ml-dsa-44-stateful-signer-${{ matrix.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ml-dsa-44-stateful-signer-output
           if-no-files-found: warn
           retention-days: 90
           compression-level: 9

--- a/ci/test/test_ml_dsa_stateful_signer_fuzz.py
+++ b/ci/test/test_ml_dsa_stateful_signer_fuzz.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINEERING_DIR = REPO_ROOT / "contrib" / "ml-dsa-engineering"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-sustained-fuzz.yml"
+
+sys.path.insert(0, str(ENGINEERING_DIR))
+import run_stateful_signer_fuzz as signer_fuzz  # noqa: E402
+
+
+class MlDsaStatefulSignerFuzzTest(unittest.TestCase):
+    def test_manifest_and_generated_corpus_are_frozen(self):
+        cases = signer_fuzz.generated_corpus()
+        summary = signer_fuzz.validate_corpus_manifest(cases)
+
+        self.assertEqual(summary["total_cases"], 31)
+        self.assertEqual(summary["unique_frames"], 31)
+        self.assertEqual(
+            set(summary["scenario_counts"]),
+            {
+                *signer_fuzz.SCENARIOS.values(),
+                signer_fuzz.INVALID_CONTEXT_SCENARIO,
+            },
+        )
+        self.assertTrue(all(summary["scenario_counts"].values()))
+        self.assertEqual(
+            summary["invalid_argument_variant_counts"],
+            {
+                **{name: 1 for name in signer_fuzz.ARGUMENT_VARIANTS.values()},
+                "alias_message": 2,
+            },
+        )
+        self.assertEqual(
+            summary["aggregate_sha256"],
+            "9ee9c275e59e8a4d383bd474b080406b764aafd9b219dffb522d9ef4e73f05d1",
+        )
+        manifest = json.loads(
+            signer_fuzz.CORPUS_MANIFEST.read_text(encoding="utf8")
+        )
+        self.assertEqual(
+            manifest["fuzz_limits"]["hedged_signing_calls_per_input_max"],
+            4,
+        )
+
+    def test_frames_round_trip_and_enforce_bounds(self):
+        for case in signer_fuzz.generated_corpus():
+            decoded = signer_fuzz.decode_frame(case.frame)
+            self.assertEqual(
+                signer_fuzz.encode_frame(**decoded.__dict__),
+                case.frame,
+            )
+            self.assertLessEqual(len(case.frame), signer_fuzz.MAX_FRAME_BYTES)
+
+        case = signer_fuzz.generated_corpus()[0]
+        with self.assertRaises(signer_fuzz.StatefulFuzzError):
+            signer_fuzz.decode_frame(case.frame[:-1])
+        with self.assertRaises(signer_fuzz.StatefulFuzzError):
+            signer_fuzz.encode_frame(
+                **{
+                    **signer_fuzz.decode_frame(case.frame).__dict__,
+                    "context": bytes(signer_fuzz.MAX_CONTEXT_BYTES + 1),
+                }
+            )
+        with self.assertRaises(signer_fuzz.StatefulFuzzError):
+            signer_fuzz.encode_frame(
+                **{
+                    **signer_fuzz.decode_frame(case.frame).__dict__,
+                    "short_length": 32,
+                }
+            )
+
+    def test_corpus_has_state_and_size_boundaries(self):
+        decoded = {
+            case.name: signer_fuzz.decode_frame(case.frame)
+            for case in signer_fuzz.generated_corpus()
+        }
+        self.assertEqual(decoded["fresh_empty_message_and_context"].message, b"")
+        self.assertEqual(decoded["fresh_empty_message_and_context"].context, b"")
+        self.assertEqual(len(decoded["fresh_maximum_context"].context), 255)
+        self.assertEqual(
+            len(
+                decoded[
+                    "fresh_a_then_invalid_256_context_then_repeat_a_then_fresh_b"
+                ].context
+            ),
+            256,
+        )
+        self.assertEqual(len(decoded["fresh_maximum_message"].message), 4096)
+        self.assertEqual(
+            len(
+                decoded[
+                    "fresh_a_then_invalid_alias_message_maximum_message_then_repeat_a_then_fresh_b"
+                ].message
+            ),
+            4096,
+        )
+        self.assertEqual(
+            {
+                frame.short_length
+                for frame in decoded.values()
+                if frame.scenario == 2
+            },
+            {0, 1, 16, 31},
+        )
+
+    def test_manifest_only_cli_replays_validation(self):
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(ENGINEERING_DIR / "run_stateful_signer_fuzz.py"),
+                "--manifest-only",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertIn("31 cases, 31 unique frames", completed.stdout)
+
+    def test_compile_contracts_are_distinct_and_testing_only(self):
+        contracts = (
+            (
+                "address-undefined",
+                True,
+                {"-fsanitize=fuzzer,address,undefined", "-fprofile-instr-generate"},
+                {"-fsanitize=fuzzer,memory", "-fsanitize-memory-track-origins=2"},
+            ),
+            (
+                "memory",
+                False,
+                {"-fsanitize=fuzzer,memory", "-fsanitize-memory-track-origins=2", "-pie"},
+                {"-fsanitize=fuzzer,address,undefined", "-fprofile-instr-generate"},
+            ),
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            for sanitizer, coverage, required, prohibited in contracts:
+                with self.subTest(sanitizer=sanitizer):
+                    with mock.patch.object(signer_fuzz.wrapper, "run") as run:
+                        signer_fuzz.compile_fuzzer(
+                            "clang",
+                            Path(temporary),
+                            sanitizer=sanitizer,
+                            coverage=coverage,
+                        )
+                    command = set(run.call_args.args[0])
+                    self.assertIn("-DPQBTC_MLDSA44_TESTING=1", command)
+                    self.assertTrue(required <= command)
+                    self.assertTrue(prohibited.isdisjoint(command))
+                    self.assertIn(str(signer_fuzz.FUZZ_SOURCE), command)
+                    self.assertIn(str(signer_fuzz.wrapper.WRAPPER_SOURCE), command)
+
+    def test_deterministic_replay_records_every_named_case(self):
+        cases = signer_fuzz.generated_corpus()[:2]
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            corpus = root / "corpus"
+            signer_fuzz.materialize_corpus(corpus, cases)
+            completed = subprocess.CompletedProcess(
+                args=["fuzzer"], returncode=0, stdout="", stderr=""
+            )
+            with mock.patch.object(
+                signer_fuzz.subprocess, "run", return_value=completed
+            ) as run:
+                report = signer_fuzz.replay_corpus(
+                    Path("fuzzer"),
+                    corpus,
+                    cases,
+                    root / "replay.log",
+                    sanitizer="address-undefined",
+                    profile_pattern=None,
+                )
+            self.assertEqual(report["status"], "pass")
+            self.assertEqual(report["case_count"], 2)
+            self.assertEqual(run.call_count, 2)
+            self.assertTrue(all(case["status"] == "pass" for case in report["cases"]))
+            self.assertIn("case:", (root / "replay.log").read_text(encoding="utf8"))
+
+    def test_campaign_report_preserves_stateful_contract(self):
+        cases = signer_fuzz.generated_corpus()
+        summary = signer_fuzz.corpus_summary(cases)
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            for name in ("corpus", "minimized-corpus", "crashes"):
+                (output / name).mkdir()
+            (output / "corpus" / "seed").write_bytes(b"seed")
+            (output / "minimized-corpus" / "seed").write_bytes(b"seed")
+            fuzzer = output / "fuzzer"
+            fuzzer.write_bytes(b"binary")
+            completed = subprocess.CompletedProcess(
+                args=["fuzzer"],
+                returncode=0,
+                stdout="",
+                stderr=(
+                    "#31 DONE\n"
+                    "stat::number_of_executed_units: 31\n"
+                    "stat::peak_rss_mb: 1\n"
+                ),
+            )
+            signer_fuzz.write_campaign_report(
+                output,
+                compiler=sys.executable,
+                sanitizer="address-undefined",
+                coverage=False,
+                runs=31,
+                seconds=None,
+                seed=188,
+                retained_source=signer_fuzz.empty_retained_source(),
+                retained_import=None,
+                source_summary=summary,
+                replay={"status": "pass", "case_count": 31, "cases": []},
+                fuzzer=fuzzer,
+                started_at="2026-07-23T00:00:00+00:00",
+                duration_seconds=1.25,
+                fuzzer_duration_seconds=1.0,
+                completed=completed,
+                processing_error=None,
+                crash_minimization=[],
+            )
+            report = json.loads((output / "campaign.json").read_text(encoding="utf8"))
+            self.assertEqual(report["target"], signer_fuzz.TARGET_NAME)
+            self.assertEqual(report["status"], "pass")
+            self.assertEqual(report["executed_units"], 31)
+            self.assertTrue(report["stateful_contract"]["seeded_keygen_determinism"])
+            self.assertTrue(report["stateful_contract"]["entropy_request_accounting"])
+            self.assertFalse(report["stateful_contract"]["external_oracles_in_process"])
+            self.assertEqual(report["resource_limits"]["harness_frame_bytes"], 4456)
+            self.assertEqual(report["minimized_corpus"]["file_count"], 1)
+            self.assertIsNone(report["retained_corpus_import"])
+            self.assertEqual(report["repository_head"], signer_fuzz.repository_head())
+            for field in (
+                "driver_sha256",
+                "verifier_fuzz_driver_sha256",
+                "wrapper_test_driver_sha256",
+            ):
+                self.assertRegex(report["source_files"][field], r"^[0-9a-f]{64}$")
+
+    def test_invalid_retained_corpus_produces_hashed_failure_evidence(self):
+        cases = signer_fuzz.generated_corpus()
+        summary = signer_fuzz.corpus_summary(cases)
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "output"
+            args = SimpleNamespace(
+                output_dir=output,
+                seed_corpus=root / "missing-corpus",
+                sanitizer="address-undefined",
+                coverage=False,
+                runs=1,
+                seconds=None,
+                seed=188,
+            )
+            with (
+                mock.patch.object(
+                    signer_fuzz.shutil, "which", return_value="/tool/clang"
+                ),
+                mock.patch.object(
+                    signer_fuzz.verifier_fuzz,
+                    "compiler_identity",
+                    return_value={"path": "/tool/clang"},
+                ),
+                mock.patch.object(
+                    signer_fuzz.verifier_fuzz,
+                    "repository_commit",
+                    return_value="a" * 40,
+                ),
+                mock.patch.object(
+                    signer_fuzz.verifier_fuzz,
+                    "repository_dirty",
+                    return_value=False,
+                ),
+            ):
+                self.assertEqual(
+                    signer_fuzz.run_campaign(args, cases, summary),
+                    1,
+                )
+            report = json.loads(
+                (output / "campaign.json").read_text(encoding="utf8")
+            )
+            self.assertEqual(report["status"], "fail")
+            self.assertIn("seed corpus does not exist", report["processing_error"])
+            self.assertEqual(report["imported_retained_seeds"], 0)
+            self.assertTrue((output / "SHA256SUMS").is_file())
+
+    def test_retained_seed_import_is_strict_bounded_and_deduplicated(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            existing = b"existing"
+            novel = b"novel"
+            (destination / "project.bin").write_bytes(existing)
+            (source / "duplicate-existing").write_bytes(existing)
+            (source / "novel").write_bytes(novel)
+            (source / "duplicate-novel").write_bytes(novel)
+
+            expected_source = signer_fuzz.verifier_fuzz.directory_summary(source)
+            (source / "novel").write_bytes(b"other")
+            with self.assertRaisesRegex(
+                signer_fuzz.StatefulFuzzError,
+                "differs from validated evidence",
+            ):
+                signer_fuzz.import_seed_corpus(
+                    source,
+                    destination,
+                    expected_source_summary=expected_source,
+                )
+            (source / "novel").write_bytes(novel)
+
+            receipt = signer_fuzz.import_seed_corpus(
+                source,
+                destination,
+                expected_source_summary=expected_source,
+            )
+            self.assertEqual(receipt["source_summary"], expected_source)
+            self.assertEqual(receipt["unique_source_summary"]["file_count"], 2)
+            self.assertEqual(receipt["imported_summary"]["file_count"], 1)
+            self.assertEqual(receipt["imported_summary"]["total_bytes"], len(novel))
+            novel_digest = hashlib.sha256(novel).hexdigest()
+            self.assertEqual(
+                (destination / f"retained_{novel_digest}.bin").read_bytes(),
+                novel,
+            )
+            self.assertEqual(
+                signer_fuzz.import_seed_corpus(
+                    source,
+                    destination,
+                    expected_source_summary=expected_source,
+                )["imported_summary"]["file_count"],
+                0,
+            )
+
+            nested = source / "nested"
+            nested.mkdir()
+            with self.assertRaisesRegex(
+                signer_fuzz.StatefulFuzzError,
+                "not a regular file",
+            ):
+                signer_fuzz.import_seed_corpus(source, destination)
+            nested.rmdir()
+
+            (source / "oversized").write_bytes(
+                bytes(signer_fuzz.MAX_FRAME_BYTES + 1)
+            )
+            with self.assertRaisesRegex(
+                signer_fuzz.StatefulFuzzError,
+                "size bound",
+            ):
+                signer_fuzz.import_seed_corpus(source, destination)
+
+    def test_retained_evidence_validation_binds_campaign_and_checksums(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence = Path(temporary)
+            minimized = evidence / "minimized-corpus"
+            minimized.mkdir()
+            seed = minimized / "seed"
+            seed.write_bytes(b"seed")
+            head = "a" * 40
+            campaign = {
+                "target": signer_fuzz.TARGET_NAME,
+                "status": "pass",
+                "return_code": 0,
+                "processing_error": None,
+                "repository_commit": head,
+                "repository_head": head,
+                "repository_dirty": False,
+                "sanitizer": "address-undefined",
+                "minimized_corpus": signer_fuzz.verifier_fuzz.directory_summary(
+                    minimized
+                ),
+            }
+            (evidence / "campaign.json").write_text(
+                json.dumps(campaign) + "\n",
+                encoding="utf8",
+            )
+            signer_fuzz.verifier_fuzz.write_evidence_hashes(evidence)
+
+            validation = signer_fuzz.validate_retained_evidence(
+                evidence,
+                expected_head=head,
+                expected_sanitizer="address-undefined",
+            )
+            self.assertEqual(validation["restored_seed_file_count"], 1)
+            self.assertRegex(
+                validation["source_evidence_sha256"],
+                r"^[0-9a-f]{64}$",
+            )
+
+            unchecked = evidence / "unchecked"
+            unchecked.mkdir()
+            (unchecked / "SHA256SUMS").write_text(
+                "not the root manifest\n",
+                encoding="utf8",
+            )
+            with self.assertRaisesRegex(
+                signer_fuzz.StatefulFuzzError,
+                "checksum inventory differs",
+            ):
+                signer_fuzz.validate_retained_evidence(
+                    evidence,
+                    expected_head=head,
+                    expected_sanitizer="address-undefined",
+                )
+            signer_fuzz.verifier_fuzz.write_evidence_hashes(evidence)
+            self.assertIn(
+                "unchecked/SHA256SUMS",
+                (evidence / "SHA256SUMS").read_text(encoding="utf8"),
+            )
+            (unchecked / "SHA256SUMS").unlink()
+            unchecked.rmdir()
+            signer_fuzz.verifier_fuzz.write_evidence_hashes(evidence)
+
+            seed.write_bytes(b"tampered")
+            with self.assertRaisesRegex(
+                signer_fuzz.StatefulFuzzError,
+                "checksum differs",
+            ):
+                signer_fuzz.validate_retained_evidence(
+                    evidence,
+                    expected_head=head,
+                    expected_sanitizer="address-undefined",
+                )
+            seed.write_bytes(b"seed")
+            nested = minimized / "nested"
+            nested.mkdir()
+            (nested / "seed").write_bytes(b"nested")
+            signer_fuzz.verifier_fuzz.write_evidence_hashes(evidence)
+            with self.assertRaisesRegex(
+                signer_fuzz.StatefulFuzzError,
+                "not a regular file",
+            ):
+                signer_fuzz.validate_retained_evidence(
+                    evidence,
+                    expected_head=head,
+                    expected_sanitizer="address-undefined",
+                )
+
+    @unittest.skipIf(sys.platform == "win32", "symlink creation needs privileges")
+    def test_retained_evidence_validation_rejects_symlinks(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            evidence = root / "evidence"
+            evidence.mkdir()
+            target = root / "target"
+            target.write_bytes(b"seed")
+            (evidence / "linked").symlink_to(target)
+            with self.assertRaisesRegex(
+                signer_fuzz.StatefulFuzzError,
+                "must not contain symlinks",
+            ):
+                signer_fuzz.validate_retained_evidence(
+                    evidence,
+                    expected_head="a" * 40,
+                    expected_sanitizer="address-undefined",
+                )
+
+    def test_target_asserts_exact_state_transition_contract(self):
+        target = signer_fuzz.FUZZ_SOURCE.read_text(encoding="utf8")
+        for required in (
+            "pqbtc_mldsa44_test_reset();",
+            "pqbtc_mldsa44_test_keypair_from_seed(",
+            "pqbtc_mldsa44_test_entropy_requests()",
+            "pqbtc_mldsa44_test_entropy_requested_bytes()",
+            "PQBTC_MLDSA44_ERR_ENTROPY_REPEAT",
+            "PQBTC_MLDSA44_ERR_ENTROPY_ALL_ZERO",
+            "PQBTC_MLDSA44_ERR_SIGN_ATTEMPTS_EXHAUSTED",
+            "PQBTC_MLDSA44_ERR_SIGNATURE_LENGTH",
+            "RequireInvalidArgumentDoesNotConsumeState",
+            "RequireInvalidContextPreservesRepeatState",
+            "RequireFreshThenEntropyFailurePreservesRepeat",
+            "RequireFaultThenRepeat",
+            "RequireSuccessfulSignature",
+            "LLVMFuzzerCustomMutator",
+        ):
+            self.assertIn(required, target)
+        entrypoint = target[target.index("int LLVMFuzzerTestOneInput") :]
+        self.assertLess(
+            entrypoint.index("pqbtc_mldsa44_test_reset();"),
+            entrypoint.index("if (!ParseFrame"),
+        )
+        self.assertNotIn("openssl", target.lower())
+        self.assertNotIn("libcrux", target.lower())
+
+    def test_entropy_observability_is_test_only_and_reset(self):
+        source = (ENGINEERING_DIR / "pqbtc_mldsa44.c").read_text(encoding="utf8")
+        test_header = (ENGINEERING_DIR / "pqbtc_mldsa44_test.h").read_text(
+            encoding="utf8"
+        )
+        public_header = (ENGINEERING_DIR / "pqbtc_mldsa44.h").read_text(
+            encoding="utf8"
+        )
+        for symbol in (
+            "pqbtc_mldsa44_test_entropy_requests",
+            "pqbtc_mldsa44_test_entropy_requested_bytes",
+        ):
+            self.assertIn(symbol, source)
+            self.assertIn(symbol, test_header)
+            self.assertNotIn(symbol, public_header)
+        self.assertIn(
+            "atomic_store_explicit(&g_test_entropy_requests, 0",
+            source,
+        )
+        self.assertIn(
+            "atomic_store_explicit(&g_test_entropy_requested_bytes, 0",
+            source,
+        )
+
+    def test_workflow_runs_separate_sanitizer_lanes_and_artifacts(self):
+        workflow = WORKFLOW.read_text(encoding="utf8")
+        for required in (
+            "stateful-signer-fuzz:",
+            "Stateful signer (${{ matrix.label }})",
+            "run_stateful_signer_fuzz.py",
+            "ml-dsa-44-stateful-signer-${{ matrix.artifact }}",
+            "sanitizer: address-undefined",
+            "sanitizer: memory",
+            "campaign_seconds=1800",
+            "campaign_seconds=60",
+            "campaign_seed=188",
+            "deterministic_replay",
+            'assert report["repository_dirty"] is False',
+            'assert expected_seconds - 1 <= report["fuzzer_duration_seconds"]',
+            "git merge-base --is-ancestor",
+            "--validate-retained-evidence",
+            'assert report["repository_head"] == sys.argv[4]',
+            "source_evidence_sha256",
+            "restored_seed_file_count",
+            "restored_seed_total_bytes",
+            "restored_seed_aggregate_sha256",
+            'report["retained_corpus_import"]',
+            "sha256sum --check SHA256SUMS",
+            "retention-days: 90",
+        ):
+            self.assertIn(required, workflow)
+        self.assertIn(
+            "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd",
+            workflow,
+        )
+        self.assertIn(
+            "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/test/test_ml_dsa_wrapper_prototype.py
+++ b/ci/test/test_ml_dsa_wrapper_prototype.py
@@ -195,6 +195,7 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
             "ci/test/03_test_script.sh",
             "ci/test/test_ml_dsa_wrapper_prototype.py",
             "contrib/ml-dsa-engineering/README.md",
+            "contrib/ml-dsa-engineering/pqbtc_mldsa44_stateful_fuzz.c",
         ):
             self.assertRegex(
                 plan["source_files"][evidence_source], r"^[0-9a-f]{64}$"
@@ -212,8 +213,8 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
         self.assertEqual(
             counts,
             {
-                "clang-tidy": 4,
-                "iwyu": 2,
+                "clang-tidy": 5,
+                "iwyu": 3,
                 "header-self-containment": 2,
             },
         )
@@ -257,8 +258,10 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
             "clang-tidy-wrapper-testing",
             "clang-tidy-smoke-testing",
             "clang-tidy-verifier-fuzz",
+            "clang-tidy-stateful-signer-fuzz",
             "iwyu-smoke-testing",
             "iwyu-verifier-fuzz",
+            "iwyu-stateful-signer-fuzz",
             "header-self-contained-production",
             "header-self-contained-testing",
         }
@@ -281,6 +284,14 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
             testing_define, checks["clang-tidy-verifier-fuzz"]["command"]
         )
         self.assertNotIn(testing_define, checks["iwyu-verifier-fuzz"]["command"])
+        self.assertIn(
+            testing_define,
+            checks["clang-tidy-stateful-signer-fuzz"]["command"],
+        )
+        self.assertIn(
+            testing_define,
+            checks["iwyu-stateful-signer-fuzz"]["command"],
+        )
 
         for check_id in (
             "header-self-contained-production",

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -78,15 +78,17 @@ clang-tidy/IWYU boundary. The wrapper workflow and the Promotion Matrix tidy
 lane constrain LLVM/clang-tidy to major version 20 and record the exact tool
 versions and binary hashes. IWYU is built from exact source commit
 `6e08906c66b3009f2d590e4bd40d60fa303bf803`. The audit runs clang-tidy over
-the production wrapper, test wrapper, smoke harness, and verifier fuzz target,
-then checks both public headers for C11 self-containment.
+the production wrapper, test wrapper, smoke harness, verifier fuzz target, and
+stateful signer fuzz target, then checks both public headers for C11
+self-containment.
 The optional Annex-K `_s` functions recommended by one analyzer check are
 unavailable on the supported Linux toolchain. That checker remains enabled and
 fatal for new call sites; the 13 reviewed portable API calls use localized,
 inventory-checked `NOLINTNEXTLINE` annotations.
 
-IWYU is enforced only on the first-party smoke and verifier-fuzz translation
-units and their wrapper headers. It intentionally does not propose edits for
+IWYU is enforced only on the first-party smoke, verifier-fuzz, and stateful
+signer-fuzz translation units and their wrapper headers. It intentionally does
+not propose edits for
 `pqbtc_mldsa44.c`, because that file includes the pinned upstream
 single-compilation-unit implementation and its nested `.c` files. Clang-tidy
 still parses that implementation as part of the wrapper translation unit, but
@@ -177,6 +179,32 @@ configuration, compiled binary, functional correctness, cryptographic
 security, constant-time behavior, leakage resistance, fault resistance,
 thread safety, or production fitness. It does not replace independent human
 review, close a production gate, or alter the release hold.
+
+## Stateful Signer and Seeded-Keygen Fuzzing
+
+`run_stateful_signer_fuzz.py` owns a separate test-only libFuzzer target for
+the wrapper's deterministic seeded-key generation and hedged-signing state
+machine. Its 31 checked-in frames cover all 12 effective bounded call
+sequences, including the oversized-context preservation path, and all
+13 invalid-argument variants, plus entropy lengths and message/context
+boundaries. Every input resets the module. Every parsed frame derives the same
+keypair twice, asserts exact entropy-call accounting, and checks failure
+zeroing, repeat detection, post-failure state, fixed-randomizer output, strict
+verification, and input immutability.
+
+The sustained workflow runs separate Clang ASan/UBSan and MSan jobs with a
+60-second pull-request/push smoke and a 1,800-second scheduled/manual campaign.
+The stateful minimized corpus and machine-readable evidence use a namespace
+separate from verifier and differential evidence. A retained restore must come
+from an ancestor `main` run and pass its complete checksum inventory, campaign
+identity, clean-head, minimized-corpus digest, flat-file, and resource-bound
+checks before import. The importer recomputes that exact count, byte total,
+and name-bound aggregate immediately before copying, then records and verifies
+a content-addressed receipt for the novel frames actually added. This is
+bounded test-only
+issue-`#188` evidence; it does not connect the wrapper to production, prove
+fork/lifecycle behavior or resource limits, close the issue, or change the
+release hold.
 
 ## Differential Verifier Fuzzing
 

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44.c
@@ -64,6 +64,8 @@ static int g_test_backend_result;
 static int g_test_force_signature_length;
 static int g_test_force_verify_failure;
 static atomic_size_t g_test_zeroized_bytes;
+static atomic_size_t g_test_entropy_requests;
+static atomic_size_t g_test_entropy_requested_bytes;
 #endif
 
 static void LockSigningModule(void)
@@ -112,6 +114,9 @@ static int ConstantTimeEqual(const uint8_t* left, const uint8_t* right, size_t l
 static int FillEntropy(uint8_t* output, size_t requested, size_t* received)
 {
 #ifdef PQBTC_MLDSA44_TESTING
+    atomic_fetch_add_explicit(&g_test_entropy_requests, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(
+        &g_test_entropy_requested_bytes, requested, memory_order_relaxed);
     if (g_test_entropy_mode == PQBTC_MLDSA44_TEST_ENTROPY_FAILURE) {
         *received = 0;
         return -1;
@@ -367,6 +372,8 @@ void pqbtc_mldsa44_test_reset(void)
     g_test_force_signature_length = 0;
     g_test_force_verify_failure = 0;
     atomic_store_explicit(&g_test_zeroized_bytes, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_test_entropy_requests, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_test_entropy_requested_bytes, 0, memory_order_relaxed);
     UnlockSigningModule();
 }
 
@@ -412,6 +419,16 @@ void pqbtc_mldsa44_test_force_verify_failure(int enabled)
 size_t pqbtc_mldsa44_test_zeroized_bytes(void)
 {
     return atomic_load_explicit(&g_test_zeroized_bytes, memory_order_relaxed);
+}
+
+size_t pqbtc_mldsa44_test_entropy_requests(void)
+{
+    return atomic_load_explicit(&g_test_entropy_requests, memory_order_relaxed);
+}
+
+size_t pqbtc_mldsa44_test_entropy_requested_bytes(void)
+{
+    return atomic_load_explicit(&g_test_entropy_requested_bytes, memory_order_relaxed);
 }
 
 int pqbtc_mldsa44_test_keypair_from_seed(

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_stateful_fuzz.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_stateful_fuzz.c
@@ -1,0 +1,1156 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+#include "pqbtc_mldsa44.h"
+#include "pqbtc_mldsa44_test.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define PQBTC_MLDSA44_STATEFUL_FRAME_VERSION 1U
+#define PQBTC_MLDSA44_STATEFUL_HEADER_BYTES 8U
+#define PQBTC_MLDSA44_STATEFUL_SEED_BYTES 32U
+#define PQBTC_MLDSA44_STATEFUL_FIXED_BYTES 96U
+#define PQBTC_MLDSA44_STATEFUL_MAX_MESSAGE_BYTES 4096U
+#define PQBTC_MLDSA44_STATEFUL_MAX_CONTEXT_BYTES 256U
+#define PQBTC_MLDSA44_STATEFUL_MAX_FRAME_BYTES \
+    (PQBTC_MLDSA44_STATEFUL_HEADER_BYTES + PQBTC_MLDSA44_STATEFUL_FIXED_BYTES + \
+     PQBTC_MLDSA44_STATEFUL_MAX_MESSAGE_BYTES + \
+     PQBTC_MLDSA44_STATEFUL_MAX_CONTEXT_BYTES)
+
+#define PQBTC_MLDSA44_STATEFUL_SCENARIOS 11U
+#define PQBTC_MLDSA44_STATEFUL_ARGUMENT_VARIANTS 13U
+
+enum stateful_scenario {
+    SCENARIO_FRESH_THEN_FRESH = 0,
+    SCENARIO_FRESH_THEN_REPEAT = 1,
+    SCENARIO_SHORT_THEN_FRESH = 2,
+    SCENARIO_FAILURE_THEN_FRESH = 3,
+    SCENARIO_ZERO_THEN_FRESH = 4,
+    SCENARIO_INVALID_THEN_FRESH = 5,
+    SCENARIO_BACKEND_THEN_REPEAT = 6,
+    SCENARIO_ATTEMPTS_THEN_REPEAT = 7,
+    SCENARIO_LENGTH_THEN_REPEAT = 8,
+    SCENARIO_VERIFY_THEN_REPEAT = 9,
+    SCENARIO_RESET_THEN_REUSE = 10
+};
+
+enum invalid_argument_variant {
+    ARGUMENT_NULL_OUTPUT = 0,
+    ARGUMENT_SHORT_OUTPUT = 1,
+    ARGUMENT_LONG_OUTPUT = 2,
+    ARGUMENT_ALIAS_SECRET_KEY = 3,
+    ARGUMENT_ALIAS_PUBLIC_KEY = 4,
+    ARGUMENT_ALIAS_MESSAGE = 5,
+    ARGUMENT_ALIAS_CONTEXT = 6,
+    ARGUMENT_NULL_SECRET_KEY = 7,
+    ARGUMENT_SHORT_SECRET_KEY = 8,
+    ARGUMENT_NULL_PUBLIC_KEY = 9,
+    ARGUMENT_SHORT_PUBLIC_KEY = 10,
+    ARGUMENT_NULL_MESSAGE = 11,
+    ARGUMENT_NULL_CONTEXT = 12
+};
+
+struct stateful_frame {
+    uint8_t scenario;
+    uint8_t argument_variant;
+    uint8_t short_length;
+    uint16_t message_size;
+    uint16_t context_size;
+    const uint8_t* seed;
+    const uint8_t* randomizer_a;
+    const uint8_t* randomizer_b;
+    const uint8_t* message;
+    const uint8_t* context;
+};
+
+_Static_assert(PQBTC_MLDSA44_PUBLIC_KEY_BYTES == 1312U, "unexpected public key size");
+_Static_assert(PQBTC_MLDSA44_SECRET_KEY_BYTES == 2560U, "unexpected secret key size");
+_Static_assert(PQBTC_MLDSA44_SIGNATURE_BYTES == 2420U, "unexpected signature size");
+_Static_assert(PQBTC_MLDSA44_RANDOMIZER_BYTES == 32U, "unexpected randomizer size");
+_Static_assert(PQBTC_MLDSA44_MAX_CONTEXT_BYTES == 255U, "unexpected context limit");
+_Static_assert(PQBTC_MLDSA44_STATEFUL_MAX_FRAME_BYTES == 4456U, "unexpected frame size");
+
+static void Require(int condition)
+{
+    if (!condition) abort();
+}
+
+static uint16_t ReadU16(const uint8_t* bytes)
+{
+    return (uint16_t)bytes[0] | ((uint16_t)bytes[1] << 8);
+}
+
+static void WriteU16(uint8_t* bytes, uint16_t value)
+{
+    bytes[0] = (uint8_t)value;
+    bytes[1] = (uint8_t)(value >> 8);
+}
+
+static void CopyBytes(uint8_t* destination, const uint8_t* source, size_t size)
+{
+    size_t i;
+    for (i = 0; i < size; ++i)
+        destination[i] = source[i];
+}
+
+static void MoveBytes(uint8_t* destination, const uint8_t* source, size_t size)
+{
+    size_t i;
+    if (destination < source) {
+        for (i = 0; i < size; ++i)
+            destination[i] = source[i];
+    } else if (destination > source) {
+        for (i = size; i > 0; --i)
+            destination[i - 1] = source[i - 1];
+    }
+}
+
+static void FillBytes(uint8_t* destination, size_t size, uint8_t value)
+{
+    size_t i;
+    for (i = 0; i < size; ++i)
+        destination[i] = value;
+}
+
+static int BytesEqual(const uint8_t* left, const uint8_t* right, size_t size)
+{
+    uint8_t difference = 0;
+    size_t i;
+    for (i = 0; i < size; ++i)
+        difference |= left[i] ^ right[i];
+    return difference == 0;
+}
+
+static int IsZero(const uint8_t* bytes, size_t size)
+{
+    uint8_t aggregate = 0;
+    size_t i;
+    for (i = 0; i < size; ++i)
+        aggregate |= bytes[i];
+    return aggregate == 0;
+}
+
+static int IsFilled(const uint8_t* bytes, size_t size, uint8_t value)
+{
+    size_t i;
+    for (i = 0; i < size; ++i) {
+        if (bytes[i] != value) return 0;
+    }
+    return 1;
+}
+
+static int ParseFrame(const uint8_t* data, size_t size, struct stateful_frame* frame)
+{
+    size_t expected_size;
+    size_t cursor;
+
+    if (size < PQBTC_MLDSA44_STATEFUL_HEADER_BYTES +
+                   PQBTC_MLDSA44_STATEFUL_FIXED_BYTES ||
+        data[0] != PQBTC_MLDSA44_STATEFUL_FRAME_VERSION) {
+        return 0;
+    }
+
+    frame->scenario = data[1] % PQBTC_MLDSA44_STATEFUL_SCENARIOS;
+    frame->argument_variant =
+        data[2] % PQBTC_MLDSA44_STATEFUL_ARGUMENT_VARIANTS;
+    frame->short_length = data[3] % PQBTC_MLDSA44_RANDOMIZER_BYTES;
+    frame->message_size = ReadU16(data + 4);
+    frame->context_size = ReadU16(data + 6);
+    if (frame->message_size > PQBTC_MLDSA44_STATEFUL_MAX_MESSAGE_BYTES ||
+        frame->context_size > PQBTC_MLDSA44_STATEFUL_MAX_CONTEXT_BYTES) {
+        return 0;
+    }
+
+    expected_size = PQBTC_MLDSA44_STATEFUL_HEADER_BYTES +
+        PQBTC_MLDSA44_STATEFUL_FIXED_BYTES + frame->message_size +
+        frame->context_size;
+    if (expected_size != size) return 0;
+
+    cursor = PQBTC_MLDSA44_STATEFUL_HEADER_BYTES;
+    frame->seed = data + cursor;
+    cursor += PQBTC_MLDSA44_STATEFUL_SEED_BYTES;
+    frame->randomizer_a = data + cursor;
+    cursor += PQBTC_MLDSA44_RANDOMIZER_BYTES;
+    frame->randomizer_b = data + cursor;
+    cursor += PQBTC_MLDSA44_RANDOMIZER_BYTES;
+    frame->message = data + cursor;
+    cursor += frame->message_size;
+    frame->context = data + cursor;
+    return 1;
+}
+
+static const uint8_t* OptionalBytes(const uint8_t* bytes, size_t size)
+{
+    return size == 0 ? NULL : bytes;
+}
+
+static void NormalizeRandomizers(
+    const struct stateful_frame* frame,
+    uint8_t randomizer_a[PQBTC_MLDSA44_RANDOMIZER_BYTES],
+    uint8_t randomizer_b[PQBTC_MLDSA44_RANDOMIZER_BYTES])
+{
+    CopyBytes(randomizer_a, frame->randomizer_a, PQBTC_MLDSA44_RANDOMIZER_BYTES);
+    CopyBytes(randomizer_b, frame->randomizer_b, PQBTC_MLDSA44_RANDOMIZER_BYTES);
+    if (IsZero(randomizer_a, PQBTC_MLDSA44_RANDOMIZER_BYTES)) randomizer_a[0] = 1U;
+    if (IsZero(randomizer_b, PQBTC_MLDSA44_RANDOMIZER_BYTES)) randomizer_b[0] = 2U;
+    if (BytesEqual(
+            randomizer_a, randomizer_b, PQBTC_MLDSA44_RANDOMIZER_BYTES)) {
+        randomizer_b[0] ^= 0x80U;
+        if (IsZero(randomizer_b, PQBTC_MLDSA44_RANDOMIZER_BYTES)) {
+            randomizer_b[0] = 2U;
+        }
+    }
+}
+
+static void RequireEntropyCount(size_t requests)
+{
+    Require(pqbtc_mldsa44_test_entropy_requests() == requests);
+    Require(
+        pqbtc_mldsa44_test_entropy_requested_bytes() ==
+        requests * PQBTC_MLDSA44_RANDOMIZER_BYTES);
+}
+
+static void ClearFaults(void)
+{
+    pqbtc_mldsa44_test_force_backend_result(0);
+    pqbtc_mldsa44_test_force_signature_length(0);
+    pqbtc_mldsa44_test_force_verify_failure(0);
+}
+
+static void SetFixedEntropy(const uint8_t randomizer[32], size_t reported_size)
+{
+    Require(
+        pqbtc_mldsa44_test_set_entropy(
+            PQBTC_MLDSA44_TEST_ENTROPY_FIXED, randomizer, reported_size) ==
+        PQBTC_MLDSA44_OK);
+}
+
+static int Sign(
+    uint8_t signature[PQBTC_MLDSA44_SIGNATURE_BYTES],
+    const uint8_t secret_key[PQBTC_MLDSA44_SECRET_KEY_BYTES],
+    const uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES],
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size)
+{
+    FillBytes(signature, PQBTC_MLDSA44_SIGNATURE_BYTES, 0xa5U);
+    return pqbtc_mldsa44_sign_hedged(
+        signature,
+        PQBTC_MLDSA44_SIGNATURE_BYTES,
+        secret_key,
+        PQBTC_MLDSA44_SECRET_KEY_BYTES,
+        public_key,
+        PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+        OptionalBytes(message, message_size),
+        message_size,
+        OptionalBytes(context, context_size),
+        context_size);
+}
+
+static void RequireSuccessfulSignature(
+    const uint8_t signature[PQBTC_MLDSA44_SIGNATURE_BYTES],
+    const uint8_t secret_key[PQBTC_MLDSA44_SECRET_KEY_BYTES],
+    const uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES],
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size,
+    const uint8_t randomizer[PQBTC_MLDSA44_RANDOMIZER_BYTES])
+{
+    uint8_t expected[PQBTC_MLDSA44_SIGNATURE_BYTES];
+
+    Require(!IsZero(signature, PQBTC_MLDSA44_SIGNATURE_BYTES));
+    Require(
+        pqbtc_mldsa44_verify_strict(
+            signature,
+            PQBTC_MLDSA44_SIGNATURE_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size) == PQBTC_MLDSA44_OK);
+    Require(
+        pqbtc_mldsa44_test_sign_fixed_randomizer(
+            expected,
+            secret_key,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size,
+            randomizer) == PQBTC_MLDSA44_OK);
+    Require(BytesEqual(signature, expected, PQBTC_MLDSA44_SIGNATURE_BYTES));
+    FillBytes(expected, sizeof(expected), 0);
+}
+
+static void RequireValidCall(
+    uint8_t signature[PQBTC_MLDSA44_SIGNATURE_BYTES],
+    const uint8_t secret_key[PQBTC_MLDSA44_SECRET_KEY_BYTES],
+    const uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES],
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size,
+    const uint8_t randomizer[PQBTC_MLDSA44_RANDOMIZER_BYTES],
+    int expected,
+    size_t expected_entropy_requests)
+{
+    int result;
+
+    SetFixedEntropy(randomizer, PQBTC_MLDSA44_RANDOMIZER_BYTES);
+    result = Sign(
+        signature,
+        secret_key,
+        public_key,
+        message,
+        message_size,
+        context,
+        context_size);
+    Require(result == expected);
+    RequireEntropyCount(expected_entropy_requests);
+    if (expected == PQBTC_MLDSA44_OK) {
+        RequireSuccessfulSignature(
+            signature,
+            secret_key,
+            public_key,
+            message,
+            message_size,
+            context,
+            context_size,
+            randomizer);
+    } else {
+        Require(IsZero(signature, PQBTC_MLDSA44_SIGNATURE_BYTES));
+    }
+}
+
+static void RequireInvalidContextPreservesRepeatState(
+    const uint8_t secret_key[PQBTC_MLDSA44_SECRET_KEY_BYTES],
+    const uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES],
+    const struct stateful_frame* frame,
+    const uint8_t randomizer_a[PQBTC_MLDSA44_RANDOMIZER_BYTES],
+    const uint8_t randomizer_b[PQBTC_MLDSA44_RANDOMIZER_BYTES])
+{
+    uint8_t signature[PQBTC_MLDSA44_SIGNATURE_BYTES];
+    int result;
+
+    RequireValidCall(
+        signature,
+        secret_key,
+        public_key,
+        frame->message,
+        frame->message_size,
+        frame->context,
+        PQBTC_MLDSA44_MAX_CONTEXT_BYTES,
+        randomizer_a,
+        PQBTC_MLDSA44_OK,
+        1);
+    SetFixedEntropy(randomizer_b, PQBTC_MLDSA44_RANDOMIZER_BYTES);
+    result = Sign(
+        signature,
+        secret_key,
+        public_key,
+        frame->message,
+        frame->message_size,
+        frame->context,
+        frame->context_size);
+    Require(result == PQBTC_MLDSA44_ERR_INVALID_ARGUMENT);
+    Require(IsZero(signature, sizeof(signature)));
+    RequireEntropyCount(1);
+    RequireValidCall(
+        signature,
+        secret_key,
+        public_key,
+        frame->message,
+        frame->message_size,
+        frame->context,
+        PQBTC_MLDSA44_MAX_CONTEXT_BYTES,
+        randomizer_a,
+        PQBTC_MLDSA44_ERR_ENTROPY_REPEAT,
+        2);
+    RequireValidCall(
+        signature,
+        secret_key,
+        public_key,
+        frame->message,
+        frame->message_size,
+        frame->context,
+        PQBTC_MLDSA44_MAX_CONTEXT_BYTES,
+        randomizer_b,
+        PQBTC_MLDSA44_OK,
+        3);
+}
+
+static void RequireInvalidArgumentDoesNotConsumeState(
+    uint8_t variant,
+    const uint8_t secret_key[PQBTC_MLDSA44_SECRET_KEY_BYTES],
+    const uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES],
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size,
+    size_t expected_entropy_requests)
+{
+    uint8_t signature[PQBTC_MLDSA44_SIGNATURE_BYTES];
+    uint8_t secret_alias[PQBTC_MLDSA44_SECRET_KEY_BYTES];
+    uint8_t public_alias[PQBTC_MLDSA44_SIGNATURE_BYTES];
+    uint8_t message_alias[PQBTC_MLDSA44_STATEFUL_MAX_MESSAGE_BYTES];
+    uint8_t context_alias[PQBTC_MLDSA44_SIGNATURE_BYTES];
+    uint8_t before[PQBTC_MLDSA44_STATEFUL_MAX_MESSAGE_BYTES];
+    size_t alias_message_size = message_size == 0 ? 1U : message_size;
+    size_t alias_context_size = context_size == 0 ? 1U : context_size;
+    int result;
+
+    FillBytes(signature, sizeof(signature), 0xa5U);
+    CopyBytes(before, signature, sizeof(signature));
+    switch (variant) {
+    case ARGUMENT_NULL_OUTPUT:
+        result = pqbtc_mldsa44_sign_hedged(
+            NULL,
+            PQBTC_MLDSA44_SIGNATURE_BYTES,
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(BytesEqual(signature, before, sizeof(signature)));
+        break;
+    case ARGUMENT_SHORT_OUTPUT:
+    case ARGUMENT_LONG_OUTPUT:
+        result = pqbtc_mldsa44_sign_hedged(
+            signature,
+            variant == ARGUMENT_SHORT_OUTPUT ?
+                PQBTC_MLDSA44_SIGNATURE_BYTES - 1U :
+                PQBTC_MLDSA44_SIGNATURE_BYTES + 1U,
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(BytesEqual(signature, before, sizeof(signature)));
+        break;
+    case ARGUMENT_ALIAS_SECRET_KEY:
+        CopyBytes(secret_alias, secret_key, sizeof(secret_alias));
+        CopyBytes(before, secret_alias, sizeof(secret_alias));
+        result = pqbtc_mldsa44_sign_hedged(
+            secret_alias,
+            PQBTC_MLDSA44_SIGNATURE_BYTES,
+            secret_alias,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(BytesEqual(secret_alias, before, sizeof(secret_alias)));
+        break;
+    case ARGUMENT_ALIAS_PUBLIC_KEY:
+        FillBytes(public_alias, sizeof(public_alias), 0x3cU);
+        CopyBytes(public_alias, public_key, PQBTC_MLDSA44_PUBLIC_KEY_BYTES);
+        CopyBytes(before, public_alias, sizeof(public_alias));
+        result = pqbtc_mldsa44_sign_hedged(
+            public_alias,
+            PQBTC_MLDSA44_SIGNATURE_BYTES,
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_alias,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(BytesEqual(public_alias, before, sizeof(public_alias)));
+        break;
+    case ARGUMENT_ALIAS_MESSAGE:
+        FillBytes(message_alias, sizeof(message_alias), 0x5aU);
+        if (message_size != 0) {
+            CopyBytes(message_alias, message, message_size);
+        }
+        CopyBytes(before, message_alias, sizeof(before));
+        result = pqbtc_mldsa44_sign_hedged(
+            message_alias,
+            PQBTC_MLDSA44_SIGNATURE_BYTES,
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            message_alias,
+            alias_message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(BytesEqual(message_alias, before, sizeof(message_alias)));
+        break;
+    case ARGUMENT_ALIAS_CONTEXT:
+        FillBytes(context_alias, sizeof(context_alias), 0x69U);
+        if (context_size != 0) {
+            CopyBytes(context_alias, context, context_size);
+        }
+        CopyBytes(before, context_alias, sizeof(context_alias));
+        result = pqbtc_mldsa44_sign_hedged(
+            context_alias,
+            PQBTC_MLDSA44_SIGNATURE_BYTES,
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            context_alias,
+            alias_context_size);
+        Require(BytesEqual(context_alias, before, sizeof(context_alias)));
+        break;
+    case ARGUMENT_NULL_SECRET_KEY:
+        result = pqbtc_mldsa44_sign_hedged(
+            signature,
+            sizeof(signature),
+            NULL,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(IsZero(signature, sizeof(signature)));
+        break;
+    case ARGUMENT_SHORT_SECRET_KEY:
+        result = pqbtc_mldsa44_sign_hedged(
+            signature,
+            sizeof(signature),
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES - 1U,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(IsZero(signature, sizeof(signature)));
+        break;
+    case ARGUMENT_NULL_PUBLIC_KEY:
+        result = pqbtc_mldsa44_sign_hedged(
+            signature,
+            sizeof(signature),
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            NULL,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(IsZero(signature, sizeof(signature)));
+        break;
+    case ARGUMENT_SHORT_PUBLIC_KEY:
+        result = pqbtc_mldsa44_sign_hedged(
+            signature,
+            sizeof(signature),
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES - 1U,
+            OptionalBytes(message, message_size),
+            message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(IsZero(signature, sizeof(signature)));
+        break;
+    case ARGUMENT_NULL_MESSAGE:
+        result = pqbtc_mldsa44_sign_hedged(
+            signature,
+            sizeof(signature),
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            NULL,
+            message_size == 0 ? 1U : message_size,
+            OptionalBytes(context, context_size),
+            context_size);
+        Require(IsZero(signature, sizeof(signature)));
+        break;
+    default:
+        result = pqbtc_mldsa44_sign_hedged(
+            signature,
+            sizeof(signature),
+            secret_key,
+            PQBTC_MLDSA44_SECRET_KEY_BYTES,
+            public_key,
+            PQBTC_MLDSA44_PUBLIC_KEY_BYTES,
+            OptionalBytes(message, message_size),
+            message_size,
+            NULL,
+            context_size == 0 ? 1U : context_size);
+        Require(IsZero(signature, sizeof(signature)));
+        break;
+    }
+    Require(result == PQBTC_MLDSA44_ERR_INVALID_ARGUMENT);
+    RequireEntropyCount(expected_entropy_requests);
+}
+
+static void RequireFreshThenEntropyFailurePreservesRepeat(
+    int entropy_mode,
+    size_t reported_size,
+    int expected,
+    const uint8_t secret_key[PQBTC_MLDSA44_SECRET_KEY_BYTES],
+    const uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES],
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size,
+    const uint8_t randomizer_a[PQBTC_MLDSA44_RANDOMIZER_BYTES],
+    const uint8_t randomizer_b[PQBTC_MLDSA44_RANDOMIZER_BYTES])
+{
+    uint8_t signature[PQBTC_MLDSA44_SIGNATURE_BYTES];
+    uint8_t zero_randomizer[PQBTC_MLDSA44_RANDOMIZER_BYTES] = {0};
+    const uint8_t* configured =
+        expected == PQBTC_MLDSA44_ERR_ENTROPY_ALL_ZERO ?
+        zero_randomizer :
+        randomizer_b;
+    int result;
+
+    RequireValidCall(
+        signature,
+        secret_key,
+        public_key,
+        message,
+        message_size,
+        context,
+        context_size,
+        randomizer_a,
+        PQBTC_MLDSA44_OK,
+        1);
+    Require(
+        pqbtc_mldsa44_test_set_entropy(
+            entropy_mode,
+            entropy_mode == PQBTC_MLDSA44_TEST_ENTROPY_FAILURE ? NULL : configured,
+            reported_size) == PQBTC_MLDSA44_OK);
+    result = Sign(
+        signature,
+        secret_key,
+        public_key,
+        message,
+        message_size,
+        context,
+        context_size);
+    Require(result == expected);
+    Require(IsZero(signature, sizeof(signature)));
+    RequireEntropyCount(2);
+    RequireValidCall(
+        signature,
+        secret_key,
+        public_key,
+        message,
+        message_size,
+        context,
+        context_size,
+        randomizer_a,
+        PQBTC_MLDSA44_ERR_ENTROPY_REPEAT,
+        3);
+    RequireValidCall(
+        signature,
+        secret_key,
+        public_key,
+        message,
+        message_size,
+        context,
+        context_size,
+        randomizer_b,
+        PQBTC_MLDSA44_OK,
+        4);
+}
+
+static void RequireFaultThenRepeat(
+    uint8_t scenario,
+    const uint8_t secret_key[PQBTC_MLDSA44_SECRET_KEY_BYTES],
+    const uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES],
+    const uint8_t* message,
+    size_t message_size,
+    const uint8_t* context,
+    size_t context_size,
+    const uint8_t randomizer_a[PQBTC_MLDSA44_RANDOMIZER_BYTES],
+    const uint8_t randomizer_b[PQBTC_MLDSA44_RANDOMIZER_BYTES])
+{
+    uint8_t signature[PQBTC_MLDSA44_SIGNATURE_BYTES];
+    int expected;
+    int result;
+
+    if (scenario == SCENARIO_BACKEND_THEN_REPEAT) {
+        pqbtc_mldsa44_test_force_backend_result(-1);
+        expected = PQBTC_MLDSA44_ERR_BACKEND;
+    } else if (scenario == SCENARIO_ATTEMPTS_THEN_REPEAT) {
+        pqbtc_mldsa44_test_force_backend_result(-4);
+        expected = PQBTC_MLDSA44_ERR_SIGN_ATTEMPTS_EXHAUSTED;
+    } else if (scenario == SCENARIO_LENGTH_THEN_REPEAT) {
+        pqbtc_mldsa44_test_force_signature_length(1);
+        expected = PQBTC_MLDSA44_ERR_SIGNATURE_LENGTH;
+    } else {
+        pqbtc_mldsa44_test_force_verify_failure(1);
+        expected = PQBTC_MLDSA44_ERR_VERIFY;
+    }
+
+    SetFixedEntropy(randomizer_a, PQBTC_MLDSA44_RANDOMIZER_BYTES);
+    result = Sign(
+        signature,
+        secret_key,
+        public_key,
+        message,
+        message_size,
+        context,
+        context_size);
+    Require(result == expected);
+    Require(IsZero(signature, sizeof(signature)));
+    RequireEntropyCount(1);
+
+    ClearFaults();
+    RequireValidCall(
+        signature,
+        secret_key,
+        public_key,
+        message,
+        message_size,
+        context,
+        context_size,
+        randomizer_a,
+        PQBTC_MLDSA44_ERR_ENTROPY_REPEAT,
+        2);
+    RequireValidCall(
+        signature,
+        secret_key,
+        public_key,
+        message,
+        message_size,
+        context,
+        context_size,
+        randomizer_b,
+        PQBTC_MLDSA44_OK,
+        3);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    struct stateful_frame frame;
+    uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES];
+    uint8_t public_key_repeat[PQBTC_MLDSA44_PUBLIC_KEY_BYTES];
+    uint8_t public_key_before[PQBTC_MLDSA44_PUBLIC_KEY_BYTES];
+    uint8_t secret_key[PQBTC_MLDSA44_SECRET_KEY_BYTES];
+    uint8_t secret_key_repeat[PQBTC_MLDSA44_SECRET_KEY_BYTES];
+    uint8_t secret_key_before[PQBTC_MLDSA44_SECRET_KEY_BYTES];
+    uint8_t frame_before[PQBTC_MLDSA44_STATEFUL_MAX_FRAME_BYTES];
+    uint8_t randomizer_a[PQBTC_MLDSA44_RANDOMIZER_BYTES];
+    uint8_t randomizer_b[PQBTC_MLDSA44_RANDOMIZER_BYTES];
+    uint8_t signature[PQBTC_MLDSA44_SIGNATURE_BYTES];
+    size_t context_size;
+
+    pqbtc_mldsa44_test_reset();
+    RequireEntropyCount(0);
+    if (!ParseFrame(data, size, &frame)) {
+        pqbtc_mldsa44_test_reset();
+        RequireEntropyCount(0);
+        return 0;
+    }
+    CopyBytes(frame_before, data, size);
+    NormalizeRandomizers(&frame, randomizer_a, randomizer_b);
+
+    Require(
+        pqbtc_mldsa44_test_keypair_from_seed(
+            public_key, secret_key, frame.seed) == PQBTC_MLDSA44_OK);
+    Require(
+        pqbtc_mldsa44_test_keypair_from_seed(
+            public_key_repeat, secret_key_repeat, frame.seed) ==
+        PQBTC_MLDSA44_OK);
+    Require(BytesEqual(public_key, public_key_repeat, sizeof(public_key)));
+    Require(BytesEqual(secret_key, secret_key_repeat, sizeof(secret_key)));
+    RequireEntropyCount(0);
+    CopyBytes(public_key_before, public_key, sizeof(public_key));
+    CopyBytes(secret_key_before, secret_key, sizeof(secret_key));
+
+    FillBytes(public_key_repeat, sizeof(public_key_repeat), 0x5aU);
+    FillBytes(secret_key_repeat, sizeof(secret_key_repeat), 0x5aU);
+    Require(
+        pqbtc_mldsa44_test_keypair_from_seed(
+            NULL, secret_key_repeat, frame.seed) ==
+        PQBTC_MLDSA44_ERR_INVALID_ARGUMENT);
+    Require(IsFilled(secret_key_repeat, sizeof(secret_key_repeat), 0x5aU));
+    FillBytes(secret_key_repeat, sizeof(secret_key_repeat), 0x69U);
+    Require(
+        pqbtc_mldsa44_test_keypair_from_seed(
+            public_key_repeat, NULL, frame.seed) ==
+        PQBTC_MLDSA44_ERR_INVALID_ARGUMENT);
+    Require(IsFilled(public_key_repeat, sizeof(public_key_repeat), 0x5aU));
+    FillBytes(public_key_repeat, sizeof(public_key_repeat), 0x3cU);
+    FillBytes(secret_key_repeat, sizeof(secret_key_repeat), 0x3cU);
+    Require(
+        pqbtc_mldsa44_test_keypair_from_seed(
+            public_key_repeat, secret_key_repeat, NULL) ==
+        PQBTC_MLDSA44_ERR_INVALID_ARGUMENT);
+    Require(IsFilled(public_key_repeat, sizeof(public_key_repeat), 0x3cU));
+    Require(IsFilled(secret_key_repeat, sizeof(secret_key_repeat), 0x3cU));
+    RequireEntropyCount(0);
+
+    if (frame.context_size == PQBTC_MLDSA44_STATEFUL_MAX_CONTEXT_BYTES) {
+        RequireInvalidContextPreservesRepeatState(
+            secret_key, public_key, &frame, randomizer_a, randomizer_b);
+        Require(BytesEqual(public_key, public_key_before, sizeof(public_key)));
+        Require(BytesEqual(secret_key, secret_key_before, sizeof(secret_key)));
+        Require(BytesEqual(data, frame_before, size));
+        pqbtc_mldsa44_test_reset();
+        RequireEntropyCount(0);
+        return 0;
+    }
+    context_size = frame.context_size;
+
+    switch (frame.scenario) {
+    case SCENARIO_FRESH_THEN_FRESH:
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            PQBTC_MLDSA44_OK,
+            1);
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_b,
+            PQBTC_MLDSA44_OK,
+            2);
+        break;
+    case SCENARIO_FRESH_THEN_REPEAT:
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            PQBTC_MLDSA44_OK,
+            1);
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            PQBTC_MLDSA44_ERR_ENTROPY_REPEAT,
+            2);
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_b,
+            PQBTC_MLDSA44_OK,
+            3);
+        break;
+    case SCENARIO_SHORT_THEN_FRESH:
+        RequireFreshThenEntropyFailurePreservesRepeat(
+            PQBTC_MLDSA44_TEST_ENTROPY_FIXED,
+            frame.short_length,
+            PQBTC_MLDSA44_ERR_ENTROPY_LENGTH,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            randomizer_b);
+        break;
+    case SCENARIO_FAILURE_THEN_FRESH:
+        RequireFreshThenEntropyFailurePreservesRepeat(
+            PQBTC_MLDSA44_TEST_ENTROPY_FAILURE,
+            0,
+            PQBTC_MLDSA44_ERR_ENTROPY_SOURCE,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            randomizer_b);
+        break;
+    case SCENARIO_ZERO_THEN_FRESH:
+        RequireFreshThenEntropyFailurePreservesRepeat(
+            PQBTC_MLDSA44_TEST_ENTROPY_FIXED,
+            PQBTC_MLDSA44_RANDOMIZER_BYTES,
+            PQBTC_MLDSA44_ERR_ENTROPY_ALL_ZERO,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            randomizer_b);
+        break;
+    case SCENARIO_INVALID_THEN_FRESH:
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            PQBTC_MLDSA44_OK,
+            1);
+        RequireInvalidArgumentDoesNotConsumeState(
+            frame.argument_variant,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            1);
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            PQBTC_MLDSA44_ERR_ENTROPY_REPEAT,
+            2);
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_b,
+            PQBTC_MLDSA44_OK,
+            3);
+        break;
+    case SCENARIO_RESET_THEN_REUSE:
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            PQBTC_MLDSA44_OK,
+            1);
+        pqbtc_mldsa44_test_reset();
+        RequireEntropyCount(0);
+        RequireValidCall(
+            signature,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            PQBTC_MLDSA44_OK,
+            1);
+        break;
+    default:
+        RequireFaultThenRepeat(
+            frame.scenario,
+            secret_key,
+            public_key,
+            frame.message,
+            frame.message_size,
+            frame.context,
+            context_size,
+            randomizer_a,
+            randomizer_b);
+        break;
+    }
+
+    Require(BytesEqual(public_key, public_key_before, sizeof(public_key)));
+    Require(BytesEqual(secret_key, secret_key_before, sizeof(secret_key)));
+    Require(BytesEqual(data, frame_before, size));
+    pqbtc_mldsa44_test_reset();
+    RequireEntropyCount(0);
+    return 0;
+}
+
+extern size_t LLVMFuzzerMutate(uint8_t* data, size_t size, size_t max_size);
+
+static uint32_t NextRandom(uint32_t* state)
+{
+    *state = *state * 1664525U + 1013904223U;
+    return *state;
+}
+
+static void FlipRandomByte(uint8_t* bytes, size_t size, uint32_t* state)
+{
+    size_t offset;
+    if (size == 0) return;
+    offset = NextRandom(state) % size;
+    bytes[offset] ^= (uint8_t)(1U << (NextRandom(state) % 8U));
+}
+
+static size_t ResizeMessage(
+    uint8_t* data,
+    size_t size,
+    size_t max_size,
+    const struct stateful_frame* frame,
+    uint16_t new_length,
+    uint32_t* state)
+{
+    size_t message_offset =
+        PQBTC_MLDSA44_STATEFUL_HEADER_BYTES + PQBTC_MLDSA44_STATEFUL_FIXED_BYTES;
+    size_t context_offset = message_offset + frame->message_size;
+    size_t new_context_offset = message_offset + new_length;
+    size_t new_size = size - frame->message_size + new_length;
+    size_t i;
+
+    if (new_size > max_size ||
+        new_size > PQBTC_MLDSA44_STATEFUL_MAX_FRAME_BYTES) {
+        return size;
+    }
+    MoveBytes(
+        data + new_context_offset, data + context_offset, frame->context_size);
+    for (i = frame->message_size; i < new_length; ++i)
+        data[message_offset + i] = (uint8_t)NextRandom(state);
+    WriteU16(data + 4, new_length);
+    return new_size;
+}
+
+static size_t ResizeContext(
+    uint8_t* data,
+    size_t size,
+    size_t max_size,
+    const struct stateful_frame* frame,
+    uint16_t new_length,
+    uint32_t* state)
+{
+    size_t context_offset = PQBTC_MLDSA44_STATEFUL_HEADER_BYTES +
+        PQBTC_MLDSA44_STATEFUL_FIXED_BYTES + frame->message_size;
+    size_t new_size = size - frame->context_size + new_length;
+    size_t i;
+
+    if (new_size > max_size ||
+        new_size > PQBTC_MLDSA44_STATEFUL_MAX_FRAME_BYTES) {
+        return size;
+    }
+    for (i = frame->context_size; i < new_length; ++i)
+        data[context_offset + i] = (uint8_t)NextRandom(state);
+    WriteU16(data + 6, new_length);
+    return new_size;
+}
+
+size_t LLVMFuzzerCustomMutator(
+    uint8_t* data, size_t size, size_t max_size, unsigned int seed)
+{
+    struct stateful_frame frame;
+    static const uint16_t message_lengths[] = {0U, 1U, 32U, 255U, 4096U};
+    static const uint16_t context_lengths[] = {0U, 1U, 254U, 255U, 256U};
+    static const uint8_t short_lengths[] = {0U, 1U, 16U, 31U};
+    uint32_t state = seed == 0 ? 1U : seed;
+    uint8_t* randomizer_a;
+    uint8_t* randomizer_b;
+
+    if (!ParseFrame(data, size, &frame)) {
+        return LLVMFuzzerMutate(data, size, max_size);
+    }
+    randomizer_a = data + PQBTC_MLDSA44_STATEFUL_HEADER_BYTES +
+        PQBTC_MLDSA44_STATEFUL_SEED_BYTES;
+    randomizer_b = randomizer_a + PQBTC_MLDSA44_RANDOMIZER_BYTES;
+
+    switch (NextRandom(&state) % 11U) {
+    case 0:
+        data[1] = (uint8_t)(NextRandom(&state) % PQBTC_MLDSA44_STATEFUL_SCENARIOS);
+        break;
+    case 1:
+        data[2] =
+            (uint8_t)(NextRandom(&state) % PQBTC_MLDSA44_STATEFUL_ARGUMENT_VARIANTS);
+        break;
+    case 2:
+        data[3] = short_lengths[NextRandom(&state) % 4U];
+        break;
+    case 3:
+        size = ResizeMessage(
+            data,
+            size,
+            max_size,
+            &frame,
+            message_lengths[NextRandom(&state) % 5U],
+            &state);
+        break;
+    case 4:
+        size = ResizeContext(
+            data,
+            size,
+            max_size,
+            &frame,
+            context_lengths[NextRandom(&state) % 5U],
+            &state);
+        break;
+    case 5:
+        FlipRandomByte(
+            data + PQBTC_MLDSA44_STATEFUL_HEADER_BYTES,
+            PQBTC_MLDSA44_STATEFUL_SEED_BYTES,
+            &state);
+        break;
+    case 6:
+        FlipRandomByte(randomizer_a, PQBTC_MLDSA44_RANDOMIZER_BYTES, &state);
+        break;
+    case 7:
+        FlipRandomByte(randomizer_b, PQBTC_MLDSA44_RANDOMIZER_BYTES, &state);
+        break;
+    case 8:
+        CopyBytes(
+            randomizer_b, randomizer_a, PQBTC_MLDSA44_RANDOMIZER_BYTES);
+        break;
+    case 9:
+        FillBytes(randomizer_a, PQBTC_MLDSA44_RANDOMIZER_BYTES, 0);
+        break;
+    default:
+        if ((NextRandom(&state) & 1U) == 0) {
+            FlipRandomByte(
+                data + PQBTC_MLDSA44_STATEFUL_HEADER_BYTES +
+                    PQBTC_MLDSA44_STATEFUL_FIXED_BYTES,
+                frame.message_size,
+                &state);
+        } else {
+            FlipRandomByte(
+                data + PQBTC_MLDSA44_STATEFUL_HEADER_BYTES +
+                    PQBTC_MLDSA44_STATEFUL_FIXED_BYTES + frame.message_size,
+                frame.context_size,
+                &state);
+        }
+        break;
+    }
+    return size;
+}

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_test.h
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_test.h
@@ -27,6 +27,8 @@ PQBTC_MLDSA44_API void pqbtc_mldsa44_test_force_backend_result(int result);
 PQBTC_MLDSA44_API void pqbtc_mldsa44_test_force_signature_length(int enabled);
 PQBTC_MLDSA44_API void pqbtc_mldsa44_test_force_verify_failure(int enabled);
 PQBTC_MLDSA44_API size_t pqbtc_mldsa44_test_zeroized_bytes(void);
+PQBTC_MLDSA44_API size_t pqbtc_mldsa44_test_entropy_requests(void);
+PQBTC_MLDSA44_API size_t pqbtc_mldsa44_test_entropy_requested_bytes(void);
 
 PQBTC_MLDSA44_API int pqbtc_mldsa44_test_keypair_from_seed(
     uint8_t public_key[PQBTC_MLDSA44_PUBLIC_KEY_BYTES],

--- a/contrib/ml-dsa-engineering/run_stateful_signer_fuzz.py
+++ b/contrib/ml-dsa-engineering/run_stateful_signer_fuzz.py
@@ -1,0 +1,1239 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+"""Replay and fuzz the isolated ML-DSA-44 signer and seeded key generator."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import re
+import shutil
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+import run_verifier_fuzz as verifier_fuzz
+import run_wrapper_tests as wrapper
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+FUZZ_SOURCE = HERE / "pqbtc_mldsa44_stateful_fuzz.c"
+CORPUS_MANIFEST = HERE / "stateful_signer_fuzz_corpus.json"
+DRIVER_SOURCE = Path(__file__).resolve()
+
+FRAME_HEADER = struct.Struct("<BBBBHH")
+FRAME_VERSION = 1
+SEED_BYTES = 32
+RANDOMIZER_BYTES = 32
+MAX_MESSAGE_BYTES = 4096
+MAX_CONTEXT_BYTES = 256
+MAX_FRAME_BYTES = (
+    FRAME_HEADER.size
+    + SEED_BYTES
+    + 2 * RANDOMIZER_BYTES
+    + MAX_MESSAGE_BYTES
+    + MAX_CONTEXT_BYTES
+)
+CAMPAIGN_SCHEMA_VERSION = 1
+TARGET_NAME = "ml-dsa-44-stateful-signer-seeded-keygen"
+RETAINED_SOURCE_ENV = {
+    "run_id": "RETAINED_SOURCE_RUN",
+    "run_attempt": "RETAINED_SOURCE_ATTEMPT",
+    "head_sha": "RETAINED_SOURCE_HEAD",
+    "artifact": "RETAINED_SOURCE_ARTIFACT",
+    "evidence_sha256": "RETAINED_SOURCE_EVIDENCE_SHA256",
+    "restored_seed_file_count": "RETAINED_SOURCE_SEED_COUNT",
+    "restored_seed_total_bytes": "RETAINED_SOURCE_SEED_BYTES",
+    "restored_seed_aggregate_sha256": "RETAINED_SOURCE_SEED_AGGREGATE_SHA256",
+}
+
+SCENARIOS = {
+    0: "fresh_a_then_fresh_b",
+    1: "fresh_a_then_repeat_a_then_fresh_b",
+    2: "fresh_a_then_short_b_then_repeat_a_then_fresh_b",
+    3: "fresh_a_then_source_failure_then_repeat_a_then_fresh_b",
+    4: "fresh_a_then_zero_then_repeat_a_then_fresh_b",
+    5: "fresh_a_then_invalid_then_repeat_a_then_fresh_b",
+    6: "backend_failure_a_then_repeat_a_then_fresh_b",
+    7: "attempts_exhausted_a_then_repeat_a_then_fresh_b",
+    8: "signature_length_failure_a_then_repeat_a_then_fresh_b",
+    9: "self_verify_failure_a_then_repeat_a_then_fresh_b",
+    10: "fresh_a_then_reset_then_reuse_a",
+}
+INVALID_CONTEXT_SCENARIO = "invalid_context_preserves_repeat_state"
+ARGUMENT_VARIANTS = {
+    0: "null_output",
+    1: "short_output",
+    2: "long_output",
+    3: "alias_secret_key",
+    4: "alias_public_key",
+    5: "alias_message",
+    6: "alias_context",
+    7: "null_secret_key",
+    8: "short_secret_key",
+    9: "null_public_key",
+    10: "short_public_key",
+    11: "null_message",
+    12: "null_context",
+}
+
+
+class StatefulFuzzError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SignerCase:
+    name: str
+    frame: bytes
+    scenario: int
+    argument_variant: int
+
+
+@dataclass(frozen=True)
+class DecodedFrame:
+    scenario: int
+    argument_variant: int
+    short_length: int
+    seed: bytes
+    randomizer_a: bytes
+    randomizer_b: bytes
+    message: bytes
+    context: bytes
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def encode_frame(
+    *,
+    scenario: int,
+    argument_variant: int,
+    short_length: int,
+    seed: bytes,
+    randomizer_a: bytes,
+    randomizer_b: bytes,
+    message: bytes,
+    context: bytes,
+) -> bytes:
+    if scenario not in SCENARIOS:
+        raise StatefulFuzzError("unsupported stateful signer scenario")
+    if argument_variant not in ARGUMENT_VARIANTS:
+        raise StatefulFuzzError("unsupported invalid-argument variant")
+    if not 0 <= short_length < RANDOMIZER_BYTES:
+        raise StatefulFuzzError("short entropy length is outside 0..31")
+    if len(seed) != SEED_BYTES:
+        raise StatefulFuzzError("seed must be exactly 32 bytes")
+    if len(randomizer_a) != RANDOMIZER_BYTES or len(randomizer_b) != RANDOMIZER_BYTES:
+        raise StatefulFuzzError("randomizers must be exactly 32 bytes")
+    if len(message) > MAX_MESSAGE_BYTES or len(context) > MAX_CONTEXT_BYTES:
+        raise StatefulFuzzError("stateful signer frame exceeds a field bound")
+    return (
+        FRAME_HEADER.pack(
+            FRAME_VERSION,
+            scenario,
+            argument_variant,
+            short_length,
+            len(message),
+            len(context),
+        )
+        + seed
+        + randomizer_a
+        + randomizer_b
+        + message
+        + context
+    )
+
+
+def decode_frame(frame: bytes) -> DecodedFrame:
+    fixed_size = FRAME_HEADER.size + SEED_BYTES + 2 * RANDOMIZER_BYTES
+    if len(frame) < fixed_size:
+        raise StatefulFuzzError("truncated stateful signer frame")
+    (
+        version,
+        scenario,
+        argument_variant,
+        short_length,
+        message_size,
+        context_size,
+    ) = FRAME_HEADER.unpack_from(frame)
+    if version != FRAME_VERSION:
+        raise StatefulFuzzError("unsupported stateful signer frame version")
+    if scenario not in SCENARIOS or argument_variant not in ARGUMENT_VARIANTS:
+        raise StatefulFuzzError("non-canonical stateful signer selector")
+    if short_length >= RANDOMIZER_BYTES:
+        raise StatefulFuzzError("non-canonical short entropy length")
+    if message_size > MAX_MESSAGE_BYTES or context_size > MAX_CONTEXT_BYTES:
+        raise StatefulFuzzError("stateful signer frame field exceeds its bound")
+    if fixed_size + message_size + context_size != len(frame):
+        raise StatefulFuzzError("stateful signer frame length mismatch")
+    cursor = FRAME_HEADER.size
+    seed = frame[cursor : cursor + SEED_BYTES]
+    cursor += SEED_BYTES
+    randomizer_a = frame[cursor : cursor + RANDOMIZER_BYTES]
+    cursor += RANDOMIZER_BYTES
+    randomizer_b = frame[cursor : cursor + RANDOMIZER_BYTES]
+    cursor += RANDOMIZER_BYTES
+    message = frame[cursor : cursor + message_size]
+    cursor += message_size
+    context = frame[cursor : cursor + context_size]
+    return DecodedFrame(
+        scenario,
+        argument_variant,
+        short_length,
+        seed,
+        randomizer_a,
+        randomizer_b,
+        message,
+        context,
+    )
+
+
+def generated_corpus() -> list[SignerCase]:
+    vectors = json.loads(wrapper.VECTORS.read_text(encoding="utf8"))["vectors"]
+    project = vectors["pqbtc_sighash_v1"]
+    seed = bytes.fromhex(project["seed_hex"])
+    message = bytes.fromhex(project["message_hex"])
+    context = bytes.fromhex(project["context_hex"])
+    randomizer_a = bytes(range(1, 33))
+    randomizer_b = bytes(range(33, 65))
+    cases: list[SignerCase] = []
+
+    def add(
+        name: str,
+        scenario: int,
+        *,
+        argument_variant: int = 0,
+        short_length: int = 31,
+        candidate_message: bytes = message,
+        candidate_context: bytes = context,
+        candidate_randomizer_a: bytes = randomizer_a,
+        candidate_randomizer_b: bytes = randomizer_b,
+    ) -> None:
+        cases.append(
+            SignerCase(
+                name=name,
+                scenario=scenario,
+                argument_variant=argument_variant,
+                frame=encode_frame(
+                    scenario=scenario,
+                    argument_variant=argument_variant,
+                    short_length=short_length,
+                    seed=seed,
+                    randomizer_a=candidate_randomizer_a,
+                    randomizer_b=candidate_randomizer_b,
+                    message=candidate_message,
+                    context=candidate_context,
+                ),
+            )
+        )
+
+    for scenario, name in SCENARIOS.items():
+        if scenario != 5:
+            add(name, scenario)
+    for variant, name in ARGUMENT_VARIANTS.items():
+        add(
+            f"fresh_a_then_invalid_{name}_then_repeat_a_then_fresh_b",
+            5,
+            argument_variant=variant,
+        )
+    add(
+        "fresh_a_then_invalid_alias_message_maximum_message_then_repeat_a_then_fresh_b",
+        5,
+        argument_variant=5,
+        candidate_message=bytes(MAX_MESSAGE_BYTES),
+    )
+    for short_length in (0, 1, 16):
+        add(
+            f"fresh_a_then_short_{short_length}_then_repeat_a_then_fresh_b",
+            2,
+            short_length=short_length,
+        )
+    add("fresh_empty_message_and_context", 0, candidate_message=b"", candidate_context=b"")
+    add("fresh_maximum_context", 0, candidate_context=bytes(range(255)))
+    add(
+        "fresh_a_then_invalid_256_context_then_repeat_a_then_fresh_b",
+        0,
+        candidate_context=bytes(256),
+    )
+    add("fresh_maximum_message", 0, candidate_message=bytes(4096))
+    return cases
+
+
+def corpus_filename(case: SignerCase) -> str:
+    safe_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", case.name)
+    return f"project_{safe_name}.bin"
+
+
+def corpus_summary(cases: list[SignerCase]) -> dict:
+    digest = hashlib.sha256()
+    scenario_counts = {
+        name: 0 for name in (*SCENARIOS.values(), INVALID_CONTEXT_SCENARIO)
+    }
+    argument_counts = {name: 0 for name in ARGUMENT_VARIANTS.values()}
+    frame_hashes = set()
+    for case in sorted(cases, key=lambda item: item.name):
+        frame_sha256 = hashlib.sha256(case.frame).hexdigest()
+        scenario_name = (
+            INVALID_CONTEXT_SCENARIO
+            if len(decode_frame(case.frame).context) == MAX_CONTEXT_BYTES
+            else SCENARIOS[case.scenario]
+        )
+        digest.update(
+            f"{case.name}\0{scenario_name}\0"
+            f"{ARGUMENT_VARIANTS[case.argument_variant]}\0{frame_sha256}\n".encode()
+        )
+        scenario_counts[scenario_name] += 1
+        if scenario_name == SCENARIOS[5]:
+            argument_counts[ARGUMENT_VARIANTS[case.argument_variant]] += 1
+        frame_hashes.add(frame_sha256)
+    return {
+        "total_cases": len(cases),
+        "unique_frames": len(frame_hashes),
+        "scenario_counts": scenario_counts,
+        "invalid_argument_variant_counts": argument_counts,
+        "aggregate_sha256": digest.hexdigest(),
+    }
+
+
+def validate_corpus_manifest(cases: list[SignerCase]) -> dict:
+    manifest = json.loads(CORPUS_MANIFEST.read_text(encoding="utf8"))
+    expected_keys = {
+        "schema_version",
+        "target",
+        "frame_version",
+        "fuzz_limits",
+        "sources",
+        "required_scenarios",
+        "required_invalid_argument_variants",
+        "generated_corpus",
+    }
+    if set(manifest) != expected_keys:
+        raise StatefulFuzzError("stateful signer corpus manifest fields differ")
+    if (
+        type(manifest["schema_version"]) is not int
+        or manifest["schema_version"] != 1
+        or type(manifest["frame_version"]) is not int
+        or manifest["frame_version"] != FRAME_VERSION
+        or manifest["target"] != TARGET_NAME
+    ):
+        raise StatefulFuzzError("unsupported stateful signer corpus manifest")
+    expected_limits = {
+        "seed_bytes": SEED_BYTES,
+        "randomizer_bytes": RANDOMIZER_BYTES,
+        "message_bytes": MAX_MESSAGE_BYTES,
+        "context_bytes": MAX_CONTEXT_BYTES,
+        "frame_bytes": MAX_FRAME_BYTES,
+        "hedged_signing_calls_per_input_max": 4,
+    }
+    if manifest["fuzz_limits"] != expected_limits:
+        raise StatefulFuzzError("stateful signer fuzz limits differ")
+    if manifest["sources"] != {"repo_vectors_sha256": sha256_file(wrapper.VECTORS)}:
+        raise StatefulFuzzError("stateful signer corpus source hash differs")
+    if manifest["required_scenarios"] != [
+        *SCENARIOS.values(),
+        INVALID_CONTEXT_SCENARIO,
+    ]:
+        raise StatefulFuzzError("stateful signer scenario inventory differs")
+    if manifest["required_invalid_argument_variants"] != list(
+        ARGUMENT_VARIANTS.values()
+    ):
+        raise StatefulFuzzError("stateful signer argument inventory differs")
+    identities = [case.name for case in cases]
+    if len(set(identities)) != len(identities):
+        raise StatefulFuzzError("stateful signer corpus identities are not unique")
+    filenames = [corpus_filename(case) for case in cases]
+    if len(set(filenames)) != len(filenames):
+        raise StatefulFuzzError("stateful signer corpus filenames collide")
+    for case in cases:
+        if encode_frame(**decode_frame(case.frame).__dict__) != case.frame:
+            raise StatefulFuzzError(f"non-canonical stateful signer frame: {case.name}")
+    summary = corpus_summary(cases)
+    if manifest["generated_corpus"] != summary:
+        raise StatefulFuzzError(
+            "generated stateful signer corpus differs from the manifest:\n"
+            + json.dumps(summary, indent=2, sort_keys=True)
+        )
+    return summary
+
+
+def materialize_corpus(directory: Path, cases: list[SignerCase]) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    for case in cases:
+        (directory / corpus_filename(case)).write_bytes(case.frame)
+
+
+def filesystem_identity(status: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        status.st_dev,
+        status.st_ino,
+        status.st_mode,
+        status.st_size,
+        status.st_mtime_ns,
+    )
+
+
+def read_stable_regular_file(path: Path, label: str, maximum_size: int) -> bytes:
+    try:
+        before = path.lstat()
+    except FileNotFoundError as error:
+        raise StatefulFuzzError(f"{label} does not exist: {path}") from error
+    if stat.S_ISLNK(before.st_mode):
+        raise StatefulFuzzError(f"{label} must not be a symlink: {path}")
+    if not stat.S_ISREG(before.st_mode):
+        raise StatefulFuzzError(f"{label} is not a regular file: {path}")
+    if before.st_size > maximum_size:
+        raise StatefulFuzzError(f"{label} exceeds its size bound: {path}")
+    data = path.read_bytes()
+    after = path.lstat()
+    if (
+        filesystem_identity(after) != filesystem_identity(before)
+        or len(data) != before.st_size
+    ):
+        raise StatefulFuzzError(f"{label} changed while it was read: {path}")
+    return data
+
+
+def named_file_summary(entries: list[tuple[str, bytes]]) -> dict:
+    digest = hashlib.sha256()
+    total_bytes = 0
+    for name, data in sorted(entries):
+        file_digest = hashlib.sha256(data).hexdigest()
+        digest.update(f"{name}\0{len(data)}\0{file_digest}\n".encode())
+        total_bytes += len(data)
+    return {
+        "file_count": len(entries),
+        "total_bytes": total_bytes,
+        "aggregate_sha256": digest.hexdigest(),
+    }
+
+
+def content_inventory_summary(contents: dict[str, bytes]) -> dict:
+    digest = hashlib.sha256()
+    total_bytes = 0
+    for file_digest, data in sorted(contents.items()):
+        digest.update(f"{len(data)}\0{file_digest}\n".encode())
+        total_bytes += len(data)
+    return {
+        "file_count": len(contents),
+        "total_bytes": total_bytes,
+        "aggregate_sha256": digest.hexdigest(),
+    }
+
+
+def read_flat_retained_corpus(
+    source: Path,
+    *,
+    label: str,
+    require_nonempty: bool,
+) -> list[tuple[str, bytes]]:
+    try:
+        source_status = source.lstat()
+    except FileNotFoundError as error:
+        raise StatefulFuzzError(f"{label} does not exist: {source}") from error
+    if stat.S_ISLNK(source_status.st_mode):
+        raise StatefulFuzzError(f"{label} must not be a symlink: {source}")
+    if not stat.S_ISDIR(source_status.st_mode):
+        raise StatefulFuzzError(f"{label} is not a directory: {source}")
+
+    candidates = sorted(source.iterdir(), key=lambda path: path.name)
+    if require_nonempty and not candidates:
+        raise StatefulFuzzError(f"{label} is empty")
+    if len(candidates) > verifier_fuzz.MAX_RETAINED_CORPUS_FILES:
+        raise StatefulFuzzError("retained corpus exceeds the file-count bound")
+    entries = []
+    total_bytes = 0
+    for path in candidates:
+        data = read_stable_regular_file(
+            path,
+            f"{label} input",
+            MAX_FRAME_BYTES,
+        )
+        total_bytes += len(data)
+        if total_bytes > verifier_fuzz.MAX_RETAINED_CORPUS_BYTES:
+            raise StatefulFuzzError("retained corpus exceeds the aggregate byte bound")
+        entries.append((path.name, data))
+    source_after = source.lstat()
+    if filesystem_identity(source_after) != filesystem_identity(source_status):
+        raise StatefulFuzzError(f"{label} changed while it was read: {source}")
+    return entries
+
+
+def empty_retained_source() -> dict:
+    return {field: None for field in RETAINED_SOURCE_ENV}
+
+
+def retained_source_metadata() -> dict:
+    raw = {
+        field: os.environ.get(environment_name) or None
+        for field, environment_name in RETAINED_SOURCE_ENV.items()
+    }
+    present = [value is not None for value in raw.values()]
+    if not any(present):
+        return empty_retained_source()
+    if not all(present):
+        raise StatefulFuzzError("retained source provenance is incomplete")
+    if (
+        re.fullmatch(r"[0-9]+", raw["run_id"]) is None
+        or int(raw["run_id"]) < 1
+        or re.fullmatch(r"[0-9]+", raw["run_attempt"]) is None
+        or int(raw["run_attempt"]) < 1
+        or re.fullmatch(r"[0-9a-f]{40}", raw["head_sha"]) is None
+        or re.fullmatch(r"[A-Za-z0-9._-]+", raw["artifact"]) is None
+        or re.fullmatch(r"[0-9a-f]{64}", raw["evidence_sha256"]) is None
+        or re.fullmatch(r"[0-9]+", raw["restored_seed_file_count"]) is None
+        or re.fullmatch(r"[0-9]+", raw["restored_seed_total_bytes"]) is None
+        or re.fullmatch(
+            r"[0-9a-f]{64}", raw["restored_seed_aggregate_sha256"]
+        )
+        is None
+    ):
+        raise StatefulFuzzError("retained source provenance is malformed")
+    file_count = int(raw["restored_seed_file_count"])
+    total_bytes = int(raw["restored_seed_total_bytes"])
+    if (
+        not 1 <= file_count <= verifier_fuzz.MAX_RETAINED_CORPUS_FILES
+        or total_bytes > verifier_fuzz.MAX_RETAINED_CORPUS_BYTES
+    ):
+        raise StatefulFuzzError("retained source provenance exceeds a resource bound")
+    return {
+        **raw,
+        "restored_seed_file_count": file_count,
+        "restored_seed_total_bytes": total_bytes,
+    }
+
+
+def restored_source_summary(metadata: dict) -> dict | None:
+    if metadata["run_id"] is None:
+        return None
+    return {
+        "file_count": metadata["restored_seed_file_count"],
+        "total_bytes": metadata["restored_seed_total_bytes"],
+        "aggregate_sha256": metadata["restored_seed_aggregate_sha256"],
+    }
+
+
+def import_seed_corpus(
+    source: Path,
+    destination: Path,
+    *,
+    expected_source_summary: dict | None = None,
+) -> dict:
+    entries = read_flat_retained_corpus(
+        source,
+        label="seed corpus",
+        require_nonempty=False,
+    )
+    source_summary = named_file_summary(entries)
+    if (
+        expected_source_summary is not None
+        and source_summary != expected_source_summary
+    ):
+        raise StatefulFuzzError(
+            "retained corpus summary differs from validated evidence"
+        )
+
+    retained: dict[str, bytes] = {}
+    for _, data in entries:
+        digest = hashlib.sha256(data).hexdigest()
+        previous = retained.setdefault(digest, data)
+        if previous != data:
+            raise StatefulFuzzError(
+                f"retained corpus SHA256 collision detected: {digest}"
+            )
+
+    destination_status = destination.lstat()
+    if stat.S_ISLNK(destination_status.st_mode) or not stat.S_ISDIR(
+        destination_status.st_mode
+    ):
+        raise StatefulFuzzError(
+            f"working corpus is not a regular directory: {destination}"
+        )
+    existing: dict[str, bytes] = {}
+    for path in sorted(destination.iterdir(), key=lambda item: item.name):
+        data = read_stable_regular_file(
+            path,
+            "working corpus input",
+            MAX_FRAME_BYTES,
+        )
+        digest = hashlib.sha256(data).hexdigest()
+        previous = existing.setdefault(digest, data)
+        if previous != data:
+            raise StatefulFuzzError(
+                f"working corpus SHA256 collision detected: {path}"
+            )
+
+    imported: dict[str, bytes] = {}
+    for digest, data in retained.items():
+        if digest in existing:
+            if existing[digest] != data:
+                raise StatefulFuzzError(
+                    f"working corpus SHA256 collision detected: {digest}"
+                )
+            continue
+        target = destination / f"retained_{digest}.bin"
+        if target.exists() or target.is_symlink():
+            raise StatefulFuzzError(
+                f"retained corpus destination already exists: {target}"
+            )
+        with target.open("xb") as stream:
+            stream.write(data)
+        copied = read_stable_regular_file(
+            target,
+            "imported retained corpus input",
+            MAX_FRAME_BYTES,
+        )
+        if copied != data:
+            raise StatefulFuzzError(
+                f"imported retained corpus input differs: {target}"
+            )
+        existing[digest] = data
+        imported[digest] = data
+    return {
+        "source_summary": source_summary,
+        "unique_source_summary": content_inventory_summary(retained),
+        "imported_summary": content_inventory_summary(imported),
+    }
+
+
+def validate_sha256_manifest(evidence_dir: Path) -> str:
+    manifest_path = evidence_dir / "SHA256SUMS"
+    manifest = read_stable_regular_file(
+        manifest_path,
+        "retained evidence checksum manifest",
+        8 * 1024 * 1024,
+    )
+    try:
+        lines = manifest.decode("utf8").splitlines()
+    except UnicodeDecodeError as error:
+        raise StatefulFuzzError(
+            "retained evidence checksum manifest is not UTF-8"
+        ) from error
+    expected: dict[str, str] = {}
+    for line in lines:
+        match = re.fullmatch(r"([0-9a-f]{64})  (.+)", line)
+        if match is None:
+            raise StatefulFuzzError("retained evidence checksum line is malformed")
+        digest, relative = match.groups()
+        path = PurePosixPath(relative)
+        if (
+            path.is_absolute()
+            or ".." in path.parts
+            or path.as_posix() != relative
+            or relative == "SHA256SUMS"
+            or relative in expected
+        ):
+            raise StatefulFuzzError(
+                f"retained evidence checksum path is unsafe: {relative}"
+            )
+        expected[relative] = digest
+
+    actual = {
+        path.relative_to(evidence_dir).as_posix(): sha256_file(path)
+        for path in sorted(evidence_dir.rglob("*"))
+        if path.is_file() and path != manifest_path
+    }
+    if set(actual) != set(expected):
+        raise StatefulFuzzError("retained evidence checksum inventory differs")
+    for relative, digest in actual.items():
+        if digest != expected[relative]:
+            raise StatefulFuzzError(
+                f"retained evidence checksum differs: {relative}"
+            )
+    return hashlib.sha256(manifest).hexdigest()
+
+
+def validate_retained_evidence(
+    evidence_dir: Path,
+    *,
+    expected_head: str,
+    expected_sanitizer: str,
+) -> dict:
+    try:
+        evidence_status = evidence_dir.lstat()
+    except FileNotFoundError as error:
+        raise StatefulFuzzError(
+            f"retained evidence does not exist: {evidence_dir}"
+        ) from error
+    if stat.S_ISLNK(evidence_status.st_mode) or not stat.S_ISDIR(
+        evidence_status.st_mode
+    ):
+        raise StatefulFuzzError("retained evidence must be a regular directory")
+    if re.fullmatch(r"[0-9a-f]{40}", expected_head) is None:
+        raise StatefulFuzzError("retained evidence head is not a Git commit")
+    if expected_sanitizer not in verifier_fuzz.SANITIZERS:
+        raise StatefulFuzzError("retained evidence sanitizer is unsupported")
+
+    for path in sorted(evidence_dir.rglob("*")):
+        status = path.lstat()
+        if stat.S_ISLNK(status.st_mode):
+            raise StatefulFuzzError(
+                f"retained evidence must not contain symlinks: {path}"
+            )
+        if not stat.S_ISDIR(status.st_mode) and not stat.S_ISREG(status.st_mode):
+            raise StatefulFuzzError(
+                f"retained evidence contains a special entry: {path}"
+            )
+
+    seed_dir = evidence_dir / "minimized-corpus"
+    seed_entries = read_flat_retained_corpus(
+        seed_dir,
+        label="retained minimized corpus",
+        require_nonempty=True,
+    )
+
+    evidence_sha256 = validate_sha256_manifest(evidence_dir)
+    campaign_path = evidence_dir / "campaign.json"
+    try:
+        campaign = json.loads(
+            read_stable_regular_file(
+                campaign_path,
+                "retained campaign report",
+                8 * 1024 * 1024,
+            ).decode("utf8")
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise StatefulFuzzError("retained campaign report is malformed") from error
+    actual_summary = named_file_summary(seed_entries)
+    if (
+        campaign.get("target") != TARGET_NAME
+        or campaign.get("status") != "pass"
+        or campaign.get("return_code") != 0
+        or campaign.get("processing_error") is not None
+        or campaign.get("repository_commit") != expected_head
+        or campaign.get("repository_head") != expected_head
+        or campaign.get("repository_dirty") is not False
+        or campaign.get("sanitizer") != expected_sanitizer
+        or campaign.get("minimized_corpus") != actual_summary
+    ):
+        raise StatefulFuzzError("retained campaign provenance differs")
+    return {
+        "source_head_sha": expected_head,
+        "source_sanitizer": expected_sanitizer,
+        "source_evidence_sha256": evidence_sha256,
+        "restored_seed_file_count": actual_summary["file_count"],
+        "restored_seed_total_bytes": actual_summary["total_bytes"],
+        "restored_seed_aggregate_sha256": actual_summary["aggregate_sha256"],
+    }
+
+
+def repository_head() -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else "unknown"
+
+
+def compile_fuzzer(
+    compiler: str,
+    build_dir: Path,
+    *,
+    sanitizer: str,
+    coverage: bool,
+) -> Path:
+    output = build_dir / "pqbtc_mldsa44_stateful_fuzz"
+    command = wrapper.common_flags(compiler)
+    command.extend(
+        [
+            "-DPQBTC_MLDSA44_TESTING=1",
+            "-O1",
+            "-g",
+            "-fno-omit-frame-pointer",
+            "-fno-sanitize-recover=all",
+            f"-fsanitize={verifier_fuzz.SANITIZERS[sanitizer]}",
+        ]
+    )
+    if sanitizer == "memory":
+        command.extend(["-fsanitize-memory-track-origins=2", "-fPIE", "-pie"])
+    if coverage:
+        command.extend(["-fprofile-instr-generate", "-fcoverage-mapping"])
+    command.extend(
+        [
+            str(wrapper.WRAPPER_SOURCE),
+            str(FUZZ_SOURCE),
+            "-o",
+            str(output),
+        ]
+    )
+    wrapper.run(command)
+    return output
+
+
+def sanitizer_environment(
+    sanitizer: str, profile_pattern: Path | None = None
+) -> dict[str, str]:
+    env = os.environ.copy()
+    if sanitizer == "address-undefined":
+        env["ASAN_OPTIONS"] = (
+            "detect_leaks=0" if sys.platform == "darwin" else "detect_leaks=1"
+        )
+    env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
+    if sanitizer == "memory":
+        env["MSAN_OPTIONS"] = "halt_on_error=1:print_stats=1"
+    if profile_pattern is not None:
+        env["LLVM_PROFILE_FILE"] = str(profile_pattern)
+    return env
+
+
+def replay_corpus(
+    executable: Path,
+    corpus_dir: Path,
+    cases: list[SignerCase],
+    log_path: Path,
+    *,
+    sanitizer: str,
+    profile_pattern: Path | None,
+) -> dict:
+    log_parts = []
+    records = []
+    env = sanitizer_environment(sanitizer, profile_pattern)
+    for case in cases:
+        path = corpus_dir / corpus_filename(case)
+        command = [
+            str(executable),
+            str(path),
+            "-runs=1",
+            "-seed=188",
+            "-timeout=5",
+            "-rss_limit_mb=1024",
+            "-malloc_limit_mb=256",
+        ]
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        log_parts.append(
+            f"case: {case.name}\ncommand: {' '.join(command)}\n"
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}\n"
+        )
+        records.append(
+            {
+                "name": case.name,
+                "frame_sha256": hashlib.sha256(case.frame).hexdigest(),
+                "return_code": completed.returncode,
+                "status": "pass" if completed.returncode == 0 else "fail",
+            }
+        )
+        if completed.returncode != 0:
+            log_path.write_text("\n".join(log_parts), encoding="utf8")
+            raise StatefulFuzzError(
+                f"deterministic stateful replay failed: {case.name}"
+            )
+    log_path.write_text("\n".join(log_parts), encoding="utf8")
+    return {
+        "status": "pass",
+        "case_count": len(records),
+        "cases": records,
+    }
+
+
+def executed_units(stderr: str) -> int | None:
+    matches = re.findall(r"stat::number_of_executed_units:\s+(\d+)", stderr)
+    return int(matches[-1]) if matches else None
+
+
+def write_campaign_report(
+    output_dir: Path,
+    *,
+    compiler: str,
+    sanitizer: str,
+    coverage: bool,
+    runs: int | None,
+    seconds: int | None,
+    seed: int,
+    retained_source: dict,
+    retained_import: dict | None,
+    source_summary: dict,
+    replay: dict | None,
+    fuzzer: Path | None,
+    started_at: str,
+    duration_seconds: float,
+    fuzzer_duration_seconds: float | None,
+    completed: subprocess.CompletedProcess[str],
+    processing_error: str | None,
+    crash_minimization: list[dict],
+) -> None:
+    progress_lines = [
+        line.strip()
+        for line in completed.stderr.splitlines()
+        if re.match(r"^#\d+", line.strip())
+    ]
+    final_stats = [
+        line.strip()
+        for line in completed.stderr.splitlines()
+        if line.strip().startswith("stat::")
+    ]
+    report = {
+        "schema_version": CAMPAIGN_SCHEMA_VERSION,
+        "target": TARGET_NAME,
+        "status": (
+            "pass" if completed.returncode == 0 and processing_error is None else "fail"
+        ),
+        "return_code": completed.returncode,
+        "processing_error": processing_error,
+        "repository_commit": verifier_fuzz.repository_commit(),
+        "repository_head": repository_head(),
+        "repository_dirty": verifier_fuzz.repository_dirty(),
+        "started_at": started_at,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "duration_seconds": round(duration_seconds, 3),
+        "fuzzer_duration_seconds": (
+            round(fuzzer_duration_seconds, 3)
+            if fuzzer_duration_seconds is not None
+            else None
+        ),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "compiler": verifier_fuzz.compiler_identity(compiler),
+        "coverage_tools": (
+            verifier_fuzz.coverage_tool_identities(compiler) if coverage else None
+        ),
+        "sanitizer": sanitizer,
+        "coverage_enabled": coverage,
+        "campaign_limit": {"runs": runs, "seconds": seconds},
+        "resource_limits": {
+            "harness_frame_bytes": MAX_FRAME_BYTES,
+            "fuzzer_max_len_bytes": MAX_FRAME_BYTES,
+            "input_timeout_seconds": 5,
+            "rss_limit_mb": 1024,
+            "malloc_limit_mb": 256,
+            "seed": seed,
+        },
+        "stateful_contract": {
+            "reset_before_and_after_every_input": True,
+            "seeded_keygen_determinism": True,
+            "entropy_request_accounting": True,
+            "post_entropy_failures_consume_repeat_state": True,
+            "pre_entropy_failures_preserve_repeat_state": True,
+            "failure_output_contract": True,
+            "strict_self_verification": True,
+            "external_oracles_in_process": False,
+        },
+        "deterministic_replay": replay,
+        "executed_units": executed_units(completed.stderr),
+        "imported_retained_seeds": (
+            retained_import["imported_summary"]["file_count"]
+            if retained_import is not None
+            else 0
+        ),
+        "retained_corpus_source": retained_source,
+        "retained_corpus_import": retained_import,
+        "source_corpus": source_summary,
+        "source_files": {
+            "wrapper_sha256": sha256_file(wrapper.WRAPPER_SOURCE),
+            "public_header_sha256": sha256_file(HERE / "pqbtc_mldsa44.h"),
+            "test_header_sha256": sha256_file(HERE / "pqbtc_mldsa44_test.h"),
+            "fuzz_target_sha256": sha256_file(FUZZ_SOURCE),
+            "driver_sha256": sha256_file(DRIVER_SOURCE),
+            "verifier_fuzz_driver_sha256": sha256_file(
+                Path(verifier_fuzz.__file__).resolve()
+            ),
+            "wrapper_test_driver_sha256": sha256_file(
+                Path(wrapper.__file__).resolve()
+            ),
+            "corpus_manifest_sha256": sha256_file(CORPUS_MANIFEST),
+            "repo_vectors_sha256": sha256_file(wrapper.VECTORS),
+            "source_manifest_sha256": sha256_file(wrapper.SOURCE_MANIFEST),
+            "source_capsule_sha256": json.loads(
+                wrapper.SOURCE_MANIFEST.read_text(encoding="utf8")
+            )["capsule_hash"]["value"],
+            "fuzzer_binary_sha256": (
+                sha256_file(fuzzer) if fuzzer is not None and fuzzer.is_file() else None
+            ),
+        },
+        "working_corpus": verifier_fuzz.directory_summary(output_dir / "corpus"),
+        "minimized_corpus": verifier_fuzz.directory_summary(
+            output_dir / "minimized-corpus"
+        ),
+        "crash_artifacts": verifier_fuzz.directory_summary(output_dir / "crashes"),
+        "minimized_crash_artifacts": verifier_fuzz.directory_summary(
+            output_dir / "minimized-crashes"
+        ),
+        "crash_minimization": crash_minimization,
+        "last_progress_line": progress_lines[-1] if progress_lines else None,
+        "final_stats": final_stats,
+    }
+    (output_dir / "campaign.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf8",
+    )
+
+
+def run_campaign(args: argparse.Namespace, cases: list[SignerCase], summary: dict) -> int:
+    compiler = os.environ.get("CC", "clang")
+    if shutil.which(compiler) is None:
+        raise StatefulFuzzError(f"stateful fuzz compiler not found: {compiler}")
+    output_dir = args.output_dir
+    if output_dir is None:
+        raise StatefulFuzzError("--output-dir is required for sanitizer campaigns")
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise StatefulFuzzError("stateful fuzz output directory is not empty")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    corpus_dir = output_dir / "corpus"
+    crashes_dir = output_dir / "crashes"
+    corpus_dir.mkdir()
+    crashes_dir.mkdir()
+    materialize_corpus(corpus_dir, cases)
+    retained_source = empty_retained_source()
+    retained_import: dict | None = None
+
+    started_at = datetime.now(timezone.utc).isoformat()
+    overall_started = time.monotonic()
+    fuzzer: Path | None = None
+    replay: dict | None = None
+    crash_minimization: list[dict] = []
+    processing_error: str | None = None
+    completed = subprocess.CompletedProcess(
+        args=["stateful-fuzzer-not-run"],
+        returncode=1,
+        stdout="",
+        stderr="",
+    )
+    fuzzer_duration: float | None = None
+
+    with tempfile.TemporaryDirectory(prefix="pqbtc-mldsa44-stateful-fuzz-") as temporary:
+        build_dir = Path(temporary)
+        try:
+            retained_source = retained_source_metadata()
+            source_expectation = restored_source_summary(retained_source)
+            if args.seed_corpus is None and source_expectation is not None:
+                raise StatefulFuzzError(
+                    "retained source provenance requires a seed corpus"
+                )
+            if args.seed_corpus is not None:
+                retained_import = import_seed_corpus(
+                    args.seed_corpus,
+                    corpus_dir,
+                    expected_source_summary=source_expectation,
+                )
+            fuzzer = compile_fuzzer(
+                compiler,
+                build_dir,
+                sanitizer=args.sanitizer,
+                coverage=args.coverage,
+            )
+            replay = replay_corpus(
+                fuzzer,
+                corpus_dir,
+                cases,
+                output_dir / "deterministic-replay.log",
+                sanitizer=args.sanitizer,
+                profile_pattern=(
+                    output_dir / "coverage-replay-%p.profraw"
+                    if args.coverage
+                    else None
+                ),
+            )
+            fuzzer_started = time.monotonic()
+            completed = verifier_fuzz.run_fuzzer(
+                fuzzer,
+                corpus_dir,
+                crashes_dir,
+                output_dir / "fuzzer.log",
+                runs=args.runs,
+                seconds=args.seconds,
+                sanitizer=args.sanitizer,
+                profile_pattern=(
+                    output_dir / "coverage-campaign-%p.profraw"
+                    if args.coverage
+                    else None
+                ),
+                seed=args.seed,
+                max_frame_bytes=MAX_FRAME_BYTES,
+            )
+            fuzzer_duration = time.monotonic() - fuzzer_started
+            if completed.returncode != 0:
+                processing_error = f"stateful fuzz campaign failed ({completed.returncode})"
+            else:
+                verifier_fuzz.minimize_corpus(
+                    fuzzer,
+                    corpus_dir,
+                    output_dir / "minimized-corpus",
+                    output_dir / "corpus-minimization.log",
+                    sanitizer=args.sanitizer,
+                    profile_pattern=(
+                        output_dir / "coverage-merge-%p.profraw"
+                        if args.coverage
+                        else None
+                    ),
+                    max_frame_bytes=MAX_FRAME_BYTES,
+                )
+                if args.coverage:
+                    verifier_fuzz.write_coverage_report(
+                        compiler, fuzzer, output_dir
+                    )
+            crash_minimization = verifier_fuzz.minimize_crash_artifacts(
+                fuzzer,
+                crashes_dir,
+                output_dir,
+                sanitizer=args.sanitizer,
+                seed=args.seed,
+                max_frame_bytes=MAX_FRAME_BYTES,
+            )
+        except (
+            OSError,
+            subprocess.SubprocessError,
+            StatefulFuzzError,
+            verifier_fuzz.FuzzHarnessError,
+            wrapper.HarnessError,
+        ) as error:
+            processing_error = str(error)
+
+        write_campaign_report(
+            output_dir,
+            compiler=compiler,
+            sanitizer=args.sanitizer,
+            coverage=args.coverage,
+            runs=args.runs,
+            seconds=args.seconds,
+            seed=args.seed,
+            retained_source=retained_source,
+            retained_import=retained_import,
+            source_summary=summary,
+            replay=replay,
+            fuzzer=fuzzer,
+            started_at=started_at,
+            duration_seconds=time.monotonic() - overall_started,
+            fuzzer_duration_seconds=fuzzer_duration,
+            completed=completed,
+            processing_error=processing_error,
+            crash_minimization=crash_minimization,
+        )
+        verifier_fuzz.write_evidence_hashes(output_dir)
+
+    return 0 if completed.returncode == 0 and processing_error is None else 1
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fuzz the isolated ML-DSA-44 stateful signer and seeded keygen"
+    )
+    parser.add_argument("--manifest-only", action="store_true")
+    parser.add_argument("--sanitizers", action="store_true")
+    parser.add_argument(
+        "--sanitizer",
+        choices=sorted(verifier_fuzz.SANITIZERS),
+        default="address-undefined",
+    )
+    parser.add_argument("--runs", type=int)
+    parser.add_argument("--seconds", type=int)
+    parser.add_argument("--seed", type=int, default=188)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--seed-corpus", type=Path)
+    parser.add_argument("--coverage", action="store_true")
+    parser.add_argument("--validate-retained-evidence", type=Path)
+    parser.add_argument("--expected-retained-head")
+    parser.add_argument(
+        "--expected-retained-sanitizer",
+        choices=sorted(verifier_fuzz.SANITIZERS),
+    )
+    args = parser.parse_args()
+    validation_mode = args.validate_retained_evidence is not None
+    if validation_mode:
+        if (
+            args.expected_retained_head is None
+            or args.expected_retained_sanitizer is None
+        ):
+            raise StatefulFuzzError(
+                "retained evidence validation requires its head and sanitizer"
+            )
+        if (
+            args.manifest_only
+            or args.sanitizers
+            or args.runs is not None
+            or args.seconds is not None
+            or args.output_dir is not None
+            or args.seed_corpus is not None
+            or args.coverage
+        ):
+            raise StatefulFuzzError(
+                "retained evidence validation cannot run a fuzz campaign"
+            )
+        return args
+    if (
+        args.expected_retained_head is not None
+        or args.expected_retained_sanitizer is not None
+    ):
+        raise StatefulFuzzError(
+            "retained evidence expectations require validation mode"
+        )
+    if args.runs is not None and args.seconds is not None:
+        raise StatefulFuzzError("--runs and --seconds are mutually exclusive")
+    if args.runs is not None and args.runs < 1:
+        raise StatefulFuzzError("--runs must be positive")
+    if args.seconds is not None and args.seconds < 1:
+        raise StatefulFuzzError("--seconds must be positive")
+    if not 1 <= args.seed <= 0xFFFFFFFF:
+        raise StatefulFuzzError("--seed must be a nonzero unsigned 32-bit integer")
+    if args.coverage and not args.sanitizers:
+        raise StatefulFuzzError("--coverage requires --sanitizers")
+    if args.coverage and args.sanitizer == "memory":
+        raise StatefulFuzzError("coverage is not combined with the MSan campaign")
+    if not args.manifest_only and not args.sanitizers:
+        raise StatefulFuzzError("campaign execution requires --sanitizers")
+    if args.sanitizers and args.runs is None and args.seconds is None:
+        args.runs = 1000
+    return args
+
+
+def main() -> int:
+    args = parse_arguments()
+    wrapper.validate_source_capsule()
+    cases = generated_corpus()
+    summary = validate_corpus_manifest(cases)
+    if args.validate_retained_evidence is not None:
+        print(
+            json.dumps(
+                validate_retained_evidence(
+                    args.validate_retained_evidence,
+                    expected_head=args.expected_retained_head,
+                    expected_sanitizer=args.expected_retained_sanitizer,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.manifest_only:
+        print(
+            "ML-DSA-44 stateful signer corpus OK: "
+            f"{summary['total_cases']} cases, {summary['unique_frames']} unique frames"
+        )
+        return 0
+    return run_campaign(args, cases, summary)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (
+        StatefulFuzzError,
+        verifier_fuzz.FuzzHarnessError,
+        wrapper.HarnessError,
+    ) as error:
+        print(f"stateful signer fuzz: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/contrib/ml-dsa-engineering/run_static_analysis.py
+++ b/contrib/ml-dsa-engineering/run_static_analysis.py
@@ -27,6 +27,7 @@ VENDOR_ROOT = f"{ENGINEERING_ROOT}/vendor"
 WRAPPER_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44.c"
 SMOKE_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_smoke.c"
 FUZZ_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_verify_fuzz.c"
+STATEFUL_FUZZ_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_stateful_fuzz.c"
 PUBLIC_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44.h"
 TEST_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_test.h"
 CONFIG_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_config.h"
@@ -70,6 +71,7 @@ EVIDENCE_SOURCES = [
     WRAPPER_SOURCE,
     SMOKE_SOURCE,
     FUZZ_SOURCE,
+    STATEFUL_FUZZ_SOURCE,
     PUBLIC_HEADER,
     TEST_HEADER,
     CONFIG_HEADER,
@@ -105,7 +107,12 @@ def annex_k_suppression_count() -> int:
     marker = f"NOLINTNEXTLINE({ANNEX_K_TIDY_CHECK})"
     return sum(
         (REPO_ROOT / relative).read_text(encoding="utf8").count(marker)
-        for relative in (WRAPPER_SOURCE, SMOKE_SOURCE, FUZZ_SOURCE)
+        for relative in (
+            WRAPPER_SOURCE,
+            SMOKE_SOURCE,
+            FUZZ_SOURCE,
+            STATEFUL_FUZZ_SOURCE,
+        )
     )
 
 
@@ -210,6 +217,18 @@ def build_plan(
             "command": tidy_command(clang_tidy, plugin, FUZZ_SOURCE),
         },
         {
+            "id": "clang-tidy-stateful-signer-fuzz",
+            "kind": "clang-tidy",
+            "input": STATEFUL_FUZZ_SOURCE,
+            "variant": "testing",
+            "command": tidy_command(
+                clang_tidy,
+                plugin,
+                STATEFUL_FUZZ_SOURCE,
+                ["-DPQBTC_MLDSA44_TESTING=1"],
+            ),
+        },
+        {
             "id": "iwyu-smoke-testing",
             "kind": "iwyu",
             "input": SMOKE_SOURCE,
@@ -229,6 +248,19 @@ def build_plan(
             "variant": "production-api",
             "check_also": [PUBLIC_HEADER],
             "command": iwyu_command(iwyu, FUZZ_SOURCE, [PUBLIC_HEADER]),
+        },
+        {
+            "id": "iwyu-stateful-signer-fuzz",
+            "kind": "iwyu",
+            "input": STATEFUL_FUZZ_SOURCE,
+            "variant": "testing",
+            "check_also": [PUBLIC_HEADER, TEST_HEADER],
+            "command": iwyu_command(
+                iwyu,
+                STATEFUL_FUZZ_SOURCE,
+                [PUBLIC_HEADER, TEST_HEADER],
+                ["-DPQBTC_MLDSA44_TESTING=1"],
+            ),
         },
         {
             "id": "header-self-contained-production",
@@ -311,8 +343,8 @@ def validate_plan(plan: dict[str, object]) -> None:
         raise AuditError("static-analysis plan has no check list")
 
     expected_counts = {
-        "clang-tidy": 4,
-        "iwyu": 2,
+        "clang-tidy": 5,
+        "iwyu": 3,
         "header-self-containment": 2,
     }
     counts = {kind: 0 for kind in expected_counts}

--- a/contrib/ml-dsa-engineering/run_verifier_fuzz.py
+++ b/contrib/ml-dsa-engineering/run_verifier_fuzz.py
@@ -1098,6 +1098,8 @@ def run_fuzzer(
     sanitizer: str,
     profile_pattern: Path | None,
     seed: int,
+    *,
+    max_frame_bytes: int = MAX_FRAME_BYTES,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     if sanitizer == "address-undefined":
@@ -1114,7 +1116,7 @@ def run_fuzzer(
         str(executable),
         str(corpus_dir),
         f"-artifact_prefix={artifact_dir}{os.sep}",
-        f"-max_len={MAX_FRAME_BYTES}",
+        f"-max_len={max_frame_bytes}",
         limit,
         f"-seed={seed}",
         "-timeout=5",
@@ -1162,6 +1164,8 @@ def minimize_corpus(
     log_path: Path,
     sanitizer: str,
     profile_pattern: Path | None,
+    *,
+    max_frame_bytes: int = MAX_FRAME_BYTES,
 ) -> None:
     destination.mkdir()
     env = os.environ.copy()
@@ -1180,7 +1184,7 @@ def minimize_corpus(
         "-use_value_profile=1",
         str(destination),
         str(corpus_dir),
-        f"-max_len={MAX_FRAME_BYTES}",
+        f"-max_len={max_frame_bytes}",
         "-timeout=5",
         "-rss_limit_mb=1024",
         "-malloc_limit_mb=256",
@@ -1224,6 +1228,8 @@ def minimize_crash_artifacts(
     output_dir: Path,
     sanitizer: str,
     seed: int,
+    *,
+    max_frame_bytes: int = MAX_FRAME_BYTES,
 ) -> list[dict]:
     artifacts = sorted(path for path in artifact_dir.iterdir() if path.is_file())
     if not artifacts:
@@ -1247,7 +1253,7 @@ def minimize_crash_artifacts(
             "-minimize_crash=1",
             f"-exact_artifact_path={minimized}",
             "-max_total_time=60",
-            f"-max_len={MAX_FRAME_BYTES}",
+            f"-max_len={max_frame_bytes}",
             f"-seed={seed}",
             "-timeout=5",
             "-rss_limit_mb=1024",
@@ -1465,12 +1471,13 @@ def write_campaign_report(
 
 def write_evidence_hashes(output_dir: Path) -> None:
     lines = []
+    manifest_path = output_dir / "SHA256SUMS"
     for path in sorted(item for item in output_dir.rglob("*") if item.is_file()):
-        if path.name == "SHA256SUMS":
+        if path == manifest_path:
             continue
         relative = path.relative_to(output_dir).as_posix()
         lines.append(f"{sha256_file(path)}  {relative}\n")
-    (output_dir / "SHA256SUMS").write_text("".join(lines), encoding="utf8")
+    manifest_path.write_text("".join(lines), encoding="utf8")
 
 
 def main() -> int:

--- a/contrib/ml-dsa-engineering/stateful_signer_fuzz_corpus.json
+++ b/contrib/ml-dsa-engineering/stateful_signer_fuzz_corpus.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "target": "ml-dsa-44-stateful-signer-seeded-keygen",
+  "frame_version": 1,
+  "fuzz_limits": {
+    "seed_bytes": 32,
+    "randomizer_bytes": 32,
+    "message_bytes": 4096,
+    "context_bytes": 256,
+    "frame_bytes": 4456,
+    "hedged_signing_calls_per_input_max": 4
+  },
+  "sources": {
+    "repo_vectors_sha256": "2fe1fffc7bfe8ec7597e408449a0d6b99f6ec0f035ab6669211d4d13f376a2b9"
+  },
+  "required_scenarios": [
+    "fresh_a_then_fresh_b",
+    "fresh_a_then_repeat_a_then_fresh_b",
+    "fresh_a_then_short_b_then_repeat_a_then_fresh_b",
+    "fresh_a_then_source_failure_then_repeat_a_then_fresh_b",
+    "fresh_a_then_zero_then_repeat_a_then_fresh_b",
+    "fresh_a_then_invalid_then_repeat_a_then_fresh_b",
+    "backend_failure_a_then_repeat_a_then_fresh_b",
+    "attempts_exhausted_a_then_repeat_a_then_fresh_b",
+    "signature_length_failure_a_then_repeat_a_then_fresh_b",
+    "self_verify_failure_a_then_repeat_a_then_fresh_b",
+    "fresh_a_then_reset_then_reuse_a",
+    "invalid_context_preserves_repeat_state"
+  ],
+  "required_invalid_argument_variants": [
+    "null_output",
+    "short_output",
+    "long_output",
+    "alias_secret_key",
+    "alias_public_key",
+    "alias_message",
+    "alias_context",
+    "null_secret_key",
+    "short_secret_key",
+    "null_public_key",
+    "short_public_key",
+    "null_message",
+    "null_context"
+  ],
+  "generated_corpus": {
+    "total_cases": 31,
+    "unique_frames": 31,
+    "scenario_counts": {
+      "fresh_a_then_fresh_b": 4,
+      "fresh_a_then_repeat_a_then_fresh_b": 1,
+      "fresh_a_then_short_b_then_repeat_a_then_fresh_b": 4,
+      "fresh_a_then_source_failure_then_repeat_a_then_fresh_b": 1,
+      "fresh_a_then_zero_then_repeat_a_then_fresh_b": 1,
+      "fresh_a_then_invalid_then_repeat_a_then_fresh_b": 14,
+      "backend_failure_a_then_repeat_a_then_fresh_b": 1,
+      "attempts_exhausted_a_then_repeat_a_then_fresh_b": 1,
+      "signature_length_failure_a_then_repeat_a_then_fresh_b": 1,
+      "self_verify_failure_a_then_repeat_a_then_fresh_b": 1,
+      "fresh_a_then_reset_then_reuse_a": 1,
+      "invalid_context_preserves_repeat_state": 1
+    },
+    "invalid_argument_variant_counts": {
+      "null_output": 1,
+      "short_output": 1,
+      "long_output": 1,
+      "alias_secret_key": 1,
+      "alias_public_key": 1,
+      "alias_message": 2,
+      "alias_context": 1,
+      "null_secret_key": 1,
+      "short_secret_key": 1,
+      "null_public_key": 1,
+      "short_public_key": 1,
+      "null_message": 1,
+      "null_context": 1
+    },
+    "aggregate_sha256": "9ee9c275e59e8a4d383bd474b080406b764aafd9b219dffb522d9ef4e73f05d1"
+  }
+}

--- a/docs/ML_DSA_44_WRAPPER_PROTOTYPE.md
+++ b/docs/ML_DSA_44_WRAPPER_PROTOTYPE.md
@@ -2,7 +2,7 @@
 
 ## Status: ISOLATED_PROTOTYPE_IMPLEMENTED - RELEASE_HOLD
 ## Spec-ID: ML-DSA-44-WRAPPER-PROTOTYPE-v1
-## Updated: 2026-07-21
+## Updated: 2026-07-23
 ## Consensus-Relevant: NO
 
 ## Scope
@@ -118,6 +118,10 @@ python3 contrib/ml-dsa-engineering/run_wrapper_tests.py --sanitizers
 python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --manifest-only
 python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py
 CC=clang python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py --sanitizers --runs 10000
+python3 contrib/ml-dsa-engineering/run_stateful_signer_fuzz.py --manifest-only
+CC=clang python3 contrib/ml-dsa-engineering/run_stateful_signer_fuzz.py \
+  --sanitizers --sanitizer address-undefined --runs 10000 \
+  --output-dir /tmp/ml-dsa-44-stateful-asan
 CC=clang python3 contrib/ml-dsa-engineering/run_verifier_fuzz.py \
   --sanitizers --sanitizer address-undefined --seconds 1800 \
   --coverage --output-dir /tmp/ml-dsa-44-asan
@@ -131,12 +135,14 @@ python3 -m unittest ci.test.test_ml_dsa_wrapper_prototype
 python3 -m unittest ci.test.test_ml_dsa_sustained_fuzz
 python3 -m unittest ci.test.test_ml_dsa_differential_fuzz
 python3 -m unittest ci.test.test_ml_dsa_cbmc_reproduction
+python3 -m unittest ci.test.test_ml_dsa_stateful_signer_fuzz
 ```
 
-The verifier harness deterministically regenerates and replays 207 bounded
+The verifier harness deterministically regenerates and replays 245 bounded
 frames: 180 cases from the pinned C2SP Wycheproof ML-DSA-44 verification file
-and 27 project cases covering commitment, `z`, hint, public-key, message,
-context, length, and null-pointer boundaries. The frozen manifest records 202
+plus 27 project cases and 38 promoted retained-corpus regressions covering
+commitment, `z`, hint, public-key, message, context, length, and null-pointer
+boundaries. The frozen manifest records 240
 unique frames and their expected strict-wrapper result classes. Its custom
 libFuzzer mutator preserves the frame format while targeting those same
 ML-DSA-44 fields. CI runs replay with GCC and Clang; the dedicated workflow
@@ -161,6 +167,35 @@ coverage still depends on LLVM interceptors and is not an all-code proof. A
 retained crash is evidence to investigate, not an
 automatically trusted regression vector: promotion into a checked-in corpus
 still requires review.
+
+The stateful signer harness adds a separate test-only target for the wrapper's
+seeded key generation and hedged-signing transition contract. Every input
+resets module state. Every parsed frame derives the same keypair twice from a
+32-byte seed and executes a bounded sequence of at most four hedged-signing
+calls. The
+checked-in 31-frame corpus covers 12 effective state-transition sequences:
+fresh and repeated randomizers, short/failed/all-zero entropy, invalid
+arguments and output aliases, injected backend/attempt/length/self-verification
+failures, output zeroing, reset-and-reuse behavior, empty and maximum-sized
+bounded messages, and 0-, 255-, and 256-byte contexts. The target asserts the
+exact entropy-request count, post-failure repeat-state transition,
+deterministic fixed-randomizer signature, strict verification, and input
+immutability.
+
+The sustained workflow runs this target in distinct Clang ASan/UBSan and MSan
+jobs so the MSan result does not include uninstrumented OpenSSL or Rust oracle
+bodies. Pull requests and pushes use 60-second smoke campaigns; weekly and
+manual runs use 1,800 seconds and may import the latest successful minimized
+stateful corpus. That restore must come from an ancestor `main` run and pass
+the complete evidence checksum inventory, campaign identity, clean-head,
+minimized-corpus digest, flat regular-file, and resource-bound checks before
+content-addressed import. The stateful evidence has its own artifact and corpus
+namespace. Immediately before copying, the importer rechecks the validated
+count, byte total, and name-bound aggregate, then records a content-addressed
+receipt for the novel imported set. These bounded
+test-only scenarios do not establish lifecycle safety across process fork,
+multi-process key isolation, worst-case signing resources, or production
+fitness.
 
 The pinned review-reproduction workflow adds a 60-second Linux Clang
 ASan/UBSan differential campaign. Its fuzz target calls the isolated wrapper,
@@ -222,8 +257,9 @@ This prototype advances engineering evidence but closes no production gate:
 - issue `#188`: deterministic Wycheproof replay, bounded structure-aware
   ASan/UBSan and MSan campaigns, and bounded three-backend differential
   verifier fuzzing with retained evidence and supplementary portable libcrux
-  Miri execution are now implemented, but stateful signer fuzzing,
-  long-duration and broader-platform differential campaigns, full Rust
+  Miri execution are now implemented; bounded stateful signer and seeded-keygen
+  fuzzing is implemented in a separate test-only lane, but long-duration
+  evidence for that lane, broader-platform differential campaigns, full Rust
   sanitizer coverage, minimum
   coverage goals, reviewed regression-vector promotion, and stack, worst-case,
   and adversarial-batch resource limits remain open;

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -246,9 +246,9 @@ tracked suites now have an explicit policy class and none remains in
 
 ## Current Follow-On Candidates
 
-Preferred next owned tranche:
+Active owned tranche:
 
-1. Add bounded stateful signer and seeded-key-generation fuzzing under issue
+1. Land bounded stateful signer and seeded-key-generation fuzzing under issue
    `#188`
    - exercise deterministic seeded key generation, fresh and repeated
      randomizers, short/zero/failed entropy, invalid arguments, backend
@@ -259,7 +259,8 @@ Preferred next owned tranche:
    - retain separate ASan/UBSan and MSan lanes so uninstrumented external
      implementations do not contaminate the memory-sanitizer result
    - keep the already-pinned comparator as a correctness preflight and record
-     exact corpus, duration, seed, crash, and sanitizer evidence
+     exact corpus, duration, seed, crash, and sanitizer evidence; the first
+     long scheduled/manual receipt remains follow-up evidence after merge
    - keep production at `NONE` and `RELEASE_HOLD`; this tranche authorizes no
      consensus, wallet, Script, `ALG_ID`, or inventory-policy change
 
@@ -1818,6 +1819,26 @@ Aineko must ask before:
 
 Entries below are dated decision snapshots. Use Current Follow-On Candidates
 above as the controlling live next-PR handoff when these older notes disagree.
+
+- 2026-07-23: Exact-main differential run `30043023928` passed at
+  `acd2337201a10b76f6354d9b3c8501483645d122` for 1,801.155 measured fuzzer
+  seconds and 1,849,222 executions after importing 53 novel seeds from the
+  retained corpus. All 245 fixed cases, five exact replays, and 38 promoted
+  regressions replayed; no crash, sanitizer marker, oracle error, or
+  disagreement was recorded. The minimized corpus contains 143 files with
+  aggregate SHA-256
+  `ce0a707bb344f3d9e8fe3ccb6787f93a433a5c0309d9a2e3dcdcf09b802723c7`.
+  Issue `#188`, production backend `NONE`, and `RELEASE_HOLD` remain unchanged.
+
+- 2026-07-23: The next bounded issue-`#188` tranche adds a separate test-only
+  stateful signer and seeded-keygen libFuzzer target. Its fixed 31-frame corpus
+  covers all 12 effective call sequences and 13 invalid-argument variants and
+  exact entropy consumption, repeat-state transitions, output zeroing,
+  deterministic seeded key generation, fixed-randomizer signatures, and
+  strict verification. Retained imports recheck the validated count, byte
+  total, and name-bound aggregate and record the novel content inventory.
+  Separate ASan/UBSan and MSan jobs preserve the existing production boundary
+  and release hold.
 
 - 2026-07-23: Exact-main differential run `29971871087` passed at
   `6d237f467f3a55d5cc48ca584a060251bdbf97dc` for 1,801.169 measured fuzzer


### PR DESCRIPTION
## Summary

- add a test-only structure-aware stateful signer and seeded-keygen fuzz target with 31 frozen cases
- exercise entropy accounting, repeat-state transitions, failure preservation/consumption, deterministic key generation, output contracts, strict verification, aliasing, and input immutability
- run separate ASan/UBSan plus coverage and MSan lanes, with fail-closed retained-corpus provenance and exact import receipts
- extend isolated-wrapper static-analysis coverage and versioned engineering evidence

## Validation

- `python3 -m unittest discover -s ci/test -p 'test_*.py'` — 135 passed
- isolated wrapper normal and sanitized suites — passed
- stateful corpus manifest — 31 cases / 31 unique frames
- standalone ASan/UBSan replay — 142 inputs passed (31 frozen seeds plus 111 boundary cross-products)
- workflow YAML parse, Python compilation, static-analysis plan, file/UTF-8/doc lints, and diff checks — passed
- independent provenance attack reproductions — nested checksum-manifest bypass and post-validation same-count mutation are both rejected

The local Apple toolchain does not include the libFuzzer runtime, so the timed sanitizer campaigns are left to the hosted 60-second jobs added here.

## Release posture

Production backend `NONE` and `RELEASE_HOLD` remain unchanged. This advances issue #188 without production integration.