### PR TITLE
Add exact ML-DSA SIMD256 advisory regressions

### DIFF
--- a/.github/workflows/ml-dsa-44-advisory-ledger.yml
+++ b/.github/workflows/ml-dsa-44-advisory-ledger.yml
@@ -5,15 +5,20 @@ on:
     paths:
       - ".github/workflows/ml-dsa-44-advisory-ledger.yml"
       - ".github/workflows/ml-dsa-44-review-reproduction.yml"
+      - ".github/workflows/ml-dsa-44-simd256-regressions.yml"
       - "contrib/ml-dsa-ref/**"
       - "contrib/ml-dsa-engineering/advisory_ledger.json"
       - "contrib/ml-dsa-engineering/backend_admission.json"
+      - "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/**"
       - "contrib/ml-dsa-engineering/README.md"
+      - "contrib/ml-dsa-engineering/libcrux_simd256_regression.rs"
       - "contrib/ml-dsa-engineering/run_advisory_ledger.py"
+      - "contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py"
       - "contrib/ml-dsa-engineering/libcrux-miri/**"
       - "ci/test/test_ml_dsa_advisory_ledger.py"
       - "ci/test/test_ml_dsa_backend_admission.py"
       - "ci/test/test_ml_dsa_reference.py"
+      - "ci/test/test_ml_dsa_simd256_regressions.py"
       - "ci/test/test_ml_dsa_sustained_fuzz.py"
       - "docs/ML_DSA_44_ADVISORY_LEDGER.md"
       - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
@@ -57,6 +62,13 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  simd256-pr-regressions:
+    name: Exact x86_64 AVX2 advisory regressions
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ml-dsa-44-simd256-regressions.yml
+
   audit:
     name: Pinned advisory, SBOM, and portable Miri audit
     runs-on: ubuntu-24.04

