### PR TITLE
Add exact ML-DSA-44 RUSTSEC-2026-0077 regression

### DIFF
--- a/.github/workflows/ml-dsa-44-review-reproduction.yml
+++ b/.github/workflows/ml-dsa-44-review-reproduction.yml
@@ -102,7 +102,36 @@ jobs:
           test -z "$repository_status"
           test "$(rustc --version | cut -d ' ' -f 2)" = "1.89.0"
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            git diff --exit-code "$BASELINE" -- contrib/ml-dsa-ref/vectors.json
+            python3 - "$BASELINE" <<'PY'
+          import hashlib
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          vectors_path = Path("contrib/ml-dsa-ref/vectors.json")
+          expected_sha256 = {
+              "baseline": (
+                  "2fe1fffc7bfe8ec7597e408449a0d6b99f6ec0f035ab6669211d4d13f376a2b9"
+              ),
+              "current": (
+                  "c2a94fe4fc8e63a6bec4528b4589958772cb0ea01f669cfd8c78bed357a68633"
+              ),
+          }
+          baseline_bytes = subprocess.run(
+              ["git", "show", f"{sys.argv[1]}:{vectors_path.as_posix()}"],
+              check=True,
+              stdout=subprocess.PIPE,
+          ).stdout
+          actual_sha256 = {
+              "baseline": hashlib.sha256(baseline_bytes).hexdigest(),
+              "current": hashlib.sha256(vectors_path.read_bytes()).hexdigest(),
+          }
+          if actual_sha256 != expected_sha256:
+              raise SystemExit(
+                  "vectors.json differs from the exact baseline-to-"
+                  "RUSTSEC-2026-0077 PR transition"
+              )
+          PY
           else
             test "$GITHUB_REF" = "refs/heads/main"
             git diff --exit-code "$BASELINE" -- \
@@ -688,10 +717,14 @@ jobs:
               "cases": 2,
               "status": "PASS",
           }
