### PR TITLE
test: observe ML-DSA-44 verifier resource envelope

### DIFF
--- a/.github/workflows/ml-dsa-44-resource-envelope.yml
+++ b/.github/workflows/ml-dsa-44-resource-envelope.yml
@@ -1,0 +1,166 @@
+name: ML-DSA-44 verifier resource envelope
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ml-dsa-44-resource-envelope.yml"
+      - ".github/workflows/ml-dsa-44-review-reproduction.yml"
+      - "ci/test/test_ml_dsa_resource_envelope.py"
+      - "ci/test/test_ml_dsa_wrapper_prototype.py"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44.c"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44.h"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44_config.h"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44_resource_probe.c"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44_test.h"
+      - "contrib/ml-dsa-engineering/run_verifier_fuzz.py"
+      - "contrib/ml-dsa-engineering/run_verifier_resource_envelope.py"
+      - "contrib/ml-dsa-engineering/run_wrapper_tests.py"
+      - "contrib/ml-dsa-engineering/verifier_fuzz_corpus.json"
+      - "contrib/ml-dsa-engineering/verifier_resource_policy.json"
+      - "contrib/ml-dsa-engineering/fuzz_sources/**"
+      - "contrib/ml-dsa-engineering/vendor/mldsa-native/**"
+      - "contrib/ml-dsa-ref/review_baseline_commit.txt"
+      - "contrib/ml-dsa-ref/validate_review_baseline.py"
+      - "contrib/ml-dsa-ref/vectors.json"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ml-dsa-44-resource-envelope.yml"
+      - ".github/workflows/ml-dsa-44-review-reproduction.yml"
+      - "ci/test/test_ml_dsa_resource_envelope.py"
+      - "ci/test/test_ml_dsa_wrapper_prototype.py"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44.c"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44.h"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44_config.h"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44_resource_probe.c"
+      - "contrib/ml-dsa-engineering/pqbtc_mldsa44_test.h"
+      - "contrib/ml-dsa-engineering/run_verifier_fuzz.py"
+      - "contrib/ml-dsa-engineering/run_verifier_resource_envelope.py"
+      - "contrib/ml-dsa-engineering/run_wrapper_tests.py"
+      - "contrib/ml-dsa-engineering/verifier_fuzz_corpus.json"
+      - "contrib/ml-dsa-engineering/verifier_resource_policy.json"
+      - "contrib/ml-dsa-engineering/fuzz_sources/**"
+      - "contrib/ml-dsa-engineering/vendor/mldsa-native/**"
+      - "contrib/ml-dsa-ref/review_baseline_commit.txt"
+      - "contrib/ml-dsa-ref/validate_review_baseline.py"
+      - "contrib/ml-dsa-ref/vectors.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  observe:
+    name: Isolated direct verifier (${{ matrix.compiler }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - gcc
+          - clang
+    env:
+      EVIDENCE_DIR: ${{ runner.temp }}/ml-dsa-44-resource-envelope-${{ matrix.compiler }}
+      PQBTC_RESOURCE_EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    steps:
+      - name: Checkout exact observation head
+        timeout-minutes: 5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify exact clean x86_64 checkout
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          test "$(uname -s)" = "Linux"
+          test "$(uname -m)" = "x86_64"
+          test "$(git rev-parse HEAD)" = "$PQBTC_RESOURCE_EXPECTED_HEAD"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          command -v "${{ matrix.compiler }}"
+
+      - name: Validate frozen observation contract
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          python3 contrib/ml-dsa-engineering/run_verifier_resource_envelope.py \
+            --plan-only
+          python3 -m unittest ci.test.test_ml_dsa_resource_envelope
+
+      - name: Observe isolated verifier resources
+        timeout-minutes: 10
+        env:
+          CC: ${{ matrix.compiler }}
+        run: |
+          set -euxo pipefail
+          python3 contrib/ml-dsa-engineering/run_verifier_resource_envelope.py \
+            --compiler "$CC" \
+            --output-dir "$EVIDENCE_DIR"
+
+      - name: Verify retained evidence
+        if: always()
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          python3 contrib/ml-dsa-engineering/run_verifier_resource_envelope.py \
+            --verify-evidence "$EVIDENCE_DIR"
+
+      - name: Verify checkout remained exact and clean
+        if: always()
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          test "$(git rev-parse HEAD)" = "$PQBTC_RESOURCE_EXPECTED_HEAD"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      # Pull-request observations are candidates only. The runner alone evaluates
+      # exact-main and frozen-baseline trust; this workflow defines no timing,
+      # CPU, wall-clock, or RSS acceptance threshold.
+      - name: Upload untrusted pull-request observation
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        timeout-minutes: 5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ml-dsa-44-resource-untrusted-pr-${{ github.event.pull_request.head.sha }}-${{ matrix.compiler }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.EVIDENCE_DIR }}/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 9
+
+      - name: Upload main observation
+        if: ${{ always() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+        timeout-minutes: 5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ml-dsa-44-resource-main-observation-${{ github.sha }}-${{ matrix.compiler }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.EVIDENCE_DIR }}/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 9
+
+      - name: Upload untrusted non-main observation
+        if: ${{ always() && github.event_name != 'pull_request' && github.ref != 'refs/heads/main' }}
+        timeout-minutes: 5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ml-dsa-44-resource-untrusted-candidate-${{ github.sha }}-${{ matrix.compiler }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.EVIDENCE_DIR }}/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 9

--- a/.github/workflows/ml-dsa-44-resource-envelope.yml
+++ b/.github/workflows/ml-dsa-44-resource-envelope.yml
@@ -70,7 +70,6 @@ jobs:
           - gcc
           - clang
     env:
-      EVIDENCE_DIR: ${{ runner.temp }}/ml-dsa-44-resource-envelope-${{ matrix.compiler }}
       PQBTC_RESOURCE_EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
 
     steps:
@@ -104,6 +103,7 @@ jobs:
         timeout-minutes: 10
         env:
           CC: ${{ matrix.compiler }}
+          EVIDENCE_DIR: ${{ runner.temp }}/ml-dsa-44-resource-envelope-${{ matrix.compiler }}
         run: |
           set -euxo pipefail
           python3 contrib/ml-dsa-engineering/run_verifier_resource_envelope.py \
@@ -113,6 +113,8 @@ jobs:
       - name: Verify retained evidence
         if: always()
         timeout-minutes: 5
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/ml-dsa-44-resource-envelope-${{ matrix.compiler }}
         run: |
           set -euxo pipefail
           python3 contrib/ml-dsa-engineering/run_verifier_resource_envelope.py \
@@ -132,6 +134,8 @@ jobs:
       - name: Upload untrusted pull-request observation
         if: ${{ always() && github.event_name == 'pull_request' }}
         timeout-minutes: 5
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/ml-dsa-44-resource-envelope-${{ matrix.compiler }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ml-dsa-44-resource-untrusted-pr-${{ github.event.pull_request.head.sha }}-${{ matrix.compiler }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -144,6 +148,8 @@ jobs:
       - name: Upload main observation
         if: ${{ always() && github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         timeout-minutes: 5
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/ml-dsa-44-resource-envelope-${{ matrix.compiler }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ml-dsa-44-resource-main-observation-${{ github.sha }}-${{ matrix.compiler }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -156,6 +162,8 @@ jobs:
       - name: Upload untrusted non-main observation
         if: ${{ always() && github.event_name != 'pull_request' && github.ref != 'refs/heads/main' }}
         timeout-minutes: 5
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/ml-dsa-44-resource-envelope-${{ matrix.compiler }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ml-dsa-44-resource-untrusted-candidate-${{ github.sha }}-${{ matrix.compiler }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/ml-dsa-44-review-reproduction.yml
+++ b/.github/workflows/ml-dsa-44-review-reproduction.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ml-dsa-44-review-reproduction.yml"
+      - ".github/workflows/ml-dsa-44-resource-envelope.yml"
       - "contrib/ml-dsa-ref/**"
       - "contrib/ml-dsa-engineering/**"
       - "ci/test/test_ml_dsa_cli_adapter_fuzz.py"
       - "ci/test/test_ml_dsa_reference.py"
       - "ci/test/test_ml_dsa_differential_fuzz.py"
+      - "ci/test/test_ml_dsa_resource_envelope.py"
       - "ci/test/test_ml_dsa_review_baseline.py"
   schedule:
     - cron: "43 5 * * 3"
@@ -170,11 +172,13 @@ jobs:
             test "$GITHUB_REF" = "refs/heads/main"
             git diff --exit-code "$BASELINE" -- \
               .github/workflows/ml-dsa-44-review-reproduction.yml \
+              .github/workflows/ml-dsa-44-resource-envelope.yml \
               contrib/ml-dsa-engineering \
               contrib/ml-dsa-ref \
               ci/test/test_ml_dsa_cli_adapter_fuzz.py \
               ci/test/test_ml_dsa_differential_fuzz.py \
               ci/test/test_ml_dsa_reference.py \
+              ci/test/test_ml_dsa_resource_envelope.py \
               ci/test/test_ml_dsa_review_baseline.py \
               ':(exclude)contrib/ml-dsa-ref/review_baseline_commit.txt' \
               ':(exclude)contrib/ml-dsa-ref/README.md' \

--- a/.github/workflows/ml-dsa-44-wrapper-prototype.yml
+++ b/.github/workflows/ml-dsa-44-wrapper-prototype.yml
@@ -3,10 +3,12 @@ name: ML-DSA-44 wrapper prototype
 on:
   pull_request:
     paths:
+      - ".github/workflows/ml-dsa-44-resource-envelope.yml"
       - ".github/workflows/ml-dsa-44-wrapper-prototype.yml"
       - "ci/test/00_setup_env_native_tidy.sh"
       - "ci/test/01_base_install.sh"
       - "ci/test/03_test_script.sh"
+      - "ci/test/test_ml_dsa_resource_envelope.py"
       - "ci/test/test_ml_dsa_wrapper_prototype.py"
       - "contrib/devtools/bitcoin-tidy/**"
       - "contrib/devtools/iwyu/bitcoin.core.imp"

--- a/ci/test/test_ml_dsa_cli_adapter_fuzz.py
+++ b/ci/test/test_ml_dsa_cli_adapter_fuzz.py
@@ -24,11 +24,13 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-review-reproduction.
 BASELINE_POINTER = REFERENCE_DIR / "review_baseline_commit.txt"
 TRUSTED_MAIN_BASELINE_PATHSPEC = (
     ".github/workflows/ml-dsa-44-review-reproduction.yml",
+    ".github/workflows/ml-dsa-44-resource-envelope.yml",
     "contrib/ml-dsa-engineering",
     "contrib/ml-dsa-ref",
     "ci/test/test_ml_dsa_cli_adapter_fuzz.py",
     "ci/test/test_ml_dsa_differential_fuzz.py",
     "ci/test/test_ml_dsa_reference.py",
+    "ci/test/test_ml_dsa_resource_envelope.py",
     "ci/test/test_ml_dsa_review_baseline.py",
     ":(exclude)contrib/ml-dsa-ref/review_baseline_commit.txt",
     ":(exclude)contrib/ml-dsa-ref/README.md",
@@ -627,6 +629,9 @@ class MlDsaCliAdapterFuzzTest(unittest.TestCase):
             ".github/workflows/ml-dsa-44-review-reproduction.yml": (
                 "name: baseline workflow\n"
             ),
+            ".github/workflows/ml-dsa-44-resource-envelope.yml": (
+                "name: resource workflow\n"
+            ),
             "contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py": (
                 "print('baseline generator')\n"
             ),
@@ -640,6 +645,9 @@ class MlDsaCliAdapterFuzzTest(unittest.TestCase):
                 "# baseline differential test\n"
             ),
             "ci/test/test_ml_dsa_reference.py": "# baseline reference test\n",
+            "ci/test/test_ml_dsa_resource_envelope.py": (
+                "# baseline resource test\n"
+            ),
             "ci/test/test_ml_dsa_review_baseline.py": (
                 "# baseline validator test\n"
             ),
@@ -730,9 +738,11 @@ class MlDsaCliAdapterFuzzTest(unittest.TestCase):
             self.assertEqual(run_guard().returncode, 0)
             guarded_paths = (
                 ".github/workflows/ml-dsa-44-review-reproduction.yml",
+                ".github/workflows/ml-dsa-44-resource-envelope.yml",
                 "contrib/ml-dsa-engineering/run_differential_verifier_fuzz.py",
                 "contrib/ml-dsa-ref/oracle_cli.h",
                 "contrib/ml-dsa-ref/validate_review_baseline.py",
+                "ci/test/test_ml_dsa_resource_envelope.py",
                 "ci/test/test_ml_dsa_review_baseline.py",
             )
             for relative in guarded_paths:

--- a/ci/test/test_ml_dsa_resource_envelope.py
+++ b/ci/test/test_ml_dsa_resource_envelope.py
@@ -565,6 +565,9 @@ class MlDsaResourceEnvelopeTest(unittest.TestCase):
 
     def test_workflow_preserves_pr_main_trust_boundary(self):
         workflow = RESOURCE_WORKFLOW.read_text(encoding="utf8")
+        observe_job_preamble = workflow.split("  observe:\n", 1)[1].split(
+            "    steps:\n", 1
+        )[0]
         for required in (
             "pull_request:",
             "push:",
@@ -585,8 +588,14 @@ class MlDsaResourceEnvelopeTest(unittest.TestCase):
             '"contrib/ml-dsa-ref/vectors.json"',
             '"contrib/ml-dsa-engineering/pqbtc_mldsa44_test.h"',
             "timeout-minutes: 30",
+            (
+                "EVIDENCE_DIR: ${{ runner.temp }}/"
+                "ml-dsa-44-resource-envelope-${{ matrix.compiler }}"
+            ),
         ):
             self.assertIn(required, workflow)
+        self.assertNotIn("${{ runner.", observe_job_preamble)
+        self.assertNotIn("EVIDENCE_DIR:", observe_job_preamble)
         self.assertNotIn("pull_request_target", workflow)
         self.assertNotIn("contents: write", workflow)
         self.assertNotIn("actions/cache", workflow)

--- a/ci/test/test_ml_dsa_resource_envelope.py
+++ b/ci/test/test_ml_dsa_resource_envelope.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+from copy import deepcopy
+import hashlib
+import json
+from pathlib import Path
+import runpy
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINEERING_DIR = REPO_ROOT / "contrib" / "ml-dsa-engineering"
+RESOURCE_POLICY = ENGINEERING_DIR / "verifier_resource_policy.json"
+RESOURCE_RUNNER = ENGINEERING_DIR / "run_verifier_resource_envelope.py"
+RESOURCE_PROBE = ENGINEERING_DIR / "pqbtc_mldsa44_resource_probe.c"
+RESOURCE_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-resource-envelope.yml"
+)
+BATCH_IDS = [
+    "mixed_rotating",
+    "valid_rotating",
+    "deep_reject_rotating",
+    "same_key_mixed",
+]
+
+
+def load_resource_plan() -> dict:
+    completed = subprocess.run(
+        [sys.executable, str(RESOURCE_RUNNER), "--plan-only"],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def load_resource_runner() -> dict[str, object]:
+    sys.path.insert(0, str(ENGINEERING_DIR))
+    try:
+        return runpy.run_path(str(RESOURCE_RUNNER))
+    finally:
+        del sys.path[0]
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class MlDsaResourceEnvelopeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.resource = load_resource_runner()
+
+    def test_resource_evidence_assets_exist(self):
+        for path in (
+            RESOURCE_POLICY,
+            RESOURCE_RUNNER,
+            RESOURCE_PROBE,
+            RESOURCE_WORKFLOW,
+        ):
+            self.assertTrue(path.is_file(), path)
+
+    def test_policy_freezes_observation_without_bootstrapping_acceptance(self):
+        policy = json.loads(RESOURCE_POLICY.read_text(encoding="utf8"))
+        self.assertEqual(policy["schema_version"], 1)
+        self.assertEqual(policy["phase"], "TRUSTED_MAIN_OBSERVATION_REQUIRED")
+        self.assertEqual(policy["target"], "pqbtc_mldsa44_verify_strict")
+        self.assertEqual(
+            policy["profile"],
+            {
+                "system": "Linux",
+                "machine": "x86_64",
+                "measurement_target": (
+                    "isolated-production-shaped-direct-verifier"
+                ),
+                "backend": "mldsa-native-portable-c",
+                "optimization": "-O2",
+                "thread_model": "one guarded pthread",
+                "allocation_model": "default upstream stack allocation",
+            },
+        )
+
+        batch = policy["batch"]
+        self.assertEqual(batch["batches"], BATCH_IDS)
+        self.assertEqual(batch["unique_frames"], 240)
+        self.assertEqual(batch["full_corpus_rounds"], 17)
+        self.assertEqual(batch["prefix_frames"], 207)
+        self.assertEqual(batch["verification_calls"], 4287)
+        self.assertEqual(17 * 240 + 207, batch["verification_calls"])
+        self.assertIn("research workload only", batch["capacity_scope"])
+        self.assertIn("not a transaction", batch["capacity_scope"])
+        self.assertEqual(
+            batch["required_accept_cases"],
+            [
+                "valid_empty_message_context",
+                "valid_frozen_vector",
+                "valid_max_context",
+                "valid_max_fuzz_message",
+            ],
+        )
+        self.assertEqual(
+            batch["required_deep_reject_cases"],
+            [
+                "reject_context_flip",
+                "reject_ctilde_bit_flip",
+                "reject_hint_counter_backwards",
+                "reject_hint_nonzero_padding",
+                "reject_message_flip",
+                "reject_public_key_rho_flip",
+                "reject_public_key_t1_flip",
+            ],
+        )
+        self.assertEqual(
+            batch["same_key_cases"],
+            [
+                "reject_context_flip",
+                "reject_ctilde_bit_flip",
+                "reject_hint_counter_backwards",
+                "reject_hint_nonzero_padding",
+                "reject_message_flip",
+                "valid_empty_message_context",
+                "valid_frozen_vector",
+                "valid_max_context",
+                "valid_max_fuzz_message",
+            ],
+        )
+
+        limits = policy["enforced_limits"]
+        self.assertEqual(limits["thread_stack_bytes"], 131072)
+        self.assertEqual(limits["thread_guard_bytes"], 4096)
+        self.assertEqual(limits["address_space_bytes"], 268435456)
+        self.assertEqual(limits["open_files"], 64)
+        self.assertEqual(limits["output_file_bytes"], 65536)
+        self.assertEqual(limits["core_file_bytes"], 0)
+        self.assertEqual(limits["project_heap_calls"], 0)
+        self.assertEqual(limits["cpu_watchdog_seconds"], 120)
+        self.assertEqual(limits["wall_watchdog_seconds"], 180)
+
+        acceptance = policy["acceptance_limits"]
+        self.assertIsNone(acceptance["cpu_seconds"])
+        self.assertIsNone(acceptance["wall_seconds"])
+        self.assertIsNone(acceptance["peak_rss_kib"])
+        self.assertEqual(
+            acceptance["status"],
+            "UNSET_PENDING_SEPARATE_REVIEW_OF_TRUSTED_MAIN_OBSERVATION",
+        )
+        stack = policy["stack_evidence"]
+        self.assertEqual(
+            stack["upstream_mld_total_alloc_44_verify_bytes"],
+            24448,
+        )
+        self.assertEqual(
+            stack["required_symbols"],
+            [
+                "pqbtc_mldsa44_upstream_verify",
+                "pqbtc_mldsa44_verify_strict",
+            ],
+        )
+        self.assertTrue(stack["require_static_stack_usage"])
+        self.assertIn(
+            ".su values are not summed into a formal call-chain bound",
+            stack["call_chain_claim"],
+        )
+        self.assertTrue(policy["promotion"]["requires_separate_policy_change"])
+        self.assertTrue(policy["promotion"]["requires_trusted_main_push"])
+        self.assertEqual(
+            policy["promotion"]["requires_both_compilers"],
+            ["clang", "gcc"],
+        )
+        self.assertTrue(policy["promotion"]["timing_threshold_bootstrap_forbidden"])
+        self.assertEqual(
+            policy["promotion"]["pull_request_evidence"],
+            "UNTRUSTED_PR_OBSERVATION",
+        )
+        self.assertEqual(
+            policy["promotion"]["trusted_main_evidence"],
+            "TRUSTED_MAIN_OBSERVATION",
+        )
+        self.assertFalse(policy["scope"]["release_hold_changed"])
+        self.assertTrue(policy["scope"]["batch_limit_is_not_consensus_policy"])
+
+    def test_plan_is_fail_closed_and_exactly_embeds_policy(self):
+        policy = self.resource["load_policy"]()
+        plan = load_resource_plan()
+        self.assertEqual(plan, self.resource["build_plan"](policy))
+        self.assertEqual(
+            set(plan),
+            {
+                "schema_version",
+                "target",
+                "host",
+                "measurement",
+                "policy",
+                "policy_sha256",
+                "inputs",
+            },
+        )
+        self.assertEqual(plan["schema_version"], 1)
+        self.assertEqual(plan["target"], "pqbtc_mldsa44_verify_strict")
+        self.assertEqual(plan["host"], {"machine": "x86_64", "system": "Linux"})
+        self.assertEqual(plan["policy"], policy)
+        self.assertRegex(plan["policy_sha256"], r"^[0-9a-f]{64}$")
+        self.assertEqual(plan["policy_sha256"], sha256(RESOURCE_POLICY))
+        self.assertEqual(
+            set(plan["inputs"]),
+            {
+                "policy",
+                "runner",
+                "probe",
+                "wrapper_source",
+                "wrapper_header",
+                "wrapper_test_header",
+                "wrapper_config",
+                "source_manifest",
+                "fuzz_driver",
+                "fuzz_manifest",
+                "vectors",
+                "wycheproof_source",
+                "promoted_source",
+                "workflow",
+                "resource_test",
+            },
+        )
+        for digest in plan["inputs"].values():
+            self.assertRegex(digest, r"^[0-9a-f]{64}$")
+        self.assertEqual(
+            plan["measurement"],
+            {
+                "profile": "isolated-production-shaped-direct-verifier",
+                "batch_ids": BATCH_IDS,
+                "sample_count": 31,
+                "raw_sample_count": 31,
+                "retain_raw_samples": True,
+                "subtract_control_samples": False,
+                "first_call_separate": True,
+                "wall_clock": "CLOCK_MONOTONIC",
+                "cpu_clock": "CLOCK_THREAD_CPUTIME_ID",
+                "control_loop": "reported separately and never subtracted",
+                "numeric_acceptance": (
+                    "unset pending a separate review of trusted main observations"
+                ),
+            },
+        )
+        self.assertEqual(plan["policy"]["batch"]["unique_frames"], 240)
+        self.assertEqual(plan["policy"]["batch"]["verification_calls"], 4287)
+        self.assertEqual(len(plan["measurement"]["batch_ids"]), 4)
+        limits = plan["policy"]["enforced_limits"]
+        self.assertEqual(limits["thread_stack_bytes"], 131072)
+        self.assertEqual(limits["thread_guard_bytes"], 4096)
+        self.assertEqual(limits["cpu_watchdog_seconds"], 120)
+        self.assertEqual(limits["wall_watchdog_seconds"], 180)
+        self.assertEqual(limits["project_heap_calls"], 0)
+        acceptance = plan["policy"]["acceptance_limits"]
+        self.assertIsNone(acceptance["cpu_seconds"])
+        self.assertIsNone(acceptance["wall_seconds"])
+        self.assertIsNone(acceptance["peak_rss_kib"])
+        scope = plan["policy"]["scope"]
+        self.assertTrue(scope["isolated_test_only"])
+        self.assertFalse(scope["production_integration"])
+        self.assertEqual(scope["production_backend"], "NONE")
+        self.assertFalse(scope["simd256_admitted"])
+        self.assertTrue(scope["release_hold"])
+
+    def test_probe_targets_only_the_direct_production_verifier(self):
+        source = RESOURCE_PROBE.read_text(encoding="utf8")
+        for required in (
+            "#if !defined(__linux__) || !defined(__x86_64__)",
+            "#define RESOURCE_EXPECTED_RECORDS 240U",
+            "#define RESOURCE_SAMPLE_COUNT 31U",
+            "#define RESOURCE_BATCH_CALLS 4287U",
+            "#define RESOURCE_THREAD_STACK_BYTES 131072U",
+            "#define RESOURCE_THREAD_GUARD_BYTES 4096U",
+            "#define RESOURCE_CPU_WATCHDOG_SECONDS 120U",
+            "#define RESOURCE_WALL_WATCHDOG_SECONDS 180U",
+            "pqbtc_mldsa44_verify_strict(",
+            "pthread_attr_setstacksize(",
+            "pthread_attr_setguardsize(",
+            "RLIMIT_CPU",
+            "RLIMIT_AS",
+            "RLIMIT_NOFILE",
+            "RLIMIT_FSIZE",
+            "RLIMIT_CORE",
+            "__wrap_malloc",
+            "__wrap_calloc",
+            "__wrap_realloc",
+            "__wrap_free",
+            "__wrap_aligned_alloc",
+            "__wrap_posix_memalign",
+            "--heap-positive-control",
+            "--stack-positive-control",
+            "--cpu-positive-control",
+            "--wall-positive-control",
+        ):
+            self.assertIn(required, source)
+        self.assertEqual(source.count("pqbtc_mldsa44_verify_strict("), 1)
+        self.assertNotIn("pqbtc_mldsa44_sign_hedged", source)
+        self.assertNotIn("pqbtc_mldsa44_test_", source)
+        self.assertNotIn('#include "pqbtc_mldsa44_test.h"', source)
+        self.assertNotIn("PQBTC_MLDSA44_TESTING", source)
+        for batch_id in BATCH_IDS:
+            self.assertIn(f'"{batch_id}"', source)
+
+    def test_stack_usage_parser_rejects_missing_dynamic_and_duplicate_symbols(self):
+        parse_stack_usage = self.resource["parse_stack_usage"]
+        error = self.resource["ResourceEnvelopeError"]
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            wrapper = root / "wrapper.su"
+            wrapper.write_text(
+                "pqbtc_mldsa44.c:300:1:"
+                "pqbtc_mldsa44_upstream_verify\t25312\tstatic\n"
+                "pqbtc_mldsa44.c:330:1:"
+                "pqbtc_mldsa44_verify_strict\t16\tstatic\n",
+                encoding="utf8",
+            )
+            parsed = parse_stack_usage([wrapper])
+            self.assertEqual(
+                set(parsed),
+                {
+                    "pqbtc_mldsa44_upstream_verify",
+                    "pqbtc_mldsa44_verify_strict",
+                },
+            )
+            self.assertEqual(
+                parsed["pqbtc_mldsa44_upstream_verify"]["observed_symbol"],
+                "pqbtc_mldsa44_upstream_verify",
+            )
+
+            wrapper.write_text(
+                "sign.c:1221:"
+                "pqbtc_mldsa44_upstream_verify\t25216\tstatic\n"
+                "pqbtc_mldsa44.c:330:"
+                "pqbtc_mldsa44_verify_strict\t16\tstatic\n",
+                encoding="utf8",
+            )
+            parsed = parse_stack_usage([wrapper])
+            self.assertEqual(
+                parsed["pqbtc_mldsa44_upstream_verify"]["source"],
+                "sign.c:1221",
+            )
+
+            wrapper.write_text(
+                "sign.c:1221:5:"
+                "pqbtc_mldsa44_upstream_verify.constprop\t448\tstatic\n"
+                "pqbtc_mldsa44.c:330:5:"
+                "pqbtc_mldsa44_verify_strict\t16\tstatic\n",
+                encoding="utf8",
+            )
+            parsed = parse_stack_usage([wrapper])
+            self.assertEqual(
+                parsed["pqbtc_mldsa44_upstream_verify"]["observed_symbol"],
+                "pqbtc_mldsa44_upstream_verify.constprop",
+            )
+
+            wrapper.write_text(
+                "pqbtc_mldsa44.c:300:1:"
+                "pqbtc_mldsa44_upstream_verify\t25312\tdynamic\n"
+                "pqbtc_mldsa44.c:330:1:"
+                "pqbtc_mldsa44_verify_strict\t16\tstatic\n",
+                encoding="utf8",
+            )
+            with self.assertRaises(error):
+                parse_stack_usage([wrapper])
+
+            wrapper.write_text(
+                "pqbtc_mldsa44.c:300:1:"
+                "pqbtc_mldsa44_upstream_verify\t25312\tstatic\n",
+                encoding="utf8",
+            )
+            with self.assertRaises(error):
+                parse_stack_usage([wrapper])
+
+            wrapper.write_text(
+                "pqbtc_mldsa44.c:300:1:"
+                "pqbtc_mldsa44_upstream_verify\t25312\tstatic\n"
+                "pqbtc_mldsa44.c:301:1:"
+                "pqbtc_mldsa44_upstream_verify\t25312\tstatic\n"
+                "pqbtc_mldsa44.c:330:1:"
+                "pqbtc_mldsa44_verify_strict\t16\tstatic\n",
+                encoding="utf8",
+            )
+            with self.assertRaises(error):
+                parse_stack_usage([wrapper])
+
+    def test_probe_observation_validation_fails_closed(self):
+        plan = load_resource_plan()
+        validate = self.resource["validate_probe_observation"]
+        error = self.resource["ResourceEnvelopeError"]
+        observation = self._synthetic_observation()
+        validated = validate(observation, plan)
+        self.assertEqual(
+            [batch["id"] for batch in validated["batches"]],
+            BATCH_IDS,
+        )
+        self.assertEqual(
+            validated["completed_calls"],
+            1 + len(BATCH_IDS) * 4287,
+        )
+
+        mutations = [
+            ("heap", lambda item: item["heap_calls"].update(malloc=1)),
+            ("heap_bool", lambda item: item["heap_calls"].update(malloc=False)),
+            ("schema_bool", lambda item: item.update(schema_version=True)),
+            (
+                "result_bool",
+                lambda item: item["first_call"].update(result=False),
+            ),
+            ("completed", lambda item: item.update(completed_calls=17148)),
+            ("sample", lambda item: item["batches"][0]["wall_samples_ns"].pop()),
+            ("outcome", lambda item: item["batches"][1]["outcomes"].update(ok=4286)),
+            (
+                "input",
+                lambda item: item.update(input_fnv1a64_after="0000000000000002"),
+            ),
+            ("extra", lambda item: item.update(unexpected=True)),
+            (
+                "rss_cap",
+                lambda item: item.update(peak_rss_kib=262145),
+            ),
+            (
+                "wall_cap",
+                lambda item: item["batches"][0].update(
+                    wall_samples_ns=[6_000_000_000] * 31
+                ),
+            ),
+            (
+                "cpu_cap",
+                lambda item: item["batches"][0].update(
+                    cpu_samples_ns=[4_000_000_000] * 31
+                ),
+            ),
+        ]
+        for label, mutate in mutations:
+            with self.subTest(label=label):
+                invalid = deepcopy(observation)
+                mutate(invalid)
+                with self.assertRaises(error):
+                    validate(invalid, plan)
+
+    def test_evidence_verifier_rejects_checksum_tamper_and_symlinks(self):
+        make_fixture = self.resource["write_test_evidence_fixture"]
+        verify = self.resource["verify_evidence"]
+        error = self.resource["ResourceEnvelopeError"]
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            evidence = root / "evidence"
+            make_fixture(evidence, self._synthetic_observation())
+            verify(evidence)
+
+            report = evidence / self.resource["REPORT_FILE"]
+            report.write_bytes(report.read_bytes() + b" ")
+            with self.assertRaises(error):
+                verify(evidence)
+
+            linked_evidence = root / "linked-evidence"
+            make_fixture(linked_evidence, self._synthetic_observation())
+            target = root / "target"
+            target.write_text("outside evidence\n", encoding="utf8")
+            link = linked_evidence / "linked"
+            link.symlink_to(target)
+            with self.assertRaises(error):
+                verify(linked_evidence)
+
+            root_target = root / "root-target"
+            make_fixture(root_target, self._synthetic_observation())
+            root_link = root / "root-link"
+            root_link.symlink_to(root_target, target_is_directory=True)
+            with self.assertRaises(error):
+                verify(root_link)
+
+            inconsistent = root / "inconsistent"
+            make_fixture(inconsistent, self._synthetic_observation())
+            (inconsistent / self.resource["JOB_STATUS_FILE"]).write_text(
+                "failure\n", encoding="ascii"
+            )
+            (inconsistent / self.resource["CHECKSUM_FILE"]).unlink()
+            self.resource["write_evidence_hashes"](inconsistent)
+            with self.assertRaises(error):
+                verify(inconsistent)
+
+    def test_failure_finalization_replaces_checksums_and_partial_observation(self):
+        make_fixture = self.resource["write_test_evidence_fixture"]
+        finalize = self.resource["_finalize_failure"]
+        verify = self.resource["verify_evidence"]
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence = Path(temporary) / "evidence"
+            make_fixture(evidence, self._synthetic_observation())
+            report = json.loads(
+                (evidence / self.resource["REPORT_FILE"]).read_text(encoding="utf8")
+            )
+            finalize(evidence, report, RuntimeError("synthetic probe failure"))
+            self.assertFalse((evidence / self.resource["OBSERVATION_FILE"]).exists())
+            self.assertEqual(verify(evidence)["status"], "FAIL")
+
+    def test_frozen_fnv1a64_and_single_job_promotion_boundary(self):
+        fnv1a64 = self.resource["fnv1a64_bytes"]
+        self.assertEqual(fnv1a64(b""), "cbf29ce484222325")
+        self.assertEqual(fnv1a64(b"hello"), "a430d84680aabd0b")
+        require_int = self.resource["_require_int"]
+        result_names = self.resource["RESULT_NAMES"]
+        for result in result_names:
+            self.assertEqual(
+                require_int(result, "frozen verifier result", min(result_names)),
+                result,
+            )
+        with self.assertRaises(self.resource["ResourceEnvelopeError"]):
+            require_int(False, "frozen verifier result", min(result_names))
+
+        local = self.resource["_local_ci_context"]()
+        local_trust = self.resource["_build_trust"](local, True)
+        self.assertEqual(local_trust["label"], "LOCAL_OBSERVATION")
+        self.assertFalse(local_trust["trusted_observation"])
+        self.assertFalse(local_trust["promotion_eligible"])
+
+        head = "a" * 40
+        main = {
+            **local,
+            "github_actions": True,
+            "server_url": "https://github.com",
+            "api_url": "https://api.github.com",
+            "repository": "scottdhughes/quantum-proof-bitcoin",
+            "repository_id": "1136579990",
+            "event_name": "push",
+            "ref": "refs/heads/main",
+            "ref_protected": True,
+            "sha": head,
+            "workflow": "ML-DSA-44 verifier resource envelope",
+            "workflow_ref": (
+                "scottdhughes/quantum-proof-bitcoin/.github/workflows/"
+                "ml-dsa-44-resource-envelope.yml@refs/heads/main"
+            ),
+            "workflow_sha": head,
+            "run_id": "123",
+            "run_attempt": "1",
+            "run_number": "7",
+            "job": "observe",
+            "expected_checkout_head": head,
+        }
+        validated = self.resource["_validate_github_context"](main, head)
+        main_trust = self.resource["_build_trust"](validated, True)
+        self.assertEqual(main_trust["label"], "TRUSTED_MAIN_OBSERVATION")
+        self.assertTrue(main_trust["trusted_observation"])
+        self.assertFalse(main_trust["promotion_eligible"])
+        manual = {**main, "event_name": "workflow_dispatch"}
+        manual_trust = self.resource["_build_trust"](
+            self.resource["_validate_github_context"](manual, head), True
+        )
+        self.assertEqual(
+            manual_trust["label"], "UNTRUSTED_MANUAL_OBSERVATION"
+        )
+        self.assertFalse(manual_trust["trusted_observation"])
+        self.assertFalse(manual_trust["promotion_eligible"])
+        invalid = deepcopy(main)
+        invalid["repository_id"] = "1"
+        with self.assertRaises(self.resource["ResourceEnvelopeError"]):
+            self.resource["_validate_github_context"](invalid, head)
+
+    def test_workflow_preserves_pr_main_trust_boundary(self):
+        workflow = RESOURCE_WORKFLOW.read_text(encoding="utf8")
+        for required in (
+            "pull_request:",
+            "push:",
+            "branches:",
+            "- main",
+            "workflow_dispatch:",
+            "contents: read",
+            "gcc",
+            "clang",
+            "fetch-depth: 0",
+            "persist-credentials: false",
+            "ref: ${{ github.event.pull_request.head.sha || github.sha }}",
+            "run_verifier_resource_envelope.py",
+            "--output-dir",
+            "--verify-evidence",
+            "upload-artifact",
+            "if: always()",
+            '"contrib/ml-dsa-ref/vectors.json"',
+            '"contrib/ml-dsa-engineering/pqbtc_mldsa44_test.h"',
+            "timeout-minutes: 30",
+        ):
+            self.assertIn(required, workflow)
+        self.assertNotIn("pull_request_target", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertNotIn("actions/cache", workflow)
+
+    def test_resource_lane_is_absent_from_production_build_surfaces(self):
+        forbidden = (
+            "pqbtc_mldsa44_resource_probe",
+            "run_verifier_resource_envelope",
+            "verifier_resource_policy",
+        )
+        tracked = subprocess.run(
+            ["git", "ls-files"],
+            cwd=REPO_ROOT,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        ).stdout.splitlines()
+        manifests = [
+            REPO_ROOT / relative
+            for relative in tracked
+            if Path(relative).name in {"CMakeLists.txt", "Makefile.am", "meson.build"}
+            or Path(relative).suffix == ".mk"
+        ]
+        self.assertTrue(manifests)
+        for manifest in manifests:
+            content = manifest.read_text(encoding="utf8", errors="replace")
+            for marker in forbidden:
+                self.assertNotIn(marker, content, manifest)
+
+        public_header = (ENGINEERING_DIR / "pqbtc_mldsa44.h").read_text(
+            encoding="utf8"
+        )
+        config = (ENGINEERING_DIR / "pqbtc_mldsa44_config.h").read_text(
+            encoding="utf8"
+        )
+        for marker in forbidden:
+            self.assertNotIn(marker, public_header)
+            self.assertNotIn(marker, config)
+
+    @staticmethod
+    def _synthetic_observation() -> dict:
+        samples = list(range(1, 32))
+        batch_outcomes = [
+            {"ok": 100, "invalid_argument": 100, "verify_rejection": 4087},
+            {"ok": 4287, "invalid_argument": 0, "verify_rejection": 0},
+            {"ok": 0, "invalid_argument": 0, "verify_rejection": 4287},
+            {"ok": 100, "invalid_argument": 0, "verify_rejection": 4187},
+        ]
+        return {
+            "schema_version": 1,
+            "status": "PASS",
+            "records": 240,
+            "sample_count": 31,
+            "batch_calls": 4287,
+            "completed_calls": 17149,
+            "selection_counts": {
+                "mixed_rotating": 240,
+                "valid_rotating": 4,
+                "deep_reject_rotating": 7,
+                "same_key_mixed": 11,
+            },
+            "first_call": {
+                "record": 0,
+                "result": 0,
+                "wall_ns": 1,
+                "cpu_ns": 1,
+            },
+            "batches": [
+                {
+                    "id": batch_id,
+                    "calls": 4287,
+                    "outcomes": batch_outcomes[index],
+                    "wall_samples_ns": samples,
+                    "cpu_samples_ns": samples,
+                }
+                for index, batch_id in enumerate(BATCH_IDS)
+            ],
+            "control": {
+                "iterations": 4287,
+                "wall_samples_ns": samples,
+                "cpu_samples_ns": samples,
+            },
+            "heap_calls": {
+                "malloc": 0,
+                "calloc": 0,
+                "realloc": 0,
+                "free": 0,
+                "aligned_alloc": 0,
+                "posix_memalign": 0,
+            },
+            "thread_stack_bytes": 131072,
+            "thread_guard_bytes": 4096,
+            "peak_rss_kib": 1024,
+            "clock_resolution_ns": {"monotonic": 1, "thread_cpu": 1},
+            "input_fnv1a64_before": "0000000000000001",
+            "input_fnv1a64_after": "0000000000000001",
+            "result_accumulator": 1,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/test/test_ml_dsa_resource_envelope.py
+++ b/ci/test/test_ml_dsa_resource_envelope.py
@@ -563,6 +563,109 @@ class MlDsaResourceEnvelopeTest(unittest.TestCase):
         with self.assertRaises(self.resource["ResourceEnvelopeError"]):
             self.resource["_validate_github_context"](invalid, head)
 
+    def test_build_command_evidence_is_relocatable(self):
+        compiler = "/opt/toolchain/bin/clang"
+        source_root = str(REPO_ROOT)
+        build_root = Path("/tmp/pqbtc-resource-build")
+        raw_commands = [
+            [
+                compiler,
+                f"-I{ENGINEERING_DIR}",
+                str(RESOURCE_PROBE),
+                "-o",
+                str(build_root / "probe.o"),
+            ]
+        ]
+        normalized = self.resource["_normalize_commands"](
+            raw_commands, build_root
+        )["commands"]
+        self.assertEqual(
+            normalized,
+            [
+                [
+                    compiler,
+                    "-I$REPO_ROOT/contrib/ml-dsa-engineering",
+                    (
+                        "$REPO_ROOT/contrib/ml-dsa-engineering/"
+                        "pqbtc_mldsa44_resource_probe.c"
+                    ),
+                    "-o",
+                    "$BUILD_DIR/probe.o",
+                ]
+            ],
+        )
+        expected = self.resource["_expected_normalized_commands"](compiler)
+        expected_text = json.dumps(expected, sort_keys=True)
+        self.assertNotIn(source_root, expected_text)
+        self.assertIn("$REPO_ROOT/contrib/ml-dsa-engineering", expected_text)
+        self.assertIn("$BUILD_DIR/pqbtc_mldsa44-resource-probe", expected_text)
+
+        expanded = [
+            [
+                argument.replace("$REPO_ROOT", source_root).replace(
+                    "$BUILD_DIR", str(build_root)
+                )
+                for argument in command
+            ]
+            for command in expected
+        ]
+        self.assertEqual(
+            self.resource["_normalize_commands"](expanded, build_root)[
+                "commands"
+            ],
+            expected,
+        )
+
+    def test_build_command_normalization_is_fail_closed(self):
+        compiler = str(REPO_ROOT / "toolchain" / "clang")
+        build_root = Path("/tmp/pqbtc-resource-build")
+        outside_substring = f"/unrelated{REPO_ROOT}/source.c"
+        normalized = self.resource["_normalize_commands"](
+            [
+                [
+                    compiler,
+                    outside_substring,
+                    f"-I{outside_substring}",
+                    str(RESOURCE_PROBE),
+                    "-o",
+                    str(build_root / "probe.o"),
+                ]
+            ],
+            build_root,
+        )["commands"][0]
+        self.assertEqual(normalized[0], compiler)
+        self.assertEqual(normalized[1], outside_substring)
+        self.assertEqual(normalized[2], f"-I{outside_substring}")
+        self.assertEqual(
+            normalized[3],
+            (
+                "$REPO_ROOT/contrib/ml-dsa-engineering/"
+                "pqbtc_mldsa44_resource_probe.c"
+            ),
+        )
+        self.assertEqual(normalized[5], "$BUILD_DIR/probe.o")
+
+        for placeholder in ("$REPO_ROOT", "$BUILD_DIR"):
+            with self.subTest(placeholder=placeholder):
+                with self.assertRaises(
+                    self.resource["ResourceEnvelopeError"]
+                ):
+                    self.resource["_normalize_commands"](
+                        [
+                            [
+                                "/usr/bin/clang",
+                                f"{placeholder}/source.c",
+                            ]
+                        ],
+                        build_root,
+                    )
+                with self.assertRaises(
+                    self.resource["ResourceEnvelopeError"]
+                ):
+                    self.resource["_expected_normalized_commands"](
+                        f"/opt/{placeholder}/clang"
+                    )
+
     def test_workflow_preserves_pr_main_trust_boundary(self):
         workflow = RESOURCE_WORKFLOW.read_text(encoding="utf8")
         observe_job_preamble = workflow.split("  observe:\n", 1)[1].split(

--- a/ci/test/test_ml_dsa_resource_envelope.py
+++ b/ci/test/test_ml_dsa_resource_envelope.py
@@ -298,9 +298,18 @@ class MlDsaResourceEnvelopeTest(unittest.TestCase):
             "--stack-positive-control",
             "--cpu-positive-control",
             "--wall-positive-control",
+            "#include <limits.h>  // IWYU pragma: keep",
+            "// IWYU pragma: no_include <bits/pthread_stack_min.h>",
+            "// IWYU pragma: no_include <bits/types/struct_rusage.h>",
         ):
             self.assertIn(required, source)
+        self.assertLess(
+            source.index("if (received != g_bundle_size)"),
+            source.index("trailing_byte = fgetc(input);"),
+        )
         self.assertEqual(source.count("pqbtc_mldsa44_verify_strict("), 1)
+        self.assertNotIn('#include <bits/', source)
+        self.assertNotIn("fprintf(", source)
         self.assertNotIn("pqbtc_mldsa44_sign_hedged", source)
         self.assertNotIn("pqbtc_mldsa44_test_", source)
         self.assertNotIn('#include "pqbtc_mldsa44_test.h"', source)

--- a/ci/test/test_ml_dsa_wrapper_prototype.py
+++ b/ci/test/test_ml_dsa_wrapper_prototype.py
@@ -162,6 +162,7 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
         self.assertTrue(
             plan["scope"]["iwyu_first_party_leaf_units_and_headers"]
         )
+        self.assertTrue(plan["scope"]["verifier_resource_probe_test_only"])
         self.assertFalse(plan["scope"]["production_integration"])
         self.assertTrue(plan["scope"]["release_hold_unchanged"])
         self.assertTrue(
@@ -188,14 +189,19 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
             },
         )
         for evidence_source in (
+            ".github/workflows/ml-dsa-44-resource-envelope.yml",
             ".github/workflows/ml-dsa-44-wrapper-prototype.yml",
             ".github/workflows/promotion-matrix.yml",
             "ci/test/00_setup_env_native_tidy.sh",
             "ci/test/01_base_install.sh",
             "ci/test/03_test_script.sh",
+            "ci/test/test_ml_dsa_resource_envelope.py",
             "ci/test/test_ml_dsa_wrapper_prototype.py",
             "contrib/ml-dsa-engineering/README.md",
+            "contrib/ml-dsa-engineering/pqbtc_mldsa44_resource_probe.c",
             "contrib/ml-dsa-engineering/pqbtc_mldsa44_stateful_fuzz.c",
+            "contrib/ml-dsa-engineering/run_verifier_resource_envelope.py",
+            "contrib/ml-dsa-engineering/verifier_resource_policy.json",
         ):
             self.assertRegex(
                 plan["source_files"][evidence_source], r"^[0-9a-f]{64}$"
@@ -213,8 +219,8 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
         self.assertEqual(
             counts,
             {
-                "clang-tidy": 5,
-                "iwyu": 3,
+                "clang-tidy": 6,
+                "iwyu": 4,
                 "header-self-containment": 2,
             },
         )
@@ -259,9 +265,11 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
             "clang-tidy-smoke-testing",
             "clang-tidy-verifier-fuzz",
             "clang-tidy-stateful-signer-fuzz",
+            "clang-tidy-verifier-resource-probe",
             "iwyu-smoke-testing",
             "iwyu-verifier-fuzz",
             "iwyu-stateful-signer-fuzz",
+            "iwyu-verifier-resource-probe",
             "header-self-contained-production",
             "header-self-contained-testing",
         }
@@ -292,6 +300,31 @@ class MlDsaWrapperPrototypeTest(unittest.TestCase):
             testing_define,
             checks["iwyu-stateful-signer-fuzz"]["command"],
         )
+        self.assertNotIn(
+            testing_define,
+            checks["clang-tidy-verifier-resource-probe"]["command"],
+        )
+        self.assertNotIn(
+            testing_define,
+            checks["iwyu-verifier-resource-probe"]["command"],
+        )
+        self.assertIn(
+            "-pthread",
+            checks["clang-tidy-verifier-resource-probe"]["command"],
+        )
+        self.assertIn("-pthread", checks["iwyu-verifier-resource-probe"]["command"])
+        for check_id in (
+            "clang-tidy-verifier-resource-probe",
+            "iwyu-verifier-resource-probe",
+        ):
+            self.assertEqual(
+                checks[check_id]["input"],
+                "contrib/ml-dsa-engineering/pqbtc_mldsa44_resource_probe.c",
+            )
+            self.assertEqual(
+                checks[check_id]["variant"],
+                "production-api-test-only",
+            )
 
         for check_id in (
             "header-self-contained-production",

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -288,3 +288,46 @@ not independent test vectors or a completeness claim. This single Linux run
 is not multi-platform differential evidence, and the prebuilt OpenSSL and Rust
 implementation bodies are not fully sanitizer-instrumented by the C fuzz
 build. It does not alter the release hold.
+
+## Direct-Verifier Resource-Envelope Observation
+
+`verifier_resource_policy.json`, `pqbtc_mldsa44_resource_probe.c`, and
+`run_verifier_resource_envelope.py` define a separate test-only Linux x86_64
+observation lane that calls `pqbtc_mldsa44_verify_strict` directly. It uses
+the 240 unique frozen verifier frames to construct four batches: rotating
+mixed inputs, rotating valid inputs, deep verification rejects, and a
+same-public-key mix of the four required accepts and five deep rejects that
+do not mutate the public key. The two public-key mutation cases remain in the
+deep-reject batch only. Each batch makes exactly
+4,287 verifier calls, matching the existing raw-payload research workload
+model. That count is not a consensus, block, transaction, mempool, or
+production verification limit.
+
+The probe executes the verifier on a 128 KiB pthread stack with a guard page
+and retains compiler-generated `.su` records. Those records are
+compiler-specific static-frame observations; they are not summed into a
+formal call-chain or worst-case stack bound. Linker interposition requires
+zero project allocation calls during the verifier observation. It does not
+claim to observe allocations made internally by the dynamic loader or system
+libraries.
+
+The four batches retain raw timing samples and untimed-loop control samples.
+The evidence validator recomputes descriptive summaries from the raw integer
+samples without subtracting the controls. Numeric CPU, wall-time, and RSS
+acceptance values remain unset until a separately reviewed trusted-main
+observation exists. Pull-request output is labeled
+`UNTRUSTED_PR_OBSERVATION`; the candidate workflow and baseline must first
+merge, then a separate reviewed baseline-pointer change must authorize an
+exact clean protected-main push `TRUSTED_MAIN_OBSERVATION`; manual dispatches
+remain diagnostic and untrusted. A later policy change may freeze numeric
+acceptance thresholds. Each GCC or Clang job remains
+`promotion_eligible=false`: promotion requires both exact-head compiler
+artifacts, externally verified GitHub Actions run/artifact provenance, and
+that separate policy review.
+
+This lane observes one production-shaped portable-C verifier configuration;
+it does not link a production backend or establish a supported-platform
+resource envelope. Issue `#188` remains open for trusted-main evidence,
+reviewed numeric limits, broader platforms, and exact-commit re-review. Issue
+`#181` remains open for qualified independent review. The production backend
+remains `NONE`, SIMD256 remains unadmitted, and the release hold remains true.

--- a/contrib/ml-dsa-engineering/README.md
+++ b/contrib/ml-dsa-engineering/README.md
@@ -325,6 +325,13 @@ acceptance thresholds. Each GCC or Clang job remains
 artifacts, externally verified GitHub Actions run/artifact provenance, and
 that separate policy review.
 
+Retained build-command argv replaces only exact repository and ephemeral
+build-path components with reserved `$REPO_ROOT` and `$BUILD_DIR`
+placeholders. The verifier rejects preexisting placeholders, preserves the
+compiler path and unrelated argv verbatim, and checks the full normalized
+command list. This lets a downloaded artifact be verified from another
+exact-commit checkout without weakening its build-command binding.
+
 This lane observes one production-shaped portable-C verifier configuration;
 it does not link a production backend or establish a supported-platform
 resource envelope. Issue `#188` remains open for trusted-main evidence,

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_resource_probe.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_resource_probe.c
@@ -1,0 +1,782 @@
+// Copyright (c) 2026 The PQBTC Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "pqbtc_mldsa44.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <time.h>
+#include <unistd.h>
+
+#if !defined(__linux__) || !defined(__x86_64__)
+#error The ML-DSA-44 resource probe is scoped to Linux x86_64
+#endif
+
+#define RESOURCE_SCHEMA_VERSION 1U
+#define RESOURCE_BUNDLE_MAGIC "PQRSC001"
+#define RESOURCE_BUNDLE_MAGIC_BYTES 8U
+#define RESOURCE_BUNDLE_HEADER_BYTES 16U
+#define RESOURCE_RECORD_HEADER_BYTES 12U
+#define RESOURCE_FRAME_HEADER_BYTES 10U
+#define RESOURCE_FRAME_VERSION 1U
+#define RESOURCE_MAX_BUNDLE_BYTES (4U * 1024U * 1024U)
+#define RESOURCE_EXPECTED_RECORDS 240U
+#define RESOURCE_MAX_RECORDS 240U
+#define RESOURCE_SAMPLE_COUNT 31U
+#define RESOURCE_BATCH_CALLS 4287U
+#define RESOURCE_BATCH_COUNT 4U
+#define RESOURCE_THREAD_STACK_BYTES 131072U
+#define RESOURCE_THREAD_GUARD_BYTES 4096U
+#define RESOURCE_ADDRESS_SPACE_BYTES (256U * 1024U * 1024U)
+#define RESOURCE_OPEN_FILES 64U
+#define RESOURCE_OUTPUT_FILE_BYTES 65536U
+#define RESOURCE_CPU_WATCHDOG_SECONDS 120U
+#define RESOURCE_WALL_WATCHDOG_SECONDS 180U
+
+#define RESOURCE_FLAG_VALID 0x01U
+#define RESOURCE_FLAG_DEEP_REJECT 0x02U
+#define RESOURCE_FLAG_SAME_KEY 0x04U
+#define RESOURCE_FLAG_FIRST_CALL 0x08U
+#define RESOURCE_FLAG_MASK 0x0fU
+
+#define RESOURCE_NULL_SIGNATURE 0x01U
+#define RESOURCE_NULL_PUBLIC_KEY 0x02U
+#define RESOURCE_NULL_CONTEXT 0x04U
+#define RESOURCE_NULL_MESSAGE 0x08U
+#define RESOURCE_NULL_MASK 0x0fU
+
+enum resource_batch_id {
+    RESOURCE_BATCH_MIXED_ROTATING = 0,
+    RESOURCE_BATCH_VALID_ROTATING = 1,
+    RESOURCE_BATCH_DEEP_REJECT_ROTATING = 2,
+    RESOURCE_BATCH_SAME_KEY_MIXED = 3
+};
+
+struct resource_record {
+    const uint8_t* frame;
+    uint32_t frame_size;
+    int32_t expected;
+    uint32_t flags;
+};
+
+struct resource_frame {
+    uint8_t null_flags;
+    uint16_t signature_size;
+    uint16_t public_key_size;
+    uint16_t context_size;
+    uint16_t message_size;
+    size_t signature_offset;
+    size_t public_key_offset;
+    size_t context_offset;
+    size_t message_offset;
+};
+
+struct resource_batch_result {
+    uint64_t wall_samples_ns[RESOURCE_SAMPLE_COUNT];
+    uint64_t cpu_samples_ns[RESOURCE_SAMPLE_COUNT];
+    uint64_t ok;
+    uint64_t invalid_argument;
+    uint64_t verify_rejection;
+};
+
+struct resource_result {
+    int failed;
+    uint32_t failed_batch;
+    uint32_t failed_record;
+    int32_t expected;
+    int32_t actual;
+    uint64_t first_wall_ns;
+    uint64_t first_cpu_ns;
+    int32_t first_result;
+    struct resource_batch_result batches[RESOURCE_BATCH_COUNT];
+    uint64_t control_wall_samples_ns[RESOURCE_SAMPLE_COUNT];
+    uint64_t control_cpu_samples_ns[RESOURCE_SAMPLE_COUNT];
+    uint64_t completed_calls;
+};
+
+static uint8_t g_bundle[RESOURCE_MAX_BUNDLE_BYTES];
+static size_t g_bundle_size;
+static struct resource_record g_records[RESOURCE_MAX_RECORDS];
+static uint32_t g_record_count;
+static uint32_t g_batch_indices[RESOURCE_BATCH_COUNT][RESOURCE_MAX_RECORDS];
+static uint32_t g_batch_record_counts[RESOURCE_BATCH_COUNT];
+static uint32_t g_first_record;
+static struct resource_result g_result;
+static volatile int64_t g_result_accumulator;
+
+static atomic_ulong g_malloc_calls;
+static atomic_ulong g_calloc_calls;
+static atomic_ulong g_realloc_calls;
+static atomic_ulong g_free_calls;
+static atomic_ulong g_aligned_alloc_calls;
+static atomic_ulong g_posix_memalign_calls;
+
+void* __wrap_malloc(size_t size)
+{
+    (void)size;
+    atomic_fetch_add_explicit(&g_malloc_calls, 1, memory_order_relaxed);
+    return NULL;
+}
+
+void* __wrap_calloc(size_t count, size_t size)
+{
+    (void)count;
+    (void)size;
+    atomic_fetch_add_explicit(&g_calloc_calls, 1, memory_order_relaxed);
+    return NULL;
+}
+
+void* __wrap_realloc(void* pointer, size_t size)
+{
+    (void)pointer;
+    (void)size;
+    atomic_fetch_add_explicit(&g_realloc_calls, 1, memory_order_relaxed);
+    return NULL;
+}
+
+void __wrap_free(void* pointer)
+{
+    (void)pointer;
+    atomic_fetch_add_explicit(&g_free_calls, 1, memory_order_relaxed);
+}
+
+void* __wrap_aligned_alloc(size_t alignment, size_t size)
+{
+    (void)alignment;
+    (void)size;
+    atomic_fetch_add_explicit(&g_aligned_alloc_calls, 1, memory_order_relaxed);
+    return NULL;
+}
+
+int __wrap_posix_memalign(void** output, size_t alignment, size_t size)
+{
+    (void)alignment;
+    (void)size;
+    atomic_fetch_add_explicit(&g_posix_memalign_calls, 1, memory_order_relaxed);
+    if (output != NULL) *output = NULL;
+    return ENOMEM;
+}
+
+static int Fail(const char* message)
+{
+    fprintf(stderr, "ML-DSA-44 resource probe: %s\n", message);
+    return 1;
+}
+
+static uint16_t ReadU16(const uint8_t* bytes)
+{
+    return (uint16_t)bytes[0] | ((uint16_t)bytes[1] << 8);
+}
+
+static uint32_t ReadU32(const uint8_t* bytes)
+{
+    return (uint32_t)bytes[0] | ((uint32_t)bytes[1] << 8) |
+        ((uint32_t)bytes[2] << 16) | ((uint32_t)bytes[3] << 24);
+}
+
+static int32_t ReadI32(const uint8_t* bytes)
+{
+    const uint32_t value = ReadU32(bytes);
+    if (value <= (uint32_t)INT32_MAX) return (int32_t)value;
+    return -(int32_t)(UINT32_MAX - value) - 1;
+}
+
+static uint64_t TimespecNanoseconds(struct timespec value)
+{
+    return (uint64_t)value.tv_sec * 1000000000ULL + (uint64_t)value.tv_nsec;
+}
+
+static uint64_t ElapsedNanoseconds(struct timespec start, struct timespec end)
+{
+    const uint64_t start_ns = TimespecNanoseconds(start);
+    const uint64_t end_ns = TimespecNanoseconds(end);
+    return end_ns >= start_ns ? end_ns - start_ns : 0;
+}
+
+static uint64_t BundleHash(void)
+{
+    uint64_t hash = 14695981039346656037ULL;
+    size_t i;
+    for (i = 0; i < g_bundle_size; ++i) {
+        hash ^= g_bundle[i];
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+static int ParseFrame(
+    const uint8_t* frame_bytes, size_t frame_size, struct resource_frame* frame)
+{
+    size_t expected_size;
+
+    if (frame_size < RESOURCE_FRAME_HEADER_BYTES ||
+        frame_bytes[0] != RESOURCE_FRAME_VERSION ||
+        (frame_bytes[1] & ~RESOURCE_NULL_MASK) != 0) {
+        return 0;
+    }
+    frame->null_flags = frame_bytes[1];
+    frame->signature_size = ReadU16(frame_bytes + 2);
+    frame->public_key_size = ReadU16(frame_bytes + 4);
+    frame->context_size = ReadU16(frame_bytes + 6);
+    frame->message_size = ReadU16(frame_bytes + 8);
+    frame->signature_offset = RESOURCE_FRAME_HEADER_BYTES;
+    frame->public_key_offset = frame->signature_offset + frame->signature_size;
+    frame->context_offset = frame->public_key_offset + frame->public_key_size;
+    frame->message_offset = frame->context_offset + frame->context_size;
+    expected_size = frame->message_offset + frame->message_size;
+    return expected_size == frame_size;
+}
+
+static const uint8_t* MaybeNull(
+    const uint8_t* frame,
+    size_t offset,
+    uint8_t null_flags,
+    uint8_t null_flag)
+{
+    return (null_flags & null_flag) != 0 ? NULL : frame + offset;
+}
+
+static int CallRecord(uint32_t index)
+{
+    struct resource_frame frame;
+    const struct resource_record* record = &g_records[index];
+    if (!ParseFrame(record->frame, record->frame_size, &frame)) {
+        return 1;
+    }
+    return pqbtc_mldsa44_verify_strict(
+        MaybeNull(
+            record->frame,
+            frame.signature_offset,
+            frame.null_flags,
+            RESOURCE_NULL_SIGNATURE),
+        frame.signature_size,
+        MaybeNull(
+            record->frame,
+            frame.public_key_offset,
+            frame.null_flags,
+            RESOURCE_NULL_PUBLIC_KEY),
+        frame.public_key_size,
+        MaybeNull(
+            record->frame,
+            frame.message_offset,
+            frame.null_flags,
+            RESOURCE_NULL_MESSAGE),
+        frame.message_size,
+        MaybeNull(
+            record->frame,
+            frame.context_offset,
+            frame.null_flags,
+            RESOURCE_NULL_CONTEXT),
+        frame.context_size);
+}
+
+static int LoadBundle(const char* path)
+{
+    FILE* input;
+    long file_size;
+    size_t received;
+    size_t cursor;
+    uint32_t i;
+    int trailing_byte;
+    int close_result;
+
+    input = fopen(path, "rb");
+    if (input == NULL) return Fail("cannot open the corpus bundle");
+    if (fseek(input, 0, SEEK_END) != 0) {
+        fclose(input);
+        return Fail("cannot seek the corpus bundle");
+    }
+    file_size = ftell(input);
+    if (file_size < (long)RESOURCE_BUNDLE_HEADER_BYTES ||
+        file_size > (long)RESOURCE_MAX_BUNDLE_BYTES ||
+        fseek(input, 0, SEEK_SET) != 0) {
+        fclose(input);
+        return Fail("corpus bundle size is outside the frozen bound");
+    }
+    g_bundle_size = (size_t)file_size;
+    received = fread(g_bundle, 1, g_bundle_size, input);
+    trailing_byte = fgetc(input);
+    close_result = fclose(input);
+    if (received != g_bundle_size || trailing_byte != EOF || close_result != 0) {
+        return Fail("cannot read the corpus bundle exactly");
+    }
+    if (memcmp(g_bundle, RESOURCE_BUNDLE_MAGIC, RESOURCE_BUNDLE_MAGIC_BYTES) != 0 ||
+        ReadU32(g_bundle + 8) != RESOURCE_SCHEMA_VERSION) {
+        return Fail("corpus bundle header differs");
+    }
+    g_record_count = ReadU32(g_bundle + 12);
+    if (g_record_count != RESOURCE_EXPECTED_RECORDS) {
+        return Fail("corpus bundle record count differs");
+    }
+
+    cursor = RESOURCE_BUNDLE_HEADER_BYTES;
+    for (i = 0; i < g_record_count; ++i) {
+        uint32_t frame_size;
+        int32_t expected;
+        uint32_t flags;
+        struct resource_frame parsed;
+        if (cursor > g_bundle_size ||
+            g_bundle_size - cursor < RESOURCE_RECORD_HEADER_BYTES) {
+            return Fail("truncated corpus record header");
+        }
+        frame_size = ReadU32(g_bundle + cursor);
+        expected = ReadI32(g_bundle + cursor + 4);
+        flags = ReadU32(g_bundle + cursor + 8);
+        cursor += RESOURCE_RECORD_HEADER_BYTES;
+        if (frame_size == 0 || frame_size > 8096U ||
+            cursor > g_bundle_size || frame_size > g_bundle_size - cursor ||
+            (expected != PQBTC_MLDSA44_OK &&
+             expected != PQBTC_MLDSA44_ERR_INVALID_ARGUMENT &&
+             expected != PQBTC_MLDSA44_ERR_VERIFY) ||
+            (flags & ~RESOURCE_FLAG_MASK) != 0 ||
+            ((flags & RESOURCE_FLAG_VALID) != 0 &&
+             expected != PQBTC_MLDSA44_OK) ||
+            ((flags & RESOURCE_FLAG_DEEP_REJECT) != 0 &&
+             expected != PQBTC_MLDSA44_ERR_VERIFY)) {
+            return Fail("invalid corpus record contract");
+        }
+        if (!ParseFrame(g_bundle + cursor, frame_size, &parsed)) {
+            return Fail("non-canonical corpus frame");
+        }
+        g_records[i].frame = g_bundle + cursor;
+        g_records[i].frame_size = frame_size;
+        g_records[i].expected = expected;
+        g_records[i].flags = flags;
+        cursor += frame_size;
+    }
+    if (cursor != g_bundle_size) return Fail("corpus bundle has trailing bytes");
+    return 0;
+}
+
+static int BuildSelections(void)
+{
+    uint32_t first_count = 0;
+    uint32_t i;
+
+    for (i = 0; i < g_record_count; ++i) {
+        g_batch_indices[RESOURCE_BATCH_MIXED_ROTATING]
+                       [g_batch_record_counts[RESOURCE_BATCH_MIXED_ROTATING]++] = i;
+        if ((g_records[i].flags & RESOURCE_FLAG_VALID) != 0) {
+            g_batch_indices[RESOURCE_BATCH_VALID_ROTATING]
+                           [g_batch_record_counts[RESOURCE_BATCH_VALID_ROTATING]++] = i;
+        }
+        if ((g_records[i].flags & RESOURCE_FLAG_DEEP_REJECT) != 0) {
+            g_batch_indices[RESOURCE_BATCH_DEEP_REJECT_ROTATING]
+                           [g_batch_record_counts
+                               [RESOURCE_BATCH_DEEP_REJECT_ROTATING]++] = i;
+        }
+        if ((g_records[i].flags & RESOURCE_FLAG_SAME_KEY) != 0) {
+            g_batch_indices[RESOURCE_BATCH_SAME_KEY_MIXED]
+                           [g_batch_record_counts[RESOURCE_BATCH_SAME_KEY_MIXED]++] = i;
+        }
+        if ((g_records[i].flags & RESOURCE_FLAG_FIRST_CALL) != 0) {
+            g_first_record = i;
+            ++first_count;
+        }
+    }
+    if (g_batch_record_counts[RESOURCE_BATCH_MIXED_ROTATING] !=
+            RESOURCE_EXPECTED_RECORDS ||
+        g_batch_record_counts[RESOURCE_BATCH_VALID_ROTATING] == 0 ||
+        g_batch_record_counts[RESOURCE_BATCH_DEEP_REJECT_ROTATING] == 0 ||
+        g_batch_record_counts[RESOURCE_BATCH_SAME_KEY_MIXED] == 0 ||
+        first_count != 1 ||
+        g_records[g_first_record].expected != PQBTC_MLDSA44_OK) {
+        return Fail("corpus batch selection contract differs");
+    }
+    return 0;
+}
+
+static int ApplyLimit(int resource_name, rlim_t soft, rlim_t hard)
+{
+    struct rlimit limit;
+    limit.rlim_cur = soft;
+    limit.rlim_max = hard;
+    return setrlimit(resource_name, &limit);
+}
+
+static int ApplyResourceLimits(void)
+{
+    if (ApplyLimit(
+            RLIMIT_CPU,
+            RESOURCE_CPU_WATCHDOG_SECONDS,
+            RESOURCE_CPU_WATCHDOG_SECONDS + 1U) != 0 ||
+        ApplyLimit(
+            RLIMIT_AS,
+            RESOURCE_ADDRESS_SPACE_BYTES,
+            RESOURCE_ADDRESS_SPACE_BYTES) != 0 ||
+        ApplyLimit(RLIMIT_NOFILE, RESOURCE_OPEN_FILES, RESOURCE_OPEN_FILES) != 0 ||
+        ApplyLimit(
+            RLIMIT_FSIZE,
+            RESOURCE_OUTPUT_FILE_BYTES,
+            RESOURCE_OUTPUT_FILE_BYTES) != 0 ||
+        ApplyLimit(RLIMIT_CORE, 0, 0) != 0) {
+        return Fail("cannot apply the frozen process limits");
+    }
+    return 0;
+}
+
+static int RecordOutcome(struct resource_batch_result* batch, int result)
+{
+    if (result == PQBTC_MLDSA44_OK) {
+        ++batch->ok;
+    } else if (result == PQBTC_MLDSA44_ERR_INVALID_ARGUMENT) {
+        ++batch->invalid_argument;
+    } else if (result == PQBTC_MLDSA44_ERR_VERIFY) {
+        ++batch->verify_rejection;
+    } else {
+        return 0;
+    }
+    return 1;
+}
+
+static void* RunResourceProbe(void* unused)
+{
+    struct timespec wall_start;
+    struct timespec wall_end;
+    struct timespec cpu_start;
+    struct timespec cpu_end;
+    uint32_t batch_id;
+    uint32_t sample;
+
+    (void)unused;
+    if (clock_gettime(CLOCK_MONOTONIC, &wall_start) != 0 ||
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpu_start) != 0) {
+        g_result.failed = 1;
+        return NULL;
+    }
+    g_result.first_result = CallRecord(g_first_record);
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpu_end) != 0 ||
+        clock_gettime(CLOCK_MONOTONIC, &wall_end) != 0) {
+        g_result.failed = 1;
+        return NULL;
+    }
+    g_result.first_wall_ns = ElapsedNanoseconds(wall_start, wall_end);
+    g_result.first_cpu_ns = ElapsedNanoseconds(cpu_start, cpu_end);
+    if (g_result.first_result != g_records[g_first_record].expected) {
+        g_result.failed = 1;
+        g_result.failed_record = g_first_record;
+        g_result.expected = g_records[g_first_record].expected;
+        g_result.actual = g_result.first_result;
+        return NULL;
+    }
+    g_result_accumulator ^= g_result.first_result;
+    ++g_result.completed_calls;
+
+    for (batch_id = 0; batch_id < RESOURCE_BATCH_COUNT; ++batch_id) {
+        uint32_t cursor = 0;
+        const uint32_t selected_count = g_batch_record_counts[batch_id];
+        for (sample = 0; sample < RESOURCE_SAMPLE_COUNT; ++sample) {
+            uint32_t sample_calls =
+                RESOURCE_BATCH_CALLS / RESOURCE_SAMPLE_COUNT +
+                (sample < RESOURCE_BATCH_CALLS % RESOURCE_SAMPLE_COUNT ? 1U : 0U);
+            uint32_t call;
+            if (clock_gettime(CLOCK_MONOTONIC, &wall_start) != 0 ||
+                clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpu_start) != 0) {
+                g_result.failed = 1;
+                return NULL;
+            }
+            for (call = 0; call < sample_calls; ++call) {
+                const uint32_t record_index =
+                    g_batch_indices[batch_id][cursor % selected_count];
+                const int result = CallRecord(record_index);
+                ++cursor;
+                if (result != g_records[record_index].expected ||
+                    !RecordOutcome(&g_result.batches[batch_id], result)) {
+                    g_result.failed = 1;
+                    g_result.failed_batch = batch_id;
+                    g_result.failed_record = record_index;
+                    g_result.expected = g_records[record_index].expected;
+                    g_result.actual = result;
+                    return NULL;
+                }
+                g_result_accumulator ^= (int64_t)result + (int64_t)record_index;
+                ++g_result.completed_calls;
+            }
+            if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpu_end) != 0 ||
+                clock_gettime(CLOCK_MONOTONIC, &wall_end) != 0) {
+                g_result.failed = 1;
+                return NULL;
+            }
+            g_result.batches[batch_id].wall_samples_ns[sample] =
+                ElapsedNanoseconds(wall_start, wall_end);
+            g_result.batches[batch_id].cpu_samples_ns[sample] =
+                ElapsedNanoseconds(cpu_start, cpu_end);
+        }
+        if (cursor != RESOURCE_BATCH_CALLS) {
+            g_result.failed = 1;
+            return NULL;
+        }
+    }
+
+    for (sample = 0; sample < RESOURCE_SAMPLE_COUNT; ++sample) {
+        uint32_t sample_calls =
+            RESOURCE_BATCH_CALLS / RESOURCE_SAMPLE_COUNT +
+            (sample < RESOURCE_BATCH_CALLS % RESOURCE_SAMPLE_COUNT ? 1U : 0U);
+        uint32_t call;
+        if (clock_gettime(CLOCK_MONOTONIC, &wall_start) != 0 ||
+            clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpu_start) != 0) {
+            g_result.failed = 1;
+            return NULL;
+        }
+        for (call = 0; call < sample_calls; ++call) {
+            g_result_accumulator ^=
+                (int64_t)g_records[call % g_record_count].expected + (int64_t)call;
+        }
+        if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpu_end) != 0 ||
+            clock_gettime(CLOCK_MONOTONIC, &wall_end) != 0) {
+            g_result.failed = 1;
+            return NULL;
+        }
+        g_result.control_wall_samples_ns[sample] =
+            ElapsedNanoseconds(wall_start, wall_end);
+        g_result.control_cpu_samples_ns[sample] =
+            ElapsedNanoseconds(cpu_start, cpu_end);
+    }
+    return NULL;
+}
+
+static void PrintSamples(const uint64_t* samples)
+{
+    uint32_t i;
+    putchar('[');
+    for (i = 0; i < RESOURCE_SAMPLE_COUNT; ++i) {
+        if (i != 0) putchar(',');
+        printf("%llu", (unsigned long long)samples[i]);
+    }
+    putchar(']');
+}
+
+static void PrintBatch(const char* id, const struct resource_batch_result* result)
+{
+    printf(
+        "{\"id\":\"%s\",\"calls\":%u,\"outcomes\":{\"ok\":%llu,"
+        "\"invalid_argument\":%llu,\"verify_rejection\":%llu},"
+        "\"wall_samples_ns\":",
+        id,
+        RESOURCE_BATCH_CALLS,
+        (unsigned long long)result->ok,
+        (unsigned long long)result->invalid_argument,
+        (unsigned long long)result->verify_rejection);
+    PrintSamples(result->wall_samples_ns);
+    printf(",\"cpu_samples_ns\":");
+    PrintSamples(result->cpu_samples_ns);
+    putchar('}');
+}
+
+static unsigned long HeapCallTotal(void)
+{
+    return atomic_load_explicit(&g_malloc_calls, memory_order_relaxed) +
+        atomic_load_explicit(&g_calloc_calls, memory_order_relaxed) +
+        atomic_load_explicit(&g_realloc_calls, memory_order_relaxed) +
+        atomic_load_explicit(&g_free_calls, memory_order_relaxed) +
+        atomic_load_explicit(&g_aligned_alloc_calls, memory_order_relaxed) +
+        atomic_load_explicit(&g_posix_memalign_calls, memory_order_relaxed);
+}
+
+static int RunHeapPositiveControl(void)
+{
+    void* pointer;
+    atomic_store_explicit(&g_malloc_calls, 0, memory_order_relaxed);
+    pointer = malloc(1);
+    if (pointer != NULL) {
+        free(pointer);
+        return Fail("heap interposition positive control returned storage");
+    }
+    if (atomic_load_explicit(&g_malloc_calls, memory_order_relaxed) != 1 ||
+        HeapCallTotal() != 1) {
+        return Fail("heap interposition positive control did not trip");
+    }
+    puts("{\"control\":\"heap_interposition\",\"status\":\"PASS\",\"calls\":1}");
+    return 0;
+}
+
+static int RunStackConfigurationPositiveControl(void)
+{
+    pthread_attr_t attributes;
+    int result;
+    if (pthread_attr_init(&attributes) != 0) {
+        return Fail("cannot initialize stack positive control");
+    }
+    result =
+        pthread_attr_setstacksize(&attributes, (size_t)PTHREAD_STACK_MIN - 1U);
+    if (pthread_attr_destroy(&attributes) != 0) {
+        return Fail("cannot destroy stack positive-control attributes");
+    }
+    if (result != EINVAL) {
+        return Fail("undersized pthread stack was not rejected");
+    }
+    puts(
+        "{\"control\":\"undersized_stack_rejection\","
+        "\"status\":\"PASS\"}");
+    return 0;
+}
+
+static int RunCpuPositiveControl(void)
+{
+    volatile uint64_t counter = 0;
+    if (ApplyLimit(RLIMIT_CORE, 0, 0) != 0 ||
+        ApplyLimit(RLIMIT_CPU, 1, 2) != 0) {
+        return Fail("cannot apply CPU positive-control limits");
+    }
+    alarm(5);
+    for (;;) {
+        ++counter;
+    }
+}
+
+static int RunWallPositiveControl(void)
+{
+    if (ApplyLimit(RLIMIT_CORE, 0, 0) != 0) {
+        return Fail("cannot apply wall positive-control limits");
+    }
+    alarm(1);
+    for (;;) {
+        pause();
+    }
+}
+
+int main(int argc, char** argv)
+{
+    static const char* batch_names[RESOURCE_BATCH_COUNT] = {
+        "mixed_rotating",
+        "valid_rotating",
+        "deep_reject_rotating",
+        "same_key_mixed",
+    };
+    pthread_attr_t attributes;
+    pthread_t worker;
+    struct timespec monotonic_resolution;
+    struct timespec cpu_resolution;
+    struct rusage usage;
+    uint64_t input_hash_before;
+    uint64_t input_hash_after;
+    size_t stack_size = 0;
+    size_t guard_size = 0;
+    uint32_t i;
+
+    if (argc != 2) return Fail("expected exactly one corpus-bundle path");
+    if (strcmp(argv[1], "--heap-positive-control") == 0) {
+        return RunHeapPositiveControl();
+    }
+    if (strcmp(argv[1], "--stack-positive-control") == 0) {
+        return RunStackConfigurationPositiveControl();
+    }
+    if (strcmp(argv[1], "--cpu-positive-control") == 0) {
+        return RunCpuPositiveControl();
+    }
+    if (strcmp(argv[1], "--wall-positive-control") == 0) {
+        return RunWallPositiveControl();
+    }
+    if (LoadBundle(argv[1]) != 0 || BuildSelections() != 0) return 1;
+    input_hash_before = BundleHash();
+
+    atomic_store_explicit(&g_malloc_calls, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_calloc_calls, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_realloc_calls, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_free_calls, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_aligned_alloc_calls, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_posix_memalign_calls, 0, memory_order_relaxed);
+
+    if (ApplyResourceLimits() != 0 ||
+        clock_getres(CLOCK_MONOTONIC, &monotonic_resolution) != 0 ||
+        clock_getres(CLOCK_THREAD_CPUTIME_ID, &cpu_resolution) != 0 ||
+        pthread_attr_init(&attributes) != 0 ||
+        pthread_attr_setstacksize(&attributes, RESOURCE_THREAD_STACK_BYTES) != 0 ||
+        pthread_attr_setguardsize(&attributes, RESOURCE_THREAD_GUARD_BYTES) != 0 ||
+        pthread_attr_getstacksize(&attributes, &stack_size) != 0 ||
+        pthread_attr_getguardsize(&attributes, &guard_size) != 0 ||
+        stack_size != RESOURCE_THREAD_STACK_BYTES ||
+        guard_size != RESOURCE_THREAD_GUARD_BYTES) {
+        return Fail("cannot establish the guarded-thread measurement contract");
+    }
+
+    alarm(RESOURCE_WALL_WATCHDOG_SECONDS);
+    if (pthread_create(&worker, &attributes, RunResourceProbe, NULL) != 0) {
+        pthread_attr_destroy(&attributes);
+        return Fail("cannot create the guarded verifier thread");
+    }
+    if (pthread_attr_destroy(&attributes) != 0) {
+        (void)pthread_join(worker, NULL);
+        return Fail("cannot destroy the guarded verifier thread attributes");
+    }
+    if (pthread_join(worker, NULL) != 0) {
+        return Fail("cannot complete the guarded verifier thread");
+    }
+    alarm(0);
+    input_hash_after = BundleHash();
+    if (g_result.failed || input_hash_before != input_hash_after ||
+        g_result.completed_calls !=
+            1U + RESOURCE_BATCH_COUNT * RESOURCE_BATCH_CALLS ||
+        HeapCallTotal() != 0 ||
+        getrusage(RUSAGE_SELF, &usage) != 0) {
+        return Fail("direct-verifier resource invariant failed");
+    }
+
+    printf(
+        "{\"schema_version\":%u,\"status\":\"PASS\","
+        "\"records\":%u,\"sample_count\":%u,\"batch_calls\":%u,"
+        "\"completed_calls\":%llu,"
+        "\"selection_counts\":{\"mixed_rotating\":%u,"
+        "\"valid_rotating\":%u,\"deep_reject_rotating\":%u,"
+        "\"same_key_mixed\":%u},"
+        "\"first_call\":{\"record\":%u,\"result\":%d,"
+        "\"wall_ns\":%llu,\"cpu_ns\":%llu},\"batches\":[",
+        RESOURCE_SCHEMA_VERSION,
+        g_record_count,
+        RESOURCE_SAMPLE_COUNT,
+        RESOURCE_BATCH_CALLS,
+        (unsigned long long)g_result.completed_calls,
+        g_batch_record_counts[RESOURCE_BATCH_MIXED_ROTATING],
+        g_batch_record_counts[RESOURCE_BATCH_VALID_ROTATING],
+        g_batch_record_counts[RESOURCE_BATCH_DEEP_REJECT_ROTATING],
+        g_batch_record_counts[RESOURCE_BATCH_SAME_KEY_MIXED],
+        g_first_record,
+        g_result.first_result,
+        (unsigned long long)g_result.first_wall_ns,
+        (unsigned long long)g_result.first_cpu_ns);
+    for (i = 0; i < RESOURCE_BATCH_COUNT; ++i) {
+        if (i != 0) putchar(',');
+        PrintBatch(batch_names[i], &g_result.batches[i]);
+    }
+    printf("],\"control\":{\"iterations\":%u,\"wall_samples_ns\":", RESOURCE_BATCH_CALLS);
+    PrintSamples(g_result.control_wall_samples_ns);
+    printf(",\"cpu_samples_ns\":");
+    PrintSamples(g_result.control_cpu_samples_ns);
+    printf(
+        "},\"heap_calls\":{\"malloc\":%lu,\"calloc\":%lu,"
+        "\"realloc\":%lu,\"free\":%lu,\"aligned_alloc\":%lu,"
+        "\"posix_memalign\":%lu},"
+        "\"thread_stack_bytes\":%zu,\"thread_guard_bytes\":%zu,"
+        "\"peak_rss_kib\":%ld,"
+        "\"clock_resolution_ns\":{\"monotonic\":%llu,"
+        "\"thread_cpu\":%llu},"
+        "\"input_fnv1a64_before\":\"%016llx\","
+        "\"input_fnv1a64_after\":\"%016llx\","
+        "\"result_accumulator\":%lld}\n",
+        atomic_load_explicit(&g_malloc_calls, memory_order_relaxed),
+        atomic_load_explicit(&g_calloc_calls, memory_order_relaxed),
+        atomic_load_explicit(&g_realloc_calls, memory_order_relaxed),
+        atomic_load_explicit(&g_free_calls, memory_order_relaxed),
+        atomic_load_explicit(&g_aligned_alloc_calls, memory_order_relaxed),
+        atomic_load_explicit(&g_posix_memalign_calls, memory_order_relaxed),
+        stack_size,
+        guard_size,
+        usage.ru_maxrss,
+        (unsigned long long)TimespecNanoseconds(monotonic_resolution),
+        (unsigned long long)TimespecNanoseconds(cpu_resolution),
+        (unsigned long long)input_hash_before,
+        (unsigned long long)input_hash_after,
+        (long long)g_result_accumulator);
+    return 0;
+}

--- a/contrib/ml-dsa-engineering/pqbtc_mldsa44_resource_probe.c
+++ b/contrib/ml-dsa-engineering/pqbtc_mldsa44_resource_probe.c
@@ -6,8 +6,11 @@
 
 #include "pqbtc_mldsa44.h"
 
+// IWYU pragma: no_include <bits/pthread_stack_min.h>
+// IWYU pragma: no_include <bits/types/struct_rusage.h>
+
 #include <errno.h>
-#include <limits.h>
+#include <limits.h>  // IWYU pragma: keep
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stddef.h>
@@ -170,7 +173,9 @@ int __wrap_posix_memalign(void** output, size_t alignment, size_t size)
 
 static int Fail(const char* message)
 {
-    fprintf(stderr, "ML-DSA-44 resource probe: %s\n", message);
+    fputs("ML-DSA-44 resource probe: ", stderr);
+    fputs(message, stderr);
+    fputc('\n', stderr);
     return 1;
 }
 
@@ -306,9 +311,17 @@ static int LoadBundle(const char* path)
     }
     g_bundle_size = (size_t)file_size;
     received = fread(g_bundle, 1, g_bundle_size, input);
+    if (received != g_bundle_size) {
+        fclose(input);
+        return Fail("cannot read the corpus bundle exactly");
+    }
     trailing_byte = fgetc(input);
+    if (trailing_byte != EOF || ferror(input) != 0) {
+        fclose(input);
+        return Fail("cannot read the corpus bundle exactly");
+    }
     close_result = fclose(input);
-    if (received != g_bundle_size || trailing_byte != EOF || close_result != 0) {
+    if (close_result != 0) {
         return Fail("cannot read the corpus bundle exactly");
     }
     if (memcmp(g_bundle, RESOURCE_BUNDLE_MAGIC, RESOURCE_BUNDLE_MAGIC_BYTES) != 0 ||

--- a/contrib/ml-dsa-engineering/run_static_analysis.py
+++ b/contrib/ml-dsa-engineering/run_static_analysis.py
@@ -28,6 +28,9 @@ WRAPPER_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44.c"
 SMOKE_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_smoke.c"
 FUZZ_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_verify_fuzz.c"
 STATEFUL_FUZZ_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_stateful_fuzz.c"
+RESOURCE_PROBE_SOURCE = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_resource_probe.c"
+RESOURCE_POLICY = f"{ENGINEERING_ROOT}/verifier_resource_policy.json"
+RESOURCE_RUNNER = f"{ENGINEERING_ROOT}/run_verifier_resource_envelope.py"
 PUBLIC_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44.h"
 TEST_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_test.h"
 CONFIG_HEADER = f"{ENGINEERING_ROOT}/pqbtc_mldsa44_config.h"
@@ -59,19 +62,24 @@ COMMON_C_FLAGS = [
 ]
 
 EVIDENCE_SOURCES = [
+    ".github/workflows/ml-dsa-44-resource-envelope.yml",
     ".github/workflows/ml-dsa-44-wrapper-prototype.yml",
     ".github/workflows/promotion-matrix.yml",
     "ci/test/00_setup_env_native_tidy.sh",
     "ci/test/01_base_install.sh",
     "ci/test/03_test_script.sh",
+    "ci/test/test_ml_dsa_resource_envelope.py",
     "ci/test/test_ml_dsa_wrapper_prototype.py",
     "contrib/ml-dsa-engineering/README.md",
     "contrib/ml-dsa-engineering/run_static_analysis.py",
+    RESOURCE_RUNNER,
     "contrib/ml-dsa-engineering/run_wrapper_tests.py",
     WRAPPER_SOURCE,
     SMOKE_SOURCE,
     FUZZ_SOURCE,
     STATEFUL_FUZZ_SOURCE,
+    RESOURCE_PROBE_SOURCE,
+    RESOURCE_POLICY,
     PUBLIC_HEADER,
     TEST_HEADER,
     CONFIG_HEADER,
@@ -112,6 +120,7 @@ def annex_k_suppression_count() -> int:
             SMOKE_SOURCE,
             FUZZ_SOURCE,
             STATEFUL_FUZZ_SOURCE,
+            RESOURCE_PROBE_SOURCE,
         )
     )
 
@@ -229,6 +238,18 @@ def build_plan(
             ),
         },
         {
+            "id": "clang-tidy-verifier-resource-probe",
+            "kind": "clang-tidy",
+            "input": RESOURCE_PROBE_SOURCE,
+            "variant": "production-api-test-only",
+            "command": tidy_command(
+                clang_tidy,
+                plugin,
+                RESOURCE_PROBE_SOURCE,
+                ["-pthread"],
+            ),
+        },
+        {
             "id": "iwyu-smoke-testing",
             "kind": "iwyu",
             "input": SMOKE_SOURCE,
@@ -263,6 +284,19 @@ def build_plan(
             ),
         },
         {
+            "id": "iwyu-verifier-resource-probe",
+            "kind": "iwyu",
+            "input": RESOURCE_PROBE_SOURCE,
+            "variant": "production-api-test-only",
+            "check_also": [PUBLIC_HEADER],
+            "command": iwyu_command(
+                iwyu,
+                RESOURCE_PROBE_SOURCE,
+                [PUBLIC_HEADER],
+                ["-pthread"],
+            ),
+        },
+        {
             "id": "header-self-contained-production",
             "kind": "header-self-containment",
             "input": PUBLIC_HEADER,
@@ -287,6 +321,7 @@ def build_plan(
             "clang_tidy_wrapper_implementation": True,
             "iwyu_wrapper_implementation": False,
             "iwyu_first_party_leaf_units_and_headers": True,
+            "verifier_resource_probe_test_only": True,
             "production_integration": False,
             "release_hold_unchanged": True,
         },
@@ -343,8 +378,8 @@ def validate_plan(plan: dict[str, object]) -> None:
         raise AuditError("static-analysis plan has no check list")
 
     expected_counts = {
-        "clang-tidy": 5,
-        "iwyu": 3,
+        "clang-tidy": 6,
+        "iwyu": 4,
         "header-self-containment": 2,
     }
     counts = {kind: 0 for kind in expected_counts}

--- a/contrib/ml-dsa-engineering/run_verifier_resource_envelope.py
+++ b/contrib/ml-dsa-engineering/run_verifier_resource_envelope.py
@@ -1,0 +1,3088 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The PQBTC Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+"""Produce fail-closed direct-verifier resource observations.
+
+The measured target is the isolated production-shaped
+``pqbtc_mldsa44_verify_strict`` wrapper.  This lane is test-only: it does not
+define a consensus, block-validation, activation, or production admission
+limit.  Pull-request observations are never promotion evidence, and numeric
+timing/RSS acceptance thresholds intentionally remain unset until a separate
+review of trusted main observations.
+"""
+
+import argparse
+import copy
+import ctypes
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import signal
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Iterable
+
+import run_verifier_fuzz as verifier
+import run_wrapper_tests as wrapper
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+POLICY_PATH = HERE / "verifier_resource_policy.json"
+PROBE_SOURCE = HERE / "pqbtc_mldsa44_resource_probe.c"
+WRAPPER_HEADER = HERE / "pqbtc_mldsa44.h"
+WRAPPER_TEST_HEADER = HERE / "pqbtc_mldsa44_test.h"
+WRAPPER_CONFIG = HERE / "pqbtc_mldsa44_config.h"
+UPSTREAM_SIGN = (
+    HERE / "vendor" / "mldsa-native" / "mldsa" / "src" / "sign.c"
+)
+UPSTREAM_HEADER = (
+    HERE / "vendor" / "mldsa-native" / "mldsa" / "mldsa_native.h"
+)
+RESOURCE_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "ml-dsa-44-resource-envelope.yml"
+)
+RESOURCE_TEST = REPO_ROOT / "ci" / "test" / "test_ml_dsa_resource_envelope.py"
+BASELINE_POINTER = (
+    REPO_ROOT / "contrib" / "ml-dsa-ref" / "review_baseline_commit.txt"
+)
+
+POLICY_SHA256 = "24813510a2fdd13e3496e2f24f557a89ff0bde408296839243346f978228bb9f"
+GITHUB_REPOSITORY = "scottdhughes/quantum-proof-bitcoin"
+GITHUB_REPOSITORY_ID = "1136579990"
+GITHUB_WORKFLOW_NAME = "ML-DSA-44 verifier resource envelope"
+GITHUB_WORKFLOW_PATH = ".github/workflows/ml-dsa-44-resource-envelope.yml"
+HEX_40 = re.compile(r"[0-9a-f]{40}")
+HEX_64 = re.compile(r"[0-9a-f]{64}")
+HEX_16 = re.compile(r"[0-9a-f]{16}")
+STACK_USAGE_LINE = re.compile(
+    r"^(?P<source>.+?):(?P<line>[0-9]+):(?:(?P<column>[0-9]+):)?"
+    r"(?P<symbol>[^\t]+)\t(?P<bytes>[0-9]+)\t(?P<qualifier>[^\t\r\n]+)$"
+)
+
+BUNDLE_MAGIC = b"PQRSC001"
+BUNDLE_HEADER = struct.Struct("<8sII")
+RECORD_HEADER = struct.Struct("<IiI")
+FLAG_VALID = 0x01
+FLAG_DEEP_REJECT = 0x02
+FLAG_SAME_KEY = 0x04
+FLAG_FIRST_CALL = 0x08
+FLAG_MASK = FLAG_VALID | FLAG_DEEP_REJECT | FLAG_SAME_KEY | FLAG_FIRST_CALL
+
+OWNER_FILE = "evidence-owner.txt"
+OWNER_CONTENT = "pqbtc-ml-dsa-44-resource-envelope-v1\n"
+PLAN_FILE = "resource-plan.json"
+POLICY_FILE = "verifier-resource-policy.json"
+BUNDLE_FILE = "verifier-corpus.bundle"
+INVENTORY_FILE = "verifier-corpus-inventory.json"
+OBSERVATION_FILE = "probe-observation.json"
+PROBE_STDERR_FILE = "probe-stderr.log"
+COMPILER_VERSION_FILE = "compiler-version.txt"
+COMPILER_TARGET_FILE = "compiler-target.txt"
+BUILD_COMMANDS_FILE = "build-commands.json"
+HOST_FILE = "host-observation.json"
+LIBRARY_FILE = "libpqbtc_mldsa44.so"
+PROBE_FILE = "pqbtc_mldsa44-resource-probe"
+WRAPPER_STACK_FILE = "wrapper-stack-usage.su"
+PROBE_STACK_FILE = "probe-stack-usage.su"
+STACK_REPORT_FILE = "stack-usage.json"
+SYMBOLS_FILE = "production-symbols.txt"
+LINKED_FILE = "linked-libraries.txt"
+GIT_HEAD_FILE = "git-head.txt"
+GIT_STATUS_FILE = "git-status.txt"
+BASELINE_DIFF_FILE = "baseline-diff.txt"
+CONTROLS_FILE = "detector-controls.json"
+REPORT_FILE = "resource-envelope-report.json"
+JOB_STATUS_FILE = "job-status.txt"
+CHECKSUM_FILE = "SHA256SUMS"
+
+SUCCESS_FILES = {
+    OWNER_FILE,
+    PLAN_FILE,
+    POLICY_FILE,
+    BUNDLE_FILE,
+    INVENTORY_FILE,
+    OBSERVATION_FILE,
+    PROBE_STDERR_FILE,
+    COMPILER_VERSION_FILE,
+    COMPILER_TARGET_FILE,
+    BUILD_COMMANDS_FILE,
+    HOST_FILE,
+    LIBRARY_FILE,
+    PROBE_FILE,
+    WRAPPER_STACK_FILE,
+    PROBE_STACK_FILE,
+    STACK_REPORT_FILE,
+    SYMBOLS_FILE,
+    LINKED_FILE,
+    GIT_HEAD_FILE,
+    GIT_STATUS_FILE,
+    BASELINE_DIFF_FILE,
+    CONTROLS_FILE,
+    REPORT_FILE,
+    JOB_STATUS_FILE,
+    CHECKSUM_FILE,
+}
+FAILURE_REQUIRED_FILES = {
+    OWNER_FILE,
+    PLAN_FILE,
+    POLICY_FILE,
+    REPORT_FILE,
+    JOB_STATUS_FILE,
+    CHECKSUM_FILE,
+}
+MAX_EVIDENCE_FILES = 32
+MAX_EVIDENCE_BYTES = 12 * 1024 * 1024
+MAX_JSON_BYTES = 4 * 1024 * 1024
+MAX_LOG_BYTES = 65536
+
+RESULT_NAMES = {
+    verifier.OK: "ok",
+    verifier.ERR_INVALID_ARGUMENT: "invalid_argument",
+    verifier.ERR_VERIFY: "verify_rejection",
+}
+OUTCOME_KEYS = ("ok", "invalid_argument", "verify_rejection")
+EXPECTED_CORPUS_SUMMARY = {
+    "total_cases": 245,
+    "unique_frames": 240,
+    "source_counts": {
+        "project": 27,
+        "wycheproof": 180,
+        "promoted": 38,
+    },
+    "expected_counts": {
+        "ok": 81,
+        "invalid_argument": 36,
+        "verify_rejection": 128,
+    },
+    "aggregate_sha256": (
+        "6ee1368b01bfd758dd1c78a79bb7789769137f8d93055dfe9c4d040706597979"
+    ),
+}
+FORBIDDEN_FLAG_CLAIMS = [
+    "-march=native",
+    "-flto",
+    "-DPQBTC_MLDSA44_TESTING=1 (measured objects)",
+    "-fsanitize",
+]
+
+GUARDED_PATHS = (
+    ".github/workflows/ml-dsa-44-resource-envelope.yml",
+    ".github/workflows/ml-dsa-44-review-reproduction.yml",
+    "contrib/ml-dsa-engineering",
+    "contrib/ml-dsa-ref/vectors.json",
+    "ci/test/test_ml_dsa_resource_envelope.py",
+    "ci/test/test_ml_dsa_wrapper_prototype.py",
+)
+
+
+class ResourceEnvelopeError(RuntimeError):
+    """Raised when resource evidence cannot be trusted."""
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def fnv1a64_bytes(value: bytes) -> str:
+    result = 14695981039346656037
+    for byte in value:
+        result ^= byte
+        result = (result * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return f"{result:016x}"
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+
+
+def _reject_duplicate_json_keys(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ResourceEnvelopeError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json(value):
+    raise ResourceEnvelopeError(f"non-finite JSON value: {value}")
+
+
+def _require_regular_file(
+    path: Path, label: str, maximum: int, *, allow_empty: bool = False
+) -> None:
+    try:
+        status = path.lstat()
+    except OSError as exc:
+        raise ResourceEnvelopeError(f"cannot inspect {label}: {exc}") from exc
+    if not stat.S_ISREG(status.st_mode):
+        raise ResourceEnvelopeError(f"{label} must be a regular non-symlink file")
+    if status.st_size > maximum or (not allow_empty and status.st_size == 0):
+        raise ResourceEnvelopeError(f"{label} size is outside the frozen bound")
+
+
+def load_json_object(path: Path, label: str, maximum: int = MAX_JSON_BYTES) -> dict:
+    _require_regular_file(path, label, maximum)
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_nonfinite_json,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ResourceEnvelopeError(f"cannot parse {label}: {exc}") from exc
+    if type(value) is not dict:
+        raise ResourceEnvelopeError(f"{label} must contain one JSON object")
+    return value
+
+
+def _read_text_file(
+    path: Path,
+    label: str,
+    *,
+    encoding: str = "utf8",
+    maximum: int = MAX_JSON_BYTES,
+    allow_empty: bool = False,
+) -> str:
+    _require_regular_file(path, label, maximum, allow_empty=allow_empty)
+    try:
+        return path.read_text(encoding=encoding)
+    except (OSError, UnicodeError) as exc:
+        raise ResourceEnvelopeError(f"cannot read {label}: {exc}") from exc
+
+
+def _require_exact_keys(value: object, keys: set[str], label: str) -> dict:
+    if type(value) is not dict or set(value) != keys:
+        actual = sorted(value) if type(value) is dict else type(value).__name__
+        raise ResourceEnvelopeError(
+            f"{label} fields differ: expected {sorted(keys)}, got {actual}"
+        )
+    return value
+
+
+def _require_int(value: object, label: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ResourceEnvelopeError(f"{label} must be an integer >= {minimum}")
+    return value
+
+
+def _require_bool(value: object, label: str) -> bool:
+    if type(value) is not bool:
+        raise ResourceEnvelopeError(f"{label} must be a boolean")
+    return value
+
+
+def _require_string(value: object, label: str) -> str:
+    if type(value) is not str or not value:
+        raise ResourceEnvelopeError(f"{label} must be a non-empty string")
+    return value
+
+
+def load_policy() -> dict:
+    policy = load_json_object(POLICY_PATH, "resource policy", 16384)
+    _require_exact_keys(
+        policy,
+        {
+            "schema_version",
+            "phase",
+            "target",
+            "profile",
+            "batch",
+            "enforced_limits",
+            "acceptance_limits",
+            "stack_evidence",
+            "promotion",
+            "scope",
+        },
+        "resource policy",
+    )
+    _require_int(policy["schema_version"], "resource policy schema")
+    if policy["schema_version"] != 1:
+        raise ResourceEnvelopeError("unsupported resource policy schema")
+    if policy["phase"] != "TRUSTED_MAIN_OBSERVATION_REQUIRED":
+        raise ResourceEnvelopeError("resource policy phase drifted")
+    if policy["target"] != "pqbtc_mldsa44_verify_strict":
+        raise ResourceEnvelopeError("resource policy target drifted")
+
+    profile = _require_exact_keys(
+        policy["profile"],
+        {
+            "system",
+            "machine",
+            "measurement_target",
+            "backend",
+            "optimization",
+            "thread_model",
+            "allocation_model",
+        },
+        "resource profile",
+    )
+    expected_profile = {
+        "system": "Linux",
+        "machine": "x86_64",
+        "measurement_target": "isolated-production-shaped-direct-verifier",
+        "backend": "mldsa-native-portable-c",
+        "optimization": "-O2",
+        "thread_model": "one guarded pthread",
+        "allocation_model": "default upstream stack allocation",
+    }
+    if profile != expected_profile:
+        raise ResourceEnvelopeError("resource profile drifted")
+
+    batch = _require_exact_keys(
+        policy["batch"],
+        {
+            "source",
+            "unique_frames",
+            "full_corpus_rounds",
+            "prefix_frames",
+            "verification_calls",
+            "sample_count",
+            "first_call_separate",
+            "batches",
+            "derivation",
+            "capacity_basis",
+            "capacity_scope",
+            "required_accept_cases",
+            "required_deep_reject_cases",
+            "same_key_cases",
+        },
+        "resource batch",
+    )
+    expected_batches = [
+        "mixed_rotating",
+        "valid_rotating",
+        "deep_reject_rotating",
+        "same_key_mixed",
+    ]
+    if (
+        batch["unique_frames"] != 240
+        or batch["full_corpus_rounds"] != 17
+        or batch["prefix_frames"] != 207
+        or batch["verification_calls"] != 4287
+        or batch["sample_count"] != 31
+        or batch["first_call_separate"] is not True
+        or batch["batches"] != expected_batches
+        or batch["verification_calls"]
+        != batch["full_corpus_rounds"] * batch["unique_frames"]
+        + batch["prefix_frames"]
+    ):
+        raise ResourceEnvelopeError("resource batch arithmetic or sampling drifted")
+    if batch["source"] != "SHA256-sorted unique verifier_fuzz_corpus.json frames":
+        raise ResourceEnvelopeError("resource batch source drifted")
+    if batch["capacity_scope"] != (
+        "research workload only; not a transaction, block-validation, "
+        "consensus, or activation limit"
+    ):
+        raise ResourceEnvelopeError("resource batch capacity scope drifted")
+    expected_accepts = [
+        "valid_empty_message_context",
+        "valid_frozen_vector",
+        "valid_max_context",
+        "valid_max_fuzz_message",
+    ]
+    expected_deep_rejects = [
+        "reject_context_flip",
+        "reject_ctilde_bit_flip",
+        "reject_hint_counter_backwards",
+        "reject_hint_nonzero_padding",
+        "reject_message_flip",
+        "reject_public_key_rho_flip",
+        "reject_public_key_t1_flip",
+    ]
+    if batch["required_accept_cases"] != expected_accepts:
+        raise ResourceEnvelopeError("required accept taxonomy drifted")
+    if batch["required_deep_reject_cases"] != expected_deep_rejects:
+        raise ResourceEnvelopeError("required deep-reject taxonomy drifted")
+    expected_same_key = [
+        "reject_context_flip",
+        "reject_ctilde_bit_flip",
+        "reject_hint_counter_backwards",
+        "reject_hint_nonzero_padding",
+        "reject_message_flip",
+        *expected_accepts,
+    ]
+    if batch["same_key_cases"] != expected_same_key:
+        raise ResourceEnvelopeError("same-key taxonomy drifted")
+
+    limits = _require_exact_keys(
+        policy["enforced_limits"],
+        {
+            "thread_stack_bytes",
+            "thread_guard_bytes",
+            "address_space_bytes",
+            "open_files",
+            "output_file_bytes",
+            "core_file_bytes",
+            "project_heap_calls",
+            "cpu_watchdog_seconds",
+            "wall_watchdog_seconds",
+        },
+        "resource safety limits",
+    )
+    if limits != {
+        "thread_stack_bytes": 131072,
+        "thread_guard_bytes": 4096,
+        "address_space_bytes": 268435456,
+        "open_files": 64,
+        "output_file_bytes": 65536,
+        "core_file_bytes": 0,
+        "project_heap_calls": 0,
+        "cpu_watchdog_seconds": 120,
+        "wall_watchdog_seconds": 180,
+    }:
+        raise ResourceEnvelopeError("resource safety limits drifted")
+
+    acceptance = _require_exact_keys(
+        policy["acceptance_limits"],
+        {"cpu_seconds", "wall_seconds", "peak_rss_kib", "status"},
+        "resource acceptance limits",
+    )
+    if acceptance != {
+        "cpu_seconds": None,
+        "wall_seconds": None,
+        "peak_rss_kib": None,
+        "status": "UNSET_PENDING_SEPARATE_REVIEW_OF_TRUSTED_MAIN_OBSERVATION",
+    }:
+        raise ResourceEnvelopeError(
+            "numeric acceptance limits must remain unset in this tranche"
+        )
+
+    stack = _require_exact_keys(
+        policy["stack_evidence"],
+        {
+            "upstream_mld_total_alloc_44_verify_bytes",
+            "required_symbols",
+            "require_static_stack_usage",
+            "call_chain_claim",
+        },
+        "stack evidence policy",
+    )
+    if (
+        stack["upstream_mld_total_alloc_44_verify_bytes"] != 24448
+        or stack["required_symbols"]
+        != ["pqbtc_mldsa44_upstream_verify", "pqbtc_mldsa44_verify_strict"]
+        or stack["require_static_stack_usage"] is not True
+        or "not summed into a formal call-chain bound"
+        not in stack["call_chain_claim"]
+    ):
+        raise ResourceEnvelopeError("stack evidence policy drifted")
+
+    promotion = _require_exact_keys(
+        policy["promotion"],
+        {
+            "requires_trusted_main_push",
+            "requires_both_compilers",
+            "requires_separate_policy_change",
+            "pull_request_evidence",
+            "trusted_main_evidence",
+            "timing_threshold_bootstrap_forbidden",
+        },
+        "resource promotion policy",
+    )
+    if promotion != {
+        "requires_trusted_main_push": True,
+        "requires_both_compilers": ["clang", "gcc"],
+        "requires_separate_policy_change": True,
+        "pull_request_evidence": "UNTRUSTED_PR_OBSERVATION",
+        "trusted_main_evidence": "TRUSTED_MAIN_OBSERVATION",
+        "timing_threshold_bootstrap_forbidden": True,
+    }:
+        raise ResourceEnvelopeError("resource promotion policy drifted")
+
+    scope = _require_exact_keys(
+        policy["scope"],
+        {
+            "isolated_test_only",
+            "production_integration",
+            "production_backend",
+            "simd256_admitted",
+            "release_hold",
+            "release_hold_changed",
+            "batch_limit_is_not_consensus_policy",
+            "closes_issue",
+        },
+        "resource scope",
+    )
+    if scope != {
+        "isolated_test_only": True,
+        "production_integration": False,
+        "production_backend": "NONE",
+        "simd256_admitted": False,
+        "release_hold": True,
+        "release_hold_changed": False,
+        "batch_limit_is_not_consensus_policy": True,
+        "closes_issue": False,
+    }:
+        raise ResourceEnvelopeError("resource scope drifted")
+    if sha256_file(POLICY_PATH) != POLICY_SHA256:
+        raise ResourceEnvelopeError("resource policy byte-level hash drifted")
+    return policy
+
+
+def _plan_inputs() -> dict[str, str]:
+    paths = {
+        "policy": POLICY_PATH,
+        "runner": Path(__file__).resolve(),
+        "probe": PROBE_SOURCE,
+        "wrapper_source": wrapper.WRAPPER_SOURCE,
+        "wrapper_header": WRAPPER_HEADER,
+        "wrapper_test_header": WRAPPER_TEST_HEADER,
+        "wrapper_config": WRAPPER_CONFIG,
+        "source_manifest": wrapper.SOURCE_MANIFEST,
+        "fuzz_driver": Path(verifier.__file__).resolve(),
+        "fuzz_manifest": verifier.CORPUS_MANIFEST,
+        "vectors": wrapper.VECTORS,
+        "wycheproof_source": verifier.WYCHEPROOF_SOURCE,
+        "promoted_source": verifier.PROMOTED_SOURCE,
+        "workflow": RESOURCE_WORKFLOW,
+        "resource_test": RESOURCE_TEST,
+    }
+    for label, path in paths.items():
+        _require_regular_file(path, f"plan input {label}", MAX_JSON_BYTES)
+    return {label: sha256_file(path) for label, path in sorted(paths.items())}
+
+
+def build_plan(policy: dict) -> dict:
+    batch = policy["batch"]
+    return {
+        "schema_version": 1,
+        "target": policy["target"],
+        "host": {
+            "system": policy["profile"]["system"],
+            "machine": policy["profile"]["machine"],
+        },
+        "measurement": {
+            "profile": policy["profile"]["measurement_target"],
+            "batch_ids": batch["batches"],
+            "sample_count": batch["sample_count"],
+            "raw_sample_count": batch["sample_count"],
+            "retain_raw_samples": True,
+            "subtract_control_samples": False,
+            "first_call_separate": batch["first_call_separate"],
+            "wall_clock": "CLOCK_MONOTONIC",
+            "cpu_clock": "CLOCK_THREAD_CPUTIME_ID",
+            "control_loop": "reported separately and never subtracted",
+            "numeric_acceptance": (
+                "unset pending a separate review of trusted main observations"
+            ),
+        },
+        "policy": copy.deepcopy(policy),
+        "policy_sha256": sha256_file(POLICY_PATH),
+        "inputs": _plan_inputs(),
+    }
+
+
+def _percentile(samples: list[int], percentile: int) -> int:
+    ordered = sorted(samples)
+    index = max(0, math.ceil(percentile * len(ordered) / 100) - 1)
+    return ordered[index]
+
+
+def summarize_samples(samples: list[int]) -> dict[str, int]:
+    ordered = sorted(samples)
+    return {
+        "min": ordered[0],
+        "median": ordered[len(ordered) // 2],
+        "p95": _percentile(ordered, 95),
+        "p99": _percentile(ordered, 99),
+        "max": ordered[-1],
+    }
+
+
+def _validate_sample_array(
+    value: object, label: str, count: int, *, allow_zero: bool
+) -> list[int]:
+    if type(value) is not list or len(value) != count:
+        raise ResourceEnvelopeError(f"{label} must contain exactly {count} samples")
+    minimum = 0 if allow_zero else 1
+    for index, sample in enumerate(value):
+        _require_int(sample, f"{label}[{index}]", minimum)
+        if sample > 10**15:
+            raise ResourceEnvelopeError(f"{label}[{index}] is implausibly large")
+    return value
+
+
+def validate_probe_observation(
+    observation: dict,
+    plan: dict,
+    *,
+    expected_input_fnv1a64: str | None = None,
+) -> dict:
+    policy = plan["policy"]
+    batch_policy = policy["batch"]
+    limits = policy["enforced_limits"]
+    _require_exact_keys(
+        observation,
+        {
+            "schema_version",
+            "status",
+            "records",
+            "sample_count",
+            "batch_calls",
+            "completed_calls",
+            "selection_counts",
+            "first_call",
+            "batches",
+            "control",
+            "heap_calls",
+            "thread_stack_bytes",
+            "thread_guard_bytes",
+            "peak_rss_kib",
+            "clock_resolution_ns",
+            "input_fnv1a64_before",
+            "input_fnv1a64_after",
+            "result_accumulator",
+        },
+        "probe observation",
+    )
+    for field in (
+        "schema_version",
+        "records",
+        "sample_count",
+        "batch_calls",
+        "completed_calls",
+    ):
+        _require_int(observation[field], f"probe observation {field}")
+    if (
+        observation["schema_version"] != 1
+        or observation["status"] != "PASS"
+        or observation["records"] != batch_policy["unique_frames"]
+        or observation["sample_count"] != batch_policy["sample_count"]
+        or observation["batch_calls"] != batch_policy["verification_calls"]
+        or observation["completed_calls"]
+        != 1 + len(batch_policy["batches"]) * batch_policy["verification_calls"]
+    ):
+        raise ResourceEnvelopeError("probe observation cardinality drifted")
+
+    selections = _require_exact_keys(
+        observation["selection_counts"],
+        set(batch_policy["batches"]),
+        "probe selection counts",
+    )
+    if selections["mixed_rotating"] != batch_policy["unique_frames"]:
+        raise ResourceEnvelopeError("mixed batch does not select every unique frame")
+    for batch_id, count in selections.items():
+        if type(count) is not int or not 1 <= count <= batch_policy["unique_frames"]:
+            raise ResourceEnvelopeError(f"invalid selection count for {batch_id}")
+
+    first = _require_exact_keys(
+        observation["first_call"],
+        {"record", "result", "wall_ns", "cpu_ns"},
+        "first-call observation",
+    )
+    _require_int(first["record"], "first-call record")
+    _require_int(first["result"], "first-call result")
+    if (
+        not 0 <= first["record"] < batch_policy["unique_frames"]
+        or first["result"] != verifier.OK
+    ):
+        raise ResourceEnvelopeError("first-call record/result drifted")
+    _require_int(first["wall_ns"], "first-call wall time", 1)
+    _require_int(first["cpu_ns"], "first-call CPU time", 1)
+
+    batches = observation["batches"]
+    if type(batches) is not list or len(batches) != len(batch_policy["batches"]):
+        raise ResourceEnvelopeError("probe batch list cardinality drifted")
+    summaries = {"first_call": {"wall_ns": first["wall_ns"], "cpu_ns": first["cpu_ns"]}}
+    total_wall_ns = first["wall_ns"]
+    total_cpu_ns = first["cpu_ns"]
+    for index, (batch_id, batch) in enumerate(zip(batch_policy["batches"], batches)):
+        _require_exact_keys(
+            batch,
+            {"id", "calls", "outcomes", "wall_samples_ns", "cpu_samples_ns"},
+            f"probe batch {index}",
+        )
+        _require_int(batch["calls"], f"{batch_id} call count")
+        if batch["id"] != batch_id or batch["calls"] != batch_policy["verification_calls"]:
+            raise ResourceEnvelopeError(f"probe batch identity drifted at index {index}")
+        outcomes = _require_exact_keys(
+            batch["outcomes"], set(OUTCOME_KEYS), f"{batch_id} outcomes"
+        )
+        for name in OUTCOME_KEYS:
+            _require_int(outcomes[name], f"{batch_id}.{name}")
+        if sum(outcomes.values()) != batch["calls"]:
+            raise ResourceEnvelopeError(f"{batch_id} outcome accounting differs")
+        if batch_id == "valid_rotating" and outcomes != {
+            "ok": batch["calls"],
+            "invalid_argument": 0,
+            "verify_rejection": 0,
+        }:
+            raise ResourceEnvelopeError("valid batch contains a non-accept outcome")
+        if batch_id == "deep_reject_rotating" and outcomes != {
+            "ok": 0,
+            "invalid_argument": 0,
+            "verify_rejection": batch["calls"],
+        }:
+            raise ResourceEnvelopeError("deep-reject batch outcome differs")
+        if batch_id == "same_key_mixed" and (
+            outcomes["invalid_argument"] != 0
+            or outcomes["ok"] == 0
+            or outcomes["verify_rejection"] == 0
+        ):
+            raise ResourceEnvelopeError("same-key mixed batch taxonomy differs")
+        wall = _validate_sample_array(
+            batch["wall_samples_ns"],
+            f"{batch_id} wall samples",
+            batch_policy["sample_count"],
+            allow_zero=False,
+        )
+        cpu = _validate_sample_array(
+            batch["cpu_samples_ns"],
+            f"{batch_id} CPU samples",
+            batch_policy["sample_count"],
+            allow_zero=False,
+        )
+        total_wall_ns += sum(wall)
+        total_cpu_ns += sum(cpu)
+        summaries[batch_id] = {
+            "wall_ns": summarize_samples(wall),
+            "cpu_ns": summarize_samples(cpu),
+            "outcomes": copy.deepcopy(outcomes),
+        }
+
+    control = _require_exact_keys(
+        observation["control"],
+        {"iterations", "wall_samples_ns", "cpu_samples_ns"},
+        "probe control loop",
+    )
+    _require_int(control["iterations"], "control-loop iteration count")
+    if control["iterations"] != batch_policy["verification_calls"]:
+        raise ResourceEnvelopeError("control-loop iteration count drifted")
+    control_wall = _validate_sample_array(
+        control["wall_samples_ns"],
+        "control wall samples",
+        batch_policy["sample_count"],
+        allow_zero=True,
+    )
+    control_cpu = _validate_sample_array(
+        control["cpu_samples_ns"],
+        "control CPU samples",
+        batch_policy["sample_count"],
+        allow_zero=True,
+    )
+    total_wall_ns += sum(control_wall)
+    total_cpu_ns += sum(control_cpu)
+    summaries["control"] = {
+        "wall_ns": summarize_samples(control_wall),
+        "cpu_ns": summarize_samples(control_cpu),
+        "subtracted_from_verifier_samples": False,
+    }
+
+    heap = _require_exact_keys(
+        observation["heap_calls"],
+        {"malloc", "calloc", "realloc", "free", "aligned_alloc", "posix_memalign"},
+        "probe heap counters",
+    )
+    for name, count in heap.items():
+        _require_int(count, f"probe heap counter {name}")
+        if count != limits["project_heap_calls"]:
+            raise ResourceEnvelopeError(f"nonzero instrumented project heap calls: {name}")
+    _require_int(observation["thread_stack_bytes"], "thread stack bytes", 1)
+    _require_int(observation["thread_guard_bytes"], "thread guard bytes", 1)
+    if (
+        observation["thread_stack_bytes"] != limits["thread_stack_bytes"]
+        or observation["thread_guard_bytes"] != limits["thread_guard_bytes"]
+    ):
+        raise ResourceEnvelopeError("guarded pthread configuration drifted")
+    peak_rss_kib = _require_int(observation["peak_rss_kib"], "peak RSS", 1)
+    if peak_rss_kib > limits["address_space_bytes"] // 1024:
+        raise ResourceEnvelopeError("peak RSS is incompatible with the address-space cap")
+    if total_wall_ns > limits["wall_watchdog_seconds"] * 1_000_000_000:
+        raise ResourceEnvelopeError("reported wall time exceeds the enforced watchdog")
+    if total_cpu_ns > limits["cpu_watchdog_seconds"] * 1_000_000_000:
+        raise ResourceEnvelopeError("reported CPU time exceeds the enforced limit")
+
+    resolution = _require_exact_keys(
+        observation["clock_resolution_ns"],
+        {"monotonic", "thread_cpu"},
+        "clock resolution",
+    )
+    _require_int(resolution["monotonic"], "monotonic clock resolution", 1)
+    _require_int(resolution["thread_cpu"], "thread CPU clock resolution", 1)
+    before = observation["input_fnv1a64_before"]
+    after = observation["input_fnv1a64_after"]
+    if (
+        type(before) is not str
+        or type(after) is not str
+        or HEX_16.fullmatch(before) is None
+        or before != after
+        or (
+            expected_input_fnv1a64 is not None
+            and before != expected_input_fnv1a64
+        )
+    ):
+        raise ResourceEnvelopeError("input immutability hash differs")
+    if type(observation["result_accumulator"]) is not int:
+        raise ResourceEnvelopeError("result accumulator must be an integer")
+
+    validated = copy.deepcopy(observation)
+    validated["derived_summaries"] = summaries
+    return validated
+
+
+def parse_stack_usage(paths: Iterable[Path]) -> dict[str, dict[str, object]]:
+    required = set(load_policy()["stack_evidence"]["required_symbols"])
+    found: dict[str, dict[str, object]] = {}
+    saw_file = False
+    for raw_path in paths:
+        path = Path(raw_path)
+        _require_regular_file(path, "compiler stack-usage record", 1024 * 1024)
+        saw_file = True
+        try:
+            lines = path.read_text(encoding="utf8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            raise ResourceEnvelopeError(f"cannot read stack-usage record: {exc}") from exc
+        if not lines:
+            raise ResourceEnvelopeError(f"empty stack-usage record: {path.name}")
+        for line in lines:
+            match = STACK_USAGE_LINE.fullmatch(line)
+            if match is None:
+                raise ResourceEnvelopeError(
+                    f"malformed compiler stack-usage row in {path.name}"
+                )
+            observed_symbol = match.group("symbol")
+            canonical_symbol = None
+            for required_symbol in required:
+                if re.fullmatch(
+                    re.escape(required_symbol)
+                    + r"(?:\.(?:constprop|isra)(?:\.[0-9]+)?)?",
+                    observed_symbol,
+                ):
+                    canonical_symbol = required_symbol
+                    break
+            if canonical_symbol is None:
+                continue
+            if canonical_symbol in found:
+                raise ResourceEnvelopeError(
+                    f"duplicate stack-usage symbol: {canonical_symbol}"
+                )
+            qualifier = match.group("qualifier")
+            if qualifier != "static":
+                raise ResourceEnvelopeError(
+                    f"required stack-usage symbol is not static: {canonical_symbol}"
+                )
+            size = int(match.group("bytes"))
+            if size <= 0:
+                raise ResourceEnvelopeError(
+                    "required stack-usage symbol has no static bytes: "
+                    f"{canonical_symbol}"
+                )
+            found[canonical_symbol] = {
+                "bytes": size,
+                "qualifier": qualifier,
+                "observed_symbol": observed_symbol,
+                "source": (
+                    f"{Path(match.group('source')).name}:{match.group('line')}"
+                    + (
+                        f":{match.group('column')}"
+                        if match.group("column") is not None
+                        else ""
+                    )
+                ),
+            }
+    if not saw_file:
+        raise ResourceEnvelopeError("no compiler stack-usage records supplied")
+    missing = sorted(required - set(found))
+    if missing:
+        raise ResourceEnvelopeError(f"missing stack-usage symbols: {missing}")
+    return {key: found[key] for key in sorted(found)}
+
+
+def _minimal_environment(extra_path: Path | None = None) -> dict[str, str]:
+    path_parts = []
+    if extra_path is not None:
+        path_parts.append(str(extra_path))
+    path_parts.extend(["/usr/local/bin", "/usr/bin", "/bin"])
+    return {
+        "PATH": ":".join(path_parts),
+        "LANG": "C",
+        "LC_ALL": "C",
+        "TZ": "UTC",
+    }
+
+
+def _run_bounded(
+    arguments: list[str],
+    *,
+    cwd: Path = REPO_ROOT,
+    timeout: int = 60,
+    maximum: int = MAX_LOG_BYTES,
+    environment: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    if not arguments or any(type(value) is not str or not value for value in arguments):
+        raise ResourceEnvelopeError("subprocess argv must be a non-empty string list")
+    try:
+        completed = subprocess.run(
+            arguments,
+            cwd=cwd,
+            env=environment or _minimal_environment(),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ResourceEnvelopeError(f"cannot complete {arguments[0]}: {exc}") from exc
+    if len(completed.stdout) > maximum or len(completed.stderr) > maximum:
+        raise ResourceEnvelopeError(f"{arguments[0]} output exceeded the frozen bound")
+    return completed
+
+
+def _require_command_success(
+    arguments: list[str],
+    *,
+    cwd: Path = REPO_ROOT,
+    timeout: int = 60,
+    environment: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    completed = _run_bounded(
+        arguments, cwd=cwd, timeout=timeout, environment=environment
+    )
+    stdout = completed.stdout.decode("utf8", errors="strict")
+    stderr = completed.stderr.decode("utf8", errors="strict")
+    if completed.returncode != 0:
+        raise ResourceEnvelopeError(
+            f"command exited {completed.returncode}: {arguments[0]}: "
+            f"{stderr.strip() or stdout.strip()}"
+        )
+    return stdout, stderr
+
+
+def _run_git(*arguments: str) -> str:
+    git = shutil.which("git")
+    if git is None:
+        raise ResourceEnvelopeError("Git is required")
+    stdout, _ = _require_command_success(
+        [str(Path(git).resolve()), "-C", str(REPO_ROOT), *arguments],
+        timeout=30,
+        environment=_minimal_environment(Path(git).resolve().parent),
+    )
+    return stdout
+
+
+def _require_positive_decimal(value: object, label: str) -> str:
+    if type(value) is not str or re.fullmatch(r"[1-9][0-9]*", value) is None:
+        raise ResourceEnvelopeError(f"{label} must be a positive decimal string")
+    return value
+
+
+def _local_ci_context() -> dict:
+    return {
+        "github_actions": False,
+        "server_url": "",
+        "api_url": "",
+        "repository": "",
+        "repository_id": "",
+        "event_name": "local",
+        "ref": "local",
+        "ref_protected": False,
+        "sha": "",
+        "workflow": "",
+        "workflow_ref": "",
+        "workflow_sha": "",
+        "run_id": "",
+        "run_attempt": "",
+        "run_number": "",
+        "job": "",
+        "head_ref": "",
+        "base_ref": "",
+        "expected_checkout_head": "",
+    }
+
+
+def _validate_github_context(context: dict, head: str) -> dict:
+    _require_exact_keys(context, set(_local_ci_context()), "GitHub Actions context")
+    if (
+        context["github_actions"] is not True
+        or context["server_url"] != "https://github.com"
+        or context["api_url"] != "https://api.github.com"
+        or context["repository"] != GITHUB_REPOSITORY
+        or context["repository_id"] != GITHUB_REPOSITORY_ID
+        or context["workflow"] != GITHUB_WORKFLOW_NAME
+        or context["job"] != "observe"
+    ):
+        raise ResourceEnvelopeError("GitHub Actions identity differs")
+    for field in (
+        "event_name",
+        "ref",
+        "sha",
+        "workflow_ref",
+        "workflow_sha",
+        "head_ref",
+        "base_ref",
+        "expected_checkout_head",
+    ):
+        if type(context[field]) is not str:
+            raise ResourceEnvelopeError(f"GitHub Actions {field} must be a string")
+    if type(context["ref_protected"]) is not bool:
+        raise ResourceEnvelopeError("GitHub Actions ref protection must be boolean")
+    for field in ("run_id", "run_attempt", "run_number"):
+        _require_positive_decimal(context[field], f"GitHub Actions {field}")
+    if (
+        HEX_40.fullmatch(context["sha"]) is None
+        or HEX_40.fullmatch(context["workflow_sha"]) is None
+        or context["expected_checkout_head"] != head
+    ):
+        raise ResourceEnvelopeError("GitHub Actions commit identity differs")
+
+    workflow_prefix = f"{GITHUB_REPOSITORY}/{GITHUB_WORKFLOW_PATH}@"
+    if not context["workflow_ref"].startswith(workflow_prefix):
+        raise ResourceEnvelopeError("GitHub Actions workflow ref differs")
+    event_name = context["event_name"]
+    ref = context["ref"]
+    if event_name == "pull_request":
+        if (
+            re.fullmatch(r"refs/pull/[1-9][0-9]*/merge", ref) is None
+            or not context["head_ref"]
+            or context["base_ref"] != "main"
+        ):
+            raise ResourceEnvelopeError("pull-request context differs")
+        workflow_source_ref = context["workflow_ref"][len(workflow_prefix) :]
+        if workflow_source_ref not in {ref, "refs/heads/main"}:
+            raise ResourceEnvelopeError("pull-request workflow source ref differs")
+    elif event_name in {"push", "workflow_dispatch"}:
+        if (
+            re.fullmatch(r"refs/heads/[A-Za-z0-9._/-]+", ref) is None
+            or context["head_ref"]
+            or context["base_ref"]
+            or context["sha"] != head
+            or context["workflow_sha"] != head
+            or context["workflow_ref"] != workflow_prefix + ref
+        ):
+            raise ResourceEnvelopeError("branch-run context differs")
+        if event_name == "push" and ref != "refs/heads/main":
+            raise ResourceEnvelopeError("resource push execution is restricted to main")
+        if ref == "refs/heads/main" and context["ref_protected"] is not True:
+            raise ResourceEnvelopeError("main resource observation requires a protected ref")
+    else:
+        raise ResourceEnvelopeError("unsupported GitHub Actions event")
+    return context
+
+
+def _ci_context_from_environment(head: str) -> dict:
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    if not event_name:
+        if os.environ.get("GITHUB_ACTIONS", "") == "true":
+            raise ResourceEnvelopeError("GitHub Actions event metadata is incomplete")
+        return _local_ci_context()
+    protected = os.environ.get("GITHUB_REF_PROTECTED", "")
+    if protected not in {"true", "false"}:
+        raise ResourceEnvelopeError("GitHub ref-protection metadata is incomplete")
+    context = {
+        "github_actions": os.environ.get("GITHUB_ACTIONS", "") == "true",
+        "server_url": os.environ.get("GITHUB_SERVER_URL", ""),
+        "api_url": os.environ.get("GITHUB_API_URL", ""),
+        "repository": os.environ.get("GITHUB_REPOSITORY", ""),
+        "repository_id": os.environ.get("GITHUB_REPOSITORY_ID", ""),
+        "event_name": event_name,
+        "ref": os.environ.get("GITHUB_REF", ""),
+        "ref_protected": protected == "true",
+        "sha": os.environ.get("GITHUB_SHA", ""),
+        "workflow": os.environ.get("GITHUB_WORKFLOW", ""),
+        "workflow_ref": os.environ.get("GITHUB_WORKFLOW_REF", ""),
+        "workflow_sha": os.environ.get("GITHUB_WORKFLOW_SHA", ""),
+        "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+        "run_number": os.environ.get("GITHUB_RUN_NUMBER", ""),
+        "job": os.environ.get("GITHUB_JOB", ""),
+        "head_ref": os.environ.get("GITHUB_HEAD_REF", ""),
+        "base_ref": os.environ.get("GITHUB_BASE_REF", ""),
+        "expected_checkout_head": os.environ.get(
+            "PQBTC_RESOURCE_EXPECTED_HEAD", ""
+        ),
+    }
+    if os.environ.get("RUNNER_OS", "") != "Linux" or os.environ.get(
+        "RUNNER_ARCH", ""
+    ) != "X64":
+        raise ResourceEnvelopeError("GitHub runner identity differs")
+    return _validate_github_context(context, head)
+
+
+def _classify_trust(
+    context: dict, baseline_guard_matches: bool
+) -> tuple[str, bool, str]:
+    event_name = context["event_name"]
+    ref = context["ref"]
+    if event_name == "pull_request":
+        return (
+            "UNTRUSTED_PR_OBSERVATION",
+            False,
+            "pull-request code cannot produce trusted promotion evidence",
+        )
+    if ref == "refs/heads/main" and event_name == "push":
+        if baseline_guard_matches:
+            return (
+                "TRUSTED_MAIN_OBSERVATION",
+                True,
+                "exact clean main head matches the separately advanced "
+                "guarded review baseline",
+            )
+        return (
+            "PENDING_BASELINE_OBSERVATION",
+            False,
+            "main observation predates a separate guarded baseline-pointer "
+            "advance",
+        )
+    if event_name == "local":
+        return (
+            "LOCAL_OBSERVATION",
+            False,
+            "local observations are diagnostic only",
+        )
+    if event_name == "workflow_dispatch":
+        return (
+            "UNTRUSTED_MANUAL_OBSERVATION",
+            False,
+            "manual observations are diagnostic only; trusted evidence "
+            "requires a protected main push",
+        )
+    raise ResourceEnvelopeError(
+        "resource execution is restricted to pull requests or branch observations"
+    )
+
+
+def _build_trust(context: dict, baseline_guard_matches: bool) -> dict:
+    label, trusted_observation, reason = _classify_trust(
+        context, baseline_guard_matches
+    )
+    return {
+        "label": label,
+        "trusted_observation": trusted_observation,
+        "promotion_eligible": False,
+        "reason": reason,
+        "ci": copy.deepcopy(context),
+        "requires_external_workflow_provenance": True,
+        "requires_companion_compilers": ["clang", "gcc"],
+        "requires_separate_numeric_policy_change": True,
+    }
+
+
+def _require_first_parent_baseline(head: str, baseline: str) -> None:
+    object_type = _run_git("cat-file", "-t", baseline).strip()
+    if object_type != "commit":
+        raise ResourceEnvelopeError("review baseline pointer is not a commit")
+    git_command = shutil.which("git")
+    if git_command is None:
+        raise ResourceEnvelopeError("Git is required")
+    git_path = Path(git_command).resolve()
+    ancestry = _run_bounded(
+        [
+            str(git_path),
+            "-C",
+            str(REPO_ROOT),
+            "merge-base",
+            "--is-ancestor",
+            baseline,
+            head,
+        ],
+        timeout=30,
+        environment=_minimal_environment(git_path.parent),
+    )
+    if ancestry.returncode != 0:
+        raise ResourceEnvelopeError("review baseline is not an ancestor of HEAD")
+    first_parent_distance_text = _run_git(
+        "rev-list", "--first-parent", "--count", f"{baseline}..{head}"
+    ).strip()
+    if not first_parent_distance_text.isdigit():
+        raise ResourceEnvelopeError("cannot determine review baseline distance")
+    first_parent_distance = int(first_parent_distance_text)
+    first_parent_commit = _run_git(
+        "rev-parse", f"{head}~{first_parent_distance}"
+    ).strip()
+    if baseline == head or first_parent_commit != baseline:
+        raise ResourceEnvelopeError(
+            "review baseline is not an earlier first-parent commit"
+        )
+
+
+def _repository_and_trust(output_dir: Path) -> tuple[dict, dict]:
+    shallow = _run_git("rev-parse", "--is-shallow-repository").strip()
+    if shallow != "false":
+        raise ResourceEnvelopeError("full Git history is required")
+    head = _run_git("rev-parse", "HEAD").strip()
+    if HEX_40.fullmatch(head) is None:
+        raise ResourceEnvelopeError("Git HEAD is not a lowercase SHA-1")
+    status_text = _run_git(
+        "status", "--porcelain=v1", "--untracked-files=all"
+    )
+    if status_text:
+        raise ResourceEnvelopeError("repository must be clean for resource execution")
+    (output_dir / GIT_HEAD_FILE).write_text(head + "\n", encoding="utf8")
+    (output_dir / GIT_STATUS_FILE).write_text(status_text, encoding="utf8")
+
+    pointer_bytes = BASELINE_POINTER.read_bytes()
+    if re.fullmatch(rb"[0-9a-f]{40}\n", pointer_bytes) is None:
+        raise ResourceEnvelopeError("review baseline pointer is malformed")
+    baseline = pointer_bytes[:-1].decode("ascii")
+    _require_first_parent_baseline(head, baseline)
+    diff_names = _run_git(
+        "diff", "--name-only", baseline, head, "--", *GUARDED_PATHS
+    )
+    (output_dir / BASELINE_DIFF_FILE).write_text(diff_names, encoding="utf8")
+    baseline_guard_matches = not bool(diff_names)
+
+    ci_context = _ci_context_from_environment(head)
+
+    repository = {
+        "head": head,
+        "clean": True,
+        "full_history": True,
+        "baseline_pointer": baseline,
+        "baseline_guard_matches": baseline_guard_matches,
+    }
+    trust = _build_trust(ci_context, baseline_guard_matches)
+    return repository, trust
+
+
+def _validate_source_contract() -> dict:
+    capsule = wrapper.validate_source_capsule()
+    wycheproof = verifier.validate_wycheproof_source()
+    promoted = verifier.validate_promoted_source()
+    config = WRAPPER_CONFIG.read_text(encoding="utf8")
+    for required in (
+        "#define MLD_CONFIG_PARAMETER_SET 44",
+        "#define MLD_CONFIG_NO_ASM",
+        "#define MLD_CONFIG_EXTERNAL_API_QUALIFIER static",
+        "#define MLD_CONFIG_INTERNAL_API_QUALIFIER static",
+    ):
+        if config.count(required) != 1:
+            raise ResourceEnvelopeError(f"wrapper configuration drifted: {required}")
+    for forbidden in ("MLD_CONFIG_CUSTOM_ALLOC_FREE", "MLD_CONFIG_REDUCE_RAM"):
+        if forbidden in config:
+            raise ResourceEnvelopeError(
+                f"default-stack verifier configuration drifted: {forbidden}"
+            )
+    header = UPSTREAM_HEADER.read_text(encoding="utf8")
+    if header.count("#define MLD_TOTAL_ALLOC_44_VERIFY 24448") != 1:
+        raise ResourceEnvelopeError("upstream verifier allocation constant drifted")
+    sign_text = UPSTREAM_SIGN.read_text(encoding="utf8")
+    start = sign_text.find("int mld_sign_verify_internal(")
+    end = sign_text.find("\nint mld_sign_verify(", start)
+    if start < 0 or end < 0:
+        raise ResourceEnvelopeError("cannot isolate upstream verifier implementation")
+    allocation_sites = re.findall(r"\bMLD_ALLOC\s*\(", sign_text[start:end])
+    if len(allocation_sites) != 9:
+        raise ResourceEnvelopeError("upstream verifier MLD_ALLOC site count drifted")
+    return {
+        "source_capsule_hash": capsule["capsule_hash"]["value"],
+        "wycheproof_tests": wycheproof["numberOfTests"],
+        "promoted_cases": len(promoted),
+        "upstream_verify_mld_alloc_sites": len(allocation_sites),
+        "upstream_verify_mld_alloc_bytes": 24448,
+        "allocation_interpretation": (
+            "accumulative upstream MLD_ALLOC scratch only; not total stack"
+        ),
+    }
+
+
+def _compiler_path(compiler_name: str) -> Path:
+    if compiler_name not in {"gcc", "clang"}:
+        raise ResourceEnvelopeError("compiler must be exactly gcc or clang")
+    compiler = shutil.which(compiler_name)
+    if compiler is None:
+        raise ResourceEnvelopeError(f"compiler is unavailable: {compiler_name}")
+    resolved = Path(compiler).resolve()
+    _require_regular_file(resolved, f"{compiler_name} executable", 100 * 1024 * 1024)
+    return resolved
+
+
+def _common_compile_flags(compiler: Path) -> list[str]:
+    return [
+        str(compiler),
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-Wno-unused-function",
+        "-Wno-unknown-pragmas",
+        "-fvisibility=hidden",
+        "-fno-lto",
+        "-O2",
+        f"-I{HERE}",
+    ]
+
+
+def _normalize_commands(commands: list[list[str]], build_dir: Path) -> dict:
+    prefix = str(build_dir)
+    normalized = []
+    for command in commands:
+        normalized.append(
+            [
+                argument.replace(prefix, "$BUILD_DIR")
+                if argument.startswith(prefix)
+                else argument
+                for argument in command
+            ]
+        )
+    return {
+        "schema_version": 1,
+        "shell_used": False,
+        "commands": normalized,
+        "forbidden_flags_absent": FORBIDDEN_FLAG_CLAIMS,
+    }
+
+
+def _expected_normalized_commands(compiler: str) -> list[list[str]]:
+    common = _common_compile_flags(Path(compiler))
+    wrapper_object = "$BUILD_DIR/wrapper.o"
+    probe_object = "$BUILD_DIR/probe.o"
+    return [
+        common
+        + [
+            "-fPIC",
+            "-shared",
+            str(wrapper.WRAPPER_SOURCE),
+            "-o",
+            f"$BUILD_DIR/{LIBRARY_FILE}",
+        ],
+        common
+        + [
+            "-fPIC",
+            "-shared",
+            "-DPQBTC_MLDSA44_TESTING=1",
+            str(wrapper.WRAPPER_SOURCE),
+            "-o",
+            "$BUILD_DIR/libpqbtc_mldsa44_test.so",
+        ],
+        common
+        + [
+            "-fstack-usage",
+            "-c",
+            str(wrapper.WRAPPER_SOURCE),
+            "-o",
+            wrapper_object,
+        ],
+        common
+        + [
+            "-fstack-usage",
+            "-fno-builtin-malloc",
+            "-fno-builtin-calloc",
+            "-fno-builtin-realloc",
+            "-fno-builtin-free",
+            "-fno-builtin-aligned_alloc",
+            "-fno-builtin-posix_memalign",
+            "-c",
+            str(PROBE_SOURCE),
+            "-o",
+            probe_object,
+        ],
+        [
+            compiler,
+            "-O2",
+            "-fno-lto",
+            wrapper_object,
+            probe_object,
+            "-pthread",
+            "-Wl,--no-undefined",
+            "-Wl,--wrap=malloc",
+            "-Wl,--wrap=calloc",
+            "-Wl,--wrap=realloc",
+            "-Wl,--wrap=free",
+            "-Wl,--wrap=aligned_alloc",
+            "-Wl,--wrap=posix_memalign",
+            "-o",
+            f"$BUILD_DIR/{PROBE_FILE}",
+        ],
+    ]
+
+
+def _compile(
+    compiler_name: str, compiler: Path, build_dir: Path, output_dir: Path
+) -> tuple[dict, Path, Path, Path]:
+    environment = _minimal_environment(compiler.parent)
+    version, version_stderr = _require_command_success(
+        [str(compiler), "--version"], environment=environment
+    )
+    target, target_stderr = _require_command_success(
+        [str(compiler), "-dumpmachine"], environment=environment
+    )
+    if version_stderr or target_stderr:
+        raise ResourceEnvelopeError("compiler identity commands wrote to stderr")
+    target = target.strip()
+    if "x86_64" not in target.lower():
+        raise ResourceEnvelopeError(f"compiler target is not x86_64: {target}")
+    (output_dir / COMPILER_VERSION_FILE).write_text(version, encoding="utf8")
+    (output_dir / COMPILER_TARGET_FILE).write_text(target + "\n", encoding="utf8")
+
+    production_library = build_dir / LIBRARY_FILE
+    test_library = build_dir / "libpqbtc_mldsa44_test.so"
+    wrapper_object = build_dir / "wrapper.o"
+    probe_object = build_dir / "probe.o"
+    probe_binary = build_dir / PROBE_FILE
+    commands: list[list[str]] = []
+
+    production_shared = _common_compile_flags(compiler) + [
+        "-fPIC",
+        "-shared",
+        str(wrapper.WRAPPER_SOURCE),
+        "-o",
+        str(production_library),
+    ]
+    test_shared = _common_compile_flags(compiler) + [
+        "-fPIC",
+        "-shared",
+        "-DPQBTC_MLDSA44_TESTING=1",
+        str(wrapper.WRAPPER_SOURCE),
+        "-o",
+        str(test_library),
+    ]
+    wrapper_compile = _common_compile_flags(compiler) + [
+        "-fstack-usage",
+        "-c",
+        str(wrapper.WRAPPER_SOURCE),
+        "-o",
+        str(wrapper_object),
+    ]
+    probe_compile = _common_compile_flags(compiler) + [
+        "-fstack-usage",
+        "-fno-builtin-malloc",
+        "-fno-builtin-calloc",
+        "-fno-builtin-realloc",
+        "-fno-builtin-free",
+        "-fno-builtin-aligned_alloc",
+        "-fno-builtin-posix_memalign",
+        "-c",
+        str(PROBE_SOURCE),
+        "-o",
+        str(probe_object),
+    ]
+    link = [
+        str(compiler),
+        "-O2",
+        "-fno-lto",
+        str(wrapper_object),
+        str(probe_object),
+        "-pthread",
+        "-Wl,--no-undefined",
+        "-Wl,--wrap=malloc",
+        "-Wl,--wrap=calloc",
+        "-Wl,--wrap=realloc",
+        "-Wl,--wrap=free",
+        "-Wl,--wrap=aligned_alloc",
+        "-Wl,--wrap=posix_memalign",
+        "-o",
+        str(probe_binary),
+    ]
+    for command in (
+        production_shared,
+        test_shared,
+        wrapper_compile,
+        probe_compile,
+        link,
+    ):
+        commands.append(command)
+        _require_command_success(
+            command, cwd=build_dir, timeout=180, environment=environment
+        )
+
+    nm = shutil.which("nm", path=environment["PATH"])
+    if nm is None:
+        raise ResourceEnvelopeError("nm is required for symbol auditing")
+    nm_path = str(Path(nm).resolve())
+    symbols, symbol_stderr = _require_command_success(
+        [nm_path, "-D", "--defined-only", str(production_library)],
+        environment=environment,
+    )
+    if symbol_stderr:
+        raise ResourceEnvelopeError("nm symbol audit wrote to stderr")
+    exported = sorted(
+        fields[-1]
+        for line in symbols.splitlines()
+        if (fields := line.split())
+    )
+    if exported != [
+        "pqbtc_mldsa44_sign_hedged",
+        "pqbtc_mldsa44_verify_strict",
+    ]:
+        raise ResourceEnvelopeError(f"production symbol surface drifted: {exported}")
+    (output_dir / SYMBOLS_FILE).write_text(
+        "".join(f"{symbol}\n" for symbol in exported), encoding="utf8"
+    )
+
+    undefined, undefined_stderr = _require_command_success(
+        [nm_path, "-u", str(wrapper_object)], environment=environment
+    )
+    if undefined_stderr:
+        raise ResourceEnvelopeError("nm undefined-symbol audit wrote to stderr")
+    allocator_names = {
+        "malloc",
+        "calloc",
+        "realloc",
+        "free",
+        "aligned_alloc",
+        "posix_memalign",
+    }
+    undefined_names = {
+        line.split()[-1].lstrip("_")
+        for line in undefined.splitlines()
+        if line.split()
+    }
+    unexpected_allocators = sorted(undefined_names & allocator_names)
+    if unexpected_allocators:
+        raise ResourceEnvelopeError(
+            f"production wrapper references heap allocators: {unexpected_allocators}"
+        )
+
+    ldd = shutil.which("ldd", path=environment["PATH"])
+    if ldd is None:
+        raise ResourceEnvelopeError("ldd is required for linked-library inventory")
+    linked, linked_stderr = _require_command_success(
+        [str(Path(ldd).resolve()), str(probe_binary)], environment=environment
+    )
+    if linked_stderr:
+        raise ResourceEnvelopeError("ldd wrote to stderr")
+    (output_dir / LINKED_FILE).write_text(linked, encoding="utf8")
+    (output_dir / BUILD_COMMANDS_FILE).write_text(
+        canonical_json(_normalize_commands(commands, build_dir)), encoding="utf8"
+    )
+
+    wrapper_stack = build_dir / "wrapper.su"
+    probe_stack = build_dir / "probe.su"
+    _require_regular_file(wrapper_stack, "wrapper stack-usage output", 1024 * 1024)
+    _require_regular_file(probe_stack, "probe stack-usage output", 1024 * 1024)
+    shutil.copyfile(wrapper_stack, output_dir / WRAPPER_STACK_FILE)
+    shutil.copyfile(probe_stack, output_dir / PROBE_STACK_FILE)
+    stack_report = {
+        "schema_version": 1,
+        "records": parse_stack_usage([wrapper_stack, probe_stack]),
+        "upstream_mld_total_alloc_44_verify_bytes": 24448,
+        "claim": (
+            "compiler-specific per-function observations corroborated by guarded "
+            "execution; values are not summed into a formal call-chain bound"
+        ),
+    }
+    (output_dir / STACK_REPORT_FILE).write_text(
+        canonical_json(stack_report), encoding="utf8"
+    )
+
+    shutil.copyfile(production_library, output_dir / LIBRARY_FILE)
+    shutil.copyfile(probe_binary, output_dir / PROBE_FILE)
+    (output_dir / PROBE_FILE).chmod(0o755)
+    build = {
+        "compiler_name": compiler_name,
+        "compiler_path": str(compiler),
+        "compiler_version_sha256": sha256_file(output_dir / COMPILER_VERSION_FILE),
+        "compiler_target": target,
+        "production_library_sha256": sha256_file(production_library),
+        "probe_sha256": sha256_file(probe_binary),
+        "production_wrapper_undefined_heap_allocators": [],
+        "production_exported_symbols": exported,
+        "optimization": "-O2",
+        "lto": False,
+        "sanitizers": False,
+        "testing_define_in_measured_objects": False,
+        "assembly": False,
+    }
+    return build, production_library, test_library, probe_binary
+
+
+def _selection_outcomes(records: list[dict], indices: list[int], calls: int) -> dict:
+    outcomes = {name: 0 for name in OUTCOME_KEYS}
+    for cursor in range(calls):
+        expected = records[indices[cursor % len(indices)]]["expected"]
+        outcomes[RESULT_NAMES[expected]] += 1
+    return outcomes
+
+
+def _materialize_corpus(
+    test_library: Path, production_library: Path, output_dir: Path, policy: dict
+) -> dict:
+    wycheproof = verifier.validate_wycheproof_source()
+    promoted = verifier.validate_promoted_source()
+    cases = (
+        verifier.project_corpus(test_library)
+        + verifier.wycheproof_corpus(wycheproof)
+        + promoted
+    )
+    summary = verifier.validate_corpus_manifest(cases)
+    verifier.replay_corpus(production_library, cases)
+
+    by_digest: dict[str, dict[str, object]] = {}
+    for case in cases:
+        digest = sha256_bytes(case.frame)
+        record = by_digest.setdefault(
+            digest,
+            {
+                "frame": case.frame,
+                "expected": case.expected,
+                "aliases": [],
+            },
+        )
+        if record["frame"] != case.frame or record["expected"] != case.expected:
+            raise ResourceEnvelopeError("duplicate corpus frame has conflicting meaning")
+        record["aliases"].append({"name": case.name, "source": case.source})
+
+    if len(by_digest) != policy["batch"]["unique_frames"]:
+        raise ResourceEnvelopeError("unique verifier frame count drifted")
+    all_names = {case.name for case in cases}
+    required_accepts = set(policy["batch"]["required_accept_cases"])
+    required_rejects = set(policy["batch"]["required_deep_reject_cases"])
+    if not required_accepts <= all_names or not required_rejects <= all_names:
+        raise ResourceEnvelopeError("required resource case taxonomy is incomplete")
+
+    project_by_name = {
+        case.name: case for case in cases if case.source == "project"
+    }
+    reference_key = verifier.decode_frame(
+        project_by_name["valid_frozen_vector"].frame
+    ).public_key
+    same_key_names = set(policy["batch"]["same_key_cases"])
+
+    records = []
+    bundle = bytearray(BUNDLE_HEADER.pack(BUNDLE_MAGIC, 1, len(by_digest)))
+    for index, digest in enumerate(sorted(by_digest)):
+        source = by_digest[digest]
+        frame = source["frame"]
+        expected = source["expected"]
+        aliases = sorted(
+            source["aliases"], key=lambda alias: (alias["source"], alias["name"])
+        )
+        names = sorted(alias["name"] for alias in aliases)
+        sources = sorted(set(alias["source"] for alias in aliases))
+        decoded = verifier.decode_frame(frame)
+        flags = 0
+        if expected == verifier.OK:
+            flags |= FLAG_VALID
+        if required_rejects & set(names):
+            flags |= FLAG_DEEP_REJECT
+        if (
+            same_key_names & set(names)
+            and not (decoded.null_flags & verifier.NULL_PUBLIC_KEY)
+            and decoded.public_key == reference_key
+        ):
+            flags |= FLAG_SAME_KEY
+        if "valid_frozen_vector" in names:
+            flags |= FLAG_FIRST_CALL
+        bundle.extend(RECORD_HEADER.pack(len(frame), expected, flags))
+        bundle.extend(frame)
+        records.append(
+            {
+                "index": index,
+                "sha256": digest,
+                "size": len(frame),
+                "expected": expected,
+                "expected_name": RESULT_NAMES[expected],
+                "flags": flags,
+                "aliases": aliases,
+                "names": names,
+                "sources": sources,
+            }
+        )
+
+    first_indices = [
+        record["index"] for record in records if record["flags"] & FLAG_FIRST_CALL
+    ]
+    selections = {
+        "mixed_rotating": [record["index"] for record in records],
+        "valid_rotating": [
+            record["index"] for record in records if record["flags"] & FLAG_VALID
+        ],
+        "deep_reject_rotating": [
+            record["index"]
+            for record in records
+            if record["flags"] & FLAG_DEEP_REJECT
+        ],
+        "same_key_mixed": [
+            record["index"] for record in records if record["flags"] & FLAG_SAME_KEY
+        ],
+    }
+    if len(first_indices) != 1:
+        raise ResourceEnvelopeError("frozen first-call selection is not unique")
+    if len(selections["deep_reject_rotating"]) != len(required_rejects):
+        raise ResourceEnvelopeError("deep-reject selection count drifted")
+    selected_same_key_names = {
+        alias["name"]
+        for index in selections["same_key_mixed"]
+        for alias in records[index]["aliases"]
+        if alias["name"] in same_key_names
+    }
+    if (
+        selected_same_key_names != same_key_names
+        or len(selections["same_key_mixed"]) != len(same_key_names)
+    ):
+        raise ResourceEnvelopeError("same-key selection coverage drifted")
+    if any(not values for values in selections.values()):
+        raise ResourceEnvelopeError("resource batch selection is empty")
+    same_key_records = [records[index] for index in selections["same_key_mixed"]]
+    if (
+        any(record["expected"] == verifier.ERR_INVALID_ARGUMENT for record in same_key_records)
+        or not any(record["expected"] == verifier.OK for record in same_key_records)
+        or not any(record["expected"] == verifier.ERR_VERIFY for record in same_key_records)
+    ):
+        raise ResourceEnvelopeError("same-key mixed selection taxonomy drifted")
+
+    bundle_path = output_dir / BUNDLE_FILE
+    bundle_path.write_bytes(bytes(bundle))
+    batch_calls = policy["batch"]["verification_calls"]
+    expected_outcomes = {
+        batch_id: _selection_outcomes(records, indices, batch_calls)
+        for batch_id, indices in selections.items()
+    }
+    inventory = {
+        "schema_version": 1,
+        "frame_format": "verifier-fuzz-frame-v1",
+        "record_order": "strictly ascending SHA-256(frame)",
+        "records": records,
+        "record_count": len(records),
+        "total_frame_bytes": sum(record["size"] for record in records),
+        "bundle_size": len(bundle),
+        "bundle_sha256": sha256_bytes(bytes(bundle)),
+        "source_summary": summary,
+        "selection_indices": selections,
+        "selection_counts": {
+            batch_id: len(indices) for batch_id, indices in selections.items()
+        },
+        "expected_outcomes": expected_outcomes,
+        "first_call_record": first_indices[0],
+        "private_key_material_retained": False,
+    }
+    (output_dir / INVENTORY_FILE).write_text(
+        canonical_json(inventory), encoding="utf8"
+    )
+    return inventory
+
+
+def _validate_inventory_bundle(
+    inventory: dict, bundle_path: Path, policy: dict
+) -> dict:
+    _require_exact_keys(
+        inventory,
+        {
+            "schema_version",
+            "frame_format",
+            "record_order",
+            "records",
+            "record_count",
+            "total_frame_bytes",
+            "bundle_size",
+            "bundle_sha256",
+            "source_summary",
+            "selection_indices",
+            "selection_counts",
+            "expected_outcomes",
+            "first_call_record",
+            "private_key_material_retained",
+        },
+        "corpus inventory",
+    )
+    _require_int(inventory["schema_version"], "corpus inventory schema")
+    _require_int(inventory["record_count"], "corpus inventory record count")
+    _require_int(inventory["total_frame_bytes"], "corpus total frame bytes", 1)
+    _require_int(inventory["bundle_size"], "corpus bundle size", 1)
+    records = inventory["records"]
+    if (
+        inventory["schema_version"] != 1
+        or inventory["frame_format"] != "verifier-fuzz-frame-v1"
+        or inventory["record_order"] != "strictly ascending SHA-256(frame)"
+        or type(records) is not list
+        or len(records) != policy["batch"]["unique_frames"]
+        or inventory["record_count"] != len(records)
+        or inventory["private_key_material_retained"] is not False
+        or canonical_json(inventory["source_summary"])
+        != canonical_json(EXPECTED_CORPUS_SUMMARY)
+    ):
+        raise ResourceEnvelopeError("corpus inventory header drifted")
+    manifest = load_json_object(
+        verifier.CORPUS_MANIFEST, "verifier fuzz corpus manifest", 16384
+    )
+    if canonical_json(manifest.get("generated_corpus")) != canonical_json(
+        EXPECTED_CORPUS_SUMMARY
+    ):
+        raise ResourceEnvelopeError("frozen verifier corpus summary drifted")
+    _require_regular_file(bundle_path, "verifier corpus bundle", 4 * 1024 * 1024)
+    bundle = bundle_path.read_bytes()
+    if (
+        type(inventory["bundle_sha256"]) is not str
+        or HEX_64.fullmatch(inventory["bundle_sha256"]) is None
+        or inventory["bundle_size"] != len(bundle)
+        or inventory["bundle_sha256"] != sha256_bytes(bundle)
+    ):
+        raise ResourceEnvelopeError("corpus bundle identity differs")
+    if len(bundle) < BUNDLE_HEADER.size:
+        raise ResourceEnvelopeError("corpus bundle is truncated")
+    magic, schema, count = BUNDLE_HEADER.unpack_from(bundle)
+    if magic != BUNDLE_MAGIC or schema != 1 or count != len(records):
+        raise ResourceEnvelopeError("corpus bundle header differs")
+    cursor = BUNDLE_HEADER.size
+    digests = []
+    decoded_frames = []
+    total_frame_bytes = 0
+    alias_rows = []
+    alias_names = set()
+    alias_identities = set()
+    source_counts = {name: 0 for name in ("project", "wycheproof", "promoted")}
+    expected_counts = {name: 0 for name in OUTCOME_KEYS}
+    for expected_index, record in enumerate(records):
+        _require_exact_keys(
+            record,
+            {
+                "index",
+                "sha256",
+                "size",
+                "expected",
+                "expected_name",
+                "flags",
+                "aliases",
+                "names",
+                "sources",
+            },
+            f"corpus record {expected_index}",
+        )
+        _require_int(record["index"], f"corpus record {expected_index} index")
+        _require_int(record["size"], f"corpus record {expected_index} size", 1)
+        _require_int(
+            record["expected"],
+            f"corpus record {expected_index} result",
+            min(RESULT_NAMES),
+        )
+        _require_int(record["flags"], f"corpus record {expected_index} flags")
+        if record["expected"] not in RESULT_NAMES:
+            raise ResourceEnvelopeError(
+                f"corpus record {expected_index} result differs"
+            )
+        aliases = record["aliases"]
+        if type(aliases) is not list or not aliases:
+            raise ResourceEnvelopeError(
+                f"corpus record {expected_index} aliases differ"
+            )
+        normalized_aliases = []
+        for alias_index, alias in enumerate(aliases):
+            _require_exact_keys(
+                alias,
+                {"name", "source"},
+                f"corpus record {expected_index} alias {alias_index}",
+            )
+            name = _require_string(
+                alias["name"],
+                f"corpus record {expected_index} alias {alias_index} name",
+            )
+            source = _require_string(
+                alias["source"],
+                f"corpus record {expected_index} alias {alias_index} source",
+            )
+            if source not in source_counts:
+                raise ResourceEnvelopeError("corpus alias source differs")
+            identity = (source, name)
+            if identity in alias_identities or name in alias_names:
+                raise ResourceEnvelopeError("corpus aliases are not globally unique")
+            alias_identities.add(identity)
+            alias_names.add(name)
+            source_counts[source] += 1
+            expected_counts[RESULT_NAMES[record["expected"]]] += 1
+            normalized_aliases.append({"name": name, "source": source})
+            alias_rows.append(
+                (source, name, record["expected_name"], record["sha256"])
+            )
+        normalized_aliases.sort(key=lambda alias: (alias["source"], alias["name"]))
+        names = sorted(alias["name"] for alias in normalized_aliases)
+        sources = sorted(set(alias["source"] for alias in normalized_aliases))
+        if (
+            record["index"] != expected_index
+            or type(record["sha256"]) is not str
+            or HEX_64.fullmatch(record["sha256"]) is None
+            or record["expected"] not in RESULT_NAMES
+            or record["expected_name"] != RESULT_NAMES[record["expected"]]
+            or record["flags"] & ~FLAG_MASK
+            or aliases != normalized_aliases
+            or record["names"] != names
+            or record["sources"] != sources
+        ):
+            raise ResourceEnvelopeError(f"corpus record {expected_index} drifted")
+        if cursor + RECORD_HEADER.size > len(bundle):
+            raise ResourceEnvelopeError("corpus bundle record header is truncated")
+        size, expected, flags = RECORD_HEADER.unpack_from(bundle, cursor)
+        cursor += RECORD_HEADER.size
+        if (
+            size != record["size"]
+            or expected != record["expected"]
+            or flags != record["flags"]
+            or size <= 0
+            or cursor + size > len(bundle)
+        ):
+            raise ResourceEnvelopeError("corpus bundle record metadata differs")
+        frame = bundle[cursor : cursor + size]
+        cursor += size
+        if sha256_bytes(frame) != record["sha256"]:
+            raise ResourceEnvelopeError("corpus bundle frame hash differs")
+        try:
+            decoded = verifier.decode_frame(frame)
+        except (verifier.FuzzHarnessError, ValueError) as exc:
+            raise ResourceEnvelopeError("corpus bundle frame is invalid") from exc
+        if (
+            verifier.encode_frame(
+                decoded.signature,
+                decoded.public_key,
+                decoded.context,
+                decoded.message,
+                decoded.null_flags,
+            )
+            != frame
+        ):
+            raise ResourceEnvelopeError("corpus bundle frame is not canonical")
+        digests.append(record["sha256"])
+        decoded_frames.append(decoded)
+        total_frame_bytes += size
+    if cursor != len(bundle) or digests != sorted(set(digests)):
+        raise ResourceEnvelopeError("corpus bundle order/trailing-byte contract differs")
+    if inventory["total_frame_bytes"] != total_frame_bytes:
+        raise ResourceEnvelopeError("corpus frame-byte accounting differs")
+    aggregate = hashlib.sha256()
+    for source, name, expected_name, frame_sha256 in sorted(alias_rows):
+        aggregate.update(
+            f"{source}\0{name}\0{expected_name}\0{frame_sha256}\n".encode()
+        )
+    recomputed_summary = {
+        "total_cases": len(alias_rows),
+        "unique_frames": len(records),
+        "source_counts": source_counts,
+        "expected_counts": expected_counts,
+        "aggregate_sha256": aggregate.hexdigest(),
+    }
+    if canonical_json(recomputed_summary) != canonical_json(EXPECTED_CORPUS_SUMMARY):
+        raise ResourceEnvelopeError("corpus alias/frame semantics differ")
+
+    required_accepts = set(policy["batch"]["required_accept_cases"])
+    required_rejects = set(policy["batch"]["required_deep_reject_cases"])
+    same_key_names = set(policy["batch"]["same_key_cases"])
+    if not required_accepts <= alias_names or not required_rejects <= alias_names:
+        raise ResourceEnvelopeError("required corpus taxonomy is incomplete")
+    alias_to_record = {
+        alias["name"]: index
+        for index, record in enumerate(records)
+        for alias in record["aliases"]
+    }
+    for name in required_accepts:
+        record = records[alias_to_record[name]]
+        if record["expected"] != verifier.OK or "project" not in record["sources"]:
+            raise ResourceEnvelopeError("required accept taxonomy differs")
+    for name in required_rejects:
+        record = records[alias_to_record[name]]
+        if record["expected"] != verifier.ERR_VERIFY or "project" not in record["sources"]:
+            raise ResourceEnvelopeError("required deep-reject taxonomy differs")
+    first_records = [
+        alias_to_record[name] for name in alias_names if name == "valid_frozen_vector"
+    ]
+    if len(first_records) != 1:
+        raise ResourceEnvelopeError("frozen first-call taxonomy differs")
+    first_record = first_records[0]
+    reference_key = decoded_frames[first_record].public_key
+
+    expected_selections = {
+        "mixed_rotating": list(range(len(records))),
+        "valid_rotating": [
+            index
+            for index, record in enumerate(records)
+            if record["expected"] == verifier.OK
+        ],
+        "deep_reject_rotating": sorted(
+            {alias_to_record[name] for name in required_rejects}
+        ),
+        "same_key_mixed": sorted(
+            {alias_to_record[name] for name in same_key_names}
+        ),
+    }
+    if len(expected_selections["deep_reject_rotating"]) != len(required_rejects):
+        raise ResourceEnvelopeError("deep-reject records are not distinct")
+    if len(expected_selections["same_key_mixed"]) != len(same_key_names):
+        raise ResourceEnvelopeError("same-key records are not distinct")
+    for index, (record, decoded) in enumerate(zip(records, decoded_frames)):
+        names = set(record["names"])
+        expected_flags = 0
+        if record["expected"] == verifier.OK:
+            expected_flags |= FLAG_VALID
+        if names & required_rejects:
+            expected_flags |= FLAG_DEEP_REJECT
+        if names & same_key_names:
+            if (
+                decoded.null_flags & verifier.NULL_PUBLIC_KEY
+                or decoded.public_key != reference_key
+            ):
+                raise ResourceEnvelopeError("same-key record public key differs")
+            expected_flags |= FLAG_SAME_KEY
+        if "valid_frozen_vector" in names:
+            expected_flags |= FLAG_FIRST_CALL
+        if record["flags"] != expected_flags:
+            raise ResourceEnvelopeError(f"corpus record {index} flags differ")
+
+    selections = _require_exact_keys(
+        inventory["selection_indices"],
+        set(policy["batch"]["batches"]),
+        "corpus selections",
+    )
+    selection_counts = _require_exact_keys(
+        inventory["selection_counts"],
+        set(policy["batch"]["batches"]),
+        "corpus selection counts",
+    )
+    expected_outcomes = _require_exact_keys(
+        inventory["expected_outcomes"],
+        set(policy["batch"]["batches"]),
+        "corpus expected outcomes",
+    )
+    for batch_id in policy["batch"]["batches"]:
+        indices = selections[batch_id]
+        if (
+            type(indices) is not list
+            or not indices
+            or any(type(index) is not int or not 0 <= index < len(records) for index in indices)
+            or indices != expected_selections[batch_id]
+            or type(selection_counts[batch_id]) is not int
+            or selection_counts[batch_id] != len(indices)
+        ):
+            raise ResourceEnvelopeError(f"corpus selection drifted: {batch_id}")
+        calculated = _selection_outcomes(
+            records, indices, policy["batch"]["verification_calls"]
+        )
+        batch_outcomes = _require_exact_keys(
+            expected_outcomes[batch_id],
+            set(OUTCOME_KEYS),
+            f"corpus expected outcomes {batch_id}",
+        )
+        for name in OUTCOME_KEYS:
+            _require_int(
+                batch_outcomes[name],
+                f"corpus expected outcomes {batch_id}.{name}",
+            )
+        if canonical_json(batch_outcomes) != canonical_json(calculated):
+            raise ResourceEnvelopeError(
+                f"corpus expected outcomes drifted: {batch_id}"
+            )
+    _require_int(inventory["first_call_record"], "corpus first-call record")
+    if inventory["first_call_record"] != first_record:
+        raise ResourceEnvelopeError("corpus first-call record drifted")
+    return inventory
+
+
+def _run_positive_controls(probe: Path, compiler: Path) -> dict:
+    environment = _minimal_environment(compiler.parent)
+    records = []
+    for mode, expected in (
+        ("--heap-positive-control", {"returncodes": [0], "marker": "heap_interposition"}),
+        ("--stack-positive-control", {"returncodes": [0], "marker": "undersized_stack_rejection"}),
+        (
+            "--cpu-positive-control",
+            {"returncodes": [-signal.SIGXCPU], "marker": None},
+        ),
+        (
+            "--wall-positive-control",
+            {"returncodes": [-signal.SIGALRM], "marker": None},
+        ),
+    ):
+        started = time.monotonic_ns()
+        completed = _run_bounded(
+            [str(probe), mode],
+            cwd=probe.parent,
+            timeout=8,
+            maximum=4096,
+            environment=environment,
+        )
+        elapsed = time.monotonic_ns() - started
+        stdout = completed.stdout.decode("utf8", errors="strict")
+        stderr = completed.stderr.decode("utf8", errors="strict")
+        if completed.returncode not in expected["returncodes"]:
+            raise ResourceEnvelopeError(
+                f"detector positive control {mode} exited {completed.returncode}"
+            )
+        if expected["marker"] is not None:
+            control = json.loads(
+                stdout,
+                object_pairs_hook=_reject_duplicate_json_keys,
+                parse_constant=_reject_nonfinite_json,
+            )
+            expected_control = {
+                "control": expected["marker"],
+                "status": "PASS",
+            }
+            if mode == "--heap-positive-control":
+                expected_control["calls"] = 1
+            if control != expected_control:
+                raise ResourceEnvelopeError(
+                    f"detector positive control {mode} marker drifted"
+                )
+        elif stdout or stderr:
+            raise ResourceEnvelopeError(
+                f"signal detector positive control {mode} produced output"
+            )
+        records.append(
+            {
+                "mode": mode,
+                "status": "PASS",
+                "returncode": completed.returncode,
+                "signal": (
+                    signal.Signals(-completed.returncode).name
+                    if completed.returncode < 0
+                    else None
+                ),
+                "elapsed_ns": elapsed,
+                "stdout": stdout,
+                "stderr": stderr,
+            }
+        )
+    return {
+        "schema_version": 1,
+        "status": "PASS",
+        "controls": records,
+        "scope": (
+            "calibrates allocator interposition, undersized-stack rejection, "
+            "RLIMIT_CPU, and alarm-based wall containment"
+        ),
+    }
+
+
+def _run_probe(
+    probe: Path, bundle: Path, output_dir: Path, compiler: Path, policy: dict
+) -> dict:
+    stdout_path = output_dir / OBSERVATION_FILE
+    stderr_path = output_dir / PROBE_STDERR_FILE
+    environment = _minimal_environment(compiler.parent)
+    with stdout_path.open("xb") as stdout_file, stderr_path.open("xb") as stderr_file:
+        try:
+            process = subprocess.Popen(
+                [str(probe), str(bundle)],
+                cwd=probe.parent,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            raise ResourceEnvelopeError(f"cannot start resource probe: {exc}") from exc
+        try:
+            returncode = process.wait(
+                timeout=policy["enforced_limits"]["wall_watchdog_seconds"] + 10
+            )
+        except subprocess.TimeoutExpired as exc:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+            raise ResourceEnvelopeError("resource probe exceeded the outer wall limit") from exc
+    for path, label in (
+        (stdout_path, "probe stdout"),
+        (stderr_path, "probe stderr"),
+    ):
+        _require_regular_file(
+            path,
+            label,
+            policy["enforced_limits"]["output_file_bytes"],
+            allow_empty=True,
+        )
+    stderr = stderr_path.read_text(encoding="utf8")
+    if returncode != 0 or stderr or stdout_path.stat().st_size == 0:
+        raise ResourceEnvelopeError(
+            f"resource probe exited {returncode}: "
+            f"{stderr.strip() or 'stdout was empty'}"
+        )
+    return load_json_object(stdout_path, "probe observation", MAX_LOG_BYTES)
+
+
+def _read_host_observation() -> dict:
+    if platform.system() != "Linux" or platform.machine() != "x86_64":
+        raise ResourceEnvelopeError(
+            f"resource execution requires Linux x86_64, got "
+            f"{platform.system()} {platform.machine()}"
+        )
+    cpu_model = ""
+    microcode = ""
+    cpuinfo_path = Path("/proc/cpuinfo")
+    if cpuinfo_path.is_file() and not cpuinfo_path.is_symlink():
+        text = cpuinfo_path.read_text(encoding="utf8", errors="strict")
+        for line in text.splitlines():
+            if not cpu_model and line.lower().startswith("model name") and ":" in line:
+                cpu_model = line.split(":", 1)[1].strip()[:160]
+            if not microcode and line.lower().startswith("microcode") and ":" in line:
+                microcode = line.split(":", 1)[1].strip()[:64]
+    def read_cgroup(name: str) -> str:
+        path = Path("/sys/fs/cgroup") / name
+        if not path.is_file() or path.is_symlink():
+            return "unavailable"
+        value = path.read_text(encoding="ascii", errors="strict").strip()
+        return value[:128] if value else "empty"
+
+    affinity_count = None
+    if hasattr(os, "sched_getaffinity"):
+        affinity_count = len(os.sched_getaffinity(0))
+    return {
+        "system": platform.system(),
+        "machine": platform.machine(),
+        "kernel_release": platform.release(),
+        "cpu_model": cpu_model or "unavailable",
+        "microcode": microcode or "unavailable",
+        "logical_cpu_count": os.cpu_count(),
+        "affinity_cpu_count": affinity_count,
+        "cgroup_cpu_max": read_cgroup("cpu.max"),
+        "cgroup_memory_max": read_cgroup("memory.max"),
+        "hostname_recorded": False,
+        "environment_recorded": False,
+    }
+
+
+def _claim_output_directory(output_dir: Path) -> None:
+    if output_dir.is_symlink():
+        raise ResourceEnvelopeError("evidence output directory must not be a symlink")
+    if output_dir.exists() and not output_dir.is_dir():
+        raise ResourceEnvelopeError("evidence output path must be a directory")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if any(output_dir.iterdir()):
+        raise ResourceEnvelopeError("evidence output directory must be empty")
+    (output_dir / OWNER_FILE).write_text(OWNER_CONTENT, encoding="utf8")
+
+
+def _resolve_evidence_directory(output_dir: Path, *, must_exist: bool) -> Path:
+    original = Path(output_dir)
+    try:
+        status = original.lstat()
+    except FileNotFoundError:
+        if must_exist:
+            raise ResourceEnvelopeError("evidence directory does not exist")
+    except OSError as exc:
+        raise ResourceEnvelopeError(f"cannot inspect evidence directory: {exc}") from exc
+    else:
+        if stat.S_ISLNK(status.st_mode) or not stat.S_ISDIR(status.st_mode):
+            raise ResourceEnvelopeError(
+                "evidence path must be a regular non-symlink directory"
+            )
+    try:
+        return original.resolve()
+    except OSError as exc:
+        raise ResourceEnvelopeError(f"cannot resolve evidence directory: {exc}") from exc
+
+
+def write_evidence_hashes(output_dir: Path) -> None:
+    checksum_path = output_dir / CHECKSUM_FILE
+    if checksum_path.exists() or checksum_path.is_symlink():
+        raise ResourceEnvelopeError("evidence checksum manifest already exists")
+    rows = []
+    for path in sorted(output_dir.iterdir(), key=lambda value: value.name):
+        status = path.lstat()
+        if not stat.S_ISREG(status.st_mode):
+            raise ResourceEnvelopeError(f"evidence entry is not regular: {path.name}")
+        rows.append(f"{sha256_file(path)}  {path.name}\n")
+    checksum_path.write_text("".join(rows), encoding="ascii")
+
+
+def _base_report(plan: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "status": "INCOMPLETE",
+        "error": "execution did not start",
+        "repository": None,
+        "trust": None,
+        "scope": {
+            **copy.deepcopy(plan["policy"]["scope"]),
+            "measurement_target": plan["policy"]["profile"]["measurement_target"],
+            "target_symbol": plan["target"],
+        },
+        "plan_sha256": None,
+        "policy_sha256": plan["policy_sha256"],
+        "source_contract": None,
+        "compiler": None,
+        "host": None,
+        "corpus": None,
+        "build": None,
+        "stack_usage": None,
+        "detector_controls": None,
+        "observation_sha256": None,
+        "timing_summaries": None,
+        "limitations": [
+            "Linux x86_64 only",
+            "sequential direct-verifier calls only",
+            "hosted-runner timing and RSS are observations, not acceptance limits",
+            "no node, wallet, script, consensus, block-scheduler, or concurrency claim",
+            "project-object allocator interposition does not measure dynamic-libc internals",
+            "compiler .su rows are per-function observations, not a formal call-chain sum",
+            "production backend remains NONE and the release hold remains active",
+        ],
+    }
+
+
+def _finalize_failure(output_dir: Path, report: dict, error: Exception) -> None:
+    for filename in (CHECKSUM_FILE, OBSERVATION_FILE):
+        path = output_dir / filename
+        if path.exists() or path.is_symlink():
+            path.unlink()
+    report["status"] = "FAIL"
+    report["error"] = str(error)[:2000] or type(error).__name__
+    (output_dir / REPORT_FILE).write_text(canonical_json(report), encoding="utf8")
+    (output_dir / JOB_STATUS_FILE).write_text("failure\n", encoding="ascii")
+    write_evidence_hashes(output_dir)
+
+
+def _report_keys() -> set[str]:
+    return set(_base_report(build_plan(load_policy())))
+
+
+def _verify_checksum_manifest(output_dir: Path, names: set[str]) -> None:
+    checksum_path = output_dir / CHECKSUM_FILE
+    _require_regular_file(checksum_path, "evidence checksum manifest", 16384)
+    try:
+        lines = checksum_path.read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise ResourceEnvelopeError(f"cannot read evidence checksums: {exc}") from exc
+    expected_names = sorted(names - {CHECKSUM_FILE})
+    if len(lines) != len(expected_names):
+        raise ResourceEnvelopeError("evidence checksum row count differs")
+    observed_names = []
+    for line in lines:
+        match = re.fullmatch(r"([0-9a-f]{64})  ([A-Za-z0-9._-]+)", line)
+        if match is None:
+            raise ResourceEnvelopeError("malformed evidence checksum row")
+        digest, name = match.groups()
+        observed_names.append(name)
+        path = output_dir / name
+        _require_regular_file(
+            path,
+            f"checksummed evidence {name}",
+            MAX_EVIDENCE_BYTES,
+            allow_empty=True,
+        )
+        if sha256_file(path) != digest:
+            raise ResourceEnvelopeError(f"evidence checksum mismatch: {name}")
+    if observed_names != expected_names:
+        raise ResourceEnvelopeError("evidence checksum inventory is not exact and sorted")
+
+
+def _verify_success_repository_and_trust(
+    report: dict, output_dir: Path
+) -> None:
+    repository = _require_exact_keys(
+        report["repository"],
+        {
+            "head",
+            "clean",
+            "full_history",
+            "baseline_pointer",
+            "baseline_guard_matches",
+        },
+        "resource report repository",
+    )
+    trust = _require_exact_keys(
+        report["trust"],
+        {
+            "label",
+            "trusted_observation",
+            "promotion_eligible",
+            "reason",
+            "ci",
+            "requires_external_workflow_provenance",
+            "requires_companion_compilers",
+            "requires_separate_numeric_policy_change",
+        },
+        "resource report trust",
+    )
+    current_head = _run_git("rev-parse", "HEAD").strip()
+    current_status = _run_git(
+        "status", "--porcelain=v1", "--untracked-files=all"
+    )
+    shallow = _run_git("rev-parse", "--is-shallow-repository").strip()
+    if (
+        repository["head"] != current_head
+        or HEX_40.fullmatch(current_head) is None
+        or repository["clean"] is not True
+        or current_status
+        or repository["full_history"] is not True
+        or shallow != "false"
+    ):
+        raise ResourceEnvelopeError("resource report repository state differs")
+    if _read_text_file(
+        output_dir / GIT_HEAD_FILE, "resource evidence Git head", maximum=64
+    ) != current_head + "\n":
+        raise ResourceEnvelopeError("resource evidence Git head differs")
+    if _read_text_file(
+        output_dir / GIT_STATUS_FILE,
+        "resource evidence Git status",
+        maximum=MAX_LOG_BYTES,
+        allow_empty=True,
+    ) != current_status:
+        raise ResourceEnvelopeError("resource evidence Git status differs")
+    pointer_bytes = BASELINE_POINTER.read_bytes()
+    if re.fullmatch(rb"[0-9a-f]{40}\n", pointer_bytes) is None:
+        raise ResourceEnvelopeError("review baseline pointer is malformed")
+    baseline = pointer_bytes[:-1].decode("ascii")
+    if repository["baseline_pointer"] != baseline:
+        raise ResourceEnvelopeError("resource report baseline pointer differs")
+    _require_first_parent_baseline(current_head, baseline)
+    current_diff = _run_git(
+        "diff", "--name-only", baseline, current_head, "--", *GUARDED_PATHS
+    )
+    if _read_text_file(
+        output_dir / BASELINE_DIFF_FILE,
+        "resource evidence baseline diff",
+        maximum=MAX_LOG_BYTES,
+        allow_empty=True,
+    ) != current_diff:
+        raise ResourceEnvelopeError("resource evidence baseline diff differs")
+    baseline_guard_matches = not bool(current_diff)
+    if repository["baseline_guard_matches"] is not baseline_guard_matches:
+        raise ResourceEnvelopeError("resource report baseline result differs")
+
+    ci_context = trust["ci"]
+    if type(ci_context) is not dict:
+        raise ResourceEnvelopeError("resource report CI context must be an object")
+    if ci_context.get("github_actions") is True:
+        _validate_github_context(ci_context, current_head)
+    elif ci_context != _local_ci_context():
+        raise ResourceEnvelopeError("resource report local context differs")
+    expected_trust = _build_trust(ci_context, baseline_guard_matches)
+    if canonical_json(trust) != canonical_json(expected_trust):
+        raise ResourceEnvelopeError("resource report trust classification differs")
+    if os.environ.get("GITHUB_ACTIONS", "") == "true":
+        if _ci_context_from_environment(current_head) != ci_context:
+            raise ResourceEnvelopeError("ambient GitHub context differs from evidence")
+
+
+def _validate_detector_controls(controls: dict) -> dict:
+    _require_exact_keys(
+        controls,
+        {"schema_version", "status", "controls", "scope"},
+        "detector controls",
+    )
+    _require_int(controls["schema_version"], "detector-control schema")
+    if (
+        controls["schema_version"] != 1
+        or controls["status"] != "PASS"
+        or controls["scope"]
+        != (
+            "calibrates allocator interposition, undersized-stack rejection, "
+            "RLIMIT_CPU, and alarm-based wall containment"
+        )
+        or type(controls["controls"]) is not list
+        or len(controls["controls"]) != 4
+    ):
+        raise ResourceEnvelopeError("detector-control header drifted")
+    expected_modes = [
+        "--heap-positive-control",
+        "--stack-positive-control",
+        "--cpu-positive-control",
+        "--wall-positive-control",
+    ]
+    for index, (record, expected_mode) in enumerate(
+        zip(controls["controls"], expected_modes)
+    ):
+        _require_exact_keys(
+            record,
+            {
+                "mode",
+                "status",
+                "returncode",
+                "signal",
+                "elapsed_ns",
+                "stdout",
+                "stderr",
+            },
+            f"detector control {index}",
+        )
+        if (
+            record["mode"] != expected_mode
+            or record["status"] != "PASS"
+            or type(record["returncode"]) is not int
+            or type(record["stdout"]) is not str
+            or type(record["stderr"]) is not str
+            or (
+                record["signal"] is not None
+                and type(record["signal"]) is not str
+            )
+            or len(record["stdout"].encode()) > 4096
+            or len(record["stderr"].encode()) > 4096
+        ):
+            raise ResourceEnvelopeError(f"detector control drifted: {expected_mode}")
+        _require_int(record["elapsed_ns"], f"{expected_mode} elapsed time", 1)
+        if expected_mode == "--heap-positive-control":
+            expected_signal = None
+            expected_returncodes = {0}
+            marker = {
+                "control": "heap_interposition",
+                "status": "PASS",
+                "calls": 1,
+            }
+        elif expected_mode == "--stack-positive-control":
+            expected_signal = None
+            expected_returncodes = {0}
+            marker = {
+                "control": "undersized_stack_rejection",
+                "status": "PASS",
+            }
+        elif expected_mode == "--cpu-positive-control":
+            expected_signal = {"SIGXCPU"}
+            expected_returncodes = {-signal.SIGXCPU}
+            marker = None
+        else:
+            expected_signal = {"SIGALRM"}
+            expected_returncodes = {-signal.SIGALRM}
+            marker = None
+        if record["returncode"] not in expected_returncodes:
+            raise ResourceEnvelopeError(
+                f"detector control return code drifted: {expected_mode}"
+            )
+        if marker is not None:
+            try:
+                parsed = json.loads(
+                    record["stdout"],
+                    object_pairs_hook=_reject_duplicate_json_keys,
+                    parse_constant=_reject_nonfinite_json,
+                )
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise ResourceEnvelopeError(
+                    f"detector control marker is invalid: {expected_mode}"
+                ) from exc
+            if (
+                parsed != marker
+                or record["signal"] is not None
+                or record["stderr"]
+            ):
+                raise ResourceEnvelopeError(
+                    f"detector control marker drifted: {expected_mode}"
+                )
+        elif (
+            record["signal"] not in expected_signal
+            or record["stdout"]
+            or record["stderr"]
+        ):
+            raise ResourceEnvelopeError(
+                f"detector control signal drifted: {expected_mode}"
+            )
+    return controls
+
+
+def _verify_success_report_bindings(
+    report: dict, output_dir: Path, inventory: dict
+) -> None:
+    compiler = _require_exact_keys(
+        report["compiler"], {"name", "path", "target"}, "resource compiler"
+    )
+    _require_string(compiler["name"], "resource compiler name")
+    _require_string(compiler["path"], "resource compiler path")
+    _require_string(compiler["target"], "resource compiler target")
+    if (
+        compiler["name"] not in {"gcc", "clang"}
+        or not Path(compiler["path"]).is_absolute()
+        or "x86_64" not in compiler["target"].lower()
+    ):
+        raise ResourceEnvelopeError("resource compiler name differs")
+    if (
+        compiler["target"]
+        != _read_text_file(
+            output_dir / COMPILER_TARGET_FILE,
+            "compiler target evidence",
+            maximum=4096,
+        ).strip()
+    ):
+        raise ResourceEnvelopeError("resource compiler identity differs")
+    build = _require_exact_keys(
+        report["build"],
+        {
+            "compiler_name",
+            "compiler_path",
+            "compiler_version_sha256",
+            "compiler_target",
+            "production_library_sha256",
+            "probe_sha256",
+            "production_wrapper_undefined_heap_allocators",
+            "production_exported_symbols",
+            "optimization",
+            "lto",
+            "sanitizers",
+            "testing_define_in_measured_objects",
+            "assembly",
+        },
+        "resource build",
+    )
+    if (
+        build["compiler_name"] != compiler["name"]
+        or build["compiler_path"] != compiler["path"]
+        or build["compiler_target"] != compiler["target"]
+        or build["compiler_version_sha256"]
+        != sha256_file(output_dir / COMPILER_VERSION_FILE)
+        or build["production_library_sha256"]
+        != sha256_file(output_dir / LIBRARY_FILE)
+        or build["probe_sha256"] != sha256_file(output_dir / PROBE_FILE)
+        or build["production_wrapper_undefined_heap_allocators"] != []
+        or build["production_exported_symbols"]
+        != ["pqbtc_mldsa44_sign_hedged", "pqbtc_mldsa44_verify_strict"]
+        or build["optimization"] != "-O2"
+        or build["lto"] is not False
+        or build["sanitizers"] is not False
+        or build["testing_define_in_measured_objects"] is not False
+        or build["assembly"] is not False
+    ):
+        raise ResourceEnvelopeError("resource build binding differs")
+    expected_symbols = (
+        "pqbtc_mldsa44_sign_hedged\npqbtc_mldsa44_verify_strict\n"
+    )
+    if _read_text_file(
+        output_dir / SYMBOLS_FILE, "production symbol evidence", maximum=4096
+    ) != expected_symbols:
+        raise ResourceEnvelopeError("production symbol evidence differs")
+    commands = load_json_object(
+        output_dir / BUILD_COMMANDS_FILE, "resource build commands"
+    )
+    _require_exact_keys(
+        commands,
+        {"schema_version", "shell_used", "commands", "forbidden_flags_absent"},
+        "resource build commands",
+    )
+    _require_int(commands["schema_version"], "resource build-command schema")
+    if (
+        commands["schema_version"] != 1
+        or commands["shell_used"] is not False
+        or commands["forbidden_flags_absent"] != FORBIDDEN_FLAG_CLAIMS
+        or commands["commands"]
+        != _expected_normalized_commands(compiler["path"])
+    ):
+        raise ResourceEnvelopeError("resource build-command evidence differs")
+
+    host = load_json_object(output_dir / HOST_FILE, "host observation")
+    _require_exact_keys(
+        host,
+        {
+            "system",
+            "machine",
+            "kernel_release",
+            "cpu_model",
+            "microcode",
+            "logical_cpu_count",
+            "affinity_cpu_count",
+            "cgroup_cpu_max",
+            "cgroup_memory_max",
+            "hostname_recorded",
+            "environment_recorded",
+        },
+        "host observation",
+    )
+    for field in (
+        "kernel_release",
+        "cpu_model",
+        "microcode",
+        "cgroup_cpu_max",
+        "cgroup_memory_max",
+    ):
+        _require_string(host[field], f"host observation {field}")
+    _require_int(host["logical_cpu_count"], "host logical CPU count", 1)
+    _require_int(host["affinity_cpu_count"], "host affinity CPU count", 1)
+    if (
+        host["system"] != "Linux"
+        or host["machine"] != "x86_64"
+        or host["hostname_recorded"] is not False
+        or host["environment_recorded"] is not False
+    ):
+        raise ResourceEnvelopeError("host observation scope differs")
+    if canonical_json(report["host"]) != canonical_json(host):
+        raise ResourceEnvelopeError("resource host observation differs")
+    if _read_text_file(
+        output_dir / PROBE_STDERR_FILE,
+        "successful probe stderr",
+        maximum=MAX_LOG_BYTES,
+        allow_empty=True,
+    ):
+        raise ResourceEnvelopeError("successful probe stderr is not empty")
+    linked = _read_text_file(
+        output_dir / LINKED_FILE, "linked-library evidence", maximum=MAX_LOG_BYTES
+    )
+    if (
+        "libc.so.6" not in linked
+        or "ld-linux-x86-64.so.2" not in linked
+        or "not found" in linked
+        or "libpqbtc" in linked
+        or "$BUILD_DIR" in linked
+        or str(REPO_ROOT) in linked
+    ):
+        raise ResourceEnvelopeError("linked-library evidence differs")
+    if canonical_json(report["source_contract"]) != canonical_json(
+        _validate_source_contract()
+    ):
+        raise ResourceEnvelopeError("resource source-contract evidence differs")
+    expected_corpus = {
+        "record_count": inventory["record_count"],
+        "total_frame_bytes": inventory["total_frame_bytes"],
+        "bundle_sha256": inventory["bundle_sha256"],
+        "selection_counts": inventory["selection_counts"],
+        "expected_outcomes": inventory["expected_outcomes"],
+        "first_call_record": inventory["first_call_record"],
+    }
+    if canonical_json(report["corpus"]) != canonical_json(expected_corpus):
+        raise ResourceEnvelopeError("resource corpus report binding differs")
+
+
+def verify_evidence(output_dir: Path) -> dict:
+    output_dir = _resolve_evidence_directory(output_dir, must_exist=True)
+    entries = sorted(output_dir.iterdir(), key=lambda value: value.name)
+    if not entries or len(entries) > MAX_EVIDENCE_FILES:
+        raise ResourceEnvelopeError("evidence file count is outside the frozen bound")
+    total_size = 0
+    names = set()
+    for path in entries:
+        status = path.lstat()
+        if not stat.S_ISREG(status.st_mode):
+            raise ResourceEnvelopeError(f"evidence contains a non-regular entry: {path.name}")
+        if "/" in path.name or path.name in names:
+            raise ResourceEnvelopeError("evidence contains an unsafe/duplicate name")
+        names.add(path.name)
+        total_size += status.st_size
+    if total_size > MAX_EVIDENCE_BYTES:
+        raise ResourceEnvelopeError("evidence total size exceeds the frozen bound")
+    if not names <= SUCCESS_FILES:
+        raise ResourceEnvelopeError(
+            f"evidence contains unexpected files: {sorted(names - SUCCESS_FILES)}"
+        )
+    _verify_checksum_manifest(output_dir, names)
+    if _read_text_file(
+        output_dir / OWNER_FILE,
+        "evidence ownership marker",
+        maximum=1024,
+    ) != OWNER_CONTENT:
+        raise ResourceEnvelopeError("evidence ownership marker differs")
+
+    plan = load_json_object(output_dir / PLAN_FILE, "evidence resource plan")
+    expected_plan = build_plan(load_policy())
+    if _read_text_file(
+        output_dir / PLAN_FILE, "evidence resource plan"
+    ) != canonical_json(expected_plan):
+        raise ResourceEnvelopeError("evidence resource plan differs from this source tree")
+    policy_copy = load_json_object(output_dir / POLICY_FILE, "evidence policy")
+    if (
+        canonical_json(policy_copy) != canonical_json(plan["policy"])
+        or (output_dir / POLICY_FILE).read_bytes() != POLICY_PATH.read_bytes()
+        or sha256_file(output_dir / POLICY_FILE) != POLICY_SHA256
+    ):
+        raise ResourceEnvelopeError("evidence policy copy differs")
+    report = load_json_object(output_dir / REPORT_FILE, "resource report")
+    _require_exact_keys(report, _report_keys(), "resource report")
+    _require_int(report["schema_version"], "resource report schema")
+    if report["schema_version"] != 1 or report["policy_sha256"] != POLICY_SHA256:
+        raise ResourceEnvelopeError("resource report identity drifted")
+    if report["plan_sha256"] != sha256_file(output_dir / PLAN_FILE):
+        raise ResourceEnvelopeError("resource report plan hash differs")
+    if canonical_json(report["scope"]) != canonical_json(_base_report(plan)["scope"]):
+        raise ResourceEnvelopeError("resource report scope drifted")
+    if report["limitations"] != _base_report(plan)["limitations"]:
+        raise ResourceEnvelopeError("resource report limitations drifted")
+    status = report["status"]
+    if status not in {"PASS", "FAIL", "INCOMPLETE"}:
+        raise ResourceEnvelopeError("resource report status is unsupported")
+    job_status = _read_text_file(
+        output_dir / JOB_STATUS_FILE,
+        "resource job status",
+        encoding="ascii",
+        maximum=64,
+    )
+    if status == "PASS":
+        if names != SUCCESS_FILES or job_status != "success\n" or report["error"] is not None:
+            raise ResourceEnvelopeError("successful evidence inventory/status differs")
+        _verify_success_repository_and_trust(report, output_dir)
+        inventory = load_json_object(
+            output_dir / INVENTORY_FILE, "verifier corpus inventory"
+        )
+        _validate_inventory_bundle(
+            inventory, output_dir / BUNDLE_FILE, plan["policy"]
+        )
+        _verify_success_report_bindings(report, output_dir, inventory)
+        observation = load_json_object(
+            output_dir / OBSERVATION_FILE, "probe observation", MAX_LOG_BYTES
+        )
+        validated = validate_probe_observation(
+            observation,
+            plan,
+            expected_input_fnv1a64=fnv1a64_bytes(
+                (output_dir / BUNDLE_FILE).read_bytes()
+            ),
+        )
+        for batch in observation["batches"]:
+            if canonical_json(batch["outcomes"]) != canonical_json(
+                inventory["expected_outcomes"][batch["id"]]
+            ):
+                raise ResourceEnvelopeError(
+                    f"probe outcomes differ from corpus: {batch['id']}"
+                )
+        if canonical_json(observation["selection_counts"]) != canonical_json(
+            inventory["selection_counts"]
+        ):
+            raise ResourceEnvelopeError("probe selection counts differ from corpus")
+        if observation["first_call"]["record"] != inventory["first_call_record"]:
+            raise ResourceEnvelopeError("probe first-call record differs from corpus")
+        if report["observation_sha256"] != sha256_file(output_dir / OBSERVATION_FILE):
+            raise ResourceEnvelopeError("resource report observation hash differs")
+        if canonical_json(report["timing_summaries"]) != canonical_json(
+            validated["derived_summaries"]
+        ):
+            raise ResourceEnvelopeError("resource report timing summaries differ")
+        stack_report = load_json_object(
+            output_dir / STACK_REPORT_FILE, "stack-usage report"
+        )
+        _require_exact_keys(
+            stack_report,
+            {
+                "schema_version",
+                "records",
+                "upstream_mld_total_alloc_44_verify_bytes",
+                "claim",
+            },
+            "stack-usage report",
+        )
+        _require_int(stack_report["schema_version"], "stack-usage schema")
+        _require_int(
+            stack_report["upstream_mld_total_alloc_44_verify_bytes"],
+            "upstream verifier scratch allocation",
+            1,
+        )
+        parsed_stack = parse_stack_usage(
+            [output_dir / WRAPPER_STACK_FILE, output_dir / PROBE_STACK_FILE]
+        )
+        if (
+            stack_report["schema_version"] != 1
+            or stack_report["upstream_mld_total_alloc_44_verify_bytes"] != 24448
+            or stack_report["claim"]
+            != (
+                "compiler-specific per-function observations corroborated by guarded "
+                "execution; values are not summed into a formal call-chain bound"
+            )
+            or canonical_json(stack_report["records"]) != canonical_json(parsed_stack)
+            or canonical_json(report["stack_usage"]) != canonical_json(stack_report)
+        ):
+            raise ResourceEnvelopeError("stack-usage evidence differs")
+        controls = load_json_object(
+            output_dir / CONTROLS_FILE, "detector controls"
+        )
+        _validate_detector_controls(controls)
+        if canonical_json(report["detector_controls"]) != canonical_json(controls):
+            raise ResourceEnvelopeError("detector-control evidence differs")
+        if report["trust"]["promotion_eligible"] is not False:
+            raise ResourceEnvelopeError("single-compiler evidence became promotion eligible")
+        if any(
+            plan["policy"]["acceptance_limits"][field] is not None
+            for field in ("cpu_seconds", "wall_seconds", "peak_rss_kib")
+        ):
+            raise ResourceEnvelopeError("numeric thresholds bootstrapped from evidence")
+    else:
+        if not FAILURE_REQUIRED_FILES <= names:
+            raise ResourceEnvelopeError("failure evidence is incomplete")
+        expected_job_status = {
+            "FAIL": "failure\n",
+            "INCOMPLETE": "incomplete\n",
+        }[status]
+        if job_status != expected_job_status:
+            raise ResourceEnvelopeError("failure evidence job status differs")
+        if type(report["error"]) is not str or not report["error"]:
+            raise ResourceEnvelopeError("failure evidence lacks an exact error")
+        if status == "FAIL" and OBSERVATION_FILE in names:
+            raise ResourceEnvelopeError(
+                "failure evidence retained a canonical observation file"
+            )
+        if status == "INCOMPLETE" and OBSERVATION_FILE in names:
+            observation = load_json_object(
+                output_dir / OBSERVATION_FILE, "incomplete fixture observation"
+            )
+            validate_probe_observation(observation, plan)
+    return report
+
+
+def write_test_evidence_fixture(
+    output_dir: Path, observation: dict, replace: bool = False
+) -> None:
+    """Create a canonical incomplete fixture used only by unit tests."""
+    if replace and output_dir.exists():
+        if output_dir.is_symlink() or not output_dir.is_dir():
+            raise ResourceEnvelopeError("test fixture path must be a regular directory")
+        for path in output_dir.iterdir():
+            if path.is_dir() and not path.is_symlink():
+                raise ResourceEnvelopeError(
+                    "test fixture replacement refuses nested directories"
+                )
+            path.unlink()
+    policy = load_policy()
+    plan = build_plan(policy)
+    validate_probe_observation(observation, plan)
+    _claim_output_directory(output_dir)
+    (output_dir / PLAN_FILE).write_text(canonical_json(plan), encoding="utf8")
+    (output_dir / POLICY_FILE).write_bytes(POLICY_PATH.read_bytes())
+    (output_dir / OBSERVATION_FILE).write_text(
+        canonical_json(observation), encoding="utf8"
+    )
+    report = _base_report(plan)
+    report["status"] = "INCOMPLETE"
+    report["error"] = "unit-test fixture; execution intentionally omitted"
+    report["plan_sha256"] = sha256_file(output_dir / PLAN_FILE)
+    report["observation_sha256"] = sha256_file(output_dir / OBSERVATION_FILE)
+    report["timing_summaries"] = validate_probe_observation(
+        observation, plan
+    )["derived_summaries"]
+    (output_dir / REPORT_FILE).write_text(canonical_json(report), encoding="utf8")
+    (output_dir / JOB_STATUS_FILE).write_text("incomplete\n", encoding="ascii")
+    write_evidence_hashes(output_dir)
+    verify_evidence(output_dir)
+
+
+def execute(compiler_name: str, output_dir: Path) -> int:
+    policy = load_policy()
+    plan = build_plan(policy)
+    output_dir = _resolve_evidence_directory(output_dir, must_exist=False)
+    resolved_repo = REPO_ROOT.resolve()
+    if resolved_repo == output_dir or resolved_repo in output_dir.parents:
+        raise ResourceEnvelopeError("evidence output directory must be outside the repository")
+    _claim_output_directory(output_dir)
+    (output_dir / PLAN_FILE).write_text(canonical_json(plan), encoding="utf8")
+    (output_dir / POLICY_FILE).write_bytes(POLICY_PATH.read_bytes())
+    report = _base_report(plan)
+    report["plan_sha256"] = sha256_file(output_dir / PLAN_FILE)
+    try:
+        repository, trust = _repository_and_trust(output_dir)
+        report["repository"] = repository
+        report["trust"] = trust
+        source_contract = _validate_source_contract()
+        report["source_contract"] = source_contract
+        host = _read_host_observation()
+        report["host"] = host
+        (output_dir / HOST_FILE).write_text(canonical_json(host), encoding="utf8")
+        compiler = _compiler_path(compiler_name)
+        with tempfile.TemporaryDirectory(
+            prefix="pqbtc-mldsa44-resource-"
+        ) as temporary:
+            build_dir = Path(temporary)
+            build, production_library, test_library, probe = _compile(
+                compiler_name, compiler, build_dir, output_dir
+            )
+            report["compiler"] = {
+                "name": compiler_name,
+                "path": str(compiler),
+                "target": build["compiler_target"],
+            }
+            report["build"] = build
+            inventory = _materialize_corpus(
+                test_library, production_library, output_dir, policy
+            )
+            _validate_inventory_bundle(
+                inventory, output_dir / BUNDLE_FILE, policy
+            )
+            report["corpus"] = {
+                "record_count": inventory["record_count"],
+                "total_frame_bytes": inventory["total_frame_bytes"],
+                "bundle_sha256": inventory["bundle_sha256"],
+                "selection_counts": inventory["selection_counts"],
+                "expected_outcomes": inventory["expected_outcomes"],
+                "first_call_record": inventory["first_call_record"],
+            }
+            controls = _run_positive_controls(probe, compiler)
+            (output_dir / CONTROLS_FILE).write_text(
+                canonical_json(controls), encoding="utf8"
+            )
+            report["detector_controls"] = controls
+            observation = _run_probe(
+                probe, output_dir / BUNDLE_FILE, output_dir, compiler, policy
+            )
+            validated = validate_probe_observation(
+                observation,
+                plan,
+                expected_input_fnv1a64=fnv1a64_bytes(
+                    (output_dir / BUNDLE_FILE).read_bytes()
+                ),
+            )
+            if observation["selection_counts"] != inventory["selection_counts"]:
+                raise ResourceEnvelopeError(
+                    "probe selection counts differ from frozen corpus"
+                )
+            for batch in observation["batches"]:
+                if (
+                    batch["outcomes"]
+                    != inventory["expected_outcomes"][batch["id"]]
+                ):
+                    raise ResourceEnvelopeError(
+                        f"probe outcome accounting differs: {batch['id']}"
+                    )
+            if observation["first_call"]["record"] != inventory["first_call_record"]:
+                raise ResourceEnvelopeError("probe first-call record differs")
+            report["observation_sha256"] = sha256_file(
+                output_dir / OBSERVATION_FILE
+            )
+            report["timing_summaries"] = validated["derived_summaries"]
+            stack_report = load_json_object(
+                output_dir / STACK_REPORT_FILE, "stack-usage report"
+            )
+            report["stack_usage"] = stack_report
+
+        status_after = _run_git(
+            "status", "--porcelain=v1", "--untracked-files=all"
+        )
+        head_after = _run_git("rev-parse", "HEAD").strip()
+        if status_after or head_after != repository["head"]:
+            raise ResourceEnvelopeError("repository changed during resource execution")
+        report["status"] = "PASS"
+        report["error"] = None
+        (output_dir / REPORT_FILE).write_text(canonical_json(report), encoding="utf8")
+        (output_dir / JOB_STATUS_FILE).write_text("success\n", encoding="ascii")
+        write_evidence_hashes(output_dir)
+        verify_evidence(output_dir)
+        return 0
+    except (
+        ResourceEnvelopeError,
+        verifier.FuzzHarnessError,
+        wrapper.HarnessError,
+        OSError,
+        UnicodeError,
+        ValueError,
+        ctypes.ArgumentError,
+    ) as exc:
+        _finalize_failure(output_dir, report, exc)
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Observe the isolated ML-DSA-44 verifier resource envelope"
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--plan-only", action="store_true")
+    mode.add_argument("--verify-evidence", type=Path)
+    mode.add_argument("--output-dir", type=Path)
+    parser.add_argument("--compiler", choices=("gcc", "clang"))
+    args = parser.parse_args(argv)
+    if args.output_dir is not None and args.compiler is None:
+        parser.error("--compiler is required with --output-dir")
+    if args.output_dir is None and args.compiler is not None:
+        parser.error("--compiler requires --output-dir")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.plan_only:
+            print(canonical_json(build_plan(load_policy())), end="")
+            return 0
+        if args.verify_evidence is not None:
+            report = verify_evidence(args.verify_evidence)
+            print(
+                f"ML-DSA-44 resource evidence verified: {report['status']}"
+            )
+            return 0
+        return execute(args.compiler, args.output_dir)
+    except (
+        ResourceEnvelopeError,
+        verifier.FuzzHarnessError,
+        wrapper.HarnessError,
+        OSError,
+        UnicodeError,
+        ValueError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/ml-dsa-engineering/run_verifier_resource_envelope.py
+++ b/contrib/ml-dsa-engineering/run_verifier_resource_envelope.py
@@ -31,7 +31,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Any, Iterable
+from typing import Iterable
 
 import run_verifier_fuzz as verifier
 import run_wrapper_tests as wrapper
@@ -1304,7 +1304,9 @@ def _compiler_path(compiler_name: str) -> Path:
     return resolved
 
 
-def _common_compile_flags(compiler: Path) -> list[str]:
+def _common_compile_flags(
+    compiler: Path, include_directory: Path | str = HERE
+) -> list[str]:
     return [
         str(compiler),
         "-std=c11",
@@ -1316,22 +1318,65 @@ def _common_compile_flags(compiler: Path) -> list[str]:
         "-fvisibility=hidden",
         "-fno-lto",
         "-O2",
-        f"-I{HERE}",
+        f"-I{include_directory}",
     ]
 
 
+def _placeholder_repo_path(path: Path) -> str:
+    try:
+        relative = path.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise ResourceEnvelopeError(
+            "recorded source path is outside the repository"
+        ) from exc
+    if not relative.parts:
+        return "$REPO_ROOT"
+    return f"$REPO_ROOT/{relative.as_posix()}"
+
+
+def _normalize_path_boundary(
+    value: str, prefix: str, placeholder: str
+) -> str:
+    if value == prefix:
+        return placeholder
+    boundary = prefix + os.sep
+    if value.startswith(boundary):
+        return placeholder + value[len(prefix) :]
+    return value
+
+
+def _reject_reserved_path_placeholders(value: str) -> None:
+    if "$BUILD_DIR" in value or "$REPO_ROOT" in value:
+        raise ResourceEnvelopeError(
+            "build command contains a reserved path placeholder"
+        )
+
+
 def _normalize_commands(commands: list[list[str]], build_dir: Path) -> dict:
-    prefix = str(build_dir)
+    build_prefix = str(build_dir)
+    repo_prefix = str(REPO_ROOT)
     normalized = []
     for command in commands:
-        normalized.append(
-            [
-                argument.replace(prefix, "$BUILD_DIR")
-                if argument.startswith(prefix)
-                else argument
-                for argument in command
-            ]
-        )
+        normalized_command = []
+        for index, argument in enumerate(command):
+            _reject_reserved_path_placeholders(argument)
+            if index == 0:
+                normalized_command.append(argument)
+                continue
+            option = ""
+            path_argument = argument
+            if argument.startswith("-I"):
+                option = "-I"
+                path_argument = argument[2:]
+            path_argument = _normalize_path_boundary(
+                path_argument, build_prefix, "$BUILD_DIR"
+            )
+            path_argument = _normalize_path_boundary(
+                path_argument, repo_prefix, "$REPO_ROOT"
+            )
+            argument = option + path_argument
+            normalized_command.append(argument)
+        normalized.append(normalized_command)
     return {
         "schema_version": 1,
         "shell_used": False,
@@ -1341,7 +1386,12 @@ def _normalize_commands(commands: list[list[str]], build_dir: Path) -> dict:
 
 
 def _expected_normalized_commands(compiler: str) -> list[list[str]]:
-    common = _common_compile_flags(Path(compiler))
+    _reject_reserved_path_placeholders(compiler)
+    common = _common_compile_flags(
+        Path(compiler), _placeholder_repo_path(HERE)
+    )
+    wrapper_source = _placeholder_repo_path(wrapper.WRAPPER_SOURCE)
+    probe_source = _placeholder_repo_path(PROBE_SOURCE)
     wrapper_object = "$BUILD_DIR/wrapper.o"
     probe_object = "$BUILD_DIR/probe.o"
     return [
@@ -1349,7 +1399,7 @@ def _expected_normalized_commands(compiler: str) -> list[list[str]]:
         + [
             "-fPIC",
             "-shared",
-            str(wrapper.WRAPPER_SOURCE),
+            wrapper_source,
             "-o",
             f"$BUILD_DIR/{LIBRARY_FILE}",
         ],
@@ -1358,7 +1408,7 @@ def _expected_normalized_commands(compiler: str) -> list[list[str]]:
             "-fPIC",
             "-shared",
             "-DPQBTC_MLDSA44_TESTING=1",
-            str(wrapper.WRAPPER_SOURCE),
+            wrapper_source,
             "-o",
             "$BUILD_DIR/libpqbtc_mldsa44_test.so",
         ],
@@ -1366,7 +1416,7 @@ def _expected_normalized_commands(compiler: str) -> list[list[str]]:
         + [
             "-fstack-usage",
             "-c",
-            str(wrapper.WRAPPER_SOURCE),
+            wrapper_source,
             "-o",
             wrapper_object,
         ],
@@ -1380,7 +1430,7 @@ def _expected_normalized_commands(compiler: str) -> list[list[str]]:
             "-fno-builtin-aligned_alloc",
             "-fno-builtin-posix_memalign",
             "-c",
-            str(PROBE_SOURCE),
+            probe_source,
             "-o",
             probe_object,
         ],

--- a/contrib/ml-dsa-engineering/verifier_resource_policy.json
+++ b/contrib/ml-dsa-engineering/verifier_resource_policy.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "phase": "TRUSTED_MAIN_OBSERVATION_REQUIRED",
+  "target": "pqbtc_mldsa44_verify_strict",
+  "profile": {
+    "system": "Linux",
+    "machine": "x86_64",
+    "measurement_target": "isolated-production-shaped-direct-verifier",
+    "backend": "mldsa-native-portable-c",
+    "optimization": "-O2",
+    "thread_model": "one guarded pthread",
+    "allocation_model": "default upstream stack allocation"
+  },
+  "batch": {
+    "source": "SHA256-sorted unique verifier_fuzz_corpus.json frames",
+    "unique_frames": 240,
+    "full_corpus_rounds": 17,
+    "prefix_frames": 207,
+    "verification_calls": 4287,
+    "sample_count": 31,
+    "first_call_separate": true,
+    "batches": [
+      "mixed_rotating",
+      "valid_rotating",
+      "deep_reject_rotating",
+      "same_key_mixed"
+    ],
+    "derivation": "17 * 240 + 207 = 4287 repeated independent verifications",
+    "capacity_basis": "raw 16000000-weight-unit witness payload model for one 2420-byte signature plus one 1312-byte public key",
+    "capacity_scope": "research workload only; not a transaction, block-validation, consensus, or activation limit",
+    "required_accept_cases": [
+      "valid_empty_message_context",
+      "valid_frozen_vector",
+      "valid_max_context",
+      "valid_max_fuzz_message"
+    ],
+    "required_deep_reject_cases": [
+      "reject_context_flip",
+      "reject_ctilde_bit_flip",
+      "reject_hint_counter_backwards",
+      "reject_hint_nonzero_padding",
+      "reject_message_flip",
+      "reject_public_key_rho_flip",
+      "reject_public_key_t1_flip"
+    ],
+    "same_key_cases": [
+      "reject_context_flip",
+      "reject_ctilde_bit_flip",
+      "reject_hint_counter_backwards",
+      "reject_hint_nonzero_padding",
+      "reject_message_flip",
+      "valid_empty_message_context",
+      "valid_frozen_vector",
+      "valid_max_context",
+      "valid_max_fuzz_message"
+    ]
+  },
+  "enforced_limits": {
+    "thread_stack_bytes": 131072,
+    "thread_guard_bytes": 4096,
+    "address_space_bytes": 268435456,
+    "open_files": 64,
+    "output_file_bytes": 65536,
+    "core_file_bytes": 0,
+    "project_heap_calls": 0,
+    "cpu_watchdog_seconds": 120,
+    "wall_watchdog_seconds": 180
+  },
+  "acceptance_limits": {
+    "cpu_seconds": null,
+    "wall_seconds": null,
+    "peak_rss_kib": null,
+    "status": "UNSET_PENDING_SEPARATE_REVIEW_OF_TRUSTED_MAIN_OBSERVATION"
+  },
+  "stack_evidence": {
+    "upstream_mld_total_alloc_44_verify_bytes": 24448,
+    "required_symbols": [
+      "pqbtc_mldsa44_upstream_verify",
+      "pqbtc_mldsa44_verify_strict"
+    ],
+    "require_static_stack_usage": true,
+    "call_chain_claim": "guarded-thread execution corroborates compiler-specific per-function .su records; .su values are not summed into a formal call-chain bound"
+  },
+  "promotion": {
+    "requires_trusted_main_push": true,
+    "requires_both_compilers": [
+      "clang",
+      "gcc"
+    ],
+    "requires_separate_policy_change": true,
+    "pull_request_evidence": "UNTRUSTED_PR_OBSERVATION",
+    "trusted_main_evidence": "TRUSTED_MAIN_OBSERVATION",
+    "timing_threshold_bootstrap_forbidden": true
+  },
+  "scope": {
+    "isolated_test_only": true,
+    "production_integration": false,
+    "production_backend": "NONE",
+    "simd256_admitted": false,
+    "release_hold": true,
+    "release_hold_changed": false,
+    "batch_limit_is_not_consensus_policy": true,
+    "closes_issue": false
+  }
+}

--- a/docs/ML_DSA_44_BACKEND_ADMISSION.md
+++ b/docs/ML_DSA_44_BACKEND_ADMISSION.md
@@ -162,6 +162,17 @@ controls only for evidence generation. The harness exercises real OS entropy,
 frozen key/signature hashes, strict verification, fail-closed output,
 zeroization-hook execution, concurrent repeat rejection, and ASan/UBSan.
 
+A separate Linux x86_64 test-only lane now defines direct strict-verifier
+resource observations. Each of four batches makes 4,287 calls on a 128 KiB
+guarded pthread stack while linker interposition requires zero project heap
+calls. It retains raw timing samples and compiler-specific `.su` static-frame
+observations. These are candidate observations only: they are not consensus,
+block, or production limits, and numeric CPU, wall-time, and RSS acceptance
+remain unset pending separately reviewed exact-head GCC and Clang
+protected-main-push `TRUSTED_MAIN_OBSERVATION` artifacts. Manual dispatches
+remain untrusted. Each single-compiler artifact remains non-promotion-eligible
+and requires external GitHub Actions provenance.
+
 This is implementation evidence for the admitted experiment, not a production
 backend disposition. The raw-key prototype ABI, process-global serialization,
 supported-platform behavior, lifecycle, compiler output, fault model, fuzzing,
@@ -179,7 +190,7 @@ Prototype admission closes no production finding:
 | Supported-platform side channels | #185 | bounded x86_64 Valgrind constant-time/variable-latency evidence; broader platforms and leakage models open |
 | Fault model and injected faults | #186 | open |
 | End-to-end secret erasure | #187 | source cleanup and sanitizer evidence only; compiler/caller/platform boundary open |
-| Structure-aware fuzzing and resource limits | #188 | pinned Wycheproof replay, scheduled structure-aware ASan/UBSan and MSan campaigns, bounded differential/stateful fuzzing, promoted regressions, portable Miri evidence, and bounded malformed research-CLI argv replay; direct verifier allocation/stack/CPU and adversarial-batch limits, broader platform/Rust sanitizer coverage, and exact-commit re-review remain open |
+| Structure-aware fuzzing and resource limits | #188 | pinned Wycheproof replay, scheduled structure-aware ASan/UBSan and MSan campaigns, bounded differential/stateful fuzzing, promoted regressions, portable Miri evidence, bounded malformed research-CLI argv replay, and a test-only Linux x86_64 direct-verifier observation lane; trusted-main resource evidence, reviewed numeric allocation/stack/CPU and adversarial-batch acceptance limits, broader platform/Rust sanitizer coverage, and exact-commit re-review remain open |
 | Backend advisories, SBOM, and reproducible build | #189 | dated fail-closed ledger, full-lock cargo-audit/OSV scans, exact selected graph, CycloneDX SBOM, weekly retained refresh, exact portable ML-DSA-44 RUSTSEC-2026-0077 regressions, and promoted trusted-main test-only SIMD256 0125/0126 PASS evidence; exact-commit independent re-review remains open, and optimized-backend admission is a separate future decision |
 | Wallet and key format | #190 | open |
 | Independent human cryptographic review | #181 | open |

--- a/docs/ML_DSA_44_WRAPPER_PROTOTYPE.md
+++ b/docs/ML_DSA_44_WRAPPER_PROTOTYPE.md
@@ -232,6 +232,49 @@ The versioned clang-tidy/IWYU plan does not cover the differential-only branch
 or external adapter sources; those C sources are compiled with fatal warnings
 and exercised dynamically in the pinned review workflow instead.
 
+## Direct-Verifier Resource-Envelope Observation
+
+The isolated resource lane calls only `pqbtc_mldsa44_verify_strict` in the
+production-shaped portable-C build on Linux x86_64. Its deterministic source
+set is the 240 unique frozen verifier frames. It expands that set into four
+separate 4,287-call batches: a rotating mixed batch, a rotating valid batch,
+deep verification rejects, and a same-public-key mixture of the four required
+accepts plus the five required deep rejects that retain the frozen key. The
+two public-key mutation cases remain in the deep-reject batch. The 4,287-call
+size comes from the existing raw-payload
+research model and is not a consensus, block, transaction, mempool, or
+production limit.
+
+The probe runs inside a 128 KiB guarded pthread and records the configured
+stack and guard sizes. GCC and Clang `.su` output is retained as
+compiler-specific static-frame observation. It is not treated as a formal
+whole-call-chain stack bound. Linker interposition around the project binary
+requires zero `malloc`, `calloc`, `realloc`, `free`, `aligned_alloc`, and
+`posix_memalign` calls during direct verification; that instrumentation does
+not claim visibility into dynamic-loader or system-library internals.
+
+Each batch retains raw integer timing samples plus matched loop-control
+samples, and the evidence validator independently recomputes the descriptive
+statistics. The initial policy deliberately defines no numeric CPU,
+wall-time, or RSS acceptance threshold. Pull-request observations are labeled
+`UNTRUSTED_PR_OBSERVATION`. A `TRUSTED_MAIN_OBSERVATION` requires the
+candidate workflow and inputs to merge, followed by a separate reviewed
+baseline-pointer update and an exact clean protected-main push. Manual
+dispatches remain diagnostic and untrusted. Numeric acceptance may be frozen
+only in a later reviewed policy change based on that trusted observation,
+never by the same pull request that defines the measurement.
+No individual compiler artifact is promotion-eligible: both exact-head GCC
+and Clang artifacts and external GitHub Actions run/artifact provenance must
+be checked before that later policy review.
+
+This is a test-only observation lane, not a supported-platform or worst-case
+resource proof. It changes no production linkage or behavior, does not admit
+SIMD256, and does not establish a consensus parser or adversarial block limit.
+Issue `#188` remains open pending trusted-main evidence, reviewed numeric
+limits, broader-platform coverage, and exact-commit re-review. Issue `#181`
+also remains open, production remains `NONE`, and `RELEASE_HOLD` remains in
+force.
+
 ## Pinned Upstream CBMC Reproduction
 
 The dedicated read-only workflow checks out exact `mldsa-native` commit
@@ -278,9 +321,9 @@ This prototype advances engineering evidence but closes no production gate:
   evidence. The three research oracle CLIs now enforce documented argv parser
   limits and replay fixed plus deterministic malformed-input mutations,
   including non-UTF-8 arguments, with separate ASan/UBSan coverage for the C
-  adapters. Broader-platform and Rust sanitizer coverage, direct verifier
-  allocation/stack/CPU measurement, adversarial-batch limits, and exact-commit
-  re-review remain open;
+  adapters. Broader-platform and Rust sanitizer coverage, trusted-main
+  resource observation, reviewed allocation/stack/CPU and adversarial-batch
+  acceptance limits, and exact-commit re-review remain open;
 - issue `#189`: a dated fail-closed selected-graph advisory ledger, full-lock
   cargo-audit/OSV scans, selected dependency graph, CycloneDX SBOM, and weekly
   retained refresh are implemented; exact-commit independent re-review remains

--- a/docs/TRACK_A_STATUS.md
+++ b/docs/TRACK_A_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Status: ACTIVE
 ## Spec-ID: TRACK-A-STATUS-v1
-## Updated: 2026-07-23
+## Updated: 2026-07-27
 ## Current Phase: Phase 1 - Cryptographic Production Hold
 
 ## Purpose
@@ -263,21 +263,30 @@ tracked suites now have an explicit policy class and none remains in
 
 Active owned tranche:
 
-1. Land bounded stateful signer and seeded-key-generation fuzzing under issue
+1. Land the bounded direct-verifier resource-envelope observation lane under
    `#188`
-   - exercise deterministic seeded key generation, fresh and repeated
-     randomizers, short/zero/failed entropy, invalid arguments, backend
-     failures, signature zeroing, alias rejection, and successful strict
-     self-verification
-   - reset state for every input and assert the exact entropy-consumption and
-     repeat-state transition contract before and after failures
-   - retain separate ASan/UBSan and MSan lanes so uninstrumented external
-     implementations do not contaminate the memory-sanitizer result
-   - keep the already-pinned comparator as a correctness preflight and record
-     exact corpus, duration, seed, crash, and sanitizer evidence; the first
-     long scheduled/manual receipt remains follow-up evidence after merge
+   - call only `pqbtc_mldsa44_verify_strict` from the production-shaped
+     portable-C build on Linux x86_64
+   - run four separately accounted 4,287-call batches covering rotating mixed
+     inputs, valid inputs, deep rejects, and a same-public-key set containing
+     four required accepts plus five deep rejects that retain the frozen key
+   - execute on a 128 KiB guarded pthread stack, require zero instrumented
+     project heap calls, retain compiler-specific `.su` observations, and
+     preserve raw timing samples
+   - label pull-request output `UNTRUSTED_PR_OBSERVATION`; require a separate
+     reviewed baseline-pointer update and exact clean protected-main push
+     `TRUSTED_MAIN_OBSERVATION` before any evidence is trusted
+   - keep manual dispatches diagnostic and untrusted
+   - keep each single-compiler artifact non-promotable; require both exact-head
+     GCC and Clang artifacts plus external GitHub Actions provenance before a
+     later policy review
+   - leave numeric CPU, wall-time, and RSS acceptance unset until a later
+     reviewed policy change evaluates that trusted-main observation
+   - treat 4,287 calls as a research workload only, not a consensus, block,
+     transaction, mempool, or production limit
    - keep production at `NONE` and `RELEASE_HOLD`; this tranche authorizes no
-     consensus, wallet, Script, `ALG_ID`, or inventory-policy change
+     SIMD256 admission or consensus, wallet, Script, `ALG_ID`, or
+     inventory-policy change, and issues `#188` and `#181` remain open
 
 Future selection boundary:
 
@@ -1834,6 +1843,20 @@ Aineko must ask before:
 
 Entries below are dated decision snapshots. Use Current Follow-On Candidates
 above as the controlling live next-PR handoff when these older notes disagree.
+
+- 2026-07-27: The next bounded issue-`#188` tranche defines a test-only Linux
+  x86_64 observation lane that calls `pqbtc_mldsa44_verify_strict` directly.
+  Four separately accounted batches make 4,287 calls each on a 128 KiB
+  guarded pthread stack, with zero instrumented project heap calls,
+  compiler-specific `.su` observations, and raw timing samples. Pull-request
+  results are `UNTRUSTED_PR_OBSERVATION`, and no numeric CPU, wall-time, or
+  RSS acceptance is set before a separate reviewed baseline update and clean
+  protected-main push `TRUSTED_MAIN_OBSERVATION`; manual dispatches remain
+  diagnostic and untrusted. Each compiler artifact remains
+  non-promotion-eligible until both exact-head jobs and their external
+  workflow provenance are reviewed. The workload is not a consensus, block, or
+  production limit. Production remains `NONE`, SIMD256 remains unadmitted,
+  issues `#188` and `#181` remain open, and `RELEASE_HOLD` remains in force.
 
 - 2026-07-23: Exact-main differential run `30043023928` passed at
   `acd2337201a10b76f6354d9b3c8501483645d122` for 1,801.155 measured fuzzer


### PR DESCRIPTION
## Summary

- add a test-only Linux x86_64 direct-verifier resource observation lane for `pqbtc_mldsa44_verify_strict`
- freeze four 4,287-call batches, guarded-stack and resource containment, allocator interposition, compiler stack records, and canonical evidence validation
- reconstruct corpus taxonomy and provenance offline, bind retained evidence to the exact repository/build/binaries, and keep single-compiler artifacts non-promotable
- normalize only exact repository/build path components so downloaded evidence remains independently verifiable after relocation
- extend clang-tidy/IWYU coverage and the guarded review-baseline path set

## Trust and release boundary

- pull-request and manual-dispatch observations remain untrusted
- trusted labeling requires a protected `main` push after a separate reviewed baseline-pointer update
- GCC and Clang artifacts both remain `promotion_eligible=false`; external workflow provenance and a later reviewed numeric-policy change are still required
- production backend remains `NONE`, SIMD256 remains unadmitted, and the release hold is unchanged
- issues #188 and #181 remain open

## Validation

- 203 repository unit tests passed
- repository-pinned Ruff 0.5.5, checksum-verified actionlint 1.7.12 for the changed workflow, Python byte compilation, whitespace/newline lint, spelling review, and `git diff --check` passed for the changed surface
- CI inventory passed (`dual_profile=141`, `legacy_only=14`, `pq_backlog=0`, `pq_required=121`)
- exact hosted x86_64 GCC and Clang resource jobs passed; both downloaded artifacts independently reverified after relocation from the runner checkout
- each compiler completed 17,149 direct calls with all six allocator counters at zero, four positive controls passing, exact corpus FNV preservation, and frozen 240/76/7/9 selection counts
- exact LLVM 20 clang-tidy and pinned IWYU evidence passed all 12 checks; downloaded checksums and the exact-head receipt reverified independently
- 23/23 exact-head checks passed, including native PQ, sanitizers, Valgrind constant-time audits, advisory/SBOM/Miri, review reproduction, and all 200 pinned CBMC proofs
- independent security, CI/release, evidence-integrity, and adversarial re-reviews found no remaining blocker

This pull request remains test-only and does not change production admission or the release hold.