--- a/.github/workflows/ml-dsa-44-simd256-regressions.yml
+++ b/.github/workflows/ml-dsa-44-simd256-regressions.yml
@@ -1,17 +1,7 @@
 name: ML-DSA-44 SIMD256 advisory regressions
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/ml-dsa-44-simd256-regressions.yml"
-      - "contrib/ml-dsa-engineering/advisory_ledger.json"
-      - "contrib/ml-dsa-engineering/backend_admission.json"
-      - "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/**"
-      - "contrib/ml-dsa-engineering/libcrux_simd256_regression.rs"
-      - "contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py"
-      - "ci/test/test_ml_dsa_simd256_regressions.py"
-      - "docs/ML_DSA_44_ADVISORY_LEDGER.md"
-      - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/ml-dsa-44-simd256-regressions.yml
+++ b/.github/workflows/ml-dsa-44-simd256-regressions.yml
@@ -1,0 +1,171 @@
+name: ML-DSA-44 SIMD256 advisory regressions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ml-dsa-44-simd256-regressions.yml"
+      - "contrib/ml-dsa-engineering/advisory_ledger.json"
+      - "contrib/ml-dsa-engineering/backend_admission.json"
+      - "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/**"
+      - "contrib/ml-dsa-engineering/libcrux_simd256_regression.rs"
+      - "contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py"
+      - "ci/test/test_ml_dsa_simd256_regressions.py"
+      - "docs/ML_DSA_44_ADVISORY_LEDGER.md"
+      - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ml-dsa-44-simd256-regressions.yml"
+      - "contrib/ml-dsa-engineering/advisory_ledger.json"
+      - "contrib/ml-dsa-engineering/backend_admission.json"
+      - "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/**"
+      - "contrib/ml-dsa-engineering/libcrux_simd256_regression.rs"
+      - "contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py"
+      - "ci/test/test_ml_dsa_simd256_regressions.py"
+      - "docs/ML_DSA_44_ADVISORY_LEDGER.md"
+      - "docs/ML_DSA_44_BACKEND_ADMISSION.md"
+  schedule:
+    - cron: "43 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ml-dsa-44-simd256-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  regressions:
+    name: Exact x86_64 AVX2 advisory regressions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      ARCHIVE: ${{ runner.temp }}/libcrux-ml-dsa-0.0.10.crate
+      EVIDENCE: ${{ runner.temp }}/ml-dsa-44-simd256-evidence
+      ML_DSA_TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      PINNED_RUST_TOOLCHAIN: "1.89.0"
+      LIBCRUX_DISABLE_SIMD128: "1"
+      LIBCRUX_ENABLE_SIMD256: "1"
+      AUDIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      AUDIT_RUN_ID: ${{ github.run_id }}
+      AUDIT_RUN_ATTEMPT: ${{ github.run_attempt }}
+
+    steps:
+      - name: Checkout exact audit head
+        timeout-minutes: 5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify exact clean checkout
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          test "$(git rev-parse HEAD)" = "$AUDIT_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Install exact Rust toolchain
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          rustup toolchain install "$PINNED_RUST_TOOLCHAIN" \
+            --profile minimal --target "$ML_DSA_TARGET_TRIPLE" \
+            --no-self-update
+          echo "RUSTUP_TOOLCHAIN=$PINNED_RUST_TOOLCHAIN" >> "$GITHUB_ENV"
+          test "$(rustc +"$PINNED_RUST_TOOLCHAIN" --version | cut -d ' ' -f 2)" \
+            = "$PINNED_RUST_TOOLCHAIN"
+          test "$(cargo +"$PINNED_RUST_TOOLCHAIN" --version | cut -d ' ' -f 2)" \
+            = "$PINNED_RUST_TOOLCHAIN"
+
+      - name: Validate checked-in regression contract
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          python3 contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py \
+            --plan-only
+          python3 -m unittest ci.test.test_ml_dsa_simd256_regressions
+
+      - name: Acquire exact libcrux release crate
+        timeout-minutes: 10
+        run: |
+          set -euxo pipefail
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --retry 5 --retry-all-errors \
+            https://static.crates.io/crates/libcrux-ml-dsa/libcrux-ml-dsa-0.0.10.crate \
+            -o "$ARCHIVE"
+          echo "783ebed7cb27de6d44ef2aa662648d1a0869694f2f754f2f1ed45e959ef3b48e  $ARCHIVE" \
+            | sha256sum --check
+          chmod 0444 "$ARCHIVE"
+
+      - name: Run test-only portable and AVX2 regressions
+        timeout-minutes: 15
+        run: |
+          set -euxo pipefail
+          python3 contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py \
+            --crate-archive "$ARCHIVE" \
+            --output-dir "$EVIDENCE" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --ref "$GITHUB_REF" \
+            --repository-commit "$AUDIT_SHA" \
+            --run-id "$AUDIT_RUN_ID" \
+            --run-attempt "$AUDIT_RUN_ATTEMPT"
+
+      - name: Verify checkout remained exact and clean
+        if: always()
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          test "$(git rev-parse HEAD)" = "$AUDIT_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Finalize retained evidence checksums
+        id: finalize_evidence
+        if: always()
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          mkdir -p "$EVIDENCE"
+          printf 'job_status=%s\n' '${{ job.status }}' > "$EVIDENCE/job-status.txt"
+          find "$EVIDENCE" -type l -print -quit \
+            > "$RUNNER_TEMP/ml-dsa-44-simd256-symlink.txt"
+          if [[ -s "$RUNNER_TEMP/ml-dsa-44-simd256-symlink.txt" ]]; then
+            echo "evidence contains a symlink" >&2
+            exit 1
+          fi
+          find "$EVIDENCE" ! -type f ! -type d -print -quit \
+            > "$RUNNER_TEMP/ml-dsa-44-simd256-special.txt"
+          if [[ -s "$RUNNER_TEMP/ml-dsa-44-simd256-special.txt" ]]; then
+            echo "evidence contains a special file" >&2
+            exit 1
+          fi
+          cd "$EVIDENCE"
+          find . -type f ! -name SHA256SUMS -print0 \
+            | sort -z \
+            | xargs -0 sha256sum > SHA256SUMS
+          sha256sum --check SHA256SUMS
+
+      - name: Upload untrusted candidate evidence
+        if: ${{ always() && steps.finalize_evidence.outcome == 'success' && (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') }}
+        timeout-minutes: 5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ml-dsa-44-simd256-candidate-${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ml-dsa-44-simd256-evidence/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload trusted-main evidence
+        if: ${{ always() && steps.finalize_evidence.outcome == 'success' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+        timeout-minutes: 5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ml-dsa-44-simd256-main-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ml-dsa-44-simd256-evidence/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/ml-dsa-44-simd256-regressions.yml
+++ b/.github/workflows/ml-dsa-44-simd256-regressions.yml
@@ -32,8 +32,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
-      ARCHIVE: ${{ runner.temp }}/libcrux-ml-dsa-0.0.10.crate
-      EVIDENCE: ${{ runner.temp }}/ml-dsa-44-simd256-evidence
       ML_DSA_TARGET_TRIPLE: x86_64-unknown-linux-gnu
       PINNED_RUST_TOOLCHAIN: "1.89.0"
       LIBCRUX_DISABLE_SIMD128: "1"
@@ -43,6 +41,15 @@ jobs:
       AUDIT_RUN_ATTEMPT: ${{ github.run_attempt }}
 
     steps:
+      - name: Initialize isolated evidence paths
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          echo "ARCHIVE=$RUNNER_TEMP/libcrux-ml-dsa-0.0.10.crate" \
+            >> "$GITHUB_ENV"
+          echo "EVIDENCE=$RUNNER_TEMP/ml-dsa-44-simd256-evidence" \
+            >> "$GITHUB_ENV"
+
       - name: Checkout exact audit head
         timeout-minutes: 5
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/ci/test/test_ml_dsa_advisory_ledger.py
+++ b/ci/test/test_ml_dsa_advisory_ledger.py
@@ -386,6 +386,31 @@ class MlDsaAdvisoryLedgerTest(unittest.TestCase):
             '{"disputed": [], "statements": []}\n', encoding="utf8"
         )
         subprocess.run(["git", "init", "-q", str(repository)], check=True)
+        # Do not let detached maintenance race TemporaryDirectory cleanup.
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repository),
+                "config",
+                "--local",
+                "maintenance.auto",
+                "false",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repository),
+                "config",
+                "--local",
+                "gc.auto",
+                "0",
+            ],
+            check=True,
+        )
         subprocess.run(
             [
                 "git",

--- a/ci/test/test_ml_dsa_simd256_regressions.py
+++ b/ci/test/test_ml_dsa_simd256_regressions.py
@@ -34,6 +34,9 @@ BACKEND_ADMISSION = ENGINEERING_DIR / "backend_admission.json"
 WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-simd256-regressions.yml"
 )
+ADVISORY_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-advisory-ledger.yml"
+)
 
 SPEC = importlib.util.spec_from_file_location(
     "run_libcrux_simd256_regressions",
@@ -346,10 +349,28 @@ class MlDsaSimd256RegressionsTest(unittest.TestCase):
 
     def test_workflow_is_x86_64_test_only_and_retains_untrusted_pr_evidence(self):
         workflow = WORKFLOW.read_text(encoding="utf8")
+        advisory_workflow = ADVISORY_WORKFLOW.read_text(encoding="utf8")
         self.assertIn("runs-on: ubuntu-24.04", workflow)
-        self.assertIn("pull_request:", workflow)
+        self.assertIn("workflow_call:", workflow)
+        self.assertNotIn("\n  pull_request:", workflow)
         self.assertIn("push:", workflow)
         self.assertIn("branches:\n      - main", workflow)
+        self.assertIn(
+            "uses: ./.github/workflows/ml-dsa-44-simd256-regressions.yml",
+            advisory_workflow,
+        )
+        self.assertIn(
+            "if: github.event_name == 'pull_request'",
+            advisory_workflow,
+        )
+        for path in (
+            ".github/workflows/ml-dsa-44-simd256-regressions.yml",
+            "contrib/ml-dsa-engineering/fuzz_sources/wycheproof/**",
+            "contrib/ml-dsa-engineering/libcrux_simd256_regression.rs",
+            "contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py",
+            "ci/test/test_ml_dsa_simd256_regressions.py",
+        ):
+            self.assertIn(f'      - "{path}"', advisory_workflow)
         self.assertIn("--event-name \"$GITHUB_EVENT_NAME\"", workflow)
         self.assertIn("--ref \"$GITHUB_REF\"", workflow)
         self.assertIn("--repository-commit \"$AUDIT_SHA\"", workflow)

--- a/ci/test/test_ml_dsa_simd256_regressions.py
+++ b/ci/test/test_ml_dsa_simd256_regressions.py
@@ -1,0 +1,422 @@
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINEERING_DIR = REPO_ROOT / "contrib" / "ml-dsa-engineering"
+DRIVER = ENGINEERING_DIR / "run_libcrux_simd256_regressions.py"
+HARNESS = ENGINEERING_DIR / "libcrux_simd256_regression.rs"
+SOURCE_MANIFEST = (
+    ENGINEERING_DIR / "fuzz_sources" / "wycheproof" / "SOURCE.json"
+)
+VECTOR_FILE = (
+    ENGINEERING_DIR
+    / "fuzz_sources"
+    / "wycheproof"
+    / "mldsa_44_verify_test.json"
+)
+LEDGER = ENGINEERING_DIR / "advisory_ledger.json"
+BACKEND_ADMISSION = ENGINEERING_DIR / "backend_admission.json"
+WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-simd256-regressions.yml"
+)
+
+SPEC = importlib.util.spec_from_file_location(
+    "run_libcrux_simd256_regressions",
+    DRIVER,
+)
+assert SPEC is not None and SPEC.loader is not None
+simd256 = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = simd256
+SPEC.loader.exec_module(simd256)
+
+
+class MlDsaSimd256RegressionsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cases = simd256.load_wycheproof_cases()
+        cls.plan = simd256.plan_document(cls.cases)
+
+    def test_wycheproof_cases_are_exactly_bound(self):
+        self.assertEqual(
+            simd256.sha256_file(SOURCE_MANIFEST),
+            "3522cf3ae87aaa929f8d6b0e3be809665d809ce97b71cc01aa3256d7f2b0f1f2",
+        )
+        self.assertEqual(
+            simd256.sha256_file(VECTOR_FILE),
+            "5ec04790c240c443ca8b662b8fc871834602c7cce87fcd36a193110745b2b9ea",
+        )
+        self.assertEqual(
+            [case["test_case_id"] for case in self.cases],
+            [147, 148],
+        )
+        self.assertEqual(
+            [case["expected_valid"] for case in self.cases],
+            [True, False],
+        )
+        self.assertEqual(
+            [case["signature_sha256"] for case in self.cases],
+            [
+                "5306515480c0f680da054413c248876024870eaccf8032703aaf06105c1a2191",
+                "0642b1cb6f51243aa6292fc11caa41e6f21ac7072988b0fa939c5d73cfcc6629",
+            ],
+        )
+        for field in ("public_key_hex", "message_hex", "context_hex"):
+            self.assertEqual(self.cases[0][field], self.cases[1][field])
+
+    def test_wycheproof_mutation_fails_before_execution(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            mutated = Path(temporary) / VECTOR_FILE.name
+            shutil.copyfile(VECTOR_FILE, mutated)
+            value = bytearray(mutated.read_bytes())
+            value[-2] ^= 1
+            mutated.write_bytes(value)
+            with self.assertRaisesRegex(
+                simd256.RegressionError,
+                "Wycheproof vector file SHA256 mismatch",
+            ):
+                simd256.load_wycheproof_cases(
+                    source_manifest_path=SOURCE_MANIFEST,
+                    vector_file_path=mutated,
+                )
+
+    def test_execution_contract_is_test_only_and_fail_closed(self):
+        execution = self.plan["execution_contract"]
+        self.assertEqual(execution["architecture"], "x86_64")
+        self.assertEqual(execution["required_cpu_feature"], "avx2")
+        self.assertEqual(execution["target_triple"], "x86_64-unknown-linux-gnu")
+        self.assertFalse(execution["default_features"])
+        self.assertEqual(execution["features"], ["mldsa44", "simd256", "std"])
+        self.assertEqual(execution["compiled_backends"], ["portable", "simd256"])
+        self.assertEqual(execution["called_backends"], ["portable", "avx2"])
+        self.assertEqual(
+            execution["required_environment"],
+            {
+                "LIBCRUX_DISABLE_SIMD128": "1",
+                "LIBCRUX_DISABLE_SIMD256": "UNSET",
+                "LIBCRUX_ENABLE_SIMD256": "1",
+            },
+        )
+        self.assertEqual(execution["production_backend"], "NONE")
+        self.assertFalse(execution["simd256_admitted"])
+        self.assertTrue(execution["release_hold"])
+        self.assertFalse(execution["release_hold_changed"])
+        self.assertEqual(execution["rustsec_2026_0125_profile"], "debug")
+        self.assertEqual(
+            execution["rustsec_2026_0126_profiles"],
+            ["debug", "release"],
+        )
+        self.assertEqual(
+            self.plan["source_contract"]["crate_tree_sha256"],
+            "26b2206e58eb6cf4de2a49c3185a85c3961bf9b5b43cc020f63a1d1b92b75faa",
+        )
+
+    def test_exact_upstream_invntt_regressions_are_frozen(self):
+        self.assertEqual(
+            self.plan["advisories"]["RUSTSEC-2026-0126"][
+                "upstream_libtest_paths"
+            ],
+            [
+                "simd::avx2::invntt::tests::inv_ntt_unreduced_max",
+                "simd::avx2::invntt::tests::inv_ntt_reduced",
+                "simd::avx2::invntt::tests::inv_ntt_reduced_large",
+            ],
+        )
+        source = DRIVER.read_text(encoding="utf8")
+        self.assertIn('"--lib",\n                    test_name,', source)
+        self.assertIn('"--",\n                    "--exact",', source)
+        self.assertIn('("release", ["--release"])', source)
+        self.assertIn("timeout_seconds=300", source)
+        self.assertNotIn("source patch", source.lower())
+        self.assertNotIn("cfg(test)", source)
+
+    def test_libtest_success_requires_one_exact_named_test(self):
+        test_name = simd256.INVNTT_TESTS[0]
+        valid = (
+            "running 1 test\n"
+            f"test {test_name} ... ok\n\n"
+            "test result: ok. 1 passed; 0 failed; 0 ignored; "
+            "0 measured; 73 filtered out; finished in 0.00s\n"
+        )
+        simd256.require_exact_libtest_success(valid, test_name)
+
+        zero_tests = (
+            "running 0 tests\n\n"
+            "test result: ok. 0 passed; 0 failed; 0 ignored; "
+            "0 measured; 74 filtered out; finished in 0.00s\n"
+        )
+        with self.assertRaisesRegex(
+            simd256.RegressionError,
+            "did not select exactly one",
+        ):
+            simd256.require_exact_libtest_success(zero_tests, test_name)
+
+        wrong_test = valid.replace(test_name, simd256.INVNTT_TESTS[1])
+        with self.assertRaisesRegex(
+            simd256.RegressionError,
+            "did not run and pass exactly once",
+        ):
+            simd256.require_exact_libtest_success(wrong_test, test_name)
+
+    def test_rust_toolchain_version_is_exact(self):
+        self.assertEqual(
+            simd256.require_tool_version(
+                "rustc 1.89.0 (29483883e 2025-08-04)\n",
+                "rustc",
+            ),
+            "rustc 1.89.0 (29483883e 2025-08-04)",
+        )
+        with self.assertRaisesRegex(simd256.RegressionError, "version drifted"):
+            simd256.require_tool_version("cargo 1.90.0 (unknown)\n", "cargo")
+
+    def test_harness_calls_portable_and_avx2_explicitly(self):
+        source = HARNESS.read_text(encoding="utf8")
+        self.assertIn("portable::verify(", source)
+        self.assertIn("avx2::verify(", source)
+        self.assertIn('std::is_x86_feature_detected!("avx2")', source)
+        self.assertIn("arguments.len() > 5", source)
+        self.assertIn("raw_arguments.next().is_some()", source)
+        self.assertIn("PUBLIC_KEY_SIZE: usize = 1312", source)
+        self.assertIn("SIGNATURE_SIZE: usize = 2420", source)
+        self.assertEqual(
+            simd256.sha256_file(HARNESS),
+            "babe124c26ce5ea6d0056c6314bd0475e6f98004fa099fc679429db3fca53008",
+        )
+
+    def test_subprocesses_never_use_a_shell(self):
+        tree = ast.parse(DRIVER.read_text(encoding="utf8"))
+        subprocess_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "subprocess"
+        ]
+        self.assertTrue(subprocess_calls)
+        for call in subprocess_calls:
+            keywords = {keyword.arg: keyword.value for keyword in call.keywords}
+            self.assertNotIn("shell", keywords)
+        environment = simd256.regression_environment()
+        self.assertEqual(environment["LIBCRUX_DISABLE_SIMD128"], "1")
+        self.assertEqual(environment["LIBCRUX_ENABLE_SIMD256"], "1")
+        self.assertNotIn("LIBCRUX_DISABLE_SIMD256", environment)
+
+    def test_pr_and_main_evidence_have_distinct_trust(self):
+        pull_request = simd256.classify_trust(
+            "pull_request",
+            "refs/pull/211/merge",
+        )
+        self.assertEqual(pull_request["label"], "UNTRUSTED_PR_EVIDENCE")
+        self.assertFalse(pull_request["may_report_pass"])
+        self.assertFalse(pull_request["eligible_for_ledger_promotion"])
+
+        main = simd256.classify_trust("push", "refs/heads/main")
+        self.assertEqual(main["label"], "TRUSTED_MAIN_EVIDENCE")
+        self.assertTrue(main["may_report_pass"])
+        self.assertTrue(main["eligible_for_ledger_promotion"])
+
+        branch = simd256.classify_trust("workflow_dispatch", "refs/heads/topic")
+        self.assertEqual(branch["label"], "UNTRUSTED_NON_MAIN_EVIDENCE")
+        self.assertFalse(branch["may_report_pass"])
+        self.assertIn(
+            '"UNTRUSTED_OBSERVATION"',
+            DRIVER.read_text(encoding="utf8"),
+        )
+
+    def test_main_failure_evidence_is_never_promotion_eligible(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "evidence"
+            simd256.claim_output_directory(output)
+            simd256.failure_report(
+                output_dir=output,
+                event_name="push",
+                ref="refs/heads/main",
+                repository_commit="0" * 40,
+                run_id="123",
+                run_attempt="1",
+                error=simd256.RegressionError("expected failure"),
+            )
+            report = json.loads(
+                (output / "simd256-regression-report.json").read_text(
+                    encoding="utf8"
+                )
+            )
+            self.assertEqual(report["status"], "FAIL")
+            self.assertEqual(report["trust"]["label"], "TRUSTED_MAIN_EVIDENCE")
+            self.assertFalse(report["trust"]["may_report_pass"])
+            self.assertFalse(report["trust"]["eligible_for_ledger_promotion"])
+            self.assertFalse(report["trust"]["actual_pass_capable"])
+
+    def test_crate_archive_path_validation_rejects_escape_and_links(self):
+        with self.assertRaisesRegex(simd256.RegressionError, "unsafe"):
+            simd256._safe_member_path("../escape")
+        with self.assertRaisesRegex(simd256.RegressionError, "unexpected"):
+            simd256._safe_member_path("different-crate/file")
+        self.assertEqual(
+            simd256._safe_member_path("libcrux-ml-dsa-0.0.10/src/lib.rs"),
+            simd256.PurePosixPath("libcrux-ml-dsa-0.0.10/src/lib.rs"),
+        )
+
+    def test_read_only_source_contract_is_enforced(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "crate"
+            nested = root / "src"
+            nested.mkdir(parents=True)
+            source = nested / "lib.rs"
+            source.write_text("pub fn marker() {}\n", encoding="utf8")
+            before = simd256.tree_digest(root)
+            simd256.make_tree_read_only(root)
+            simd256.require_tree_read_only(root)
+            self.assertEqual(before, simd256.tree_digest(root))
+            self.assertFalse(source.stat().st_mode & stat.S_IWUSR)
+
+    def test_evidence_directory_requires_an_exact_ownership_marker(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            empty = Path(temporary) / "empty"
+            simd256.claim_output_directory(empty)
+            marker = empty / simd256.EVIDENCE_MARKER
+            self.assertEqual(
+                marker.read_text(encoding="utf8"),
+                simd256.EVIDENCE_MARKER_CONTENT,
+            )
+            simd256.claim_output_directory(empty)
+
+            unrelated = Path(temporary) / "unrelated"
+            unrelated.mkdir()
+            retained = unrelated / "keep.txt"
+            retained.write_text("do not overwrite\n", encoding="utf8")
+            with self.assertRaisesRegex(
+                simd256.RegressionError,
+                "not owned",
+            ):
+                simd256.claim_output_directory(unrelated)
+            self.assertEqual(retained.read_text(encoding="utf8"), "do not overwrite\n")
+
+            link = empty / "evidence-link"
+            link.symlink_to(marker)
+            with self.assertRaisesRegex(
+                simd256.RegressionError,
+                "evidence contains a symlink",
+            ):
+                simd256.claim_output_directory(empty)
+            link.unlink()
+
+            stale = empty / "stale.log"
+            stale.write_text("stale\n", encoding="utf8")
+            with self.assertRaisesRegex(
+                simd256.RegressionError,
+                "contains stale files",
+            ):
+                simd256.claim_output_directory(empty)
+
+    def test_checked_in_ledger_and_backend_remain_unpromoted(self):
+        ledger = json.loads(LEDGER.read_text(encoding="utf8"))
+        advisories = {entry["id"]: entry for entry in ledger["advisories"]}
+        for advisory_id in ("RUSTSEC-2026-0125", "RUSTSEC-2026-0126"):
+            entry = advisories[advisory_id]
+            self.assertEqual(entry["current_path_applicability"], "NOT_APPLICABLE")
+            self.assertEqual(entry["test_status"], "UNTESTED")
+            self.assertEqual(
+                entry["future_admission"],
+                "BLOCKED_UNTIL_EXACT_SIMD256_REGRESSION_PASSES",
+            )
+        self.assertFalse(ledger["execution_contract"]["simd256_admitted"])
+        self.assertEqual(ledger["execution_contract"]["production_backend"], "NONE")
+        self.assertTrue(ledger["execution_contract"]["release_hold"])
+
+        admission = json.loads(BACKEND_ADMISSION.read_text(encoding="utf8"))
+        serialized = json.dumps(admission, sort_keys=True)
+        self.assertIn('"release_hold": true', serialized)
+        self.assertIn('"production_backend": "NONE"', serialized)
+
+    def test_workflow_is_x86_64_test_only_and_retains_untrusted_pr_evidence(self):
+        workflow = WORKFLOW.read_text(encoding="utf8")
+        self.assertIn("runs-on: ubuntu-24.04", workflow)
+        self.assertIn("pull_request:", workflow)
+        self.assertIn("push:", workflow)
+        self.assertIn("branches:\n      - main", workflow)
+        self.assertIn("--event-name \"$GITHUB_EVENT_NAME\"", workflow)
+        self.assertIn("--ref \"$GITHUB_REF\"", workflow)
+        self.assertIn("--repository-commit \"$AUDIT_SHA\"", workflow)
+        self.assertIn("--run-id \"$AUDIT_RUN_ID\"", workflow)
+        self.assertIn("--run-attempt \"$AUDIT_RUN_ATTEMPT\"", workflow)
+        self.assertIn("PINNED_RUST_TOOLCHAIN: \"1.89.0\"", workflow)
+        self.assertIn(
+            'echo "RUSTUP_TOOLCHAIN=$PINNED_RUST_TOOLCHAIN" >> "$GITHUB_ENV"',
+            workflow,
+        )
+        self.assertGreaterEqual(
+            workflow.count(
+                'test "$(git rev-parse HEAD)" = "$AUDIT_SHA"'
+            ),
+            2,
+        )
+        self.assertGreaterEqual(
+            workflow.count(
+                'git status --porcelain=v1 --untracked-files=all'
+            ),
+            2,
+        )
+        self.assertIn("LIBCRUX_DISABLE_SIMD128: \"1\"", workflow)
+        self.assertIn("LIBCRUX_ENABLE_SIMD256: \"1\"", workflow)
+        self.assertNotIn("LIBCRUX_DISABLE_SIMD256:", workflow)
+        self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("if: always()", workflow)
+        self.assertIn("sha256sum --check SHA256SUMS", workflow)
+        self.assertIn('find "$EVIDENCE" -type l -print -quit', workflow)
+        self.assertIn("${{ runner.temp }}/ml-dsa-44-simd256-evidence/", workflow)
+        self.assertIn("timeout-minutes: 20", workflow)
+        self.assertIn("ml-dsa-44-simd256-candidate-", workflow)
+        self.assertIn("ml-dsa-44-simd256-main-", workflow)
+        upload_v6 = (
+            "actions/upload-artifact@"
+            "b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6"
+        )
+        self.assertEqual(workflow.count(upload_v6), 2)
+        self.assertEqual(workflow.count("include-hidden-files: true"), 2)
+        self.assertNotIn("actions/upload-artifact@ea165f8d", workflow)
+        self.assertIn("id: finalize_evidence", workflow)
+        self.assertEqual(
+            workflow.count(
+                "steps.finalize_evidence.outcome == 'success'"
+            ),
+            2,
+        )
+        self.assertIn(
+            "783ebed7cb27de6d44ef2aa662648d1a0869694f2f754f2f1ed45e959ef3b48e",
+            workflow,
+        )
+
+    def test_plan_only_cli(self):
+        completed = subprocess.run(
+            [sys.executable, str(DRIVER), "--plan-only"],
+            cwd=REPO_ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        result = json.loads(completed.stdout)
+        self.assertEqual(result, self.plan)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/test/test_ml_dsa_simd256_regressions.py
+++ b/ci/test/test_ml_dsa_simd256_regressions.py
@@ -377,6 +377,20 @@ class MlDsaSimd256RegressionsTest(unittest.TestCase):
         self.assertIn("--run-id \"$AUDIT_RUN_ID\"", workflow)
         self.assertIn("--run-attempt \"$AUDIT_RUN_ATTEMPT\"", workflow)
         self.assertIn("PINNED_RUST_TOOLCHAIN: \"1.89.0\"", workflow)
+        self.assertNotIn("ARCHIVE: ${{ runner.temp }}", workflow)
+        self.assertNotIn("EVIDENCE: ${{ runner.temp }}", workflow)
+        self.assertIn(
+            'echo "ARCHIVE=$RUNNER_TEMP/libcrux-ml-dsa-0.0.10.crate"',
+            workflow,
+        )
+        self.assertIn(
+            'echo "EVIDENCE=$RUNNER_TEMP/ml-dsa-44-simd256-evidence"',
+            workflow,
+        )
+        self.assertLess(
+            workflow.index("Initialize isolated evidence paths"),
+            workflow.index("Checkout exact audit head"),
+        )
         self.assertIn(
             'echo "RUSTUP_TOOLCHAIN=$PINNED_RUST_TOOLCHAIN" >> "$GITHUB_ENV"',
             workflow,

--- a/ci/test/test_ml_dsa_simd256_regressions.py
+++ b/ci/test/test_ml_dsa_simd256_regressions.py
@@ -175,6 +175,36 @@ class MlDsaSimd256RegressionsTest(unittest.TestCase):
         ):
             simd256.require_exact_libtest_success(wrong_test, test_name)
 
+    def test_rustc_searches_target_and_host_dependency_directories(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target_dir = Path(temporary) / "target"
+            target_dependencies = (
+                target_dir
+                / simd256.TARGET_TRIPLE
+                / "debug"
+                / "deps"
+            )
+            host_dependencies = target_dir / "debug" / "deps"
+            target_dependencies.mkdir(parents=True)
+            host_dependencies.mkdir(parents=True)
+
+            self.assertEqual(
+                simd256.rustc_dependency_arguments(target_dir),
+                [
+                    "-L",
+                    f"dependency={target_dependencies}",
+                    "-L",
+                    f"dependency={host_dependencies}",
+                ],
+            )
+
+            shutil.rmtree(host_dependencies)
+            with self.assertRaisesRegex(
+                simd256.RegressionError,
+                "host dependency directory is missing or unsafe",
+            ):
+                simd256.rustc_dependency_arguments(target_dir)
+
     def test_rust_toolchain_version_is_exact(self):
         self.assertEqual(
             simd256.require_tool_version(

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -71,6 +71,31 @@ evidence. Exact-commit independent re-review remains pending under issue #181,
 the production backend remains `NONE`, and the release hold is unchanged. See
 `docs/ML_DSA_44_ADVISORY_LEDGER.md` for the full disposition.
 
+## Test-Only SIMD256 Advisory Regressions
+
+`run_libcrux_simd256_regressions.py` defines a separate x86_64-Linux AVX2
+test lane for RUSTSEC-2026-0125 and RUSTSEC-2026-0126. It verifies the exact
+published `libcrux-ml-dsa 0.0.10` crate archive, makes the extracted source
+read-only, and proves that its source tree is unchanged after execution. It
+fails rather than skips unless `uname -m` is `x86_64` and `/proc/cpuinfo`
+advertises AVX2.
+
+For 0125, the checked-in Rust harness calls the crate's portable and AVX2
+ML-DSA-44 verification entry points explicitly for pinned Wycheproof tcIds 147
+and 148. The source manifest, vector file, source commit, group metadata,
+valid/invalid semantics, and public-key/message/context/signature hashes are
+all frozen. For 0126, the lane invokes the three exact iNTT regressions already
+shipped in the verified crate in debug and release profiles; it does not patch
+or inject tests into the third-party source. The workflow pins Rust 1.89.0,
+requires every exact libtest invocation to prove that one named test ran and
+passed, and requires the repository checkout to remain exact and clean.
+
+Pull-request artifacts are labeled `UNTRUSTED_PR_EVIDENCE` and cannot promote
+the checked-in advisory ledger. A successful run at `refs/heads/main` may
+report `PASS`, but ledger promotion remains a separate reviewed change. This
+lane compiles SIMD256 solely for tests: `production_backend` remains `NONE`,
+`simd256_admitted` remains false, and the release hold remains true.
+
 ## Versioned Static-Analysis Audit
 
 `run_static_analysis.py` defines the isolated wrapper's versioned

--- a/contrib/ml-dsa-engineering/libcrux_simd256_regression.rs
+++ b/contrib/ml-dsa-engineering/libcrux_simd256_regression.rs
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+use libcrux_ml_dsa::ml_dsa_44::{avx2, portable, MLDSA44Signature, MLDSA44VerificationKey};
+use std::env;
+use std::process::ExitCode;
+
+const PUBLIC_KEY_SIZE: usize = 1312;
+const SIGNATURE_SIZE: usize = 2420;
+const MAX_MESSAGE_SIZE: usize = 8192;
+const MAX_CONTEXT_SIZE: usize = 255;
+
+fn decode_hex(value: &str, maximum_size: usize, label: &str) -> Result<Vec<u8>, String> {
+    if value.len() > maximum_size * 2 {
+        return Err(format!("{label} exceeds {maximum_size} bytes"));
+    }
+    if !value.len().is_multiple_of(2) {
+        return Err(format!("{label} hex input has odd length"));
+    }
+    let mut decoded = Vec::with_capacity(value.len() / 2);
+    for pair in value.as_bytes().chunks_exact(2) {
+        let text = std::str::from_utf8(pair).map_err(|_| format!("{label} is not ASCII hex"))?;
+        decoded.push(
+            u8::from_str_radix(text, 16)
+                .map_err(|_| format!("{label} contains a non-hex digit"))?,
+        );
+    }
+    Ok(decoded)
+}
+
+fn decode_array<const SIZE: usize>(value: &str, label: &str) -> Result<[u8; SIZE], String> {
+    decode_hex(value, SIZE, label)?
+        .try_into()
+        .map_err(|_| format!("{label} must be exactly {SIZE} bytes"))
+}
+
+fn verify_case(
+    public_key: &MLDSA44VerificationKey,
+    message: &[u8],
+    context: &[u8],
+    signature_hex: &str,
+    expected_valid: bool,
+    test_case_id: u16,
+) -> Result<(), String> {
+    let signature =
+        MLDSA44Signature::new(decode_array::<SIGNATURE_SIZE>(signature_hex, "signature")?);
+    let portable_valid = portable::verify(public_key, message, context, &signature).is_ok();
+    let avx2_valid = avx2::verify(public_key, message, context, &signature).is_ok();
+
+    if portable_valid != expected_valid {
+        return Err(format!(
+            "tcId {test_case_id} portable result drifted: expected {expected_valid}, got {portable_valid}"
+        ));
+    }
+    if avx2_valid != expected_valid {
+        return Err(format!(
+            "tcId {test_case_id} AVX2 result drifted: expected {expected_valid}, got {avx2_valid}"
+        ));
+    }
+    if portable_valid != avx2_valid {
+        return Err(format!(
+            "tcId {test_case_id} portable and AVX2 results disagree"
+        ));
+    }
+
+    println!(
+        "tcId={test_case_id} portable={} avx2={} expected={}",
+        u8::from(portable_valid),
+        u8::from(avx2_valid),
+        u8::from(expected_valid),
+    );
+    Ok(())
+}
+
+fn run(arguments: &[String]) -> Result<(), String> {
+    if !std::is_x86_feature_detected!("avx2") {
+        return Err("AVX2 is unavailable at runtime".to_owned());
+    }
+    let [public_key_hex, message_hex, context_hex, valid_signature_hex, invalid_signature_hex] =
+        arguments
+    else {
+        return Err(
+            "expected exactly: <pk-hex> <message-hex> <context-hex> <tc147-sig-hex> <tc148-sig-hex>"
+                .to_owned(),
+        );
+    };
+
+    let public_key = MLDSA44VerificationKey::new(decode_array::<PUBLIC_KEY_SIZE>(
+        public_key_hex,
+        "public key",
+    )?);
+    let message = decode_hex(message_hex, MAX_MESSAGE_SIZE, "message")?;
+    let context = decode_hex(context_hex, MAX_CONTEXT_SIZE, "context")?;
+
+    verify_case(
+        &public_key,
+        &message,
+        &context,
+        valid_signature_hex,
+        true,
+        147,
+    )?;
+    verify_case(
+        &public_key,
+        &message,
+        &context,
+        invalid_signature_hex,
+        false,
+        148,
+    )?;
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    let mut raw_arguments = env::args_os();
+    let _program = raw_arguments.next();
+    let mut arguments = Vec::with_capacity(6);
+    for argument in raw_arguments.by_ref().take(6) {
+        match argument.into_string() {
+            Ok(value) => arguments.push(value),
+            Err(_) => {
+                eprintln!("libcrux SIMD256 regression arguments must be UTF-8");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+    if arguments.len() > 5 || raw_arguments.next().is_some() {
+        eprintln!("libcrux SIMD256 regression received too many arguments");
+        return ExitCode::from(2);
+    }
+
+    match run(&arguments) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("libcrux SIMD256 regression: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py
+++ b/contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py
@@ -635,6 +635,25 @@ def find_built_library(target_dir: Path) -> Path:
     return candidates[0]
 
 
+def rustc_dependency_arguments(target_dir: Path) -> list[str]:
+    target_dependencies = target_dir / TARGET_TRIPLE / "debug" / "deps"
+    host_dependencies = target_dir / "debug" / "deps"
+    for label, path in (
+        ("target", target_dependencies),
+        ("host", host_dependencies),
+    ):
+        if path.is_symlink() or not path.is_dir():
+            raise RegressionError(
+                f"{label} dependency directory is missing or unsafe"
+            )
+    return [
+        "-L",
+        f"dependency={target_dependencies}",
+        "-L",
+        f"dependency={host_dependencies}",
+    ]
+
+
 def write_checksums(output_dir: Path) -> None:
     rows = []
     for path in sorted(output_dir.rglob("*")):
@@ -779,7 +798,6 @@ def execute(
             timeout_seconds=900,
         )
 
-        dependencies = target_dir / TARGET_TRIPLE / "debug" / "deps"
         library = find_built_library(target_dir)
         harness_binary = work_root / "pqbtc-libcrux-simd256-regression"
         rustc_build = [
@@ -790,8 +808,7 @@ def execute(
             TARGET_TRIPLE,
             "--crate-name",
             "pqbtc_libcrux_simd256_regression",
-            "-L",
-            f"dependency={dependencies}",
+            *rustc_dependency_arguments(target_dir),
             "--extern",
             f"libcrux_ml_dsa={library}",
             "-o",

--- a/contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py
+++ b/contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py
@@ -1,0 +1,1115 @@
+#!/usr/bin/env python3
+"""Run exact, test-only libcrux ML-DSA-44 AVX2 advisory regressions."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+from typing import Any
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+SOURCE_MANIFEST = HERE / "fuzz_sources" / "wycheproof" / "SOURCE.json"
+VECTOR_FILE = (
+    HERE / "fuzz_sources" / "wycheproof" / "mldsa_44_verify_test.json"
+)
+HARNESS_SOURCE = HERE / "libcrux_simd256_regression.rs"
+
+SOURCE_MANIFEST_SHA256 = (
+    "3522cf3ae87aaa929f8d6b0e3be809665d809ce97b71cc01aa3256d7f2b0f1f2"
+)
+VECTOR_FILE_SHA256 = (
+    "5ec04790c240c443ca8b662b8fc871834602c7cce87fcd36a193110745b2b9ea"
+)
+HARNESS_SOURCE_SHA256 = (
+    "babe124c26ce5ea6d0056c6314bd0475e6f98004fa099fc679429db3fca53008"
+)
+CRATE_ARCHIVE_SHA256 = (
+    "783ebed7cb27de6d44ef2aa662648d1a0869694f2f754f2f1ed45e959ef3b48e"
+)
+CRATE_NAME = "libcrux-ml-dsa"
+CRATE_VERSION = "0.0.10"
+CRATE_ROOT = f"{CRATE_NAME}-{CRATE_VERSION}"
+CRATE_COMMIT = "c5fb80f37530ee9b2df9501ae5ff8cb4a973a4bd"
+CRATE_CARGO_TOML_SHA256 = (
+    "5796c72c70ced10baba72fdb0fa2345163a2ab628b2c04d89ef883ede90f44c1"
+)
+CRATE_CARGO_LOCK_SHA256 = (
+    "10e6505cebc85f9cbf7836002fe5b3b1d9c6c7d84cfc6dd5b6e1f38ebbb6648d"
+)
+CRATE_VCS_INFO_SHA256 = (
+    "52ea479dc21f621e72e8d0abd130f5e202eb6aa0797bc6e7504c7e771b8227c3"
+)
+CRATE_TREE_SHA256 = (
+    "26b2206e58eb6cf4de2a49c3185a85c3961bf9b5b43cc020f63a1d1b92b75faa"
+)
+SOURCE_COMMIT = "fc24cd5b787d8e496bff31b0468af693a652b0f2"
+TARGET_TRIPLE = "x86_64-unknown-linux-gnu"
+RUST_TOOLCHAIN_VERSION = "1.89.0"
+HEX_40 = re.compile(r"^[0-9a-f]{40}$")
+HEX_BYTES = re.compile(r"^(?:[0-9a-f]{2})*$")
+LIBTEST_SUMMARY = re.compile(
+    r"^test result: ok\. 1 passed; 0 failed; 0 ignored; "
+    r"0 measured; \d+ filtered out; finished in .+$"
+)
+EVIDENCE_MARKER = ".pqbtc-simd256-evidence"
+EVIDENCE_MARKER_CONTENT = "pqbtc-libcrux-simd256-regression-v1\n"
+
+INVNTT_TESTS = (
+    "simd::avx2::invntt::tests::inv_ntt_unreduced_max",
+    "simd::avx2::invntt::tests::inv_ntt_reduced",
+    "simd::avx2::invntt::tests::inv_ntt_reduced_large",
+)
+CASE_CONTRACTS = {
+    147: {
+        "comment": "signature that calls use_hint(1, 0)",
+        "result": "valid",
+        "flags": {
+            "ValidSignature",
+            "BoundaryCondition",
+            "ZeroPublicKey",
+        },
+        "public_key_sha256": (
+            "b07bcb1a9e37ac843cb678d6c3c57b960c2b0d2d5d02bc91f3b642258d75b50f"
+        ),
+        "message_sha256": (
+            "64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c"
+        ),
+        "context_sha256": (
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        ),
+        "signature_sha256": (
+            "5306515480c0f680da054413c248876024870eaccf8032703aaf06105c1a2191"
+        ),
+    },
+    148: {
+        "comment": "invalid signature that calls use_hint(1, 0)",
+        "result": "invalid",
+        "flags": {
+            "InvalidSignature",
+            "BoundaryCondition",
+            "ZeroPublicKey",
+        },
+        "public_key_sha256": (
+            "b07bcb1a9e37ac843cb678d6c3c57b960c2b0d2d5d02bc91f3b642258d75b50f"
+        ),
+        "message_sha256": (
+            "64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c"
+        ),
+        "context_sha256": (
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        ),
+        "signature_sha256": (
+            "0642b1cb6f51243aa6292fc11caa41e6f21ac7072988b0fa939c5d73cfcc6629"
+        ),
+    },
+}
+
+
+class RegressionError(RuntimeError):
+    """The exact SIMD256 regression contract was not satisfied."""
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    try:
+        return sha256_bytes(path.read_bytes())
+    except OSError as exc:
+        raise RegressionError(f"cannot read {path}: {exc}") from exc
+
+
+def _reject_duplicate(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise RegressionError(f"duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_constant(value: str) -> None:
+    raise RegressionError(f"non-finite JSON value: {value}")
+
+
+def load_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf8"),
+            object_pairs_hook=_reject_duplicate,
+            parse_constant=_reject_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, RegressionError) as exc:
+        raise RegressionError(f"invalid {label}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RegressionError(f"{label} must be a JSON object")
+    return value
+
+
+def require_file_hash(path: Path, expected: str, label: str) -> None:
+    actual = sha256_file(path)
+    if actual != expected:
+        raise RegressionError(
+            f"{label} SHA256 mismatch: expected {expected}, got {actual}"
+        )
+
+
+def require_hex(
+    value: object,
+    *,
+    exact_bytes: int | None,
+    maximum_bytes: int | None,
+    label: str,
+) -> str:
+    if not isinstance(value, str) or HEX_BYTES.fullmatch(value) is None:
+        raise RegressionError(f"{label} must be lowercase even-length hex")
+    byte_length = len(value) // 2
+    if exact_bytes is not None and byte_length != exact_bytes:
+        raise RegressionError(f"{label} must be exactly {exact_bytes} bytes")
+    if maximum_bytes is not None and byte_length > maximum_bytes:
+        raise RegressionError(f"{label} exceeds {maximum_bytes} bytes")
+    return value
+
+
+def load_wycheproof_cases(
+    source_manifest_path: Path = SOURCE_MANIFEST,
+    vector_file_path: Path = VECTOR_FILE,
+) -> list[dict[str, Any]]:
+    require_file_hash(
+        source_manifest_path,
+        SOURCE_MANIFEST_SHA256,
+        "Wycheproof source manifest",
+    )
+    require_file_hash(vector_file_path, VECTOR_FILE_SHA256, "Wycheproof vector file")
+
+    manifest = load_json_object(source_manifest_path, "Wycheproof source manifest")
+    source = manifest.get("source")
+    vector_record = manifest.get("vector_file")
+    if not isinstance(source, dict) or not isinstance(vector_record, dict):
+        raise RegressionError("Wycheproof source manifest records are missing")
+    if source != {
+        "commit": SOURCE_COMMIT,
+        "imported": "2026-07-20",
+        "license": "Apache-2.0",
+        "repository": "https://github.com/C2SP/wycheproof",
+    }:
+        raise RegressionError("Wycheproof source identity drifted")
+    expected_vector_record = {
+        "algorithm": "ML-DSA-44",
+        "generator_version": "1",
+        "git_blob_sha1": "44f1c08df53338b7a9ffd9c2e123e82e1cfbfaea",
+        "number_of_tests": 180,
+        "sha256": VECTOR_FILE_SHA256,
+        "size": 1081169,
+        "upstream_path": "testvectors_v1/mldsa_44_verify_test.json",
+    }
+    if vector_record != expected_vector_record:
+        raise RegressionError("Wycheproof vector manifest record drifted")
+
+    document = load_json_object(vector_file_path, "Wycheproof vector file")
+    if (
+        document.get("algorithm") != "ML-DSA-44"
+        or str(document.get("generatorVersion")) != "1"
+        or document.get("numberOfTests") != 180
+    ):
+        raise RegressionError("Wycheproof vector metadata drifted")
+    groups = document.get("testGroups")
+    if not isinstance(groups, list):
+        raise RegressionError("Wycheproof testGroups must be a list")
+
+    indexed: dict[int, tuple[dict[str, Any], dict[str, Any]]] = {}
+    for group in groups:
+        if not isinstance(group, dict) or not isinstance(group.get("tests"), list):
+            raise RegressionError("Wycheproof test group is malformed")
+        for case in group["tests"]:
+            if not isinstance(case, dict):
+                raise RegressionError("Wycheproof test case is malformed")
+            test_case_id = case.get("tcId")
+            if not isinstance(test_case_id, int) or test_case_id in indexed:
+                raise RegressionError("Wycheproof test IDs are invalid or duplicated")
+            indexed[test_case_id] = (group, case)
+    if len(indexed) != 180:
+        raise RegressionError("Wycheproof test inventory is not exactly 180 cases")
+
+    selected: list[dict[str, Any]] = []
+    for test_case_id, contract in CASE_CONTRACTS.items():
+        if test_case_id not in indexed:
+            raise RegressionError(f"Wycheproof tcId {test_case_id} is missing")
+        group, case = indexed[test_case_id]
+        if group.get("type") != "MlDsaVerify" or group.get("source") != {
+            "name": "github/gendx",
+            "version": "0.1",
+        }:
+            raise RegressionError(f"Wycheproof tcId {test_case_id} group drifted")
+        flags = case.get("flags")
+        if (
+            case.get("comment") != contract["comment"]
+            or case.get("result") != contract["result"]
+            or not isinstance(flags, list)
+            or len(flags) != len(set(flags))
+            or set(flags) != contract["flags"]
+        ):
+            raise RegressionError(f"Wycheproof tcId {test_case_id} semantics drifted")
+
+        public_key_hex = require_hex(
+            group.get("publicKey"),
+            exact_bytes=1312,
+            maximum_bytes=None,
+            label=f"tcId {test_case_id} public key",
+        )
+        message_hex = require_hex(
+            case.get("msg"),
+            exact_bytes=None,
+            maximum_bytes=8192,
+            label=f"tcId {test_case_id} message",
+        )
+        context_hex = require_hex(
+            case.get("ctx") or "",
+            exact_bytes=None,
+            maximum_bytes=255,
+            label=f"tcId {test_case_id} context",
+        )
+        signature_hex = require_hex(
+            case.get("sig"),
+            exact_bytes=2420,
+            maximum_bytes=None,
+            label=f"tcId {test_case_id} signature",
+        )
+        for field, value in (
+            ("public_key_sha256", public_key_hex),
+            ("message_sha256", message_hex),
+            ("context_sha256", context_hex),
+            ("signature_sha256", signature_hex),
+        ):
+            actual = sha256_bytes(bytes.fromhex(value))
+            if actual != contract[field]:
+                raise RegressionError(
+                    f"Wycheproof tcId {test_case_id} {field} mismatch"
+                )
+        selected.append(
+            {
+                "test_case_id": test_case_id,
+                "expected_valid": contract["result"] == "valid",
+                "public_key_hex": public_key_hex,
+                "message_hex": message_hex,
+                "context_hex": context_hex,
+                "signature_hex": signature_hex,
+                "signature_sha256": contract["signature_sha256"],
+            }
+        )
+
+    common_fields = ("public_key_hex", "message_hex", "context_hex")
+    for field in common_fields:
+        if len({str(case[field]) for case in selected}) != 1:
+            raise RegressionError(f"Wycheproof tcIds 147/148 {field} mismatch")
+    return selected
+
+
+def classify_trust(event_name: str, ref: str) -> dict[str, Any]:
+    if event_name == "pull_request":
+        return {
+            "label": "UNTRUSTED_PR_EVIDENCE",
+            "scope": "pull_request_head_candidate",
+            "may_report_pass": False,
+            "eligible_for_ledger_promotion": False,
+        }
+    if event_name in {"push", "schedule", "workflow_dispatch"} and ref == (
+        "refs/heads/main"
+    ):
+        return {
+            "label": "TRUSTED_MAIN_EVIDENCE",
+            "scope": "trusted_main",
+            "may_report_pass": True,
+            "eligible_for_ledger_promotion": True,
+        }
+    return {
+        "label": "UNTRUSTED_NON_MAIN_EVIDENCE",
+        "scope": "non_main_candidate",
+        "may_report_pass": False,
+        "eligible_for_ledger_promotion": False,
+    }
+
+
+def plan_document(cases: list[dict[str, Any]]) -> dict[str, Any]:
+    require_file_hash(HARNESS_SOURCE, HARNESS_SOURCE_SHA256, "Rust regression harness")
+    return {
+        "schema_version": 1,
+        "advisories": {
+            "RUSTSEC-2026-0125": {
+                "parameter_set": "ML-DSA-44",
+                "test_case_ids": [case["test_case_id"] for case in cases],
+                "expected_validity": {
+                    str(case["test_case_id"]): case["expected_valid"] for case in cases
+                },
+                "called_backends": ["portable", "avx2"],
+            },
+            "RUSTSEC-2026-0126": {
+                "upstream_libtest_paths": list(INVNTT_TESTS),
+                "called_backends": ["portable", "avx2"],
+            },
+        },
+        "source_contract": {
+            "wycheproof_commit": SOURCE_COMMIT,
+            "source_manifest_sha256": SOURCE_MANIFEST_SHA256,
+            "vector_file_sha256": VECTOR_FILE_SHA256,
+            "crate": f"{CRATE_NAME} {CRATE_VERSION}",
+            "crate_commit": CRATE_COMMIT,
+            "crate_archive_sha256": CRATE_ARCHIVE_SHA256,
+            "crate_cargo_toml_sha256": CRATE_CARGO_TOML_SHA256,
+            "crate_cargo_lock_sha256": CRATE_CARGO_LOCK_SHA256,
+            "crate_vcs_info_sha256": CRATE_VCS_INFO_SHA256,
+            "crate_tree_sha256": CRATE_TREE_SHA256,
+            "harness_sha256": HARNESS_SOURCE_SHA256,
+        },
+        "execution_contract": {
+            "architecture": "x86_64",
+            "required_cpu_feature": "avx2",
+            "target_triple": TARGET_TRIPLE,
+            "default_features": False,
+            "features": ["mldsa44", "simd256", "std"],
+            "compiled_backends": ["portable", "simd256"],
+            "called_backends": ["portable", "avx2"],
+            "required_environment": {
+                "LIBCRUX_DISABLE_SIMD128": "1",
+                "LIBCRUX_ENABLE_SIMD256": "1",
+                "LIBCRUX_DISABLE_SIMD256": "UNSET",
+            },
+            "production_backend": "NONE",
+            "simd256_admitted": False,
+            "release_hold": True,
+            "release_hold_changed": False,
+            "rustsec_2026_0125_profile": "debug",
+            "rustsec_2026_0126_profiles": ["debug", "release"],
+        },
+    }
+
+
+def require_x86_64_avx2() -> dict[str, Any]:
+    machine = os.uname().machine
+    if machine != "x86_64":
+        raise RegressionError(
+            f"SIMD256 regression requires uname -m x86_64, got {machine}"
+        )
+    if not sys.platform.startswith("linux"):
+        raise RegressionError(
+            f"SIMD256 regression requires Linux /proc/cpuinfo, got {sys.platform}"
+        )
+    cpuinfo = Path("/proc/cpuinfo")
+    try:
+        cpuinfo_text = cpuinfo.read_text(encoding="utf8").lower()
+    except OSError as exc:
+        raise RegressionError(f"cannot read /proc/cpuinfo: {exc}") from exc
+    flags = set()
+    for line in cpuinfo_text.splitlines():
+        if line.startswith(("flags", "features")) and ":" in line:
+            flags.update(line.split(":", 1)[1].split())
+    if "avx2" not in flags:
+        raise RegressionError("SIMD256 regression requires the AVX2 CPU flag")
+    return {
+        "uname_machine": machine,
+        "platform_machine": platform.machine().lower(),
+        "avx2": "present",
+        "cpu_flags": sorted(flags),
+        "cpuinfo_sha256": sha256_bytes(cpuinfo_text.encode("utf8")),
+    }
+
+
+def _safe_member_path(member_name: str) -> PurePosixPath:
+    path = PurePosixPath(member_name)
+    if path.is_absolute() or ".." in path.parts or not path.parts:
+        raise RegressionError(f"unsafe crate archive member path: {member_name}")
+    if path.parts[0] != CRATE_ROOT:
+        raise RegressionError(f"unexpected crate archive root: {member_name}")
+    return path
+
+
+def make_tree_read_only(root: Path) -> None:
+    for path in sorted(root.rglob("*"), reverse=True):
+        if path.is_symlink():
+            raise RegressionError(f"crate source contains a symlink: {path}")
+        mode = path.stat().st_mode
+        path.chmod(mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+    root.chmod(root.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+
+
+def require_tree_read_only(root: Path) -> None:
+    for path in (root, *root.rglob("*")):
+        if path.is_symlink():
+            raise RegressionError(f"crate source contains a symlink: {path}")
+        if path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH):
+            raise RegressionError(f"crate source is writable: {path}")
+
+
+def tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise RegressionError(f"crate source contains a symlink: {path}")
+        relative = path.relative_to(root).as_posix().encode("utf8")
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        kind = b"d" if path.is_dir() else b"f"
+        digest.update(kind)
+        if path.is_file():
+            content = path.read_bytes()
+            digest.update(len(content).to_bytes(8, "big"))
+            digest.update(content)
+    return digest.hexdigest()
+
+
+def extract_verified_crate(archive: Path, destination: Path) -> Path:
+    if archive.is_symlink() or not archive.is_file():
+        raise RegressionError("libcrux crate archive must be a regular file")
+    require_file_hash(archive, CRATE_ARCHIVE_SHA256, "libcrux crate archive")
+    archive.chmod(archive.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+    destination.mkdir(parents=True, exist_ok=False)
+    try:
+        with tarfile.open(archive, mode="r:gz") as bundle:
+            members = bundle.getmembers()
+            if not members:
+                raise RegressionError("libcrux crate archive is empty")
+            for member in members:
+                _safe_member_path(member.name)
+                if not (member.isfile() or member.isdir()):
+                    raise RegressionError(
+                        f"unsupported crate archive member type: {member.name}"
+                    )
+            bundle.extractall(destination, members=members, filter="data")
+    except (OSError, tarfile.TarError) as exc:
+        raise RegressionError(f"cannot extract libcrux crate archive: {exc}") from exc
+    crate_dir = destination / CRATE_ROOT
+    if not (crate_dir / "Cargo.toml").is_file() or not (
+        crate_dir / "Cargo.lock"
+    ).is_file():
+        raise RegressionError("libcrux crate is missing Cargo.toml or Cargo.lock")
+    require_file_hash(
+        crate_dir / "Cargo.toml",
+        CRATE_CARGO_TOML_SHA256,
+        "libcrux Cargo.toml",
+    )
+    require_file_hash(
+        crate_dir / "Cargo.lock",
+        CRATE_CARGO_LOCK_SHA256,
+        "libcrux Cargo.lock",
+    )
+    vcs_info_path = crate_dir / ".cargo_vcs_info.json"
+    require_file_hash(vcs_info_path, CRATE_VCS_INFO_SHA256, "libcrux VCS metadata")
+    vcs_info = load_json_object(vcs_info_path, "libcrux VCS metadata")
+    if vcs_info != {
+        "git": {"sha1": CRATE_COMMIT},
+        "path_in_vcs": "libcrux-ml-dsa",
+    }:
+        raise RegressionError("libcrux VCS identity drifted")
+    make_tree_read_only(crate_dir)
+    require_tree_read_only(crate_dir)
+    return crate_dir
+
+
+def regression_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["LIBCRUX_DISABLE_SIMD128"] = "1"
+    environment["LIBCRUX_ENABLE_SIMD256"] = "1"
+    environment.pop("LIBCRUX_DISABLE_SIMD256", None)
+    environment["CARGO_TERM_COLOR"] = "never"
+    return environment
+
+
+def run_command(
+    arguments: list[str],
+    *,
+    environment: dict[str, str],
+    log_path: Path,
+    timeout_seconds: int,
+) -> str:
+    if not arguments or any(not isinstance(argument, str) for argument in arguments):
+        raise RegressionError("subprocess arguments must be a fixed string list")
+    try:
+        completed = subprocess.run(
+            arguments,
+            cwd=REPO_ROOT,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        captured = exc.stdout or b""
+        if isinstance(captured, str):
+            captured = captured.encode("utf8", errors="replace")
+        log_path.write_bytes(captured)
+        raise RegressionError(
+            f"{arguments[0]} exceeded {timeout_seconds} seconds; "
+            f"see {log_path.name}"
+        ) from exc
+    except OSError as exc:
+        raise RegressionError(f"cannot execute {arguments[0]}: {exc}") from exc
+    log_path.write_bytes(completed.stdout)
+    if completed.returncode != 0:
+        raise RegressionError(
+            f"{arguments[0]} exited {completed.returncode}; see {log_path.name}"
+        )
+    return completed.stdout.decode("utf8", errors="replace")
+
+
+def require_tool_version(output: str, tool: str) -> str:
+    lines = output.splitlines()
+    if not lines:
+        raise RegressionError(f"{tool} version output is empty")
+    fields = lines[0].split()
+    if len(fields) < 2 or fields[0] != tool or fields[1] != RUST_TOOLCHAIN_VERSION:
+        raise RegressionError(
+            f"{tool} version drifted; expected {RUST_TOOLCHAIN_VERSION}"
+        )
+    return output.strip()
+
+
+def require_exact_libtest_success(output: str, test_name: str) -> None:
+    lines = [line.strip() for line in output.splitlines()]
+    if lines.count("running 1 test") != 1:
+        raise RegressionError(
+            f"{test_name} did not select exactly one libtest"
+        )
+    if lines.count(f"test {test_name} ... ok") != 1:
+        raise RegressionError(f"{test_name} did not run and pass exactly once")
+    summaries = [line for line in lines if line.startswith("test result:")]
+    if len(summaries) != 1 or LIBTEST_SUMMARY.fullmatch(summaries[0]) is None:
+        raise RegressionError(f"{test_name} libtest summary drifted")
+
+
+def require_repository_state(
+    git: str,
+    repository_commit: str,
+    *,
+    environment: dict[str, str],
+    output_dir: Path,
+    phase: str,
+) -> dict[str, Any]:
+    head = run_command(
+        [git, "rev-parse", "HEAD"],
+        environment=environment,
+        log_path=output_dir / f"git-head-{phase}.log",
+        timeout_seconds=30,
+    ).strip()
+    if head != repository_commit:
+        raise RegressionError(
+            f"repository HEAD drifted during {phase}: expected "
+            f"{repository_commit}, got {head}"
+        )
+    status = run_command(
+        [git, "status", "--porcelain=v1", "--untracked-files=all"],
+        environment=environment,
+        log_path=output_dir / f"git-status-{phase}.log",
+        timeout_seconds=30,
+    )
+    if status:
+        raise RegressionError(f"repository is dirty during {phase}")
+    return {
+        "head": head,
+        "clean": True,
+    }
+
+
+def find_built_library(target_dir: Path) -> Path:
+    dependencies = target_dir / TARGET_TRIPLE / "debug" / "deps"
+    candidates = sorted(dependencies.glob("liblibcrux_ml_dsa-*.rlib"))
+    if len(candidates) != 1:
+        raise RegressionError(
+            f"expected exactly one libcrux ML-DSA rlib, found {len(candidates)}"
+        )
+    return candidates[0]
+
+
+def write_checksums(output_dir: Path) -> None:
+    rows = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_symlink():
+            raise RegressionError(f"evidence contains a symlink: {path}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise RegressionError(f"evidence contains a special file: {path}")
+        if path.name != "SHA256SUMS":
+            rows.append(
+                f"{sha256_file(path)}  {path.relative_to(output_dir).as_posix()}"
+            )
+    (output_dir / "SHA256SUMS").write_text("\n".join(rows) + "\n", encoding="utf8")
+
+
+def require_owned_output_directory(output_dir: Path) -> None:
+    if output_dir.is_symlink():
+        raise RegressionError("evidence output directory must not be a symlink")
+    if not output_dir.is_dir():
+        raise RegressionError("evidence output path must be a directory")
+    marker = output_dir / EVIDENCE_MARKER
+    if (
+        not marker.is_file()
+        or marker.is_symlink()
+        or marker.read_text(encoding="utf8") != EVIDENCE_MARKER_CONTENT
+    ):
+        raise RegressionError("evidence output directory is not owned by this run")
+    for path in output_dir.rglob("*"):
+        if path.is_symlink():
+            raise RegressionError(f"evidence contains a symlink: {path}")
+        if not (path.is_file() or path.is_dir()):
+            raise RegressionError(f"evidence contains a special file: {path}")
+
+
+def claim_output_directory(output_dir: Path) -> None:
+    if output_dir.is_symlink():
+        raise RegressionError("evidence output directory must not be a symlink")
+    if output_dir.exists() and not output_dir.is_dir():
+        raise RegressionError("evidence output path must be a directory")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    entries = list(output_dir.iterdir())
+    marker = output_dir / EVIDENCE_MARKER
+    if not entries:
+        marker.write_text(EVIDENCE_MARKER_CONTENT, encoding="utf8")
+        return
+    require_owned_output_directory(output_dir)
+    if entries != [marker]:
+        raise RegressionError("evidence output directory contains stale files")
+
+
+def execute(
+    *,
+    archive: Path,
+    output_dir: Path,
+    event_name: str,
+    ref: str,
+    repository_commit: str,
+    run_id: str,
+    run_attempt: str,
+    cases: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if HEX_40.fullmatch(repository_commit) is None:
+        raise RegressionError("repository commit must be lowercase 40-byte hex")
+    if not run_id.isdigit() or int(run_id) < 1:
+        raise RegressionError("workflow run ID must be a positive integer")
+    if not run_attempt.isdigit() or int(run_attempt) < 1:
+        raise RegressionError("workflow run attempt must be a positive integer")
+    claim_output_directory(output_dir)
+
+    plan = plan_document(cases)
+    trust = classify_trust(event_name, ref)
+    preflight = require_x86_64_avx2()
+    cargo = shutil.which("cargo")
+    rustc = shutil.which("rustc")
+    git = shutil.which("git")
+    if cargo is None or rustc is None or git is None:
+        raise RegressionError("cargo, rustc, and git are required")
+    environment = regression_environment()
+    cargo_version = require_tool_version(
+        run_command(
+            [cargo, "--version", "--verbose"],
+            environment=environment,
+            log_path=output_dir / "cargo-version.log",
+            timeout_seconds=30,
+        ),
+        "cargo",
+    )
+    rustc_version = require_tool_version(
+        run_command(
+            [rustc, "--version", "--verbose"],
+            environment=environment,
+            log_path=output_dir / "rustc-version.log",
+            timeout_seconds=30,
+        ),
+        "rustc",
+    )
+    repository_before = require_repository_state(
+        git,
+        repository_commit,
+        environment=environment,
+        output_dir=output_dir,
+        phase="before",
+    )
+    (output_dir / "toolchain.txt").write_text(
+        f"cargo={cargo_version}\n"
+        f"rustc={rustc_version}\n"
+        f"uname_machine={preflight['uname_machine']}\n"
+        f"target={TARGET_TRIPLE}\n",
+        encoding="utf8",
+    )
+
+    with tempfile.TemporaryDirectory(prefix="pqbtc-libcrux-simd256-") as temporary:
+        work_root = Path(temporary)
+        crate_dir = extract_verified_crate(archive, work_root / "source")
+        source_digest_before = tree_digest(crate_dir)
+        if source_digest_before != CRATE_TREE_SHA256:
+            raise RegressionError("verified libcrux crate tree digest drifted")
+        cargo_toml_sha256 = sha256_file(crate_dir / "Cargo.toml")
+        cargo_lock_sha256 = sha256_file(crate_dir / "Cargo.lock")
+        target_dir = work_root / "target"
+
+        cargo_build = [
+            cargo,
+            "build",
+            "--manifest-path",
+            str(crate_dir / "Cargo.toml"),
+            "--target",
+            TARGET_TRIPLE,
+            "--target-dir",
+            str(target_dir),
+            "--locked",
+            "--no-default-features",
+            "--features",
+            "std,mldsa44,simd256",
+            "--lib",
+        ]
+        run_command(
+            cargo_build,
+            environment=environment,
+            log_path=output_dir / "cargo-build.log",
+            timeout_seconds=900,
+        )
+
+        dependencies = target_dir / TARGET_TRIPLE / "debug" / "deps"
+        library = find_built_library(target_dir)
+        harness_binary = work_root / "pqbtc-libcrux-simd256-regression"
+        rustc_build = [
+            rustc,
+            str(HARNESS_SOURCE),
+            "--edition=2021",
+            "--target",
+            TARGET_TRIPLE,
+            "--crate-name",
+            "pqbtc_libcrux_simd256_regression",
+            "-L",
+            f"dependency={dependencies}",
+            "--extern",
+            f"libcrux_ml_dsa={library}",
+            "-o",
+            str(harness_binary),
+        ]
+        run_command(
+            rustc_build,
+            environment=environment,
+            log_path=output_dir / "rustc-harness.log",
+            timeout_seconds=120,
+        )
+        if not harness_binary.is_file():
+            raise RegressionError("rustc did not produce the SIMD256 harness")
+
+        valid_case, invalid_case = cases
+        harness_arguments = [
+            str(harness_binary),
+            str(valid_case["public_key_hex"]),
+            str(valid_case["message_hex"]),
+            str(valid_case["context_hex"]),
+            str(valid_case["signature_hex"]),
+            str(invalid_case["signature_hex"]),
+        ]
+        harness_output = run_command(
+            harness_arguments,
+            environment=environment,
+            log_path=output_dir / "rustsec-2026-0125.log",
+            timeout_seconds=120,
+        )
+        observations = [
+            line.strip()
+            for line in harness_output.splitlines()
+            if line.startswith("tcId=")
+        ]
+        expected_observations = [
+            "tcId=147 portable=1 avx2=1 expected=1",
+            "tcId=148 portable=0 avx2=0 expected=0",
+        ]
+        if observations != expected_observations:
+            raise RegressionError(
+                "RUSTSEC-2026-0125 harness observations were incomplete or drifted"
+            )
+
+        for profile_name, profile_arguments in (
+            ("debug", []),
+            ("release", ["--release"]),
+        ):
+            for index, test_name in enumerate(INVNTT_TESTS, start=1):
+                cargo_test = [
+                    cargo,
+                    "test",
+                    "--manifest-path",
+                    str(crate_dir / "Cargo.toml"),
+                    "--target",
+                    TARGET_TRIPLE,
+                    "--target-dir",
+                    str(target_dir),
+                    "--locked",
+                    "--no-default-features",
+                    "--features",
+                    "std,mldsa44,simd256",
+                    *profile_arguments,
+                    "--lib",
+                    test_name,
+                    "--",
+                    "--exact",
+                ]
+                libtest_output = run_command(
+                    cargo_test,
+                    environment=environment,
+                    log_path=(
+                        output_dir
+                        / f"rustsec-2026-0126-{profile_name}-{index}.log"
+                    ),
+                    timeout_seconds=300,
+                )
+                require_exact_libtest_success(libtest_output, test_name)
+
+        require_tree_read_only(crate_dir)
+        source_digest_after = tree_digest(crate_dir)
+        if source_digest_after != source_digest_before:
+            raise RegressionError("verified libcrux crate source changed during tests")
+
+    repository_after = require_repository_state(
+        git,
+        repository_commit,
+        environment=environment,
+        output_dir=output_dir,
+        phase="after",
+    )
+    report = {
+        **plan,
+        "status": "PASS" if trust["may_report_pass"] else "UNTESTED",
+        "trust": {
+            "event_name": event_name,
+            "ref": ref,
+            **trust,
+        },
+        "repository_commit": repository_commit,
+        "workflow_run": {
+            "id": run_id,
+            "attempt": run_attempt,
+        },
+        "preflight": preflight,
+        "toolchain": {
+            "cargo": cargo_version,
+            "rustc": rustc_version,
+            "pinned_version": RUST_TOOLCHAIN_VERSION,
+        },
+        "repository_state": {
+            "before": repository_before,
+            "after": repository_after,
+        },
+        "crate_source": {
+            "archive_sha256": CRATE_ARCHIVE_SHA256,
+            "commit": CRATE_COMMIT,
+            "cargo_toml_original_sha256": cargo_toml_sha256,
+            "cargo_toml_prepared_sha256": cargo_toml_sha256,
+            "cargo_lock_sha256": cargo_lock_sha256,
+            "manifest_preparation": "NONE",
+            "read_only": True,
+            "unchanged": True,
+            "tree_sha256": source_digest_after,
+        },
+        "results": {
+            "RUSTSEC-2026-0125": {
+                "status": (
+                    "PASS"
+                    if trust["may_report_pass"]
+                    else "UNTRUSTED_OBSERVATION"
+                ),
+                "test_case_ids": [147, 148],
+                "portable_results": {"147": "valid", "148": "invalid"},
+                "avx2_results": {"147": "valid", "148": "invalid"},
+                "observations": observations,
+                "profile": "debug",
+                "cases": [
+                    {
+                        "test_case_id": case["test_case_id"],
+                        "expected_valid": case["expected_valid"],
+                        "flags": sorted(CASE_CONTRACTS[case["test_case_id"]]["flags"]),
+                        "public_key_sha256": CASE_CONTRACTS[case["test_case_id"]][
+                            "public_key_sha256"
+                        ],
+                        "message_sha256": CASE_CONTRACTS[case["test_case_id"]][
+                            "message_sha256"
+                        ],
+                        "context_sha256": CASE_CONTRACTS[case["test_case_id"]][
+                            "context_sha256"
+                        ],
+                        "signature_sha256": case["signature_sha256"],
+                    }
+                    for case in cases
+                ],
+            },
+            "RUSTSEC-2026-0126": {
+                "status": (
+                    "PASS"
+                    if trust["may_report_pass"]
+                    else "UNTRUSTED_OBSERVATION"
+                ),
+                "upstream_libtest_paths": list(INVNTT_TESTS),
+                "profiles": ["debug", "release"],
+            },
+        },
+        "checked_in_ledger_updated": False,
+    }
+    (output_dir / "simd256-regression-report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf8",
+    )
+    write_checksums(output_dir)
+    return report
+
+
+def failure_report(
+    *,
+    output_dir: Path,
+    event_name: str,
+    ref: str,
+    repository_commit: str,
+    run_id: str,
+    run_attempt: str,
+    error: Exception,
+) -> None:
+    try:
+        require_owned_output_directory(output_dir)
+    except (OSError, UnicodeError, RegressionError):
+        return
+    trust = classify_trust(event_name, ref)
+    failure_trust = {
+        **trust,
+        "may_report_pass": False,
+        "eligible_for_ledger_promotion": False,
+        "actual_pass_capable": False,
+    }
+    report = {
+        "schema_version": 1,
+        "status": "FAIL",
+        "trust": {
+            "event_name": event_name,
+            "ref": ref,
+            **failure_trust,
+        },
+        "repository_commit": repository_commit,
+        "workflow_run": {
+            "id": run_id,
+            "attempt": run_attempt,
+        },
+        "error": str(error),
+        "execution_contract": {
+            "production_backend": "NONE",
+            "simd256_admitted": False,
+            "release_hold": True,
+            "release_hold_changed": False,
+        },
+        "checked_in_ledger_updated": False,
+    }
+    (output_dir / "simd256-regression-report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf8",
+    )
+    write_checksums(output_dir)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan-only", action="store_true")
+    parser.add_argument("--crate-archive", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument(
+        "--event-name",
+        choices=("pull_request", "push", "schedule", "workflow_dispatch"),
+    )
+    parser.add_argument("--ref")
+    parser.add_argument("--repository-commit")
+    parser.add_argument("--run-id")
+    parser.add_argument("--run-attempt")
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_args()
+    output_path = (
+        Path(os.path.abspath(arguments.output_dir))
+        if arguments.output_dir is not None
+        else None
+    )
+    output_claimed = False
+    try:
+        if not arguments.plan_only and output_path is not None:
+            claim_output_directory(output_path)
+            output_claimed = True
+        cases = load_wycheproof_cases()
+        if arguments.plan_only:
+            if any(
+                value is not None
+                for value in (
+                    arguments.crate_archive,
+                    arguments.output_dir,
+                    arguments.event_name,
+                    arguments.ref,
+                    arguments.repository_commit,
+                    arguments.run_id,
+                    arguments.run_attempt,
+                )
+            ):
+                raise RegressionError("--plan-only does not accept execution inputs")
+            print(json.dumps(plan_document(cases), indent=2, sort_keys=True))
+            return 0
+        if any(
+            value is None
+            for value in (
+                arguments.crate_archive,
+                arguments.output_dir,
+                arguments.event_name,
+                arguments.ref,
+                arguments.repository_commit,
+                arguments.run_id,
+                arguments.run_attempt,
+            )
+        ):
+            raise RegressionError(
+                "execution requires --crate-archive, --output-dir, "
+                "--event-name, --ref, --repository-commit, --run-id, "
+                "and --run-attempt"
+            )
+        execute(
+            archive=Path(os.path.abspath(arguments.crate_archive)),
+            output_dir=output_path,
+            event_name=arguments.event_name,
+            ref=arguments.ref,
+            repository_commit=arguments.repository_commit,
+            run_id=arguments.run_id,
+            run_attempt=arguments.run_attempt,
+            cases=cases,
+        )
+        return 0
+    except RegressionError as exc:
+        if (
+            not arguments.plan_only
+            and output_path is not None
+            and output_claimed
+            and arguments.event_name is not None
+            and arguments.ref is not None
+        ):
+            failure_report(
+                output_dir=output_path,
+                event_name=arguments.event_name,
+                ref=arguments.ref,
+                repository_commit=arguments.repository_commit or "UNKNOWN",
+                run_id=arguments.run_id or "UNKNOWN",
+                run_attempt=arguments.run_attempt or "UNKNOWN",
+                error=exc,
+            )
+        print(f"run_libcrux_simd256_regressions.py: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ML_DSA_44_ADVISORY_LEDGER.md
+++ b/docs/ML_DSA_44_ADVISORY_LEDGER.md
@@ -93,6 +93,29 @@ a fixed range is not represented as a regression-test PASS. `UNTESTED` is
 permitted only when the pin is not affected or the current path is not
 applicable and a future admission block is explicit.
 
+## SIMD256 Regression Promotion Boundary
+
+The test-only x86_64 AVX2 workflow now encodes the exact regression tranche
+needed before the 0125/0126 ledger rows can be reconsidered:
+
+- RUSTSEC-2026-0125 uses pinned Wycheproof ML-DSA-44 tcIds 147 and 148 and
+  requires identical expected valid/invalid results from explicit
+  `portable::verify` and `avx2::verify` calls;
+- RUSTSEC-2026-0126 runs the exact shipped
+  `inv_ntt_unreduced_max`, `inv_ntt_reduced`, and
+  `inv_ntt_reduced_large` AVX2 libtests in debug and release profiles from the
+  verified 0.0.10 crate;
+- the crate archive, Wycheproof source manifest, vector file, harness, case
+  semantics, and case payload hashes are fixed; and
+- the extracted crate remains read-only and byte-identical through execution.
+
+The lane fails closed when x86_64 or AVX2 is unavailable. Pull-request output
+is explicitly untrusted. Only evidence produced at `refs/heads/main` may
+report `PASS`, and even that evidence does not mutate the ledger or admit
+SIMD256. Accordingly, the checked-in rows above remain `UNTESTED`,
+`production_backend` remains `NONE`, `simd256_admitted` remains false, and the
+release hold remains true until a separate reviewed promotion.
+
 ## Current Full-Lock Findings
 
 The reviewed lock is not scanner-empty. The exact current set is retained and
@@ -166,6 +189,9 @@ Primary machine inputs are:
 - `contrib/ml-dsa-engineering/advisory_ledger.json`
 - `contrib/ml-dsa-engineering/run_advisory_ledger.py`
 - `.github/workflows/ml-dsa-44-advisory-ledger.yml`
+- `contrib/ml-dsa-engineering/run_libcrux_simd256_regressions.py`
+- `contrib/ml-dsa-engineering/libcrux_simd256_regression.rs`
+- `.github/workflows/ml-dsa-44-simd256-regressions.yml`
 
 The prior checksummed technical review and its JSON evidence are immutable
 historical artifacts. This dated follow-up supersedes only the old generator's

--- a/docs/ML_DSA_44_BACKEND_ADMISSION.md
+++ b/docs/ML_DSA_44_BACKEND_ADMISSION.md
@@ -110,6 +110,13 @@ AVX2-specific 0125/0126 regressions block any future SIMD256 admission. This is
 useful evidence, not a reason to prefer a wider integration boundary for the
 first prototype.
 
+The separate SIMD256 test lane now implements those exact regressions without
+changing the production backend or admitting SIMD256. Pull-request evidence is
+untrusted; a successful `main` run may support a later reviewed ledger
+promotion, but it does not promote the ledger by itself. Until that separate
+promotion, the 0125/0126 rows remain `UNTESTED`, `production_backend` remains
+`NONE`, `simd256_admitted` remains false, and the release hold remains true.
+
 ## Frozen Prototype Build Contract
 
 The implemented wrapper uses the exact source pin in `backend_admission.json`
@@ -170,7 +177,7 @@ Prototype admission closes no production finding:
 | Fault model and injected faults | #186 | open |
 | End-to-end secret erasure | #187 | source cleanup and sanitizer evidence only; compiler/caller/platform boundary open |
 | Structure-aware fuzzing and resource limits | #188 | pinned Wycheproof replay, scheduled structure-aware ASan/UBSan and MSan campaigns, bounded differential/stateful fuzzing, promoted regressions, portable Miri evidence, and bounded malformed research-CLI argv replay; direct verifier allocation/stack/CPU and adversarial-batch limits, broader platform/Rust sanitizer coverage, and exact-commit re-review remain open |
-| Backend advisories, SBOM, and reproducible build | #189 | dated fail-closed ledger, full-lock cargo-audit/OSV scans, exact selected graph, CycloneDX SBOM, weekly retained refresh, and exact portable ML-DSA-44 RUSTSEC-2026-0077 regressions implemented; exact SIMD256 RUSTSEC-2026-0125/0126 regressions before optimized-backend admission and exact-commit independent re-review remain open |
+| Backend advisories, SBOM, and reproducible build | #189 | dated fail-closed ledger, full-lock cargo-audit/OSV scans, exact selected graph, CycloneDX SBOM, weekly retained refresh, exact portable ML-DSA-44 RUSTSEC-2026-0077 regressions, and a test-only SIMD256 0125/0126 lane implemented; trusted-main evidence, separate ledger promotion before optimized-backend admission, and exact-commit independent re-review remain open |
 | Wallet and key format | #190 | open |
 | Independent human cryptographic review | #181 | open |
 


### PR DESCRIPTION
## Summary

Add a separate, test-only x86_64 AVX2 regression lane for RUSTSEC-2026-0125 and RUSTSEC-2026-0126.

- verify the exact published `libcrux-ml-dsa 0.0.10` crate and frozen Wycheproof tcIds 147/148
- call the portable and AVX2 ML-DSA-44 verification paths explicitly
- run all three shipped AVX2 iNTT regressions in debug and release profiles, proving exactly one named test ran each time
- pin Rust 1.89.0 and retain checksummed, fail-closed evidence with distinct PR-versus-main trust labels
- keep the extracted third-party source read-only and byte-identical

The workflow does not patch upstream source, update the checked-in advisory ledger, admit SIMD256, or change production code.

## Local validation

- exact SIMD256 regression module: 17 passed
- focused advisory, backend, and SIMD policy suite: 47 passed
- full `ci/test` discovery: 184 passed
- CI inventory, Python compilation, plan-only validation, file/UTF-8/test lint, aggregate Python lint runner, and diff hygiene: passed
- exact Rust 1.89.0 cross-compilation reproduced the original missing-host-dependency failure and verified the corrected target-plus-host dependency search through metadata generation
- targeted evidence-integrity and attack-surface review: no remaining blocker

The aggregate lint runner completed successfully but reported unavailable optional tools: codespell, vulture, lief, shellcheck, and ruff.

Local arm64 cannot execute AVX2. This PR's x86_64 workflow is the required runtime verification, and its candidate artifact remains explicitly untrusted.

## Release posture

The production backend remains `NONE`, SIMD256 remains unadmitted, the 0125/0126 ledger rows remain `UNTESTED`, and the release hold remains unchanged. A successful trusted-main run will support a separate reviewed ledger-promotion change.