-          assert (
-              advisory["RUSTSEC-2026-0077"]["pqbtc_exact_regression"]["status"]
-              == "UNTESTED"
-          )
+          assert advisory["RUSTSEC-2026-0077"]["pqbtc_exact_regression"] == {
+              "parameter_set": "ML-DSA-44",
+              "called_backend": "portable",
+              "source": "C2SP Wycheproof ML-DSA-44 verification vectors",
+              "test_case_ids": [125, 126],
+              "cases": 2,
+              "status": "PASS",
+          }
           assert report["signature_sha256"] == {
               "nist_deterministic": "f2554d7153750b4deed79f80e5aa237a219fc92f83e59e7317c8d2089c4e7b91",
               "nist_randomized": "8a17b6ff3f9633cd3c7cd0687d6384408e145bfd3725f6c57a8a2727f50ec989",

--- a/ci/test/test_ml_dsa_advisory_ledger.py
+++ b/ci/test/test_ml_dsa_advisory_ledger.py
@@ -496,6 +496,10 @@ class MlDsaAdvisoryLedgerTest(unittest.TestCase):
         self.assertEqual(contract["production_backend"], "NONE")
         self.assertFalse(contract["simd256_admitted"])
         self.assertEqual(contract["miri_role"], "SUPPLEMENTARY")
+        self.assertEqual(
+            self.ledger["scope"]["issue_189"],
+            "REMAINS_OPEN_PENDING_SIMD_ADMISSION_REGRESSIONS_AND_RE_REVIEW",
+        )
         libcrux = next(
             source
             for source in self.ledger["source_contract"]["oracles"]
@@ -913,9 +917,22 @@ class MlDsaAdvisoryLedgerTest(unittest.TestCase):
                 with self.assertRaises(advisory.AuditError):
                     advisory.validate_ledger(mutated, self.vectors)
 
+    def test_issue_189_cannot_omit_open_simd_or_re_review_gates(self):
+        for scope in (
+            "REMAINS_OPEN_PENDING_SIMD_ADMISSION_REGRESSIONS",
+            "REMAINS_OPEN_PENDING_RE_REVIEW",
+        ):
+            with self.subTest(scope=scope):
+                mutated = copy.deepcopy(self.ledger)
+                mutated["scope"]["issue_189"] = scope
+                with self.assertRaisesRegex(
+                    advisory.AuditError,
+                    "SIMD256 admission regressions and exact-commit re-review",
+                ):
+                    advisory.validate_ledger(mutated, self.vectors)
+
     def test_advisory_test_dispositions_cannot_be_promoted_or_detached(self):
         for finding_id in (
-            "RUSTSEC-2026-0077",
             "RUSTSEC-2026-0125",
             "RUSTSEC-2026-0126",
         ):
@@ -929,15 +946,20 @@ class MlDsaAdvisoryLedgerTest(unittest.TestCase):
                 with self.assertRaisesRegex(advisory.AuditError, "disposition drifted"):
                     advisory.validate_ledger(mutated, self.vectors)
 
-        detached = copy.deepcopy(self.ledger)
-        entry = next(
-            item
-            for item in detached["advisories"]
-            if item["id"] == "RUSTSEC-2026-0076"
-        )
-        entry["evidence"] = ["nonempty but inexact"]
-        with self.assertRaisesRegex(advisory.AuditError, "not bound to exact evidence"):
-            advisory.validate_ledger(detached, self.vectors)
+        for finding_id in ("RUSTSEC-2026-0076", "RUSTSEC-2026-0077"):
+            with self.subTest(detached_finding_id=finding_id):
+                detached = copy.deepcopy(self.ledger)
+                entry = next(
+                    item
+                    for item in detached["advisories"]
+                    if item["id"] == finding_id
+                )
+                entry["evidence"] = ["nonempty but inexact"]
+                with self.assertRaisesRegex(
+                    advisory.AuditError,
+                    "not bound to exact evidence",
+                ):
+                    advisory.validate_ledger(detached, self.vectors)
 
     def test_full_lock_and_sbom_graph_fail_closed(self):
         mutated = copy.deepcopy(self.ledger)

--- a/ci/test/test_ml_dsa_backend_admission.py
+++ b/ci/test/test_ml_dsa_backend_admission.py
@@ -127,7 +127,7 @@ class MLDSABackendAdmissionTests(unittest.TestCase):
         )
         self.assertEqual(
             advisory_gate["status"],
-            "TECHNICAL_LEDGER_AND_SCHEDULED_SCAN_IMPLEMENTED_RE_REVIEW_OPEN",
+            "PORTABLE_REGRESSIONS_AND_SCHEDULED_SCAN_IMPLEMENTED_SIMD_AND_RE_REVIEW_OPEN",
         )
         libcrux = self.admission["candidate_assessments"][
             "libcrux_ml_dsa_0_0_10_portable"

--- a/ci/test/test_ml_dsa_cli_adapter_fuzz.py
+++ b/ci/test/test_ml_dsa_cli_adapter_fuzz.py
@@ -458,20 +458,31 @@ class MlDsaCliAdapterFuzzTest(unittest.TestCase):
             self.skipTest("Git unavailable")
         workflow = WORKFLOW.read_text(encoding="utf8")
         guard = pr_vector_guard_script(workflow)
-        baseline_revision = next(
-            line.split("BASELINE:", 1)[1].strip()
-            for line in workflow.splitlines()
-            if line.strip().startswith("BASELINE:")
-        )
         relative_vector_path = "contrib/ml-dsa-ref/vectors.json"
-        baseline_bytes = subprocess.run(
-            [git, "show", f"{baseline_revision}:{relative_vector_path}"],
-            cwd=REPO_ROOT,
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        ).stdout
         candidate_bytes = (REFERENCE_DIR / "vectors.json").read_bytes()
+        regression_marker = (
+            b'    "rustsec_2026_0077_norm_regression": {\n'
+        )
+        following_marker = b'    "pqbtc_sighash_v1": {\n'
+        self.assertEqual(candidate_bytes.count(regression_marker), 1)
+        self.assertEqual(candidate_bytes.count(following_marker), 1)
+        regression_start = candidate_bytes.index(regression_marker)
+        regression_end = candidate_bytes.index(
+            following_marker,
+            regression_start,
+        )
+        baseline_bytes = (
+            candidate_bytes[:regression_start]
+            + candidate_bytes[regression_end:]
+        )
+        self.assertEqual(
+            hashlib.sha256(baseline_bytes).hexdigest(),
+            "2fe1fffc7bfe8ec7597e408449a0d6b99f6ec0f035ab6669211d4d13f376a2b9",
+        )
+        self.assertEqual(
+            hashlib.sha256(candidate_bytes).hexdigest(),
+            "c2a94fe4fc8e63a6bec4528b4589958772cb0ea01f669cfd8c78bed357a68633",
+        )
 
         def run_guard(current_bytes, *, committed_baseline=baseline_bytes):
             with tempfile.TemporaryDirectory() as temporary:

--- a/ci/test/test_ml_dsa_cli_adapter_fuzz.py
+++ b/ci/test/test_ml_dsa_cli_adapter_fuzz.py
@@ -55,6 +55,26 @@ def trusted_main_baseline_pathspec(workflow):
     return tuple(pathspec)
 
 
+def pr_vector_guard_script(workflow):
+    lines = workflow.splitlines()
+    marker = 'python3 - "$BASELINE" <<\'PY\''
+    starts = [
+        index for index, line in enumerate(lines) if line.strip() == marker
+    ]
+    if len(starts) != 1:
+        raise ValueError("PR vector-delta guard is missing or ambiguous")
+    start = starts[0] + 1
+    try:
+        end = next(
+            index
+            for index in range(start, len(lines))
+            if lines[index].strip() == "PY"
+        )
+    except StopIteration as exc:
+        raise ValueError("PR vector-delta guard has no heredoc terminator") from exc
+    return textwrap.dedent("\n".join(lines[start:end])) + "\n"
+
+
 class DummyOracle:
     def __init__(
         self,
@@ -307,6 +327,17 @@ class MlDsaCliAdapterFuzzTest(unittest.TestCase):
         self.assertIn(
             "python3 contrib/ml-dsa-ref/compare_oracles.py", workflow
         )
+        self.assertNotIn(
+            'advisory["RUSTSEC-2026-0077"]["pqbtc_exact_regression"]["status"]',
+            workflow,
+        )
+        for exact_field in (
+            '"source": "C2SP Wycheproof ML-DSA-44 verification vectors"',
+            '"test_case_ids": [125, 126]',
+            '"cases": 2',
+            '"status": "PASS"',
+        ):
+            self.assertIn(exact_field, workflow)
 
     def test_workflow_separates_pr_smoke_from_frozen_main_evidence(self):
         workflow = WORKFLOW.read_text(encoding="utf8")
@@ -349,7 +380,20 @@ class MlDsaCliAdapterFuzzTest(unittest.TestCase):
             normalized,
         )
         self.assertIn(expected_scope, normalized)
+        vector_guard = pr_vector_guard_script(workflow)
         self.assertIn(
+            '"2fe1fffc7bfe8ec7597e408449a0d6b99f6ec0f035ab6669211d4d13f376a2b9"',
+            vector_guard,
+        )
+        self.assertIn(
+            '"c2a94fe4fc8e63a6bec4528b4589958772cb0ea01f669cfd8c78bed357a68633"',
+            vector_guard,
+        )
+        self.assertIn(
+            "if actual_sha256 != expected_sha256:",
+            vector_guard,
+        )
+        self.assertNotIn(
             'git diff --exit-code "$BASELINE" -- '
             "contrib/ml-dsa-ref/vectors.json",
             normalized,
@@ -407,6 +451,115 @@ class MlDsaCliAdapterFuzzTest(unittest.TestCase):
                 event_name == "pull_request" or ref == "refs/heads/main",
                 expected,
             )
+
+    def test_pr_vector_guard_allows_only_exact_rustsec_0077_delta(self):
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("Git unavailable")
+        workflow = WORKFLOW.read_text(encoding="utf8")
+        guard = pr_vector_guard_script(workflow)
+        baseline_revision = next(
+            line.split("BASELINE:", 1)[1].strip()
+            for line in workflow.splitlines()
+            if line.strip().startswith("BASELINE:")
+        )
+        relative_vector_path = "contrib/ml-dsa-ref/vectors.json"
+        baseline_bytes = subprocess.run(
+            [git, "show", f"{baseline_revision}:{relative_vector_path}"],
+            cwd=REPO_ROOT,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout
+        candidate_bytes = (REFERENCE_DIR / "vectors.json").read_bytes()
+
+        def run_guard(current_bytes, *, committed_baseline=baseline_bytes):
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                vector_path = root / relative_vector_path
+                vector_path.parent.mkdir(parents=True)
+                vector_path.write_bytes(committed_baseline)
+                for arguments in (
+                    ("init", "--quiet"),
+                    ("add", relative_vector_path),
+                    (
+                        "-c",
+                        "user.name=PQBTC CI",
+                        "-c",
+                        "user.email=pqbtc-ci@example.invalid",
+                        "-c",
+                        "commit.gpgsign=false",
+                        "commit",
+                        "--quiet",
+                        "--no-verify",
+                        "-m",
+                        "baseline",
+                    ),
+                ):
+                    subprocess.run(
+                        [git, *arguments],
+                        cwd=root,
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    )
+                baseline_revision = subprocess.run(
+                    [git, "rev-parse", "HEAD"],
+                    cwd=root,
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                ).stdout.strip()
+                vector_path.write_bytes(current_bytes)
+                return subprocess.run(
+                    [sys.executable, "-", baseline_revision],
+                    cwd=root,
+                    check=False,
+                    input=guard,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+
+        exact = run_guard(candidate_bytes)
+        self.assertEqual(exact.returncode, 0, exact.stdout + exact.stderr)
+
+        tampered_regression = candidate_bytes.replace(
+            b'"test_case_id": 125',
+            b'"test_case_id": 124',
+            1,
+        )
+        unrelated_drift = candidate_bytes.replace(
+            b'"signature_bytes": 2420',
+            b'"signature_bytes": 2421',
+            1,
+        )
+        cases = (
+            ("tampered regression", tampered_regression, baseline_bytes),
+            ("unrelated drift", unrelated_drift, baseline_bytes),
+            (
+                "tampered baseline",
+                candidate_bytes,
+                baseline_bytes + b"\n",
+            ),
+        )
+        for label, rejected, rejected_baseline in cases:
+            if label == "tampered baseline":
+                self.assertNotEqual(rejected_baseline, baseline_bytes)
+            else:
+                self.assertNotEqual(rejected, candidate_bytes, label)
+            with self.subTest(label=label):
+                result = run_guard(
+                    rejected,
+                    committed_baseline=rejected_baseline,
+                )
+                self.assertNotEqual(
+                    result.returncode,
+                    0,
+                    result.stdout + result.stderr,
+                )
 
     def test_trusted_main_baseline_pathspec_is_semantically_fail_closed(self):
         git = shutil.which("git")

--- a/ci/test/test_ml_dsa_reference.py
+++ b/ci/test/test_ml_dsa_reference.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import sys
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -141,6 +142,146 @@ class MLDSAReferenceTests(unittest.TestCase):
             out_of_bounds[hint_offset + 80 : hint_offset + 84],
             bytes((21, 42, 63, 85)),
         )
+
+    def test_libcrux_norm_regressions_are_exact_pinned_mldsa44_cases(self):
+        contract = self.manifest["vectors"][
+            "rustsec_2026_0077_norm_regression"
+        ]
+        cases = compare_oracles.load_rustsec_2026_0077_cases(
+            self.manifest["profile"],
+            contract,
+        )
+        self.assertEqual(
+            [case["test_case_id"] for case in cases],
+            [125, 126],
+        )
+        self.assertEqual(
+            {len(bytes.fromhex(case["public_key_hex"])) for case in cases},
+            {self.manifest["profile"]["public_key_bytes"]},
+        )
+        self.assertEqual(
+            {len(bytes.fromhex(case["signature_hex"])) for case in cases},
+            {self.manifest["profile"]["signature_bytes"]},
+        )
+        self.assertEqual(
+            {case["context_hex"] for case in cases},
+            {""},
+        )
+
+    def test_manifest_rejects_detached_norm_regression_contract(self):
+        mutated = copy.deepcopy(self.manifest)
+        mutated["vectors"]["rustsec_2026_0077_norm_regression"]["cases"][0][
+            "test_case_id"
+        ] = 124
+        with self.assertRaisesRegex(
+            compare_oracles.ReferenceError,
+            "RUSTSEC-2026-0077 regression contract",
+        ):
+            compare_oracles.validate_manifest(mutated)
+
+    def test_norm_regression_loader_rejects_path_escape(self):
+        mutated = copy.deepcopy(
+            self.manifest["vectors"]["rustsec_2026_0077_norm_regression"]
+        )
+        mutated["vector_file_path"] = "../outside.json"
+        with self.assertRaisesRegex(
+            compare_oracles.ReferenceError,
+            "source path escapes",
+        ):
+            compare_oracles.load_rustsec_2026_0077_cases(
+                self.manifest["profile"],
+                mutated,
+            )
+
+    def test_advisory_report_marks_exact_norm_regression_pass(self):
+        upstream_report = {
+            "execution": {
+                "compiled_backend": "portable",
+                "simd128_disabled": True,
+                "simd256_disabled": True,
+            },
+            "results": {
+                advisory_id: {"status": "PASS"}
+                for advisory_id in (
+                    "RUSTSEC-2026-0076",
+                    "RUSTSEC-2026-0077",
+                )
+            },
+        }
+        oracles = {
+            name: compare_oracles.Oracle(Path(name))
+            for name in ("openssl", "mldsa_native", "libcrux")
+        }
+        with mock.patch.object(
+            compare_oracles,
+            "require_verification",
+        ) as require_verification:
+            report = compare_oracles.evaluate_libcrux_advisory_regressions(
+                self.manifest["profile"],
+                oracles,
+                "00" * self.manifest["profile"]["public_key_bytes"],
+                "",
+                "",
+                upstream_report,
+                self.manifest["vectors"][
+                    "rustsec_2026_0077_norm_regression"
+                ],
+            )
+        exact = report["advisories"]["RUSTSEC-2026-0077"][
+            "pqbtc_exact_regression"
+        ]
+        self.assertEqual(exact["status"], "PASS")
+        self.assertEqual(exact["test_case_ids"], [125, 126])
+        self.assertEqual(exact["cases"], 2)
+        self.assertEqual(require_verification.call_count, 4)
+
+    def test_advisory_report_requires_exact_three_oracle_set(self):
+        upstream_report = {
+            "execution": {
+                "compiled_backend": "portable",
+                "simd128_disabled": True,
+                "simd256_disabled": True,
+            },
+            "results": {
+                advisory_id: {"status": "PASS"}
+                for advisory_id in (
+                    "RUSTSEC-2026-0076",
+                    "RUSTSEC-2026-0077",
+                )
+            },
+        }
+        oracles = {
+            name: compare_oracles.Oracle(Path(name))
+            for name in ("openssl", "mldsa_native", "libcrux")
+        }
+        cases = {
+            "missing": {
+                name: oracle
+                for name, oracle in oracles.items()
+                if name != "libcrux"
+            },
+            "extra": {
+                **oracles,
+                "unexpected": compare_oracles.Oracle(Path("unexpected")),
+            },
+        }
+        for label, candidate_oracles in cases.items():
+            with self.subTest(label=label):
+                with self.assertRaisesRegex(
+                    compare_oracles.ReferenceError,
+                    "require exactly",
+                ):
+                    compare_oracles.evaluate_libcrux_advisory_regressions(
+                        self.manifest["profile"],
+                        candidate_oracles,
+                        "00" * self.manifest["profile"]["public_key_bytes"],
+                        "",
+                        "",
+                        upstream_report,
+                        self.manifest["vectors"][
+                            "rustsec_2026_0077_norm_regression"
+                        ],
+                    )
 
     def test_manifest_only_cli(self):
         result = subprocess.run(

--- a/contrib/ml-dsa-engineering/advisory_ledger.json
+++ b/contrib/ml-dsa-engineering/advisory_ledger.json
@@ -469,11 +469,11 @@
       "affected_backends_or_functions": ["ML-DSA-44 verify", "ML-DSA-65 verify", "ML-DSA-87 verify"],
       "affected_status": "NOT_AFFECTED",
       "current_path_applicability": "APPLICABLE",
-      "test_status": "UNTESTED",
-      "reason_code": "PIN_ABOVE_FIXED_EXACT_PARAMETER_REGRESSION_MISSING",
-      "reason": "The pin is above the fixed version. The retained upstream mask_exceeds_norm regression is ML-DSA-65; it is not an exact ML-DSA-44 portable regression.",
-      "evidence": ["upstream ML-DSA-65 mask_exceeds_norm"],
-      "future_admission": "EXACT_ML_DSA_44_REGRESSION_REQUIRED_BEFORE_PRODUCTION"
+      "test_status": "PASS",
+      "reason_code": "PIN_ABOVE_FIXED_WITH_BOUNDED_REGRESSION",
+      "reason": "The pin is above the fixed version. The comparator rejects the positive and negative ML-DSA-44 signer-response coefficient cases at the infinity-norm boundary from pinned Wycheproof tcIds 125 and 126 across all three oracles; the retained upstream mask_exceeds_norm test is separately identified as ML-DSA-65.",
+      "evidence": ["compare_oracles.py ML-DSA-44 Wycheproof tcIds 125 and 126", "upstream ML-DSA-65 mask_exceeds_norm"],
+      "future_admission": "RERUN_EXACT_REGRESSION_ON_REPIN"
     },
     {
       "id": "RUSTSEC-2026-0125",
@@ -709,7 +709,7 @@
   "scope": {
     "technical_remediation": "IMPLEMENTED_WHEN_WORKFLOW_GREEN",
     "external_re_review": "PENDING_EXACT_COMMIT_REVIEW_UNDER_ISSUE_181",
-    "issue_189": "REMAINS_OPEN_PENDING_RE_REVIEW",
+    "issue_189": "REMAINS_OPEN_PENDING_SIMD_ADMISSION_REGRESSIONS_AND_RE_REVIEW",
     "production_change": false,
     "release_hold_changed": false
   }

--- a/contrib/ml-dsa-engineering/backend_admission.json
+++ b/contrib/ml-dsa-engineering/backend_admission.json
@@ -167,7 +167,7 @@
     },
     {
       "id": "backend_advisory_and_sbom_refresh",
-      "status": "TECHNICAL_LEDGER_AND_SCHEDULED_SCAN_IMPLEMENTED_RE_REVIEW_OPEN",
+      "status": "PORTABLE_REGRESSIONS_AND_SCHEDULED_SCAN_IMPLEMENTED_SIMD_AND_RE_REVIEW_OPEN",
       "tracking_issue": 189
     },
     {

--- a/contrib/ml-dsa-engineering/run_advisory_ledger.py
+++ b/contrib/ml-dsa-engineering/run_advisory_ledger.py
@@ -114,9 +114,9 @@ EXPECTED_ADVISORY_DISPOSITIONS = {
     ),
     "RUSTSEC-2026-0077": (
         "APPLICABLE",
-        "UNTESTED",
-        "PIN_ABOVE_FIXED_EXACT_PARAMETER_REGRESSION_MISSING",
-        "EXACT_ML_DSA_44_REGRESSION_REQUIRED_BEFORE_PRODUCTION",
+        "PASS",
+        "PIN_ABOVE_FIXED_WITH_BOUNDED_REGRESSION",
+        "RERUN_EXACT_REGRESSION_ON_REPIN",
     ),
     "RUSTSEC-2026-0097": (
         "NOT_APPLICABLE",
@@ -575,11 +575,21 @@ def validate_ledger(ledger: dict[str, Any], vectors: dict[str, Any]) -> None:
         )
         if actual_disposition != EXPECTED_ADVISORY_DISPOSITIONS[entry["id"]]:
             raise AuditError(f"{entry['id']} dated disposition drifted")
-        if entry["id"] == "RUSTSEC-2026-0076" and entry["evidence"] != [
-            "compare_oracles.py ML-DSA-44 malformed-hint cases",
-            "upstream ML-DSA-65 bad_hint_out_of_bounds",
-        ]:
-            raise AuditError("RUSTSEC-2026-0076 PASS is not bound to exact evidence")
+        exact_regression_evidence = {
+            "RUSTSEC-2026-0076": [
+                "compare_oracles.py ML-DSA-44 malformed-hint cases",
+                "upstream ML-DSA-65 bad_hint_out_of_bounds",
+            ],
+            "RUSTSEC-2026-0077": [
+                "compare_oracles.py ML-DSA-44 Wycheproof tcIds 125 and 126",
+                "upstream ML-DSA-65 mask_exceeds_norm",
+            ],
+        }
+        if (
+            entry["id"] in exact_regression_evidence
+            and entry["evidence"] != exact_regression_evidence[entry["id"]]
+        ):
+            raise AuditError(f"{entry['id']} PASS is not bound to exact evidence")
         for alias in entry["aliases"]:
             if alias in aliases:
                 raise AuditError(f"duplicate advisory alias: {alias}")
@@ -641,8 +651,14 @@ def validate_ledger(ledger: dict[str, Any], vectors: dict[str, Any]) -> None:
         raise AuditError("Miri source must be pinned by SHA256")
 
     scope = ledger["scope"]
-    if scope.get("issue_189") != "REMAINS_OPEN_PENDING_RE_REVIEW":
-        raise AuditError("issue #189 must remain open pending exact-commit re-review")
+    if (
+        scope.get("issue_189")
+        != "REMAINS_OPEN_PENDING_SIMD_ADMISSION_REGRESSIONS_AND_RE_REVIEW"
+    ):
+        raise AuditError(
+            "issue #189 must remain open pending exact SIMD256 admission "
+            "regressions and exact-commit re-review"
+        )
     if (
         scope.get("production_change") is not False
         or scope.get("release_hold_changed") is not False

--- a/contrib/ml-dsa-engineering/stateful_signer_fuzz_corpus.json
+++ b/contrib/ml-dsa-engineering/stateful_signer_fuzz_corpus.json
@@ -11,7 +11,7 @@
     "hedged_signing_calls_per_input_max": 4
   },
   "sources": {
-    "repo_vectors_sha256": "2fe1fffc7bfe8ec7597e408449a0d6b99f6ec0f035ab6669211d4d13f376a2b9"
+    "repo_vectors_sha256": "c2a94fe4fc8e63a6bec4528b4589958772cb0ea01f669cfd8c78bed357a68633"
   },
   "required_scenarios": [
     "fresh_a_then_fresh_b",

--- a/contrib/ml-dsa-engineering/verifier_fuzz_corpus.json
+++ b/contrib/ml-dsa-engineering/verifier_fuzz_corpus.json
@@ -9,7 +9,7 @@
     "frame_bytes": 8096
   },
   "sources": {
-    "repo_vectors_sha256": "2fe1fffc7bfe8ec7597e408449a0d6b99f6ec0f035ab6669211d4d13f376a2b9",
+    "repo_vectors_sha256": "c2a94fe4fc8e63a6bec4528b4589958772cb0ea01f669cfd8c78bed357a68633",
     "wycheproof_vectors_sha256": "5ec04790c240c443ca8b662b8fc871834602c7cce87fcd36a193110745b2b9ea",
     "promoted_source_sha256": "458f8902fc50e240145a2dd6bfa717c3fca14d58e792ddbafe6f985b1c45ecc0"
   },

--- a/contrib/ml-dsa-ref/README.md
+++ b/contrib/ml-dsa-ref/README.md
@@ -61,10 +61,13 @@ accept/reject cases against all three oracles. It also checks complete
 signature-byte agreement, cross-verification, randomized-signature diversity,
 empty and maximum contexts, malformed lengths, key/message/context/signature
 mutations, the two retained upstream libcrux security tests, two exact
-ML-DSA-44 malformed-hint regression cases, and bounded ASan/UBSan runs for the two
-portable-C adapters. The upstream tests are accurately labeled ML-DSA-65; the
-comparator no longer treats them as a package-wide advisory PASS. The complete
-dated advisory inventory and scheduled dependency scans are defined by
+ML-DSA-44 malformed-hint regression cases, the pinned Wycheproof ML-DSA-44
+tcIds 125 and 126 for positive and negative signer-response coefficients at
+the infinity-norm boundary, and
+bounded ASan/UBSan runs for the two portable-C adapters. The upstream tests are
+accurately labeled ML-DSA-65; the comparator no longer treats them as a
+package-wide advisory PASS. The complete dated advisory inventory and
+scheduled dependency scans are defined by
 `contrib/ml-dsa-engineering/advisory_ledger.json`. The JSON report includes
 ten-run timing medians, an explicitly scoped raw-payload block-space model, and
 the separate research-CLI malformed-input report described below.

--- a/contrib/ml-dsa-ref/cli_adapter_fuzz_corpus.json
+++ b/contrib/ml-dsa-ref/cli_adapter_fuzz_corpus.json
@@ -137,11 +137,11 @@
   "sources": {
     "c_helper_sha256": "c7f8169dbbd87eccfe64b13c34e3b99f704c88bce4a459607c73fc64a8d67de9",
     "cli_fuzz_driver_sha256": "76161ca5c4d5cdc9064796340b2a7246d59548d75bcf05bab30a84c699f60341",
-    "compare_driver_sha256": "67ec1c1baea51b4cf9785d3edecf46029b50108633ad62f21c1b7f99b418fb44",
+    "compare_driver_sha256": "f31284db38cadffab82ec42492ab48d45020618d3931a6eeb1d4232f7aef94fa",
     "libcrux_adapter_sha256": "3b924df4f1f6eefa575dd4dd87440fc978affd1141790d8a7c4172303cf157a2",
     "mldsa_native_adapter_sha256": "d5465aabbf1ffb0a72e4f919421be7959269a94c70a05c17d7cd03a121f33361",
     "openssl_adapter_sha256": "fb213f8e669dad1d435bde9d3139bf217a1f3ebbdd843e5233e2bd7420a9f39d",
-    "vectors_sha256": "2fe1fffc7bfe8ec7597e408449a0d6b99f6ec0f035ab6669211d4d13f376a2b9"
+    "vectors_sha256": "c2a94fe4fc8e63a6bec4528b4589958772cb0ea01f669cfd8c78bed357a68633"
   },
   "target": "ml-dsa-44-research-oracle-cli-adapters"
 }

--- a/contrib/ml-dsa-ref/compare_oracles.py
+++ b/contrib/ml-dsa-ref/compare_oracles.py
@@ -30,6 +30,7 @@ MANIFEST_PATH = HERE / "vectors.json"
 OPENSSL_SOURCE = HERE / "openssl_oracle.c"
 MLDSA_NATIVE_SOURCE = HERE / "mldsa_native_oracle.c"
 LIBCRUX_SOURCE = HERE / "libcrux_oracle.rs"
+REPO_ROOT = HERE.parents[1]
 HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -260,11 +261,72 @@ def validate_manifest(manifest: dict) -> None:
         if HEX_64.fullmatch(pqbtc[field]) is None:
             raise ReferenceError(f"PQBTC {field} must be SHA256")
 
+    expected_norm_regression = {
+        "source": "C2SP Wycheproof ML-DSA-44 verification vectors",
+        "source_commit": "fc24cd5b787d8e496bff31b0468af693a652b0f2",
+        "source_manifest_path": (
+            "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/SOURCE.json"
+        ),
+        "source_manifest_sha256": (
+            "3522cf3ae87aaa929f8d6b0e3be809665d809ce97b71cc01aa3256d7f2b0f1f2"
+        ),
+        "vector_file_path": (
+            "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/"
+            "mldsa_44_verify_test.json"
+        ),
+        "vector_file_sha256": (
+            "5ec04790c240c443ca8b662b8fc871834602c7cce87fcd36a193110745b2b9ea"
+        ),
+        "parameter_set": "ML-DSA-44",
+        "expected_result": "invalid",
+        "required_flags": ["BoundaryCondition", "InfinityNormViolation"],
+        "cases": [
+            {
+                "test_case_id": 125,
+                "comment": "index 0 is exactly gamma1 - tau*eta",
+                "public_key_sha256": (
+                    "d87f8ca136ac1aa55e2d6c4521680efb3a378cbb9bc0bfb446e9c60893931ea3"
+                ),
+                "message_sha256": (
+                    "653f3f7ec47d73c38ee34378a05741e48aedb4fff7f9caf0a8abb8747ae8b241"
+                ),
+                "context_sha256": (
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                ),
+                "signature_sha256": (
+                    "1bde001dd0eae0c4435341cc236a8363b58feeaaeaf02373fd9d5b1f3ef70f32"
+                ),
+            },
+            {
+                "test_case_id": 126,
+                "comment": "index 255 is exactly -(gamma1 - tau*eta)",
+                "public_key_sha256": (
+                    "d87f8ca136ac1aa55e2d6c4521680efb3a378cbb9bc0bfb446e9c60893931ea3"
+                ),
+                "message_sha256": (
+                    "653f3f7ec47d73c38ee34378a05741e48aedb4fff7f9caf0a8abb8747ae8b241"
+                ),
+                "context_sha256": (
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                ),
+                "signature_sha256": (
+                    "1d217254a38c2773b3e19f24167b876595cf92fc68b5d40d4e99985c70786e20"
+                ),
+            },
+        ],
+    }
+    if vectors.get("rustsec_2026_0077_norm_regression") != expected_norm_regression:
+        raise ReferenceError("RUSTSEC-2026-0077 regression contract mismatch")
+
 
 def load_manifest() -> dict:
     with MANIFEST_PATH.open(encoding="utf8") as manifest_file:
         manifest = json.load(manifest_file)
     validate_manifest(manifest)
+    load_rustsec_2026_0077_cases(
+        manifest["profile"],
+        manifest["vectors"]["rustsec_2026_0077_norm_regression"],
+    )
     cli_adapter_fuzz.validate_manifest()
     return manifest
 
@@ -1623,6 +1685,116 @@ def libcrux_malformed_hint_signature(profile: dict, final_counter: int) -> str:
     return signature.hex()
 
 
+def load_rustsec_2026_0077_cases(profile: dict, contract: dict) -> list[dict]:
+    if profile["name"] != "ML-DSA-44":
+        raise ReferenceError("RUSTSEC-2026-0077 regression requires ML-DSA-44")
+
+    source_manifest_path = (REPO_ROOT / contract["source_manifest_path"]).resolve()
+    vector_path = (REPO_ROOT / contract["vector_file_path"]).resolve()
+    repository_root = REPO_ROOT.resolve()
+    if not source_manifest_path.is_relative_to(
+        repository_root
+    ) or not vector_path.is_relative_to(repository_root):
+        raise ReferenceError("RUSTSEC-2026-0077 source path escapes the repository")
+    require_artifact(
+        source_manifest_path,
+        contract["source_manifest_sha256"],
+        "RUSTSEC-2026-0077 Wycheproof source manifest",
+    )
+    require_artifact(
+        vector_path,
+        contract["vector_file_sha256"],
+        "RUSTSEC-2026-0077 Wycheproof vector file",
+    )
+
+    source_manifest = json.loads(source_manifest_path.read_text(encoding="utf8"))
+    if source_manifest.get("source", {}).get("commit") != contract["source_commit"]:
+        raise ReferenceError("RUSTSEC-2026-0077 Wycheproof source commit mismatch")
+    vector_record = source_manifest.get("vector_file", {})
+    if (
+        vector_record.get("sha256") != contract["vector_file_sha256"]
+        or vector_record.get("algorithm") != contract["parameter_set"]
+        or vector_record.get("number_of_tests") != 180
+    ):
+        raise ReferenceError("RUSTSEC-2026-0077 Wycheproof source metadata mismatch")
+
+    vectors = json.loads(vector_path.read_text(encoding="utf8"))
+    if (
+        vectors.get("algorithm") != contract["parameter_set"]
+        or str(vectors.get("generatorVersion")) != "1"
+        or vectors.get("numberOfTests") != 180
+    ):
+        raise ReferenceError("RUSTSEC-2026-0077 Wycheproof vector metadata mismatch")
+
+    indexed: dict[int, tuple[dict, dict]] = {}
+    for group in vectors.get("testGroups", []):
+        for test in group.get("tests", []):
+            test_case_id = test.get("tcId")
+            if not isinstance(test_case_id, int) or test_case_id in indexed:
+                raise ReferenceError(
+                    "RUSTSEC-2026-0077 Wycheproof test IDs are invalid or duplicated"
+                )
+            indexed[test_case_id] = (group, test)
+    if len(indexed) != vectors["numberOfTests"]:
+        raise ReferenceError("RUSTSEC-2026-0077 Wycheproof test count mismatch")
+
+    selected = []
+    for expected in contract["cases"]:
+        test_case_id = expected["test_case_id"]
+        if test_case_id not in indexed:
+            raise ReferenceError(
+                f"RUSTSEC-2026-0077 Wycheproof tcId {test_case_id} is missing"
+            )
+        group, test = indexed[test_case_id]
+        public_key_hex = group.get("publicKey", "")
+        message_hex = test.get("msg", "")
+        context_hex = test.get("ctx") or ""
+        signature_hex = test.get("sig", "")
+        if (
+            test.get("comment") != expected["comment"]
+            or test.get("result") != contract["expected_result"]
+            or set(test.get("flags", [])) != set(contract["required_flags"])
+        ):
+            raise ReferenceError(
+                f"RUSTSEC-2026-0077 Wycheproof tcId {test_case_id} semantics mismatch"
+            )
+        require_hex(
+            public_key_hex,
+            profile["public_key_bytes"],
+            f"RUSTSEC-2026-0077 tcId {test_case_id} public key",
+        )
+        require_hex(
+            signature_hex,
+            profile["signature_bytes"],
+            f"RUSTSEC-2026-0077 tcId {test_case_id} signature",
+        )
+        if len(bytes.fromhex(context_hex)) > 255:
+            raise ReferenceError(
+                f"RUSTSEC-2026-0077 tcId {test_case_id} context exceeds FIPS 204"
+            )
+        for value, field in (
+            (public_key_hex, "public_key_sha256"),
+            (message_hex, "message_sha256"),
+            (context_hex, "context_sha256"),
+            (signature_hex, "signature_sha256"),
+        ):
+            if sha256_hex(value) != expected[field]:
+                raise ReferenceError(
+                    f"RUSTSEC-2026-0077 Wycheproof tcId {test_case_id} "
+                    f"{field} mismatch"
+                )
+        selected.append(
+            {
+                "test_case_id": test_case_id,
+                "public_key_hex": public_key_hex,
+                "message_hex": message_hex,
+                "context_hex": context_hex,
+                "signature_hex": signature_hex,
+            }
+        )
+    return selected
+
+
 def evaluate_libcrux_advisory_regressions(
     profile: dict,
     oracles: dict[str, Oracle],
@@ -1630,7 +1802,14 @@ def evaluate_libcrux_advisory_regressions(
     message_hex: str,
     context_hex: str,
     upstream_report: dict,
+    norm_regression_contract: dict,
 ) -> dict:
+    expected_oracles = {"openssl", "mldsa_native", "libcrux"}
+    if set(oracles) != expected_oracles:
+        raise ReferenceError(
+            "libcrux advisory regressions require exactly the "
+            "openssl, mldsa_native, and libcrux oracles"
+        )
     expected_advisories = {"RUSTSEC-2026-0076", "RUSTSEC-2026-0077"}
     upstream_results = upstream_report.get("results", {})
     execution = upstream_report.get("execution", {})
@@ -1658,6 +1837,20 @@ def evaluate_libcrux_advisory_regressions(
             "0",
             f"libcrux {label} rejection",
         )
+    norm_cases = load_rustsec_2026_0077_cases(
+        profile,
+        norm_regression_contract,
+    )
+    for case in norm_cases:
+        require_verification(
+            oracles,
+            case["public_key_hex"],
+            case["message_hex"],
+            case["context_hex"],
+            case["signature_hex"],
+            "0",
+            f"libcrux RUSTSEC-2026-0077 Wycheproof tcId {case['test_case_id']}",
+        )
     return {
         "execution": execution,
         "advisories": {
@@ -1677,8 +1870,12 @@ def evaluate_libcrux_advisory_regressions(
                 "pqbtc_exact_regression": {
                     "parameter_set": "ML-DSA-44",
                     "called_backend": "portable",
-                    "status": "UNTESTED",
-                    "reason": "retained upstream regression is ML-DSA-65",
+                    "source": norm_regression_contract["source"],
+                    "test_case_ids": [
+                        case["test_case_id"] for case in norm_cases
+                    ],
+                    "cases": len(norm_cases),
+                    "status": "PASS",
                 },
             },
         },
@@ -1778,6 +1975,7 @@ def evaluate(
         vector["message_hex"],
         vector["context_hex"],
         libcrux_upstream_report,
+        manifest["vectors"]["rustsec_2026_0077_norm_regression"],
     )
     benchmark = benchmark_profile(
         profile, oracles, vector, benchmark_iterations

--- a/contrib/ml-dsa-ref/vectors.json
+++ b/contrib/ml-dsa-ref/vectors.json
@@ -188,6 +188,35 @@
         }
       ]
     },
+    "rustsec_2026_0077_norm_regression": {
+      "source": "C2SP Wycheproof ML-DSA-44 verification vectors",
+      "source_commit": "fc24cd5b787d8e496bff31b0468af693a652b0f2",
+      "source_manifest_path": "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/SOURCE.json",
+      "source_manifest_sha256": "3522cf3ae87aaa929f8d6b0e3be809665d809ce97b71cc01aa3256d7f2b0f1f2",
+      "vector_file_path": "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/mldsa_44_verify_test.json",
+      "vector_file_sha256": "5ec04790c240c443ca8b662b8fc871834602c7cce87fcd36a193110745b2b9ea",
+      "parameter_set": "ML-DSA-44",
+      "expected_result": "invalid",
+      "required_flags": ["BoundaryCondition", "InfinityNormViolation"],
+      "cases": [
+        {
+          "test_case_id": 125,
+          "comment": "index 0 is exactly gamma1 - tau*eta",
+          "public_key_sha256": "d87f8ca136ac1aa55e2d6c4521680efb3a378cbb9bc0bfb446e9c60893931ea3",
+          "message_sha256": "653f3f7ec47d73c38ee34378a05741e48aedb4fff7f9caf0a8abb8747ae8b241",
+          "context_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "signature_sha256": "1bde001dd0eae0c4435341cc236a8363b58feeaaeaf02373fd9d5b1f3ef70f32"
+        },
+        {
+          "test_case_id": 126,
+          "comment": "index 255 is exactly -(gamma1 - tau*eta)",
+          "public_key_sha256": "d87f8ca136ac1aa55e2d6c4521680efb3a378cbb9bc0bfb446e9c60893931ea3",
+          "message_sha256": "653f3f7ec47d73c38ee34378a05741e48aedb4fff7f9caf0a8abb8747ae8b241",
+          "context_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "signature_sha256": "1d217254a38c2773b3e19f24167b876595cf92fc68b5d40d4e99985c70786e20"
+        }
+      ]
+    },
     "pqbtc_sighash_v1": {
       "source": "repo-defined deterministic interoperability vector",
       "seed_hex": "d71361c000f9a7bc99dfb425bcb6bb27c32c36ab444ff3708b2d93b4e66d5b5b",

--- a/docs/ML_DSA_44_ADVISORY_LEDGER.md
+++ b/docs/ML_DSA_44_ADVISORY_LEDGER.md
@@ -78,7 +78,7 @@ The 2026-07-21 ledger covers every RustSec entry currently present across all
 | RUSTSEC-2025-0133 | libcrux-intrinsics 0.0.8 | not affected; above fixed 0.0.4 and current runner is not AArch64 | not applicable to current architecture |
 | RUSTSEC-2026-0074 | libcrux-sha3 0.0.10 | not affected; above fixed 0.0.8 and affected incremental API is outside ML-DSA | not applicable |
 | RUSTSEC-2026-0076 | libcrux-ml-dsa 0.0.10 | not affected; above fixed 0.0.8 | PASS for two exact ML-DSA-44 portable malformed-hint rejections; upstream retained test is separately labeled ML-DSA-65 |
-| RUSTSEC-2026-0077 | libcrux-ml-dsa 0.0.10 | not affected; above fixed 0.0.8 | UNTESTED for an exact ML-DSA-44 regression; retained upstream test is ML-DSA-65 |
+| RUSTSEC-2026-0077 | libcrux-ml-dsa 0.0.10 | not affected; above fixed 0.0.8 | PASS for pinned Wycheproof ML-DSA-44 tcIds 125 and 126 with positive and negative signer-response coefficients at the infinity-norm boundary across all three oracles; upstream retained test is separately labeled ML-DSA-65 |
 | RUSTSEC-2026-0125 | libcrux-ml-dsa 0.0.10 | not affected; above fixed 0.0.9 | UNTESTED and not applicable to portable; blocks SIMD256 admission until an exact regression passes |
 | RUSTSEC-2026-0126 | libcrux-ml-dsa 0.0.10 | not affected; above fixed 0.0.9 | UNTESTED and not applicable to portable; blocks SIMD256 admission until an exact regression passes |
 | RUSTSEC-2026-0207 | libcrux-sha3 0.0.10 | not affected; at fixed 0.0.10 and advisory excludes ML-DSA use | not applicable |
@@ -156,8 +156,10 @@ claim closure of issue #189 by itself.
 
 This tranche may be engineered and merged after its required checks pass; it
 does not need to wait for an external reviewer. Issue #189 remains open for
-the exact-commit independent re-review required by issue #181. Production
-admission and any release-hold decision remain separate and unchanged.
+exact SIMD256 regressions for RUSTSEC-2026-0125 and RUSTSEC-2026-0126 before
+any optimized-backend admission, and for the exact-commit independent re-review
+required by issue #181. Production admission and any release-hold decision
+remain separate and unchanged.
 
 Primary machine inputs are:
 

--- a/docs/ML_DSA_44_BACKEND_ADMISSION.md
+++ b/docs/ML_DSA_44_BACKEND_ADMISSION.md
@@ -102,10 +102,13 @@ packages in the selected graph: nine libcrux-family entries plus three patched
 rand/rand_core entries. Every selected pin is at or above its published fixed
 version, but regression status is reported separately from version status.
 The exact ML-DSA-44 portable malformed-hint check for RUSTSEC-2026-0076 passes;
-the retained upstream 0076/0077 tests are explicitly labeled ML-DSA-65, and an
-exact ML-DSA-44 0077 regression remains untested. The AVX2-specific 0125/0126
-regressions block any future SIMD256 admission. This is useful evidence, not a
-reason to prefer a wider integration boundary for the first prototype.
+the retained upstream 0076/0077 tests are explicitly labeled ML-DSA-65, and
+pinned Wycheproof ML-DSA-44 tcIds 125 and 126 provide exact three-oracle
+regressions for positive and negative signer-response coefficients at the
+infinity-norm boundary for 0077. The
+AVX2-specific 0125/0126 regressions block any future SIMD256 admission. This is
+useful evidence, not a reason to prefer a wider integration boundary for the
+first prototype.
 
 ## Frozen Prototype Build Contract
 
@@ -167,7 +170,7 @@ Prototype admission closes no production finding:
 | Fault model and injected faults | #186 | open |
 | End-to-end secret erasure | #187 | source cleanup and sanitizer evidence only; compiler/caller/platform boundary open |
 | Structure-aware fuzzing and resource limits | #188 | pinned Wycheproof replay, scheduled structure-aware ASan/UBSan and MSan campaigns, bounded differential/stateful fuzzing, promoted regressions, portable Miri evidence, and bounded malformed research-CLI argv replay; direct verifier allocation/stack/CPU and adversarial-batch limits, broader platform/Rust sanitizer coverage, and exact-commit re-review remain open |
-| Backend advisories, SBOM, and reproducible build | #189 | dated fail-closed ledger, full-lock cargo-audit/OSV scans, exact selected graph, CycloneDX SBOM, and weekly retained refresh implemented; exact-commit independent re-review remains open |
+| Backend advisories, SBOM, and reproducible build | #189 | dated fail-closed ledger, full-lock cargo-audit/OSV scans, exact selected graph, CycloneDX SBOM, weekly retained refresh, and exact portable ML-DSA-44 RUSTSEC-2026-0077 regressions implemented; exact SIMD256 RUSTSEC-2026-0125/0126 regressions before optimized-backend admission and exact-commit independent re-review remain open |
 | Wallet and key format | #190 | open |
 | Independent human cryptographic review | #181 | open |
 

--- a/docs/ML_DSA_44_EXTERNAL_REVIEW.md
+++ b/docs/ML_DSA_44_EXTERNAL_REVIEW.md
@@ -187,8 +187,10 @@ signature hashes above, and `PASS` for every entry under `checks`, including
 `adapter_asan_ubsan`. Both retained upstream libcrux security tests must pass
 and be reported as ML-DSA-65. Both repo-defined exact ML-DSA-44
 RUSTSEC-2026-0076 malformed-hint cases must reject without panic. The reviewer
-must retain the explicit `UNTESTED` disposition for an exact ML-DSA-44
-RUSTSEC-2026-0077 regression unless separate evidence is supplied.
+must also confirm that the source- and case-hash-bound Wycheproof ML-DSA-44
+tcIds 125 and 126 reject across all three oracles for the exact
+RUSTSEC-2026-0077 positive and negative signer-response coefficient cases at
+the infinity-norm boundary.
 
 The complete report has no universal expected SHA256 because it contains host-
 specific benchmark values. The run also exercises fresh randomized-signing

--- a/docs/ML_DSA_44_REFERENCE.md
+++ b/docs/ML_DSA_44_REFERENCE.md
@@ -127,6 +127,10 @@ implementation evidence, not independent design, external cryptographic
 review, or production approval. The harness also reruns the upstream
 regressions for `RUSTSEC-2026-0076` and `RUSTSEC-2026-0077` and adds two
 ML-DSA-44 malformed-hint rejections, including the old out-of-bounds shape.
+For 0077 it binds pinned Wycheproof ML-DSA-44 tcIds 125 and 126 by source,
+case identity, and component hashes, then requires all three oracles to reject
+the positive and negative signer-response coefficient cases at the
+infinity-norm boundary.
 
 Run:
 
@@ -211,7 +215,8 @@ Established:
 6. both portable-C adapters pass the bounded ASan/UBSan exercise
 7. both retained upstream libcrux security tests pass on their ML-DSA-65
    scope, and two exact ML-DSA-44 RUSTSEC-2026-0076 malformed-hint cases reject
-   without panic; exact ML-DSA-44 RUSTSEC-2026-0077 coverage remains untested
+   without panic; exact pinned Wycheproof ML-DSA-44 RUSTSEC-2026-0077 tcIds
+   125 and 126 reject across all three oracles
 8. a separate implementation lineage agrees with the full comparator contract
 9. the candidate has a reproducible ten-run performance and raw-payload model
 

--- a/docs/PQSIG_CANDIDATE_SELECTION.md
+++ b/docs/PQSIG_CANDIDATE_SELECTION.md
@@ -240,7 +240,7 @@ if any of these occur:
 
 ## Independent Implementation Evidence
 
-Completed on 2026-07-19:
+Initial evidence completed on 2026-07-19:
 
 1. pin libcrux 0.0.10 source, tag, subtree, initial implementation commit, and
    exact crates.io archive
@@ -249,10 +249,13 @@ Completed on 2026-07-19:
    vector to pass OpenSSL, `mldsa-native`, and libcrux
 3. rerun the two retained upstream libcrux security tests on their ML-DSA-65
    scope and two exact ML-DSA-44 RUSTSEC-2026-0076 malformed-hint rejection
-   cases without panic; retain `UNTESTED` for exact ML-DSA-44
-   RUSTSEC-2026-0077 coverage
+   cases without panic
 4. record the qualified lineage assessment rather than claiming independent
    design or external review
+
+The 2026-07-25 follow-up binds pinned Wycheproof ML-DSA-44 tcIds 125 and 126
+and requires all three oracles to reject the exact RUSTSEC-2026-0077 positive
+and negative signer-response coefficient cases at the infinity-norm boundary.
 
 ## Next Gates
 

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -64,11 +64,13 @@ codebases agree on all official and repo-defined exact outputs, cross-verify
 randomized signatures, and reject the bounded malformed/mutated corpus. The
 two portable-C adapters pass the ASan/UBSan tranche. Both retained upstream
 libcrux security tests pass on their ML-DSA-65 scope; two exact ML-DSA-44
-RUSTSEC-2026-0076 malformed-hint cases reject without panic, while exact
-ML-DSA-44 RUSTSEC-2026-0077 coverage remains untested. Ten-run arm64 timings
-and a raw-payload cost model are recorded. The qualified libcrux result closes the independent
-implementation evidence gate but is not independent design, external
-cryptographic review, or production approval.
+RUSTSEC-2026-0076 malformed-hint cases reject without panic, and pinned
+Wycheproof tcIds 125 and 126 provide exact ML-DSA-44 RUSTSEC-2026-0077
+rejections for positive and negative signer-response coefficients at the
+infinity-norm boundary across all three oracles.
+Ten-run arm64 timings and a raw-payload cost model are recorded. The qualified
+libcrux result closes the independent implementation evidence gate but is not
+independent design, external cryptographic review, or production approval.
 
 The measured decision in `PQSIG_CANDIDATE_SELECTION.md` selects FIPS 204
 `ML-DSA-44` as the primary engineering candidate and retains FIPS 205


### PR DESCRIPTION
## Summary

- Bind pinned C2SP Wycheproof ML-DSA-44 tcIds 125 and 126 by source commit, source/vector hashes, case identity, semantics, and component hashes.
- Require OpenSSL, mldsa-native, and libcrux to reject both signed-coefficient boundary cases before reporting the exact RUSTSEC-2026-0077 regression as passing.
- Fail closed if the oracle set is missing or extended, if vector provenance drifts, or if the PR changes any other byte of the frozen vector contract.
- Update the advisory ledger, reproduction workflow, derived corpus hashes, admission status, tests, and review documentation.

## Evidence

A disposable probe built from the official libcrux-ml-dsa 0.0.7 crate archive (SHA256 `2b34d977eb95b8fe93e6eb87197b55ee21e50e725bc3f206a7cb3a0d7d719c4b`) accepted 37 of the 42 pinned `InfinityNormViolation` cases, including tcIds 125 and 126. The pinned 0.0.10 portable oracle rejected all 42. The current differential replay rejected tcIds 125 and 126 across all three required oracles.

## Verification

- `python3 -m unittest discover -s ci/test -p 'test_ml_dsa*.py'` — 138 passed
- Reference, CLI-adapter, verifier, stateful-signer, and differential-fuzz manifest validation — passed
- Advisory ledger plan validation — passed
- JSON, YAML, Python bytecode, whitespace, and staged-diff checks — passed
- Exact PR transition test — exact vector transition passes; tampered regression, unrelated drift, and tampered baseline fail

The required PR reproduction workflow remains the authoritative full three-oracle run for the exact PR head.

## Scope

The production backend remains `NONE`, the release hold is unchanged, and no node, wallet, consensus, or production cryptographic surface changes. Issue #189 remains open for exact SIMD256 regressions for RUSTSEC-2026-0125/0126 before any optimized-backend admission and for exact-commit independent re-review under #181.

Advances #189.